### PR TITLE
Fix #131:  return datetime w/ UTC zone.

### DIFF
--- a/gcloud/datastore/helpers.py
+++ b/gcloud/datastore/helpers.py
@@ -78,8 +78,9 @@ def get_value_from_protobuf(pb):
 
   if pb.value.HasField('timestamp_microseconds_value'):
     microseconds = pb.value.timestamp_microseconds_value
-    return (datetime.utcfromtimestamp(0) +
-            timedelta(microseconds=microseconds))
+    naive = (datetime.utcfromtimestamp(0) +
+             timedelta(microseconds=microseconds))
+    return naive.replace(tzinfo=pytz.utc)
 
   elif pb.value.HasField('key_value'):
     return Key.from_protobuf(pb.value.key_value)

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -92,9 +92,7 @@ class Test_get_value_from_protobuf(unittest2.TestCase):
         utc = datetime.datetime(2014, 9, 16, 10, 19, 32, 4375, pytz.utc)
         micros = (calendar.timegm(utc.timetuple()) * 1000000) + 4375
         pb = self._makePB('timestamp_microseconds_value', micros)
-        # self.assertEqual(self._callFUT(pb), utc) XXX
-        # see https://github.com/GoogleCloudPlatform/gcloud-python/issues/131
-        self.assertEqual(self._callFUT(pb), naive)
+        self.assertEqual(self._callFUT(pb), utc)
 
     def test_key(self):
         from gcloud.datastore.datastore_v1_pb2 import Property


### PR DESCRIPTION
See #131 for rationale.
