### PR TITLE
Speeding up lint by only considering files which are different.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ before_install:
   - git clone https://github.com/GoogleCloudPlatform/gcloud-python-wheels
         gcloud-python-wheels
   - export WHEELHOUSE="$(pwd)/gcloud-python-wheels/wheelhouse/"
+  - export GCLOUD_REMOTE_FOR_LINT="origin"
+  - export GCLOUD_BRANCH_FOR_LINT="master"
 
 install:
   - scripts/custom_pip_install.sh tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -104,6 +104,17 @@ Coding Style
 
    $ tox -e lint
 
+- In order to make ``tox -e lint`` run faster, you can set some environment
+  variables::
+
+   export GCLOUD_REMOTE_FOR_LINT="upstream"
+   export GCLOUD_BRANCH_FOR_LINT="master"
+
+  By doing this, you are specifying the location of the most up-to-date
+  version of ``gcloud-python``. The the suggested remote name ``upstream``
+  should point to the official ``GoogleCloudPlatform`` checkout and the
+  the branch should be the main branch on that remote (``master``).
+
 Exceptions to PEP8:
 
 - Many unit tests use a helper method, ``_callFUT`` ("FUT" is short for


### PR DESCRIPTION
H/T to @sk- and https://github.com/sk-/git-lint for the inspiration.

This is related to #290 but covers the last annoying slowdown we have. (At least as well as `pylint` allow.)
