### PR TITLE
Unpin oauth2client after 1.4.4 release.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if sys.version_info <= (2, 5):
 
 REQUIREMENTS = [
     'httplib2',
-    'oauth2client == 1.3',
+    'oauth2client',
     'protobuf >= 2.5.0',
     'pycrypto',
     'pyopenssl',


### PR DESCRIPTION
oauth2client-1.4.4 fixes the bug we were pinning to avoid:

```
$ tox --recreate -e regression
GLOB sdist-make: /home/tseaver/projects/agendaless/Google/src/gcloud-python/setup.py
regression recreate: /home/tseaver/projects/agendaless/Google/src/gcloud-python/.tox/regression
regression installdeps: unittest2
regression inst: /home/tseaver/projects/agendaless/Google/src/gcloud-python/.tox/dist/gcloud-0.3.0.zip
regression runtests: PYTHONHASHSEED='1425230368'
regression runtests: commands[0] | /home/tseaver/projects/agendaless/Google/src/gcloud-python/scripts/run_regression.sh

# If we're on Travis, we need to set up the environment.
if [[ "${TRAVIS}" == "true" ]]; then
# If merging to master and not a pull request, run regression test.
if [[ "${TRAVIS_BRANCH}" == "master" ]] && \
        [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
    echo "Running in Travis during merge, decrypting stored key file."

    # Convert encrypted key file into decrypted file to be used.
    openssl aes-256-cbc -K $encrypted_a1b222e8c14d_key \
        -iv $encrypted_a1b222e8c14d_iv \
        -in regression/key.p12.enc \
        -out $GCLOUD_TESTS_KEY_FILE -d
else
    echo "Running in Travis during non-merge to master, doing nothing."
    exit
fi
fi

# Run the regression tests for each tested package.
python regression/run_regression.py --package datastore
test_allocate_ids (datastore.TestDatastoreAllocateIDs) ... ok
test_ancestor_query (datastore.TestDatastoreQuery) ... ok
test_limit_queries (datastore.TestDatastoreQuery) ... ok
test_ordered_query (datastore.TestDatastoreQuery) ... ok
test_projection_query (datastore.TestDatastoreQuery) ... ok
test_query___key___filter (datastore.TestDatastoreQuery) ... ok
test_query_group_by (datastore.TestDatastoreQuery) ... ok
test_query_multiple_filters (datastore.TestDatastoreQuery) ... ok
test_query_paginate_with_offset (datastore.TestDatastoreQuery) ... ok
test_query_paginate_with_start_cursor (datastore.TestDatastoreQuery) ... ok
test_query_simple_filter (datastore.TestDatastoreQuery) ... ok
test_empty_kind (datastore.TestDatastoreSave) ... ok
test_post_with_generated_id (datastore.TestDatastoreSave) ... ok
test_post_with_id (datastore.TestDatastoreSave) ... ok
test_post_with_name (datastore.TestDatastoreSave) ... ok
test_save_multiple (datastore.TestDatastoreSave) ... ok
test_save_key_self_reference (datastore.TestDatastoreSaveKeys) ... ok
test_transaction (datastore.TestDatastoreTransaction) ... ok

----------------------------------------------------------------------
Ran 18 tests in 9.684s

OK
python regression/run_regression.py --package storage
test_create_bucket (storage.TestStorageBuckets) ... ok
test_get_buckets (storage.TestStorageBuckets) ... ok
test_list_files (storage.TestStorageListFiles) ... ok
test_paginate_files (storage.TestStorageListFiles) ... ok
test_first_level (storage.TestStoragePseudoHierarchy) ... ok
test_root_level_w_delimiter (storage.TestStoragePseudoHierarchy) ... ok
test_second_level (storage.TestStoragePseudoHierarchy) ... ok
test_third_level (storage.TestStoragePseudoHierarchy) ... ok
test_create_signed_delete_url (storage.TestStorageSignURLs) ... ok
test_create_signed_read_url (storage.TestStorageSignURLs) ... ok
test_copy_existing_file (storage.TestStorageWriteFiles) ... ok
test_direct_write_and_read_into_file (storage.TestStorageWriteFiles) ... ok
test_large_file_write_from_stream (storage.TestStorageWriteFiles) ... ok
test_small_file_write_from_filename (storage.TestStorageWriteFiles) ... ok
test_write_metadata (storage.TestStorageWriteFiles) ... ok

----------------------------------------------------------------------
Ran 15 tests in 24.126s

OK
___________________________________ summary ____________________________________
regression: commands succeeded
congratulations :)
$ ls -l  .tox/regression/lib/python2.7/site-packages/ | grep oauth2client
drwxrwxr-x  2 tseaver tseaver   4096 Dec 15 12:15 oauth2client
drwxrwxr-x  2 tseaver tseaver   4096 Dec 15 12:15 oauth2client-1.4.4-py2.7.egg-info
```
