### PR TITLE
Add bucket location support

### DIFF
--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -24,6 +24,7 @@ class Bucket(_MetadataMixin):
     CUSTOM_METADATA_FIELDS = {
         'acl': 'get_acl',
         'defaultObjectAcl': 'get_default_object_acl',
+        'location': 'get_location',
     }
     """Mapping of field name -> accessor for fields w/ custom accessors."""
 
@@ -440,6 +441,30 @@ class Bucket(_MetadataMixin):
             for key in self:
                 key.get_acl().all().grant_read()
                 key.save_acl()
+
+    def get_location(self):
+        """Retrieve location configured for this bucket.
+
+        See: https://cloud.google.com/storage/docs/json_api/v1/buckets and
+        https://cloud.google.com/storage/docs/concepts-techniques#specifyinglocations
+
+        :rtype: string
+        :returns: The configured location.
+        """
+        if not self.has_metadata('location'):
+            self.reload_metadata()
+        return self.metadata.get('location')
+
+    def set_location(self, location):
+        """Update location configured for this bucket.
+
+        See: https://cloud.google.com/storage/docs/json_api/v1/buckets and
+        https://cloud.google.com/storage/docs/concepts-techniques#specifyinglocations
+
+        :type location: string
+        :param location: The new configured location.
+        """
+        self.patch_metadata({'location': location})
 
 
 class BucketIterator(Iterator):

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -489,6 +489,23 @@ class Test_Bucket(unittest2.TestCase):
         kw = connection._requested
         self.assertEqual(len(kw), 0)
 
+    def test_get_metadata_location_no_default(self):
+        NAME = 'name'
+        connection = _Connection()
+        bucket = self._makeOne(connection, NAME)
+        self.assertRaises(KeyError, bucket.get_metadata, 'location')
+        kw = connection._requested
+        self.assertEqual(len(kw), 0)
+
+    def test_get_metadata_location_w_default(self):
+        NAME = 'name'
+        connection = _Connection()
+        bucket = self._makeOne(connection, NAME)
+        default = object()
+        self.assertRaises(KeyError, bucket.get_metadata, 'location', default)
+        kw = connection._requested
+        self.assertEqual(len(kw), 0)
+
     def test_get_metadata_miss(self):
         NAME = 'name'
         before = {'bar': 'Bar'}
@@ -712,6 +729,38 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[1]['method'], 'GET')
         self.assertEqual(kw[1]['path'], '/b/%s/o' % NAME)
         self.assertEqual(kw[1]['query_params'], None)
+
+    def test_get_location_eager(self):
+        NAME = 'name'
+        connection = _Connection()
+        before = {'location': 'AS'}
+        bucket = self._makeOne(connection, NAME, before)
+        self.assertEqual(bucket.get_location(), 'AS')
+        kw = connection._requested
+        self.assertEqual(len(kw), 0)
+
+    def test_get_location_lazy(self):
+        NAME = 'name'
+        connection = _Connection({'location': 'AS'})
+        bucket = self._makeOne(connection, NAME)
+        self.assertEqual(bucket.get_location(), 'AS')
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'GET')
+        self.assertEqual(kw[0]['path'], '/b/%s' % NAME)
+
+    def test_update_location(self):
+        NAME = 'name'
+        connection = _Connection({'location': 'AS'})
+        bucket = self._makeOne(connection, NAME)
+        bucket.set_location('AS')
+        self.assertEqual(bucket.get_location(), 'AS')
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/b/%s' % NAME)
+        self.assertEqual(kw[0]['data'], {'location': 'AS'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
 
 
 class TestBucketIterator(unittest2.TestCase):


### PR DESCRIPTION
Presumes #339 is merged to master already (merged on this branch).

See: https://cloud.google.com/storage/docs/json_api/v1/buckets and https://cloud.google.com/storage/docs/concepts-techniques#specifyinglocations

Addresses 'location' part of #314.
