### PR TITLE
Fix #121: don't copy project ID to the Key protobuf's dataset_id.

### DIFF
--- a/gcloud/datastore/key.py
+++ b/gcloud/datastore/key.py
@@ -4,7 +4,6 @@ import copy
 from itertools import izip
 
 from gcloud.datastore import datastore_v1_pb2 as datastore_pb
-from gcloud.datastore.dataset import Dataset
 
 
 class Key(object):
@@ -13,11 +12,8 @@ class Key(object):
     .. automethod:: __init__
     """
 
-    def __init__(self, dataset=None, namespace=None, path=None):
+    def __init__(self, path=None, namespace=None, dataset_id=None):
         """Constructor / initializer for a key.
-
-        :type dataset: :class:`gcloud.datastore.dataset.Dataset`
-        :param dataset: A dataset instance for the key.
 
         :type namespace: :class:`str`
         :param namespace: A namespace identifier for the key.
@@ -25,10 +21,14 @@ class Key(object):
         :type path: sequence of dicts
         :param path: Each dict must have keys 'kind' (a string) and optionally
                      'name' (a string) or 'id' (an integer).
+
+        :type dataset_id: string
+        :param dataset: The dataset ID assigned by back-end for the key.
+                        Leave as None for newly-created keys.
         """
-        self._dataset = dataset
-        self._namespace = namespace
         self._path = path or [{'kind': ''}]
+        self._namespace = namespace
+        self._dataset_id = dataset_id
 
     def _clone(self):
         """Duplicates the Key.
@@ -40,12 +40,10 @@ class Key(object):
         :rtype: :class:`gcloud.datastore.key.Key`
         :returns: a new `Key` instance
         """
-        clone = copy.deepcopy(self)
-        clone._dataset = self._dataset  # Make a shallow copy of the Dataset.
-        return clone
+        return copy.deepcopy(self)
 
     @classmethod
-    def from_protobuf(cls, pb, dataset=None):
+    def from_protobuf(cls, pb):
         """Factory method for creating a key based on a protobuf.
 
         The protobuf should be one returned from the Cloud Datastore
@@ -53,10 +51,6 @@ class Key(object):
 
         :type pb: :class:`gcloud.datastore.datastore_v1_pb2.Key`
         :param pb: The Protobuf representing the key.
-
-        :type dataset: :class:`gcloud.datastore.dataset.Dataset`
-        :param dataset: A dataset instance.  If not passed, defaults to an
-                        instance whose ID is derived from pb.
 
         :rtype: :class:`gcloud.datastore.key.Key`
         :returns: a new `Key` instance
@@ -75,13 +69,10 @@ class Key(object):
 
             path.append(element_dict)
 
-        if not dataset:
-            dataset = Dataset(id=pb.partition_id.dataset_id)
-            namespace = pb.partition_id.namespace
-        else:
-            namespace = None
+        dataset_id = pb.partition_id.dataset_id or None
+        namespace = pb.partition_id.namespace
 
-        return cls(dataset, namespace, path)
+        return cls(path, namespace, dataset_id)
 
     def to_protobuf(self):
         """Return a protobuf corresponding to the key.
@@ -91,9 +82,8 @@ class Key(object):
         """
         key = datastore_pb.Key()
 
-        # Don't copy the dataset ID to the protobuf:  the backend
-        # already knows the dataset we are working with, and sets
-        # it on returned keys.
+        if self._dataset_id is not None:
+            key.partition_id.dataset_id = self._dataset_id
 
         if self._namespace:
             key.partition_id.namespace = self._namespace
@@ -151,24 +141,6 @@ class Key(object):
                   an 'id' or a 'name'.
         """
         return self.id_or_name() is None
-
-    def dataset(self, dataset=None):
-        """Dataset setter / getter.
-
-        :type dataset: :class:`gcloud.datastore.dataset.Dataset`
-        :param dataset: A dataset instance for the key.
-
-        :rtype: :class:`Key` (for setter); or
-                :class:`gcloud.datastore.dataset.Dataset` (for getter)
-        :returns: a new key, cloned from self., with the given dataset
-                  (setter); or self's dataset (getter).
-        """
-        if dataset:
-            clone = self._clone()
-            clone._dataset = dataset
-            return clone
-        else:
-            return self._dataset
 
     def namespace(self, namespace=None):
         """Namespace setter / getter.

