### PR TITLE
Revert "Fix #121:  Drop munging of 's~' prefix onto keys."

### DIFF
--- a/gcloud/datastore/key.py
+++ b/gcloud/datastore/key.py
@@ -95,8 +95,13 @@ class Key(object):
         # but we shouldn't throw a cryptic error if one isn't provided
         # in the initializer.
         if self.dataset():
+            # Apparently 's~' is a prefix for High-Replication and is necessary
+            # here. Another valid preflix is 'e~' indicating EU datacenters.
             dataset_id = self.dataset().id()
             if dataset_id:
+                if dataset_id[:2] not in ['s~', 'e~']:
+                    dataset_id = 's~' + dataset_id
+
                 key.partition_id.dataset_id = dataset_id
 
         if self._namespace:

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -425,7 +425,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(cw['method'], 'POST')
         expected_headers = {
             'Content-Type': 'application/x-protobuf',
-            'Content-Length': '24',
+            'Content-Length': '26',
             'User-Agent': conn.USER_AGENT,
         }
         self.assertEqual(cw['headers'], expected_headers)
@@ -466,7 +466,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(cw['method'], 'POST')
         expected_headers = {
             'Content-Type': 'application/x-protobuf',
-            'Content-Length': '24',
+            'Content-Length': '26',
             'User-Agent': conn.USER_AGENT,
         }
         self.assertEqual(cw['headers'], expected_headers)
@@ -504,7 +504,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(cw['method'], 'POST')
         expected_headers = {
             'Content-Type': 'application/x-protobuf',
-            'Content-Length': '48',
+            'Content-Length': '52',
             'User-Agent': conn.USER_AGENT,
         }
         self.assertEqual(cw['headers'], expected_headers)
@@ -549,7 +549,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(cw['method'], 'POST')
         expected_headers = {
             'Content-Type': 'application/x-protobuf',
-            'Content-Length': '45',
+            'Content-Length': '47',
             'User-Agent': conn.USER_AGENT,
         }
         self.assertEqual(cw['headers'], expected_headers)
@@ -597,7 +597,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(cw['method'], 'POST')
         expected_headers = {
             'Content-Type': 'application/x-protobuf',
-            'Content-Length': '51',
+            'Content-Length': '53',
             'User-Agent': conn.USER_AGENT,
         }
         self.assertEqual(cw['headers'], expected_headers)
@@ -634,7 +634,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(cw['method'], 'POST')
         expected_headers = {
             'Content-Type': 'application/x-protobuf',
-            'Content-Length': '45',
+            'Content-Length': '47',
             'User-Agent': conn.USER_AGENT,
         }
         self.assertEqual(cw['headers'], expected_headers)
@@ -687,7 +687,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(cw['method'], 'POST')
         expected_headers = {
             'Content-Type': 'application/x-protobuf',
-            'Content-Length': '42',
+            'Content-Length': '44',
             'User-Agent': conn.USER_AGENT,
         }
         self.assertEqual(cw['headers'], expected_headers)
@@ -784,7 +784,7 @@ class TestConnection(unittest2.TestCase):
         self.assertEqual(cw['method'], 'POST')
         expected_headers = {
             'Content-Type': 'application/x-protobuf',
-            'Content-Length': '28',
+            'Content-Length': '30',
             'User-Agent': conn.USER_AGENT,
         }
         self.assertEqual(cw['headers'], expected_headers)

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -133,9 +133,25 @@ class TestKey(unittest2.TestCase):
         pb = key.to_protobuf()
         self.assertEqual(pb.partition_id.dataset_id, '')
 
-    def test_to_protobuf_w_explicit_dataset(self):
+    def test_to_protobuf_w_explicit_dataset_no_prefix(self):
         from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
+        dataset = Dataset(_DATASET)
+        key = self._makeOne(dataset)
+        pb = key.to_protobuf()
+        self.assertEqual(pb.partition_id.dataset_id, 's~%s' % _DATASET)
+
+    def test_to_protobuf_w_explicit_dataset_w_s_prefix(self):
+        from gcloud.datastore.dataset import Dataset
+        _DATASET = 's~DATASET'
+        dataset = Dataset(_DATASET)
+        key = self._makeOne(dataset)
+        pb = key.to_protobuf()
+        self.assertEqual(pb.partition_id.dataset_id, _DATASET)
+
+    def test_to_protobuf_w_explicit_dataset_w_e_prefix(self):
+        from gcloud.datastore.dataset import Dataset
+        _DATASET = 'e~DATASET'
         dataset = Dataset(_DATASET)
         key = self._makeOne(dataset)
         pb = key.to_protobuf()


### PR DESCRIPTION
Reverts GoogleCloudPlatform/gcloud-python#259
