### PR TITLE
Fix #137:  default key based on filename.

### DIFF
--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -1,3 +1,5 @@
+import os
+
 from gcloud.storage import exceptions
 from gcloud.storage.acl import BucketACL
 from gcloud.storage.acl import DefaultObjectACL
@@ -230,6 +232,8 @@ class Bucket(object):
                 to the root of the bucket
                 with the same name as on your local file system.
     """
+    if key is None:
+        key = os.path.basename(filename)
     key = self.new_key(key)
     return key.set_contents_from_filename(filename)
 

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -246,8 +246,22 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[1]['method'], 'DELETE')
         self.assertEqual(kw[1]['path'], '/b/%s/o/%s' % (NAME, NONESUCH))
 
-    # See: https://github.com/GoogleCloudPlatform/gcloud-python/issues/137
-    #def test_upload_file_default_key(self):
+    def test_upload_file_default_key(self):
+        from gcloud.test_credentials import _Monkey
+        from gcloud.storage import bucket as MUT
+        BASENAME = 'file.ext'
+        FILENAME = '/path/to/%s' % BASENAME
+        _uploaded = []
+        class _Key(object):
+            def __init__(self, bucket, name):
+                self._bucket = bucket
+                self._name = name
+            def set_contents_from_filename(self, filename):
+                _uploaded.append((self._bucket, self._name, filename))
+        bucket = self._makeOne()
+        with _Monkey(MUT, Key=_Key):
+            bucket.upload_file(FILENAME)
+        self.assertEqual(_uploaded, [(bucket, BASENAME, FILENAME)])
 
     def test_upload_file_explicit_key(self):
         from gcloud.test_credentials import _Monkey


### PR DESCRIPTION
When no key is passed, guess it based on the basename of filename, as required by docstring.

See #137
