### PR TITLE
Allow EU dataset ID prefix

### DIFF
--- a/gcloud/datastore/key.py
+++ b/gcloud/datastore/key.py
@@ -50,9 +50,10 @@ class Key(object):
     key = datastore_pb.Key()
 
     # Apparently 's~' is a prefix for High-Replication and is necessary here.
+    # Another valid preflix is 'e~' indicating EU datacenters.
     dataset_id = self.dataset().id()
     if dataset_id:
-      if not dataset_id.startswith('s~'):
+      if dataset_id[:2] not in ['s~', 'e~']:
         dataset_id = 's~' + dataset_id
 
       key.partition_id.dataset_id = dataset_id

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -1,5 +1,6 @@
 import unittest2
 
+from dataset import Dataset
 from key import Key
 
 
@@ -11,3 +12,16 @@ class TestKey(unittest2.TestCase):
     self.assertEqual('', key.kind())
     self.assertEqual(None, key.dataset())
     self.assertEqual(None, key.namespace())
+
+  def test_dataset_prefix(self):
+    key = Key(dataset=Dataset('dset'))
+    protokey = key.to_protobuf()
+    self.assertEqual('s~dset', protokey.partition_id.dataset_id)
+
+    key = Key(dataset=Dataset('s~dset'))
+    protokey = key.to_protobuf()
+    self.assertEqual('s~dset', protokey.partition_id.dataset_id)
+
+    key = Key(dataset=Dataset('e~dset'))
+    protokey = key.to_protobuf()
+    self.assertEqual('e~dset', protokey.partition_id.dataset_id)


### PR DESCRIPTION
This PR adds support for datasets located in EU datacenters.
EU apps are prefixed with `e~`. 

Without this patch EU users will most likely see one of the following errors:

`Exception: Request failed. Error was: app e~dataset cannot access app dataset's data`

or 

`Exception: Request failed. Error was: Application Id (app) format is invalid: 's~e~dataset'`
