### PR TITLE
Make 'tox -e docs' rebulid docs from scratch.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps =
 basepython =
     python2.7
 commands =
+    python -c "import shutil; shutil.rmtree('docs/_build')"
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
 deps =
     Sphinx


### PR DESCRIPTION
Avoid make-like optimizations which can get out of sync after git operations.
