### PR TITLE
Implements group_by, projection and offset on datastore Query.

### DIFF
--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -59,9 +59,7 @@ class Query(object):
         self._namespace = namespace
         self._pb = datastore_pb.Query()
         self._cursor = None
-        self._projection = []
         self._offset = 0
-        self._group_by = []
 
         if kind:
             self._pb.kind.add().name = kind
@@ -440,13 +438,13 @@ class Query(object):
                   :class:`Query` with that projection set.
         """
         if projection is None:
-            return self._projection
+            return [prop_expr.property.name
+                    for prop_expr in self._pb.projection]
 
         clone = self._clone()
-        clone._projection = projection
 
         # Reset projection values to empty.
-        clone._pb.projection._values = []
+        clone._pb.ClearField('projection')
 
         # Add each name to list of projections.
         for projection_name in projection:
@@ -506,13 +504,12 @@ class Query(object):
                   of the :class:`Query` with that list of values set.
         """
         if group_by is None:
-            return self._group_by
+            return [prop_ref.name for prop_ref in self._pb.group_by]
 
         clone = self._clone()
-        clone._group_by = group_by
 
         # Reset group_by values to empty.
-        clone._pb.group_by._values = []
+        clone._pb.ClearField('group_by')
 
         # Add each name to list of group_bys.
         for group_by_name in group_by:

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -476,6 +476,15 @@ class TestQuery(unittest2.TestCase):
         after = self._makeOne(_KIND).projection(_PROJECTION)
         self.assertEqual(after.projection(), _PROJECTION)
 
+    def test_projection_multiple_calls(self):
+        _KIND = 'KIND'
+        _PROJECTION1 = ['field1', 'field2']
+        _PROJECTION2 = ['field3']
+        before = self._makeOne(_KIND).projection(_PROJECTION1)
+        self.assertEqual(before.projection(), _PROJECTION1)
+        after = before.projection(_PROJECTION2)
+        self.assertEqual(after.projection(), _PROJECTION2)
+
     def test_set_offset(self):
         _KIND = 'KIND'
         _OFFSET = 42
@@ -514,6 +523,15 @@ class TestQuery(unittest2.TestCase):
         _GROUP_BY = ['field1', 'field2']
         after = self._makeOne(_KIND).group_by(_GROUP_BY)
         self.assertEqual(after.group_by(), _GROUP_BY)
+
+    def test_group_by_multiple_calls(self):
+        _KIND = 'KIND'
+        _GROUP_BY1 = ['field1', 'field2']
+        _GROUP_BY2 = ['field3']
+        before = self._makeOne(_KIND).group_by(_GROUP_BY1)
+        self.assertEqual(before.group_by(), _GROUP_BY1)
+        after = before.group_by(_GROUP_BY2)
+        self.assertEqual(after.group_by(), _GROUP_BY2)
 
 
 class _Dataset(object):


### PR DESCRIPTION
In addition, `__eq__` was implemented on datastore.key.Key to allow for easy comparison.

See #281 for some context. As mentioned there, I looked and didn't see any equivalent bugs for these features.
