### PR TITLE
Finish #223:  Support marshalling lists to 'value_pb.list_value'

### DIFF
--- a/gcloud/datastore/_helpers.py
+++ b/gcloud/datastore/_helpers.py
@@ -66,6 +66,8 @@ def _get_protobuf_attribute_and_value(val):
         name, value = 'string', val
     elif isinstance(val, Entity):
         name, value = 'entity', val
+    elif isinstance(val, list):
+        name, value = 'list', val
     else:
         raise ValueError("Unknown protobuf attr type %s" % type(val))
 
@@ -167,5 +169,10 @@ def _set_protobuf_value(value_pb, val):
             p_pb = e_pb.property.add()
             p_pb.name = item_key
             _set_protobuf_value(p_pb.value, value)
+    elif attr == 'list_value':
+        l_pb = value_pb.list_value
+        for item in val:
+            i_pb = l_pb.add()
+            _set_protobuf_value(i_pb, item)
     else:  # scalar, just assign
         setattr(value_pb, attr, val)

--- a/gcloud/datastore/test__helpers.py
+++ b/gcloud/datastore/test__helpers.py
@@ -90,6 +90,12 @@ class Test__get_protobuf_attribute_and_value(unittest2.TestCase):
         self.assertEqual(name, 'entity_value')
         self.assertTrue(value is entity)
 
+    def test_list(self):
+        values = ['a', 0, 3.14]
+        name, value = self._callFUT(values)
+        self.assertEqual(name, 'list_value')
+        self.assertTrue(value is values)
+
     def test_object(self):
         self.assertRaises(ValueError, self._callFUT, object())
 
@@ -301,3 +307,13 @@ class Test_set_protobuf_value(unittest2.TestCase):
         self.assertEqual(len(props), 1)
         self.assertEqual(props[0].name, 'foo')
         self.assertEqual(props[0].value.string_value, 'Foo')
+
+    def test_list(self):
+        pb = self._makePB()
+        values = ['a', 0, 3.14]
+        self._callFUT(pb, values)
+        marshalled = pb.list_value
+        self.assertEqual(len(marshalled), len(values))
+        self.assertEqual(marshalled[0].string_value, values[0])
+        self.assertEqual(marshalled[1].integer_value, values[1])
+        self.assertEqual(marshalled[2].double_value, values[2])


### PR DESCRIPTION
Closes #223.  (again).
