### PR TITLE
storage: update api version

### DIFF
--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -68,7 +68,7 @@ class Connection(connection.Connection):
       True
     """
 
-    API_VERSION = 'v1beta2'
+    API_VERSION = 'v1'
     """The version of the API, used in building the API call's URL."""
 
     API_URL_TEMPLATE = '{api_base_url}/storage/{api_version}{path}'


### PR DESCRIPTION
We don't have regression tests yet, but it doesn't break the storage demo, so it should be fine.

Fixes #123.
