### PR TITLE
Suppress two useless PEP8 errors.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps =
     Sphinx
 
 [pep8]
+ignore = E124,E127
 exclude = gcloud/datastore/datastore_v1_pb2.py,docs/conf.py,*.egg/,.*/
 verbose = 1
 


### PR DESCRIPTION
- E124: closing bracket does not match visual indentation.
- E127: continuation line over-indented for visual indent.

They are over-opinionated, and without sufficient justification from the PEP.
