### PR TITLE
Fix #159: Document exceptions (currently) raised from 'Bucket.delete'.

### DIFF
--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -144,7 +144,10 @@ class Bucket(object):
         :type force: bool
         :param full: If True, empties the bucket's objects then deletes it.
 
-        :raises: :class:`gcloud.storage.exceptions.NotFoundError`
+        :raises: :class:`gcloud.storage.exceptions.NotFoundError` if the
+                 bucket does not exist, or
+                 :class:`gcloud.storage.exceptions.ConnectionError` if the
+                 bucket has keys and `force` is not passed.
         """
         return self.connection.delete_bucket(self.name, force=force)
 

--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -378,7 +378,10 @@ class Connection(connection.Connection):
 
         :rtype: bool
         :returns: True if the bucket was deleted.
-        :raises: :class:`gcloud.storage.exceptions.NotFoundError`
+        :raises: :class:`gcloud.storage.exceptions.NotFoundError` if the
+                 bucket doesn't exist, or
+                 :class:`gcloud.storage.exceptions.ConnectionError` if the
+                 bucket has keys and `force` is not passed.
         """
         bucket = self.new_bucket(bucket)
 


### PR DESCRIPTION
Note that #164 would change this (by adding fine-grained exceptions for 409, 401, etc.).

Fixes #159 (but should be revisited if #164 lands).
