### PR TITLE
#370: Avoid extra URL-quoting of key name on upload.

### DIFF
--- a/gcloud/storage/key.py
+++ b/gcloud/storage/key.py
@@ -285,7 +285,7 @@ class Key(_PropertyMixin):
 
         query_params = {
             'uploadType': 'resumable',
-            'name': urllib.quote_plus(self.name),
+            'name': self.name,
         }
 
         upload_url = self.connection.build_api_url(

--- a/gcloud/storage/test_key.py
+++ b/gcloud/storage/test_key.py
@@ -298,7 +298,7 @@ class Test_Key(unittest2.TestCase):
         self.assertEqual(netloc, 'example.com')
         self.assertEqual(path, '/b/name/o')
         self.assertEqual(dict(parse_qsl(qs)),
-                         {'uploadType': 'resumable', 'name': 'parent%2Fchild'})
+                         {'uploadType': 'resumable', 'name': 'parent/child'})
         self.assertEqual(rq[0]['headers'],
                          {'X-Upload-Content-Length': 6,
                           'X-Upload-Content-Type': 'application/unknown'})


### PR DESCRIPTION
Fixes #370.
