### PR TITLE
Address #293:  document that app code should not pass 'dataset_id' to 'Key.__init__'.

### DIFF
--- a/gcloud/datastore/key.py
+++ b/gcloud/datastore/key.py
@@ -29,7 +29,7 @@ class Key(object):
 
            The key's ``_dataset_id`` field must be None for keys created
            by application code.  The
-           :func:`gcloud.datastore.helpers.key_from_protobuf` factory 
+           :func:`gcloud.datastore.helpers.key_from_protobuf` factory
            will be set the field to an appropriate value for keys returned
            from the datastore backend.  The application **must** treat any
            value set by the back-end as opaque.


### PR DESCRIPTION
Only the 'helpers.key_from_protobuf' factory should pass it.

Fixes #293.