--- a/gcloud/datastore/test__helpers.py
+++ b/gcloud/datastore/test__helpers.py
@@ -32,14 +32,13 @@ class Test__get_protobuf_attribute_and_value(unittest2.TestCase):
         self.assertEqual(value % 1000000, 4375)
 
     def test_key(self):
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         _DATASET = 'DATASET'
         _KIND = 'KIND'
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
-        key = Key(dataset=Dataset(_DATASET), path=_PATH)
+        key = Key(dataset_id=_DATASET, path=_PATH)
         name, value = self._callFUT(key)
         self.assertEqual(name, 'key_value')
         self.assertEqual(value, key.to_protobuf())
@@ -131,7 +130,6 @@ class Test__get_value_from_value_pb(unittest2.TestCase):
 
     def test_key(self):
         from gcloud.datastore.datastore_v1_pb2 import Value
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         _DATASET = 'DATASET'
@@ -139,7 +137,7 @@ class Test__get_value_from_value_pb(unittest2.TestCase):
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
         pb = Value()
-        expected = Key(dataset=Dataset(_DATASET), path=_PATH).to_protobuf()
+        expected = Key(dataset_id=_DATASET, path=_PATH).to_protobuf()
         pb.key_value.CopyFrom(expected)
         found = self._callFUT(pb)
         self.assertEqual(found.to_protobuf(), expected)
@@ -236,7 +234,6 @@ class Test_set_protobuf_value(unittest2.TestCase):
         self.assertEqual(value % 1000000, 4375)
 
     def test_key(self):
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         _DATASET = 'DATASET'
@@ -244,7 +241,7 @@ class Test_set_protobuf_value(unittest2.TestCase):
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
         pb = self._makePB()
-        key = Key(dataset=Dataset(_DATASET), path=_PATH)
+        key = Key(dataset_id=_DATASET, path=_PATH)
         self._callFUT(pb, key)
         value = pb.key_value
         self.assertEqual(value, key.to_protobuf())

