### PR TITLE
Fixes #52 - Allow query-string authentication (aka, signing URLs).

### DIFF
--- a/gcloud/connection.py
+++ b/gcloud/connection.py
@@ -26,6 +26,10 @@ class Connection(object):
     self._credentials = credentials
 
   @property
+  def credentials(self):
+    return self._credentials
+
+  @property
   def http(self):
     """A getter for the HTTP transport used in talking to the API.
 


### PR DESCRIPTION
- Moved the connection property around (no code change, just relocation)
- Put the signing logic in storage.connection.Connection
- Put shortcut method on storage.key.Key

CC:@proppy 
