### PR TITLE
Fix #138: clear existing (local) ACL when saving ACL to server.

### DIFF
--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -443,7 +443,9 @@ class Bucket(object):
     if acl is None:
       return self
 
-    return self.patch_metadata({'acl': list(acl)})
+    self.patch_metadata({'acl': list(acl)})
+    self.reload_acl()
+    return self
 
   def clear_acl(self):
     """Remove all ACL rules from the bucket.

--- a/gcloud/storage/key.py
+++ b/gcloud/storage/key.py
@@ -404,7 +404,9 @@ class Key(object):
     if acl is None:
       return self
 
-    return self.patch_metadata({'acl': list(acl)})
+    self.patch_metadata({'acl': list(acl)})
+    self.reload_acl()
+    return self
 
   def clear_acl(self):
     """Remove all ACL rules from the key.

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -532,8 +532,7 @@ class Test_Bucket(unittest2.TestCase):
         bucket = self._makeOne(connection, NAME, metadata)
         bucket.reload_acl()
         self.assertTrue(bucket.save_acl(new_acl) is bucket)
-        # See: https://github.com/GoogleCloudPlatform/gcloud-python/issues/138
-        #self.assertEqual(list(bucket.acl), new_acl)
+        self.assertEqual(list(bucket.acl), new_acl)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PATCH')
@@ -550,8 +549,7 @@ class Test_Bucket(unittest2.TestCase):
         bucket = self._makeOne(connection, NAME, metadata)
         bucket.reload_acl()
         self.assertTrue(bucket.clear_acl() is bucket)
-        # See: https://github.com/GoogleCloudPlatform/gcloud-python/issues/138
-        #self.assertEqual(list(bucket.acl), [])
+        self.assertEqual(list(bucket.acl), [])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PATCH')

--- a/gcloud/storage/test_key.py
+++ b/gcloud/storage/test_key.py
@@ -509,8 +509,7 @@ class Test_Key(unittest2.TestCase):
         key = self._makeOne(bucket, KEY, metadata)
         key.reload_acl()
         self.assertTrue(key.save_acl(new_acl) is key)
-        # See: https://github.com/GoogleCloudPlatform/gcloud-python/issues/138
-        #self.assertEqual(list(bucket.acl), new_acl)
+        self.assertEqual(list(key.acl), new_acl)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PATCH')
@@ -528,8 +527,7 @@ class Test_Key(unittest2.TestCase):
         key = self._makeOne(bucket, KEY, metadata)
         key.reload_acl()
         self.assertTrue(key.clear_acl() is key)
-        # See: https://github.com/GoogleCloudPlatform/gcloud-python/issues/138
-        #self.assertEqual(list(key.acl), [])
+        self.assertEqual(list(key.acl), [])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PATCH')


### PR DESCRIPTION
See #138.
