### PR TITLE
Fix #161: Make 'Bucket.delete_keys' take an 'on_error' callback

### DIFF
--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -198,6 +198,8 @@ class Bucket(object):
             except exceptions.NotFoundError:
                 if on_error is not None:
                     on_error(key)
+                else:
+                    raise
 
     def copy_key(self, key, destination_bucket, new_name=None):
         """Copy the given key to the given bucket, optionally with a new name.

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -232,13 +232,14 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'DELETE')
         self.assertEqual(kw[0]['path'], '/b/%s/o/%s' % (NAME, KEY))
 
-    def test_delete_keys_miss(self):
+    def test_delete_keys_miss_no_on_error(self):
+        from gcloud.storage.exceptions import NotFoundError
         NAME = 'name'
         KEY = 'key'
         NONESUCH = 'nonesuch'
         connection = _Connection({})
         bucket = self._makeOne(connection, NAME)
-        bucket.delete_keys([KEY, NONESUCH])
+        self.assertRaises(NotFoundError, bucket.delete_keys, [KEY, NONESUCH])
         kw = connection._requested
         self.assertEqual(len(kw), 2)
         self.assertEqual(kw[0]['method'], 'DELETE')


### PR DESCRIPTION
Result is a list of (key, success) tuples, one per requested key.

Fixes #161.

Addresses #160 (users who want to delete without raising can use
'Bucket.delete_keys([key])' instead of 'Bucket.delete_key(key)').
