### PR TITLE
Fix #167:  Update docstring for 'Connection.save_entity'.

### DIFF
--- a/gcloud/datastore/connection.py
+++ b/gcloud/datastore/connection.py
@@ -339,8 +339,9 @@ class Connection(connection.Connection):
         """Save an entity to the Cloud Datastore with the provided properties.
 
         .. note::
-           Any existing properties for the entity will be cleared before
-           applying those passed in 'properties'.
+           Any existing properties for the entity identified by 'key_pb'
+           will be replaced by those passed in 'properties';  properties
+           not passed in 'properties' no longer be set for the entity.
 
         :type dataset_id: string
         :param dataset_id: The dataset in which to save the entity.

--- a/gcloud/datastore/entity.py
+++ b/gcloud/datastore/entity.py
@@ -187,6 +187,12 @@ class Entity(dict):  # pylint: disable=too-many-public-methods
     def save(self):
         """Save the entity in the Cloud Datastore.
 
+        .. note::
+           Any existing properties for the entity will be replaced by those
+           currently set on this instance.  Already-stored properties which do
+           not correspond to keys set on this instance will be removed from
+           the datastore.
+
         :rtype: :class:`gcloud.datastore.entity.Entity`
         :returns: The entity with a possibly updated Key.
         """


### PR DESCRIPTION
Indicate that upsert clears existing properties before applying those passed to the API.

Fixes #167.
