### PR TITLE
Adding "sudo: false" to allow faster builds on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 
 before_install:
   - git clone https://github.com/GoogleCloudPlatform/gcloud-python-wheels


### PR DESCRIPTION
See
http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
for more info.

I will try to rework the `gcloud-python-wheels` stuff to utilize caching, but at the very least, this gives us better performance. Some snippets from the post:

> Rather than wait for builds to start for a long time, your builds now start in less than 10 seconds.

and

> The CPU resources are now guaranteed, which means less impact by noisy neighbors on the 
> same host machine. Build times throughout the day should be much more consistent on the
> new container stack
