### PR TITLE
Only using 'id' OR 'name' from pb path in datastore.Entity.save.

### DIFF
--- a/gcloud/datastore/entity.py
+++ b/gcloud/datastore/entity.py
@@ -222,9 +222,12 @@ class Entity(dict):
             transaction.add_auto_id_entity(self)
 
         if isinstance(key_pb, datastore_pb.Key):
-            path = [
-                {'kind': element.kind, 'id': element.id, 'name': element.name}
-                for element in key_pb.path_element]
+            path = []
+            for element in key_pb.path_element:
+                key_part = {}
+                for descriptor, value in element._fields.items():
+                    key_part[descriptor.name] = value
+                path.append(key_part)
             # Update the path (which may have been altered).
             self._key = key.path(path)
 

--- a/gcloud/datastore/test_entity.py
+++ b/gcloud/datastore/test_entity.py
@@ -182,7 +182,7 @@ class TestEntity(unittest2.TestCase):
         self.assertEqual(entity['foo'], 'Foo')
         self.assertEqual(connection._saved,
                          (_DATASET_ID, 'KEY', {'foo': 'Foo'}))
-        self.assertEqual(key._path, [{'kind': _KIND, 'id': _ID, 'name': ''}])
+        self.assertEqual(key._path, [{'kind': _KIND, 'id': _ID}])
 
     def test_delete_no_key(self):
         from gcloud.datastore.entity import NoKey


### PR DESCRIPTION
This was introduced in #289 and discovered while rebasing those
changes into #281.

The datastore backend fails if both 'id' and 'name' are set on
a key, so this only copies the parts of the saved pb key that
are actually set.

@tseaver Please give this a look. #289 actually broke `datastore` when saving keys with no `id`/`name` set.