--- a/gcloud/datastore/test_connection.py
+++ b/gcloud/datastore/test_connection.py
@@ -380,12 +380,10 @@ class TestConnection(unittest2.TestCase):
 
     def test_lookup_single_key_empty_response(self):
         from gcloud.datastore.connection import datastore_pb
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         DATASET_ID = 'DATASET'
-        key_pb = Key(dataset=Dataset(DATASET_ID),
-                     path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
+        key_pb = Key(path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
         rsp_pb = datastore_pb.LookupResponse()
         conn = self._makeOne()
         URI = '/'.join([
@@ -413,12 +411,10 @@ class TestConnection(unittest2.TestCase):
 
     def test_lookup_single_key_nonempty_response(self):
         from gcloud.datastore.connection import datastore_pb
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         DATASET_ID = 'DATASET'
-        key_pb = Key(dataset=Dataset(DATASET_ID),
-                     path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
+        key_pb = Key(path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
         rsp_pb = datastore_pb.LookupResponse()
         entity = datastore_pb.Entity()
         entity.key.CopyFrom(key_pb)
@@ -451,14 +447,11 @@ class TestConnection(unittest2.TestCase):
 
     def test_lookup_multiple_keys_empty_response(self):
         from gcloud.datastore.connection import datastore_pb
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         DATASET_ID = 'DATASET'
-        key_pb1 = Key(dataset=Dataset(DATASET_ID),
-                      path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
-        key_pb2 = Key(dataset=Dataset(DATASET_ID),
-                      path=[{'kind': 'Kind', 'id': 2345}]).to_protobuf()
+        key_pb1 = Key(path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
+        key_pb2 = Key(path=[{'kind': 'Kind', 'id': 2345}]).to_protobuf()
         rsp_pb = datastore_pb.LookupResponse()
         conn = self._makeOne()
         URI = '/'.join([
@@ -487,12 +480,10 @@ class TestConnection(unittest2.TestCase):
 
     def test_commit_wo_transaction(self):
         from gcloud.datastore.connection import datastore_pb
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         DATASET_ID = 'DATASET'
-        key_pb = Key(dataset=Dataset(DATASET_ID),
-                     path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
+        key_pb = Key(path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
         rsp_pb = datastore_pb.CommitResponse()
         mutation = datastore_pb.Mutation()
         insert = mutation.upsert.add()
@@ -528,15 +519,13 @@ class TestConnection(unittest2.TestCase):
 
     def test_commit_w_transaction(self):
         from gcloud.datastore.connection import datastore_pb
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         class Xact(object):
             def id(self):
                 return 'xact'
         DATASET_ID = 'DATASET'
-        key_pb = Key(dataset=Dataset(DATASET_ID),
-                     path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
+        key_pb = Key(path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
         rsp_pb = datastore_pb.CommitResponse()
         mutation = datastore_pb.Mutation()
         insert = mutation.upsert.add()
@@ -573,12 +562,10 @@ class TestConnection(unittest2.TestCase):
 
     def test_save_entity_wo_transaction_w_upsert(self):
         from gcloud.datastore.connection import datastore_pb
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         DATASET_ID = 'DATASET'
-        key_pb = Key(dataset=Dataset(DATASET_ID),
-                     path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
+        key_pb = Key(path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
         rsp_pb = datastore_pb.CommitResponse()
         conn = self._makeOne()
         URI = '/'.join([
@@ -617,14 +604,11 @@ class TestConnection(unittest2.TestCase):
 
     def test_save_entity_wo_transaction_w_auto_id(self):
         from gcloud.datastore.connection import datastore_pb
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         DATASET_ID = 'DATASET'
-        key_pb = Key(dataset=Dataset(DATASET_ID),
-                     path=[{'kind': 'Kind'}]).to_protobuf()
-        updated_key_pb = Key(dataset=Dataset(DATASET_ID),
-                             path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
+        key_pb = Key(path=[{'kind': 'Kind'}]).to_protobuf()
+        updated_key_pb = Key(path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
         rsp_pb = datastore_pb.CommitResponse()
         mr_pb = rsp_pb.mutation_result
         mr_pb.index_updates = 0
@@ -668,7 +652,6 @@ class TestConnection(unittest2.TestCase):
 
     def test_save_entity_w_transaction(self):
         from gcloud.datastore.connection import datastore_pb
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         mutation = datastore_pb.Mutation()
@@ -677,8 +660,7 @@ class TestConnection(unittest2.TestCase):
             def mutation(self):
                 return mutation
         DATASET_ID = 'DATASET'
-        key_pb = Key(dataset=Dataset(DATASET_ID),
-                     path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
+        key_pb = Key(path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
         rsp_pb = datastore_pb.CommitResponse()
         conn = self._makeOne()
         conn.transaction(Xact())
@@ -691,7 +673,6 @@ class TestConnection(unittest2.TestCase):
 
     def test_save_entity_w_transaction_nested_entity(self):
         from gcloud.datastore.connection import datastore_pb
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.entity import Entity
         from gcloud.datastore.key import Key
 
@@ -703,8 +684,7 @@ class TestConnection(unittest2.TestCase):
         DATASET_ID = 'DATASET'
         nested = Entity()
         nested['bar'] = u'Bar'
-        key_pb = Key(dataset=Dataset(DATASET_ID),
-                     path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
+        key_pb = Key(path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
         rsp_pb = datastore_pb.CommitResponse()
         conn = self._makeOne()
         conn.transaction(Xact())
@@ -717,12 +697,10 @@ class TestConnection(unittest2.TestCase):
 
     def test_delete_entities_wo_transaction(self):
         from gcloud.datastore.connection import datastore_pb
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         DATASET_ID = 'DATASET'
-        key_pb = Key(dataset=Dataset(DATASET_ID),
-                     path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
+        key_pb = Key(path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
         rsp_pb = datastore_pb.CommitResponse()
         conn = self._makeOne()
         URI = '/'.join([
@@ -757,7 +735,6 @@ class TestConnection(unittest2.TestCase):
 
     def test_delete_entities_w_transaction(self):
         from gcloud.datastore.connection import datastore_pb
-        from gcloud.datastore.dataset import Dataset
         from gcloud.datastore.key import Key
 
         mutation = datastore_pb.Mutation()
@@ -766,8 +743,7 @@ class TestConnection(unittest2.TestCase):
             def mutation(self):
                 return mutation
         DATASET_ID = 'DATASET'
-        key_pb = Key(dataset=Dataset(DATASET_ID),
-                     path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
+        key_pb = Key(path=[{'kind': 'Kind', 'id': 1234}]).to_protobuf()
         rsp_pb = datastore_pb.CommitResponse()
         conn = self._makeOne()
         conn.transaction(Xact())

--- a/gcloud/datastore/test_dataset.py
+++ b/gcloud/datastore/test_dataset.py
@@ -56,7 +56,7 @@ class TestDataset(unittest2.TestCase):
         DATASET_ID = 'DATASET'
         connection = _Connection()
         dataset = self._makeOne(DATASET_ID, connection)
-        key = Key(dataset=dataset, path=[{'kind': 'Kind', 'id': 1234}])
+        key = Key(path=[{'kind': 'Kind', 'id': 1234}])
         self.assertEqual(dataset.get_entities([key]), [])
 
     def test_get_entities_hit(self):
@@ -67,6 +67,7 @@ class TestDataset(unittest2.TestCase):
         ID = 1234
         PATH = [{'kind': KIND, 'id': ID}]
         entity_pb = datastore_pb.Entity()
+        entity_pb.key.partition_id.dataset_id = DATASET_ID
         path_element = entity_pb.key.path_element.add()
         path_element.kind = KIND
         path_element.id = ID
@@ -75,10 +76,10 @@ class TestDataset(unittest2.TestCase):
         prop.value.string_value = 'Foo'
         connection = _Connection(entity_pb)
         dataset = self._makeOne(DATASET_ID, connection)
-        key = Key(dataset=dataset, path=PATH)
+        key = Key(path=PATH)
         result, = dataset.get_entities([key])
         key = result.key()
-        self.assertTrue(key.dataset() is dataset)
+        self.assertEqual(key._dataset_id, DATASET_ID)
         self.assertEqual(key.path(), PATH)
         self.assertEqual(list(result), ['foo'])
         self.assertEqual(result['foo'], 'Foo')
@@ -88,7 +89,7 @@ class TestDataset(unittest2.TestCase):
         DATASET_ID = 'DATASET'
         connection = _Connection()
         dataset = self._makeOne(DATASET_ID, connection)
-        key = Key(dataset=dataset, path=[{'kind': 'Kind', 'id': 1234}])
+        key = Key(path=[{'kind': 'Kind', 'id': 1234}])
         self.assertEqual(dataset.get_entity(key), None)
 
     def test_get_entity_hit(self):
@@ -99,6 +100,7 @@ class TestDataset(unittest2.TestCase):
         ID = 1234
         PATH = [{'kind': KIND, 'id': ID}]
         entity_pb = datastore_pb.Entity()
+        entity_pb.key.partition_id.dataset_id = DATASET_ID
         path_element = entity_pb.key.path_element.add()
         path_element.kind = KIND
         path_element.id = ID
@@ -107,10 +109,10 @@ class TestDataset(unittest2.TestCase):
         prop.value.string_value = 'Foo'
         connection = _Connection(entity_pb)
         dataset = self._makeOne(DATASET_ID, connection)
-        key = Key(dataset=dataset, path=PATH)
+        key = Key(path=PATH)
         result = dataset.get_entity(key)
         key = result.key()
-        self.assertTrue(key.dataset() is dataset)
+        self.assertEqual(key._dataset_id, DATASET_ID)
         self.assertEqual(key.path(), PATH)
         self.assertEqual(list(result), ['foo'])
         self.assertEqual(result['foo'], 'Foo')

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -7,8 +7,8 @@ class TestKey(unittest2.TestCase):
         from gcloud.datastore.key import Key
         return Key
 
-    def _makeOne(self, dataset=None, namespace=None, path=None):
-        return self._getTargetClass()(dataset, namespace, path)
+    def _makeOne(self, path=None, namespace=None, dataset_id=None):
+        return self._getTargetClass()(path, namespace, dataset_id)
 
     def _makePB(self, dataset_id=None, namespace=None, path=()):
         from gcloud.datastore.datastore_v1_pb2 import Key
@@ -28,71 +28,47 @@ class TestKey(unittest2.TestCase):
 
     def test_ctor_defaults(self):
         key = self._makeOne()
-        self.assertEqual(key.dataset(), None)
+        self.assertEqual(key._dataset_id, None)
         self.assertEqual(key.namespace(), None)
         self.assertEqual(key.kind(), '')
         self.assertEqual(key.path(), [{'kind': ''}])
 
     def test_ctor_explicit(self):
-        from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
         _NAMESPACE = 'NAMESPACE'
         _KIND = 'KIND'
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset, _NAMESPACE, _PATH)
-        self.assertTrue(key.dataset() is dataset)
+        key = self._makeOne(_PATH, _NAMESPACE, _DATASET)
+        self.assertEqual(key._dataset_id, _DATASET)
         self.assertEqual(key.namespace(), _NAMESPACE)
         self.assertEqual(key.kind(), _KIND)
         self.assertEqual(key.path(), _PATH)
 
     def test__clone(self):
-        from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
         _NAMESPACE = 'NAMESPACE'
         _KIND = 'KIND'
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset, _NAMESPACE, _PATH)
+        key = self._makeOne(_PATH, _NAMESPACE, _DATASET)
         clone = key._clone()
-        self.assertTrue(clone.dataset() is dataset)
+        self.assertEqual(clone._dataset_id, _DATASET)
         self.assertEqual(clone.namespace(), _NAMESPACE)
         self.assertEqual(clone.kind(), _KIND)
         self.assertEqual(clone.path(), _PATH)
 
-    def test_from_protobuf_empty_path_explicit_dataset(self):
-        from gcloud.datastore.dataset import Dataset
-        _DATASET = 'DATASET'
-        dataset = Dataset(_DATASET)
-        pb = self._makePB()
-        key = self._getTargetClass().from_protobuf(pb, dataset)
-        self.assertTrue(key.dataset() is dataset)
-        self.assertEqual(key.namespace(), None)
-        self.assertEqual(key.kind(), '')
-        self.assertEqual(key.path(), [{'kind': ''}])
-
-    def test_from_protobuf_w_dataset_in_pb(self):
+    def test_from_protobuf_w_dataset_id_in_pb(self):
         _DATASET = 'DATASET'
         pb = self._makePB(_DATASET)
         key = self._getTargetClass().from_protobuf(pb)
-        self.assertEqual(key.dataset().id(), _DATASET)
+        self.assertEqual(key._dataset_id, _DATASET)
 
-    def test_from_protobuf_w_namespace_in_pb_wo_dataset_passed(self):
+    def test_from_protobuf_w_namespace_in_pb(self):
         _NAMESPACE = 'NAMESPACE'
         pb = self._makePB(namespace=_NAMESPACE)
         key = self._getTargetClass().from_protobuf(pb)
         self.assertEqual(key.namespace(), _NAMESPACE)
-
-    def test_from_protobuf_w_namespace_in_pb_w_dataset_passed(self):
-        from gcloud.datastore.dataset import Dataset
-        _DATASET = 'DATASET'
-        _NAMESPACE = 'NAMESPACE'
-        dataset = Dataset(_DATASET)
-        pb = self._makePB(namespace=_NAMESPACE)
-        key = self._getTargetClass().from_protobuf(pb, dataset)
-        self.assertEqual(key.namespace(), None)
 
     def test_from_protobuf_w_path_in_pb(self):
         _DATASET = 'DATASET'
@@ -126,36 +102,11 @@ class TestKey(unittest2.TestCase):
         self.assertEqual(elem.name, '')
         self.assertEqual(elem.id, 0)
 
-    def test_to_protobuf_w_explicit_dataset_empty_id(self):
-        from gcloud.datastore.dataset import Dataset
-        dataset = Dataset('')
-        key = self._makeOne(dataset)
-        pb = key.to_protobuf()
-        self.assertEqual(pb.partition_id.dataset_id, '')
-
     def test_to_protobuf_w_explicit_dataset_no_prefix(self):
-        from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset)
+        key = self._makeOne(dataset_id=_DATASET)
         pb = key.to_protobuf()
-        self.assertEqual(pb.partition_id.dataset_id, '')
-
-    def test_to_protobuf_w_explicit_dataset_w_s_prefix(self):
-        from gcloud.datastore.dataset import Dataset
-        _DATASET = 's~DATASET'
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset)
-        pb = key.to_protobuf()
-        self.assertEqual(pb.partition_id.dataset_id, '')
-
-    def test_to_protobuf_w_explicit_dataset_w_e_prefix(self):
-        from gcloud.datastore.dataset import Dataset
-        _DATASET = 'e~DATASET'
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset)
-        pb = key.to_protobuf()
-        self.assertEqual(pb.partition_id.dataset_id, '')
+        self.assertEqual(pb.partition_id.dataset_id, _DATASET)
 
     def test_to_protobuf_w_explicit_namespace(self):
         _NAMESPACE = 'NAMESPACE'
@@ -187,7 +138,7 @@ class TestKey(unittest2.TestCase):
 
     def test_from_path_empty(self):
         key = self._getTargetClass().from_path()
-        self.assertEqual(key.dataset(), None)
+        self.assertEqual(key._dataset_id, None)
         self.assertEqual(key.namespace(), None)
         self.assertEqual(key.kind(), '')
         self.assertEqual(key.path(), [{'kind': ''}])
@@ -236,129 +187,93 @@ class TestKey(unittest2.TestCase):
         key = self._makeOne(path=_PATH)
         self.assertFalse(key.is_partial())
 
-    def test_dataset_setter(self):
-        from gcloud.datastore.dataset import Dataset
-        _DATASET = 'DATASET'
-        _NAMESPACE = 'NAMESPACE'
-        _KIND = 'KIND'
-        _NAME = 'NAME'
-        _PATH = [{'kind': _KIND, 'name': _NAME}]
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(namespace=_NAMESPACE, path=_PATH)
-        after = key.dataset(dataset)
-        self.assertFalse(after is key)
-        self.assertTrue(isinstance(after, self._getTargetClass()))
-        self.assertTrue(after.dataset() is dataset)
-        self.assertEqual(after.namespace(), _NAMESPACE)
-        self.assertEqual(after.path(), _PATH)
-
     def test_namespace_setter(self):
-        from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
         _NAMESPACE = 'NAMESPACE'
         _KIND = 'KIND'
         _NAME = 'NAME'
         _PATH = [{'kind': _KIND, 'name': _NAME}]
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset, path=_PATH)
+        key = self._makeOne(path=_PATH, dataset_id=_DATASET)
         after = key.namespace(_NAMESPACE)
         self.assertFalse(after is key)
         self.assertTrue(isinstance(after, self._getTargetClass()))
-        self.assertTrue(after.dataset() is dataset)
+        self.assertEqual(after._dataset_id, _DATASET)
         self.assertEqual(after.namespace(), _NAMESPACE)
         self.assertEqual(after.path(), _PATH)
 
     def test_path_setter(self):
-        from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
         _NAMESPACE = 'NAMESPACE'
         _KIND = 'KIND'
         _NAME = 'NAME'
         _PATH = [{'kind': _KIND, 'name': _NAME}]
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset, _NAMESPACE)
+        key = self._makeOne(namespace=_NAMESPACE, dataset_id=_DATASET)
         after = key.path(_PATH)
         self.assertFalse(after is key)
         self.assertTrue(isinstance(after, self._getTargetClass()))
-        self.assertTrue(after.dataset() is dataset)
+        self.assertEqual(after._dataset_id, _DATASET)
         self.assertEqual(after.namespace(), _NAMESPACE)
         self.assertEqual(after.path(), _PATH)
 
     def test_kind_getter_empty_path(self):
-        from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
         _NAMESPACE = 'NAMESPACE'
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset, _NAMESPACE)
+        key = self._makeOne(namespace=_NAMESPACE, dataset_id=_DATASET)
         key._path = ()  # edge case
         self.assertEqual(key.kind(), None)
 
     def test_kind_setter(self):
-        from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
         _NAMESPACE = 'NAMESPACE'
         _KIND_BEFORE = 'KIND_BEFORE'
         _KIND_AFTER = 'KIND_AFTER'
         _NAME = 'NAME'
         _PATH = [{'kind': _KIND_BEFORE, 'name': _NAME}]
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset, _NAMESPACE, _PATH)
+        key = self._makeOne(_PATH, _NAMESPACE, _DATASET)
         after = key.kind(_KIND_AFTER)
         self.assertFalse(after is key)
         self.assertTrue(isinstance(after, self._getTargetClass()))
-        self.assertTrue(after.dataset() is dataset)
+        self.assertEqual(after._dataset_id, _DATASET)
         self.assertEqual(after.namespace(), _NAMESPACE)
         self.assertEqual(after.path(), [{'kind': _KIND_AFTER, 'name': _NAME}])
 
     def test_id_getter_empty_path(self):
-        from gcloud.datastore.dataset import Dataset
-        _DATASET = 'DATASET'
-        _NAMESPACE = 'NAMESPACE'
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset, _NAMESPACE)
+        key = self._makeOne()
         key._path = ()  # edge case
         self.assertEqual(key.id(), None)
 
     def test_id_setter(self):
-        from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
         _NAMESPACE = 'NAMESPACE'
         _KIND = 'KIND'
         _ID_BEFORE = 1234
         _ID_AFTER = 5678
         _PATH = [{'kind': _KIND, 'id': _ID_BEFORE}]
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset, _NAMESPACE, _PATH)
+        key = self._makeOne(_PATH, _NAMESPACE, _DATASET)
         after = key.id(_ID_AFTER)
         self.assertFalse(after is key)
         self.assertTrue(isinstance(after, self._getTargetClass()))
-        self.assertTrue(after.dataset() is dataset)
+        self.assertEqual(after._dataset_id, _DATASET)
         self.assertEqual(after.namespace(), _NAMESPACE)
         self.assertEqual(after.path(), [{'kind': _KIND, 'id': _ID_AFTER}])
 
     def test_name_getter_empty_path(self):
-        from gcloud.datastore.dataset import Dataset
-        _DATASET = 'DATASET'
-        _NAMESPACE = 'NAMESPACE'
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset, _NAMESPACE)
+        key = self._makeOne()
         key._path = ()  # edge case
         self.assertEqual(key.name(), None)
 
     def test_name_setter(self):
-        from gcloud.datastore.dataset import Dataset
         _DATASET = 'DATASET'
         _NAMESPACE = 'NAMESPACE'
         _KIND = 'KIND'
         _NAME_BEFORE = 'NAME_BEFORE'
         _NAME_AFTER = 'NAME_AFTER'
         _PATH = [{'kind': _KIND, 'name': _NAME_BEFORE}]
-        dataset = Dataset(_DATASET)
-        key = self._makeOne(dataset, _NAMESPACE, _PATH)
+        key = self._makeOne(_PATH, _NAMESPACE, _DATASET)
         after = key.name(_NAME_AFTER)
         self.assertFalse(after is key)
         self.assertTrue(isinstance(after, self._getTargetClass()))
-        self.assertTrue(after.dataset() is dataset)
+        self.assertEqual(after._dataset_id, _DATASET)
         self.assertEqual(after.namespace(), _NAMESPACE)
         self.assertEqual(after.path(), [{'kind': _KIND, 'name': _NAME_AFTER}])
 


### PR DESCRIPTION
The back-end already knows it, and it is actually different than the 'project ID' we are assigning to the dataset as its ID.

See #121.
