### PR TITLE
Work around protobuf 2.6.1 install failure on Python 2.6.x.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,14 @@
 envlist =
     py26,py27,cover,docs,lint
 
+[testenv:py26]
+commands =
+    nosetests
+deps =
+    nose
+    unittest2
+    protobuf==2.6.0
+
 [testenv]
 commands =
     nosetests


### PR DESCRIPTION
Pin 'protobuf==2.6.0' (but only for Python 2.6).
