### PR TITLE
Rename 'metadata' to 'properties'

### DIFF
--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -4,34 +4,22 @@ These are *not* part of the API.
 """
 
 
-class _MetadataMixin(object):
-    """Abstract mixin for cloud storage classes with associated metadata.
+class _PropertyMixin(object):
+    """Abstract mixin for cloud storage classes with associated propertties.
 
     Non-abstract subclasses should implement:
-      - CUSTOM_METADATA_FIELDS
+      - CUSTOM_PROPERTY_ACCESSORS
       - connection
       - path
     """
 
-    CUSTOM_METADATA_FIELDS = None
+    CUSTOM_PROPERTY_ACCESSORS = None
     """Mapping of field name -> accessor for fields w/ custom accessors.
 
     Expected to be set by subclasses. Fields in this mapping will cause
-    `get_metadata()` to raise a KeyError with a message to use the relevant
-    accessor methods.
+    :meth:`_get_property()` to raise a KeyError with a message to use the
+    relevant accessor methods.
     """
-
-    def __init__(self, name=None, metadata=None):
-        """_MetadataMixin constructor.
-
-        :type name: string
-        :param name: The name of the object.
-
-        :type metadata: dict
-        :param metadata: All the other data provided by Cloud Storage.
-        """
-        self.name = name
-        self.metadata = metadata
 
     @property
     def connection(self):
@@ -43,90 +31,112 @@ class _MetadataMixin(object):
         """Abstract getter for the object path."""
         raise NotImplementedError
 
-    def has_metadata(self, field=None):
-        """Check if metadata is available.
+    def __init__(self, name=None, properties=None):
+        """_PropertyMixin constructor.
 
-        :type field: string
-        :param field: (optional) the particular field to check for.
+        :type name: string
+        :param name: The name of the object.
 
-        :rtype: bool
-        :returns: Whether metadata is available locally.
+        :type metadata: dict
+        :param metadata: All the other data provided by Cloud Storage.
         """
-        if not self.metadata:
-            return False
-        elif field and field not in self.metadata:
-            return False
-        else:
-            return True
+        self.name = name
+        self._properties = {}
+        if properties is not None:
+            self._properties.update(properties)
 
-    def reload_metadata(self):
-        """Reload metadata from Cloud Storage.
+    @property
+    def properties(self):
+        """Ensure properties are loaded, and return a copy.
+        """
+        if not self._properties:
+            self._reload_properties()
+        return self._properties.copy()
 
-        :rtype: :class:`_MetadataMixin`
+    metadata = properties  # Backward-compatibiltiy alias
+
+    def _reload_properties(self):
+        """Reload properties from Cloud Storage.
+
+        :rtype: :class:`_PropertyMixin`
         :returns: The object you just reloaded data for.
         """
         # Pass only '?projection=noAcl' here because 'acl' and related
         # are handled via 'get_acl()' etc.
         query_params = {'projection': 'noAcl'}
