### PR TITLE
Fixing README.rst to render correctly on PyPI.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Google Cloud Python Client
 ==========================
 
-    Python idiomatic client for Google Cloud Platform services.
+Python idiomatic client for Google Cloud Platform services.
 
 |build| |coverage|
 ------------------
@@ -152,7 +152,9 @@ We also explicitly decided to support Python 3 beginning with version
 License
 -------
 
-Apache 2.0 - See `LICENSE <LICENSE>`__ for more information.
+Apache 2.0 - See `LICENSE`_ for more information.
+
+.. _LICENSE: https://github.com/GoogleCloudPlatform/gcloud-python/blob/master/LICENSE
 
 .. |build| image:: https://travis-ci.org/GoogleCloudPlatform/gcloud-python.svg?branch=master
    :target: https://travis-ci.org/GoogleCloudPlatform/gcloud-python


### PR DESCRIPTION
Main changes:
- Using named links instead of anonymous
- Using an absolute instead of project relative link for
  `CONTRIBUTING`
- Changing duplicated link text so that they differ
- Lining up `:target:` with the line above for embedded img's

H/T to
https://github.com/coagulant/coveralls-python/blob/master/README.rst
for guidance.
