### PR TITLE
Fix #266: Document further how 'text' vs. 'bytes' values are stored.

### DIFF
--- a/gcloud/datastore/entity.py
+++ b/gcloud/datastore/entity.py
@@ -75,7 +75,7 @@ class Entity(dict):
        the 'text_value' field, after being encoded to UTF-8.  When
        retrieved from the back-end, such values will be decoded to "text"
        again.  Values which are "bytes" ('str' in Python2, 'bytes' in
-       Python3), will be saved using the 'bytes_value' field, without
+       Python3), will be saved using the 'blob_value' field, without
        any decoding / encoding step.
 
     """


### PR DESCRIPTION
Note how the two differ in Python2 vs. Python3.

Fixes #266.
