### PR TITLE
Fix #166: Document exceptions (currently) raised from 'Connection.create_bucket'.

### DIFF
--- a/gcloud/storage/connection.py
+++ b/gcloud/storage/connection.py
@@ -338,6 +338,8 @@ class Connection(connection.Connection):
 
         :rtype: :class:`gcloud.storage.bucket.Bucket`
         :returns: The newly created bucket.
+        :raises: :class:`gcloud.storage.exceptions.ConnectionError` if
+                 there is a confict (bucket already exists, invalid name, etc.)
         """
         bucket = self.new_bucket(bucket)
         response = self.api_request(method='POST', path='/b',


### PR DESCRIPTION
Note that #164 would change this (by adding fine-grained exceptions for 409, 401, etc.).

Fixes #166 (but should be revisited if #164 lands).
