### PR TITLE
DISCUSSION PR: Re-writing Entity to subclass object instead of dict.

### DIFF
--- a/gcloud/datastore/helpers.py
+++ b/gcloud/datastore/helpers.py
@@ -252,7 +252,7 @@ def _set_protobuf_value(value_pb, val):
         key = val.key()
         if key is not None:
             e_pb.key.CopyFrom(key.to_protobuf())
-        for item_key, value in val.items():
+        for item_key, value in val.to_dict().items():
             p_pb = e_pb.property.add()
             p_pb.name = item_key
             _set_protobuf_value(p_pb.value, value)

--- a/gcloud/datastore/test_dataset.py
+++ b/gcloud/datastore/test_dataset.py
@@ -106,7 +106,7 @@ class TestDataset(unittest2.TestCase):
         key = result.key()
         self.assertEqual(key._dataset_id, DATASET_ID)
         self.assertEqual(key.path(), PATH)
-        self.assertEqual(list(result), ['foo'])
+        self.assertEqual(result.to_dict().keys(), ['foo'])
         self.assertEqual(result['foo'], 'Foo')
 
     def test_get_entity_path(self):
@@ -129,7 +129,7 @@ class TestDataset(unittest2.TestCase):
         key = result.key()
         self.assertEqual(key._dataset_id, DATASET_ID)
         self.assertEqual(key.path(), PATH)
-        self.assertEqual(list(result), ['foo'])
+        self.assertEqual(result.to_dict().keys(), ['foo'])
         self.assertEqual(result['foo'], 'Foo')
 
     def test_get_entity_odd_nonetype(self):
@@ -210,7 +210,7 @@ class TestDataset(unittest2.TestCase):
         key = result.key()
         self.assertEqual(key._dataset_id, DATASET_ID)
         self.assertEqual(key.path(), PATH)
-        self.assertEqual(list(result), ['foo'])
+        self.assertEqual(result.to_dict().keys(), ['foo'])
         self.assertEqual(result['foo'], 'Foo')
 
     def test_allocate_ids(self):

--- a/regression/datastore.py
+++ b/regression/datastore.py
@@ -67,7 +67,7 @@ class TestDatastoreSave(TestDatastore):
         }
         # Create an entity with the given content in our dataset.
         entity = self.dataset.entity(kind='Post')
-        entity.update(post_content)
+        entity.update_properties(post_content)
 
         # Update the entity key.
         key = None
@@ -98,9 +98,7 @@ class TestDatastoreSave(TestDatastore):
                          entity.key().namespace())
 
         # Check the data is the same.
-        retrieved_dict = dict(retrieved_entity.items())
-        entity_dict = dict(entity.items())
-        self.assertEqual(retrieved_dict, entity_dict)
+        self.assertEqual(retrieved_entity.to_dict(), entity.to_dict())
 
     def test_post_with_name(self):
         self._generic_test_post(name='post1')
@@ -249,17 +247,15 @@ class TestDatastoreQuery(TestDatastore):
         self.assertEqual(len(entities), expected_matches)
 
         arya_entity = entities[0]
-        arya_dict = dict(arya_entity.items())
-        self.assertEqual(arya_dict, {'name': 'Arya', 'family': 'Stark'})
+        self.assertEqual(arya_entity.to_dict(),
+                         {'name': 'Arya', 'family': 'Stark'})
 
         catelyn_stark_entity = entities[2]
-        catelyn_stark_dict = dict(catelyn_stark_entity.items())
-        self.assertEqual(catelyn_stark_dict,
+        self.assertEqual(catelyn_stark_entity.to_dict(),
                          {'name': 'Catelyn', 'family': 'Stark'})
 
         catelyn_tully_entity = entities[3]
-        catelyn_tully_dict = dict(catelyn_tully_entity.items())
-        self.assertEqual(catelyn_tully_dict,
+        self.assertEqual(catelyn_tully_entity.to_dict(),
                          {'name': 'Catelyn', 'family': 'Tully'})
 
         # Check both Catelyn keys are the same.
@@ -273,8 +269,8 @@ class TestDatastoreQuery(TestDatastore):
                          catelyn_tully_key._dataset_id)
 
         sansa_entity = entities[8]
-        sansa_dict = dict(sansa_entity.items())
-        self.assertEqual(sansa_dict, {'name': 'Sansa', 'family': 'Stark'})
+        self.assertEqual(sansa_entity.to_dict(),
+                         {'name': 'Sansa', 'family': 'Stark'})
 
     def test_query_paginate_with_offset(self):
         query = self._base_query()
@@ -346,7 +342,5 @@ class TestDatastoreTransaction(TestDatastore):
 
         # This will always return after the transaction.
         retrieved_entity = self.dataset.get_entity(key)
-        retrieved_dict = dict(retrieved_entity.items())
-        entity_dict = dict(entity.items())
-        self.assertEqual(retrieved_dict, entity_dict)
+        self.assertEqual(retrieved_entity.to_dict(), entity.to_dict())
         retrieved_entity.delete()

--- a/regression/populate_datastore.py
+++ b/regression/populate_datastore.py
@@ -95,7 +95,7 @@ def add_characters():
                                   key_path, character))
             key = datastore.key.Key(path=key_path)
             entity = datastore.entity.Entity(dataset=dataset).key(key)
-            entity.update(character)
+            entity.update_properties(character)
             entity.save()
             print('Adding Character %s %s' % (character['name'],
                                               character['family']))


### PR DESCRIPTION
This fixes #396, but I am happy to close it if there are issues with it. (Hence the **DISCUSSION** in the description.)

It is a first-step towards the discussion in #336 with @elibixby and @proppy.

The `Entity` class doesn't attempt to be a dictionary, rather it provides `__getitem__` (and `set` and `del`) semantics and `update_properties` and `clear_properties` methods for updating the properties and leaving the rest of the entity alone.

The long term goal is to provide a way to do something like:

``` python
>>> e1 = Entity('SomeKind', 1, prop1=u'foo', prop2=u'bar')
>>> e1
<Entity[{'kind': 'SomeKind', 'id': 1}] {'prop1': u'foo', 'prop2': u'bar'}>
>>> e2 = Entity('SomeKind', 1, {'prop1': u'foo', 'prop2': u'bar'})
>>> e2
<Entity[{'kind': 'SomeKind', 'id': 1}] {'prop1': u'foo', 'prop2': u'bar'}>
>>> e1 == e2
True
>>> e_partial = Entity('ParentKind', 1, 'ChildKind', prop=True)
>>> e_partial
<Entity[{'kind': 'Parent', 'id': 1}, {'kind': 'Child'}] {'prop': True}>
```

and I think to get there this is necessary to separate the property data (as `_data`) from the other metadata.

I am still trying to figure out a way to squeeze in "special" keyword arguments like
- `key` (may be possible to just implement a method like `key.to_args()` so we don't need a kwarg. Or instead we could check if `len(positional_args) == 1 and isinstance(positional_args[0], Key)`)
- `dataset` (#444 may make this unnecessary if we take it a bit further and my [design doc](https://docs.google.com/document/d/1xKw8Tz6lfN5uOcv0my4uUgFSeDoRzwCLho2UGlBpqDU/edit) just says forget about it and set it on the key. Though the ID is still needed if we only have the key parts from `positional_args`.)
- `exclude_from_indexes` (as a power-user feature, it may not be necessary to put this in the constructor)

but that is outside the scope of this PR / discussion.
