### PR TITLE
Expanded exceptions gcloud and its storage sub-module.

### DIFF
--- a/gcloud/exceptions.py
+++ b/gcloud/exceptions.py
@@ -1,0 +1,36 @@
+# TODO: Make these super useful.
+import ast
+
+class Error(Exception):
+  """General Gcloud error."""
+  def __init__(self, message, *args):
+      super(GcloudClientError, self).__init__(message, *args)
+      self.message = message
+
+  def __repr__(self):
+      return 'GcloudClientError: %s' % self.message
+
+  def __str__(self):
+      return 'GcloudClientError: %s' % self.message
+
+
+class ConnectionError(Exception):
+  """General error handler for HTTP errors for gclouds sub-modules."""
+  def __init__(self, response, content, *args):
+    super(ConnectionError, self).__init__(response, content, *args)
+    evaluated_content = ast.literal_eval(content)
+    self.headers = response
+    self.status = response.status
+    self.date = response['date']
+    self.expires = response['expires']
+    self.errors = evaluated_content["error"]["errors"]
+    self.message = evaluated_content["error"]["message"]
+
+
+  def __repr__(self):
+    return '%s: Status: %s Message: %s' % (self.__class__.__name__,
+                                           self.status, self.message)
+
+  def __str__(self):
+    return '%s: Status: %s Message: %s' % (self.__class__.__name__,
+                                           self.status, self.message)

--- a/gcloud/storage/exceptions.py
+++ b/gcloud/storage/exceptions.py
@@ -1,21 +1,48 @@
 # TODO: Make these super useful.
+from gcloud import exceptions
 
-class StorageError(Exception):
+class StorageError(exceptions.Error):
   pass
 
 
-class ConnectionError(StorageError):
-
-  def __init__(self, response, content):
-    message = str(response) + content
-    super(ConnectionError, self).__init__(message)
+class ConnectionError(exceptions.ConnectionError):
+  """
+  Storage error handler for HTTP response errors for gcloud storage.
+  """
+  pass
 
 
 class NotFoundError(ConnectionError):
-
-  def __init__(self, response, content):
-    self.message = 'Request returned a 404. Headers: %s' % (response)
+  pass
 
 
-class StorageDataError(StorageError):
+class UnauthorizedError(ConnectionError):
+  pass
+
+
+class InvalidBucketNameError(ConnectionError):
+  pass
+
+
+class TooManyBucketsError(ConnectionError):
+  pass
+
+
+class BucketAlreadyExistsError(ConnectionError):
+  pass
+
+
+class DomainVerificationRequiredError(ConnectionError):
+  pass
+
+
+class BucketAlreadyOwnedByYouError(ConnectionError):
+  pass
+
+
+class BucketNameUnavailableError(ConnectionError):
+  pass
+
+
+class KeyTooLongError(ConnectionError):
   pass


### PR DESCRIPTION
Not sure what direction to expand exceptions in, should I map them directly to errors referenced form here https://developers.google.com/storage/docs/reference-status ?

Or group 
InvalidBucketNameError
BucketNameUnavailableError
KeyTooLongError 
and simalar

Into something like StorageCreateError/S3CreateError in boto.

Todo could use a little fleshing out, but any guidance please?
