### PR TITLE
Using both user name and email for gh-pages commits.

### DIFF
--- a/scripts/update_docs.sh
+++ b/scripts/update_docs.sh
@@ -31,7 +31,8 @@ git status
 # H/T: https://github.com/dhermes
 if [[ -n "$(git status --porcelain)" ]]; then
     # Commit to gh-pages branch to apply changes.
-    git config user.name "selfiebot"
+    git config --global user.email "travis@travis-ci.org"
+    git config --global user.name "travis-ci"
     git commit -m "Update docs after merge to master."
     git push \
         "https://${GH_OAUTH_TOKEN}@github.com/${GH_OWNER}/${GH_PROJECT_NAME}" \


### PR DESCRIPTION
The Travis logs indicate git is hinting that both an
email and a name should be set:

```
Update docs after merge to master.
 Committer: selfiebot <travis@testing-worker-linux-docker-981a76b7-3328-linux-4.prod.travis-ci.org>
Your name and email address were configured automatically based
on your username and hostname. Please check that they are accurate.
You can suppress this message by setting them explicitly:
    git config --global user.name "Your Name"
    git config --global user.email you@example.com
After doing this, you may fix the identity used for this commit with:
    git commit --amend --reset-author
```

From https://travis-ci.org/GoogleCloudPlatform/gcloud-python/builds/44498713
