### PR TITLE
Remove install-time requirements from 'setup_requires'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
                        'gcloud/storage/demo.key']},
     include_package_data=True,
     zip_safe=False,
-    setup_requires=REQUIREMENTS,
     install_requires=REQUIREMENTS,
     classifiers=[
         'Development Status :: 1 - Planning',


### PR DESCRIPTION
That field is used for stuff needed at packaging time, but causes eggs
to be downloaded and installed in the project directory, which is
undesirable.