-        self.metadata = self.connection.api_request(
+        self._properties = self.connection.api_request(
             method='GET', path=self.path, query_params=query_params)
         return self
+    reload_metadata = _reload_properties  # backward-compat alias
 
-    def get_metadata(self, field=None, default=None):
-        """Get all metadata or a specific field.
-
-        If you request a field that isn't available, and that field can
-        be retrieved by refreshing data from Cloud Storage, this method
-        will reload the data using :func:`_MetadataMixin.reload_metadata`.
-
-        :type field: string
-        :param field: (optional) A particular field to retrieve from metadata.
-
-        :type default: anything
-        :param default: The value to return if the field provided wasn't found.
-
-        :rtype: dict or anything
-        :returns: All metadata or the value of the specific field.
-
-        :raises: :class:`KeyError` if the field is in CUSTOM_METADATA_FIELDS.
-        """
-        # We ignore 'acl' and related fields because they are meant to be
-        # handled via 'get_acl()' and related methods.
-        custom = self.CUSTOM_METADATA_FIELDS.get(field)
-        if custom is not None:
-            message = 'Use %s or related methods instead.' % custom
-            raise KeyError((field, message))
-
-        if not self.has_metadata(field=field):
-            self.reload_metadata()
-
-        if field:
-            return self.metadata.get(field, default)
-        else:
-            return self.metadata
-
-    def patch_metadata(self, metadata):
-        """Update particular fields of this object's metadata.
+    def _patch_properties(self, properties):
+        """Update particular fields of this object's properties.
 
         This method will only update the fields provided and will not
         touch the other fields.
 
-        It will also reload the metadata locally based on the server's
+        It will also reload the properties locally based on the server's
         response.
 
-        :type metadata: dict
-        :param metadata: The dictionary of values to update.
+        :type properties: dict
+        :param properties: The dictionary of values to update.
 
-        :rtype: :class:`_MetadataMixin`
+        :rtype: :class:`_PropertyMixin`
         :returns: The current object.
         """
-        self.metadata = self.connection.api_request(
-            method='PATCH', path=self.path, data=metadata,
+        # Pass '?projection=full' here because 'PATCH' documented not
+        # to work properly w/ 'noAcl'.
+        self._properties = self.connection.api_request(
+            method='PATCH', path=self.path, data=properties,
             query_params={'projection': 'full'})
         return self
+    patch_metadata = _patch_properties  # backward-compat alias
+
+    def _has_property(self, field=None):
+        """Check if property is available.
+
+        :type field: string
+        :param field: (optional) the particular field to check for.
+
+        :rtype: boolean
+        :returns: Whether property is available locally.  If no ``field``
+                  passed, return whether *any* properties are available.
+        """
+        if field and field not in self._properties:
+            return False
+        return len(self._properties) > 0
+    has_metadata = _has_property  # backward-compat alias
+
+    def _get_property(self, field, default=None):
+        """Return the value of a field from the server-side representation.
+
+        If you request a field that isn't available, and that field can
+        be retrieved by refreshing data from Cloud Storage, this method
+        will reload the data using :func:`_PropertyMixin._reload_properties`.
+
+        :type field: string
+        :param field: A particular field to retrieve from properties.
+
+        :type default: anything
+        :param default: The value to return if the field provided wasn't found.
+
+        :rtype: anything
+        :returns: value of the specific field, or the default if not found.
+        """
+        # Raise for fields which have custom accessors.
+        custom = self.CUSTOM_PROPERTY_ACCESSORS.get(field)
+        if custom is not None:
+            message = 'Use %s or related methods instead.' % custom
+            raise KeyError((field, message))
+
+        if not self._properties or field not in self._properties:
+            self._reload_properties()
+
+        return self._properties.get(field, default)
+    get_metadata = _get_property  # Backward-compat alias
 
     def get_acl(self):
-        """Get ACL metadata as an object.
+        """Get ACL as an object.
 
         :returns: An ACL object for the current object.
         """

--- a/gcloud/storage/key.py
+++ b/gcloud/storage/key.py
@@ -4,19 +4,19 @@ import mimetypes
 import os
 from StringIO import StringIO
 
-from gcloud.storage._helpers import _MetadataMixin
+from gcloud.storage._helpers import _PropertyMixin
 from gcloud.storage.acl import ObjectACL
 from gcloud.storage.exceptions import StorageError
 from gcloud.storage.iterator import Iterator
 
 
-class Key(_MetadataMixin):
+class Key(_PropertyMixin):
     """A wrapper around Cloud Storage's concept of an ``Object``."""
 
-    CUSTOM_METADATA_FIELDS = {
+    CUSTOM_PROPERTY_ACCESSORS = {
         'acl': 'get_acl',
     }
-    """Mapping of field name -> accessor for fields w/ custom accessors."""
+    """Map field name -> accessor for fields w/ custom accessors."""
 
     CHUNK_SIZE = 1024 * 1024  # 1 MB.
     """The size of a chunk of data whenever iterating (1 MB).
@@ -26,7 +26,7 @@ class Key(_MetadataMixin):
     # ACL rules are lazily retrieved.
     _acl = None
 
-    def __init__(self, bucket=None, name=None, metadata=None):
+    def __init__(self, bucket=None, name=None, properties=None):
         """Key constructor.
 
         :type bucket: :class:`gcloud.storage.bucket.Bucket`
@@ -36,10 +36,10 @@ class Key(_MetadataMixin):
         :param name: The name of the key.  This corresponds to the
                      unique path of the object in the bucket.
 
-        :type metadata: dict
-        :param metadata: All the other data provided by Cloud Storage.
+        :type properties: dict
+        :param properties: All the other data provided by Cloud Storage.
         """
-        super(Key, self).__init__(name=name, metadata=metadata or {})
+        super(Key, self).__init__(name=name, properties=properties)
         self.bucket = bucket
 
     @property
@@ -65,7 +65,7 @@ class Key(_MetadataMixin):
         :returns: A key based on the data provided.
         """
 
-        return cls(bucket=bucket, name=key_dict['name'], metadata=key_dict)
+        return cls(bucket=bucket, name=key_dict['name'], properties=key_dict)
 
     def __repr__(self):
         if self.bucket:

--- a/gcloud/storage/test_key.py
+++ b/gcloud/storage/test_key.py
@@ -15,43 +15,43 @@ class Test_Key(unittest2.TestCase):
         self.assertEqual(key.bucket, None)
         self.assertEqual(key.connection, None)
         self.assertEqual(key.name, None)
-        self.assertEqual(key.metadata, {})
+        self.assertEqual(key._properties, {})
         self.assertTrue(key._acl is None)
 
     def test_ctor_explicit(self):
         KEY = 'key'
         connection = _Connection()
         bucket = _Bucket(connection)
-        metadata = {'key': 'value'}
-        key = self._makeOne(bucket, KEY, metadata)
+        properties = {'key': 'value'}
+        key = self._makeOne(bucket, KEY, properties)
         self.assertTrue(key.bucket is bucket)
         self.assertTrue(key.connection is connection)
         self.assertEqual(key.name, KEY)
-        self.assertEqual(key.metadata, metadata)
+        self.assertEqual(key.properties, properties)
         self.assertTrue(key._acl is None)
 
     def test_from_dict_defaults(self):
         KEY = 'key'
-        metadata = {'key': 'value', 'name': KEY}
+        properties = {'key': 'value', 'name': KEY}
         klass = self._getTargetClass()
-        key = klass.from_dict(metadata)
+        key = klass.from_dict(properties)
         self.assertEqual(key.bucket, None)
         self.assertEqual(key.connection, None)
         self.assertEqual(key.name, KEY)
-        self.assertEqual(key.metadata, metadata)
+        self.assertEqual(key.properties, properties)
         self.assertTrue(key._acl is None)
 
     def test_from_dict_explicit(self):
         KEY = 'key'
         connection = _Connection()
         bucket = _Bucket(connection)
-        metadata = {'key': 'value', 'name': KEY}
+        properties = {'key': 'value', 'name': KEY}
         klass = self._getTargetClass()
-        key = klass.from_dict(metadata, bucket)
+        key = klass.from_dict(properties, bucket)
         self.assertTrue(key.bucket is bucket)
         self.assertTrue(key.connection is connection)
         self.assertEqual(key.name, KEY)
-        self.assertEqual(key.metadata, metadata)
+        self.assertEqual(key.properties, properties)
         self.assertTrue(key._acl is None)
 
     def test_acl_property(self):


### PR DESCRIPTION
Update / merge after merging #340, #341, #342, #343, #344.

This PR refactors the base class providing access to server-side representations of `Bucket` and `Object` properties.

Removes ongoing use of `metadata` as a generic term for those properties (when `metdata` is actually only one of them).
