### PR TITLE
Fixes #354

### DIFF
--- a/gcloud/storage/key.py
+++ b/gcloud/storage/key.py
@@ -4,6 +4,7 @@ import copy
 import mimetypes
 import os
 from StringIO import StringIO
+from urllib import quote_plus
 
 from gcloud.storage._helpers import _PropertyMixin
 from gcloud.storage._helpers import _scalar_property
@@ -117,7 +118,7 @@ class Key(_PropertyMixin):
         elif not self.name:
             raise ValueError('Cannot determine path without a key name.')
 
-        return self.bucket.path + '/o/' + self.name
+        return self.bucket.path + '/o/' + quote_plus(self.name)
 
     @property
     def public_url(self):


### PR DESCRIPTION
The issue #354 is fixed. 

See code below for a minimal working example.

``` python
import time
from gcloud import storage
from gcloud.storage.demo import get_connection

c  = storage.demo.get_connection()
b = c.create_bucket('debug-gcloud-%d' % int(time.time()))
k = b.new_key("bare/my-new-file.txt")
k = k.set_contents_from_string("this is some dataaaaa!")
k = b.get_key("bare/my-new-file.txt")
print k.get_contents_as_string()
```
