### PR TITLE
Address second part of 451: Remove all setters and make attrs into @property

### DIFF
--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -186,7 +186,7 @@ class Dataset(object):
         :returns: The (complete) keys allocated with `incomplete_key` as root.
         :raises: `ValueError` if `incomplete_key` is not a partial key.
         """
-        if not incomplete_key.is_partial():
+        if not incomplete_key.is_partial:
             raise ValueError(('Key is not partial.', incomplete_key))
 
         incomplete_key_pb = incomplete_key.to_protobuf()
@@ -196,5 +196,17 @@ class Dataset(object):
             self.id(), incomplete_key_pbs)
         allocated_ids = [allocated_key_pb.path_element[-1].id
                          for allocated_key_pb in allocated_key_pbs]
-        return [incomplete_key.id(allocated_id)
+
+        # This method is temporary and will move over to Key in
+        # part 5 of #451.
+        def create_new_key(new_id):
+            """Temporary method to complete `incomplete_key`.
+
+            Uses `incomplete_key` from outside scope.
+            """
+            clone = incomplete_key._clone()
+            clone._path[-1]['id'] = new_id
+            return clone
+
+        return [create_new_key(allocated_id)
                 for allocated_id in allocated_ids]

--- a/gcloud/datastore/entity.py
+++ b/gcloud/datastore/entity.py
@@ -100,7 +100,7 @@ class Entity(dict):
         # _implicit_environ._DatastoreBase to avoid split MRO.
         self._dataset = dataset or _implicit_environ.DATASET
         if kind:
-            self._key = Key().kind(kind)
+            self._key = Key(path=[{'kind': kind}])
         else:
             self._key = None
         self._exclude_from_indexes = set(exclude_from_indexes)
@@ -153,7 +153,7 @@ class Entity(dict):
         """
 
         if self._key:
-            return self._key.kind()
+            return self._key.kind
 
     def exclude_from_indexes(self):
         """Names of fields which are *not* to be indexed for this entity.
@@ -250,7 +250,7 @@ class Entity(dict):
         # If we are in a transaction and the current entity needs an
         # automatically assigned ID, tell the transaction where to put that.
         transaction = connection.transaction()
-        if transaction and key.is_partial():
+        if transaction and key.is_partial:
             transaction.add_auto_id_entity(self)
 
         if isinstance(key_pb, datastore_pb.Key):
@@ -266,7 +266,10 @@ class Entity(dict):
                 for descriptor, value in element._fields.items():
                     key_part[descriptor.name] = value
                 path.append(key_part)
-            self._key = key.path(path)
+            # This is temporary. Will be addressed throughout #451.
+            clone = key._clone()
+            clone._path = path
+            self._key = clone
 
         return self
 
@@ -287,7 +290,7 @@ class Entity(dict):
 
     def __repr__(self):
         if self._key:
-            return '<Entity%s %s>' % (self._key.path(),
+            return '<Entity%s %s>' % (self._key.path,
                                       super(Entity, self).__repr__())
         else:
             return '<Entity %s>' % (super(Entity, self).__repr__())

--- a/gcloud/datastore/test___init__.py
+++ b/gcloud/datastore/test___init__.py
@@ -173,4 +173,4 @@ class Test_implicit_behavior(unittest2.TestCase):
             result = gcloud.datastore.allocate_ids(INCOMPLETE_KEY, NUM_IDS)
 
         # Check the IDs returned.
-        self.assertEqual([key.id() for key in result], range(1, NUM_IDS + 1))
+        self.assertEqual([key.id for key in result], range(1, NUM_IDS + 1))

--- a/gcloud/datastore/test_dataset.py
+++ b/gcloud/datastore/test_dataset.py
@@ -104,8 +104,8 @@ class TestDataset(unittest2.TestCase):
         key = Key(path=PATH)
         result = dataset.get_entity(key)
         key = result.key()
-        self.assertEqual(key._dataset_id, DATASET_ID)
-        self.assertEqual(key.path(), PATH)
+        self.assertEqual(key.dataset_id, DATASET_ID)
+        self.assertEqual(key.path, PATH)
         self.assertEqual(list(result), ['foo'])
         self.assertEqual(result['foo'], 'Foo')
 
@@ -175,19 +175,15 @@ class TestDataset(unittest2.TestCase):
         key = Key(path=PATH)
         result, = dataset.get_entities([key])
         key = result.key()
-        self.assertEqual(key._dataset_id, DATASET_ID)
-        self.assertEqual(key.path(), PATH)
+        self.assertEqual(key.dataset_id, DATASET_ID)
+        self.assertEqual(key.path, PATH)
         self.assertEqual(list(result), ['foo'])
         self.assertEqual(result['foo'], 'Foo')
 
     def test_allocate_ids(self):
-        from gcloud.datastore.test_entity import _Key
+        from gcloud.datastore.key import Key
 
-        INCOMPLETE_KEY = _Key()
-        PROTO_ID = object()
-        INCOMPLETE_KEY._key = _KeyProto(PROTO_ID)
-        INCOMPLETE_KEY._partial = True
-
+        INCOMPLETE_KEY = Key(path=[{'kind': 'foo'}])
         CONNECTION = _Connection()
         NUM_IDS = 2
         DATASET_ID = 'foo'
@@ -195,16 +191,11 @@ class TestDataset(unittest2.TestCase):
         result = DATASET.allocate_ids(INCOMPLETE_KEY, NUM_IDS)
 
         # Check the IDs returned match.
-        self.assertEqual([key._id for key in result], range(NUM_IDS))
+        self.assertEqual([key.id for key in result], range(NUM_IDS))
 
         # Check connection is called correctly.
         self.assertEqual(CONNECTION._called_dataset_id, DATASET_ID)
         self.assertEqual(len(CONNECTION._called_key_pbs), NUM_IDS)
-
-        # Check the IDs passed to Connection.allocate_ids.
-        key_paths = [key_pb.path_element[-1].id
-                     for key_pb in CONNECTION._called_key_pbs]
-        self.assertEqual(key_paths, [PROTO_ID] * NUM_IDS)
 
     def test_allocate_ids_with_complete(self):
         from gcloud.datastore.test_entity import _Key

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -53,10 +53,10 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         self.assertEqual(entity.kind(), _KIND)
         self.assertEqual(entity['foo'], 'Foo')
         key = entity.key()
-        self.assertEqual(key._dataset_id, _DATASET_ID)
-        self.assertEqual(key.namespace(), None)
-        self.assertEqual(key.kind(), _KIND)
-        self.assertEqual(key.id(), _ID)
+        self.assertEqual(key.dataset_id, _DATASET_ID)
+        self.assertEqual(key.namespace, None)
+        self.assertEqual(key.kind, _KIND)
+        self.assertEqual(key.id, _ID)
 
     def test_w_dataset(self):
         from gcloud.datastore import datastore_v1_pb2 as datastore_pb
@@ -77,10 +77,10 @@ class Test_entity_from_protobuf(unittest2.TestCase):
         self.assertEqual(entity.kind(), _KIND)
         self.assertEqual(entity['foo'], 'Foo')
         key = entity.key()
-        self.assertEqual(key._dataset_id, _DATASET_ID)
-        self.assertEqual(key.namespace(), None)
-        self.assertEqual(key.kind(), _KIND)
-        self.assertEqual(key.id(), _ID)
+        self.assertEqual(key.dataset_id, _DATASET_ID)
+        self.assertEqual(key.namespace, None)
+        self.assertEqual(key.kind, _KIND)
+        self.assertEqual(key.id, _ID)
 
 
 class Test_key_from_protobuf(unittest2.TestCase):
@@ -110,15 +110,15 @@ class Test_key_from_protobuf(unittest2.TestCase):
         _DATASET = 'DATASET'
         pb = self._makePB(_DATASET)
         key = self._callFUT(pb)
-        self.assertEqual(key._dataset_id, _DATASET)
-        self.assertEqual(key.namespace(), None)
+        self.assertEqual(key.dataset_id, _DATASET)
+        self.assertEqual(key.namespace, None)
 
     def test_w_namespace_in_pb(self):
         _NAMESPACE = 'NAMESPACE'
         pb = self._makePB(namespace=_NAMESPACE)
         key = self._callFUT(pb)
-        self.assertEqual(key._dataset_id, None)
-        self.assertEqual(key.namespace(), _NAMESPACE)
+        self.assertEqual(key.dataset_id, None)
+        self.assertEqual(key.namespace, _NAMESPACE)
 
     def test_w_path_in_pb(self):
         _DATASET = 'DATASET'
@@ -138,7 +138,7 @@ class Test_key_from_protobuf(unittest2.TestCase):
         ]
         pb = self._makePB(path=_PATH)
         key = self._callFUT(pb)
-        self.assertEqual(key.path(), _PATH)
+        self.assertEqual(key.path, _PATH)
 
 
 class Test__pb_attr_value(unittest2.TestCase):

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -26,10 +26,10 @@ class TestKey(unittest2.TestCase):
 
     def test_ctor_defaults(self):
         key = self._makeOne()
-        self.assertEqual(key._dataset_id, None)
-        self.assertEqual(key.namespace(), None)
-        self.assertEqual(key.kind(), '')
-        self.assertEqual(key.path(), [{'kind': ''}])
+        self.assertEqual(key.dataset_id, None)
+        self.assertEqual(key.namespace, None)
+        self.assertEqual(key.kind, '')
+        self.assertEqual(key.path, [{'kind': ''}])
 
     def test_ctor_explicit(self):
         _DATASET = 'DATASET'
@@ -38,10 +38,10 @@ class TestKey(unittest2.TestCase):
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
         key = self._makeOne(_PATH, _NAMESPACE, _DATASET)
-        self.assertEqual(key._dataset_id, _DATASET)
-        self.assertEqual(key.namespace(), _NAMESPACE)
-        self.assertEqual(key.kind(), _KIND)
-        self.assertEqual(key.path(), _PATH)
+        self.assertEqual(key.dataset_id, _DATASET)
+        self.assertEqual(key.namespace, _NAMESPACE)
+        self.assertEqual(key.kind, _KIND)
+        self.assertEqual(key.path, _PATH)
 
     def test__clone(self):
         _DATASET = 'DATASET'
@@ -51,10 +51,10 @@ class TestKey(unittest2.TestCase):
         _PATH = [{'kind': _KIND, 'id': _ID}]
         key = self._makeOne(_PATH, _NAMESPACE, _DATASET)
         clone = key._clone()
-        self.assertEqual(clone._dataset_id, _DATASET)
-        self.assertEqual(clone.namespace(), _NAMESPACE)
-        self.assertEqual(clone.kind(), _KIND)
-        self.assertEqual(clone.path(), _PATH)
+        self.assertEqual(clone.dataset_id, _DATASET)
+        self.assertEqual(clone.namespace, _NAMESPACE)
+        self.assertEqual(clone.kind, _KIND)
+        self.assertEqual(clone.path, _PATH)
 
     def test_to_protobuf_defaults(self):
         from gcloud.datastore.datastore_v1_pb2 import Key as KeyPB
@@ -104,115 +104,42 @@ class TestKey(unittest2.TestCase):
 
     def test_is_partial_no_name_or_id(self):
         key = self._makeOne()
-        self.assertTrue(key.is_partial())
+        self.assertTrue(key.is_partial)
 
     def test_is_partial_w_id(self):
         _KIND = 'KIND'
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
         key = self._makeOne(path=_PATH)
-        self.assertFalse(key.is_partial())
+        self.assertFalse(key.is_partial)
 
     def test_is_partial_w_name(self):
         _KIND = 'KIND'
         _NAME = 'NAME'
         _PATH = [{'kind': _KIND, 'name': _NAME}]
         key = self._makeOne(path=_PATH)
-        self.assertFalse(key.is_partial())
-
-    def test_namespace_setter(self):
-        _DATASET = 'DATASET'
-        _NAMESPACE = 'NAMESPACE'
-        _KIND = 'KIND'
-        _NAME = 'NAME'
-        _PATH = [{'kind': _KIND, 'name': _NAME}]
-        key = self._makeOne(path=_PATH, dataset_id=_DATASET)
-        after = key.namespace(_NAMESPACE)
-        self.assertFalse(after is key)
-        self.assertTrue(isinstance(after, self._getTargetClass()))
-        self.assertEqual(after._dataset_id, _DATASET)
-        self.assertEqual(after.namespace(), _NAMESPACE)
-        self.assertEqual(after.path(), _PATH)
-
-    def test_path_setter(self):
-        _DATASET = 'DATASET'
-        _NAMESPACE = 'NAMESPACE'
-        _KIND = 'KIND'
-        _NAME = 'NAME'
-        _PATH = [{'kind': _KIND, 'name': _NAME}]
-        key = self._makeOne(namespace=_NAMESPACE, dataset_id=_DATASET)
-        after = key.path(_PATH)
-        self.assertFalse(after is key)
-        self.assertTrue(isinstance(after, self._getTargetClass()))
-        self.assertEqual(after._dataset_id, _DATASET)
-        self.assertEqual(after.namespace(), _NAMESPACE)
-        self.assertEqual(after.path(), _PATH)
+        self.assertFalse(key.is_partial)
 
     def test_kind_getter_empty_path(self):
         _DATASET = 'DATASET'
         _NAMESPACE = 'NAMESPACE'
         key = self._makeOne(namespace=_NAMESPACE, dataset_id=_DATASET)
         key._path = ()  # edge case
-        self.assertEqual(key.kind(), None)
-
-    def test_kind_setter(self):
-        _DATASET = 'DATASET'
-        _NAMESPACE = 'NAMESPACE'
-        _KIND_BEFORE = 'KIND_BEFORE'
-        _KIND_AFTER = 'KIND_AFTER'
-        _NAME = 'NAME'
-        _PATH = [{'kind': _KIND_BEFORE, 'name': _NAME}]
-        key = self._makeOne(_PATH, _NAMESPACE, _DATASET)
-        after = key.kind(_KIND_AFTER)
-        self.assertFalse(after is key)
-        self.assertTrue(isinstance(after, self._getTargetClass()))
-        self.assertEqual(after._dataset_id, _DATASET)
-        self.assertEqual(after.namespace(), _NAMESPACE)
-        self.assertEqual(after.path(), [{'kind': _KIND_AFTER, 'name': _NAME}])
+        self.assertEqual(key.kind, None)
 
     def test_id_getter_empty_path(self):
         key = self._makeOne()
         key._path = ()  # edge case
-        self.assertEqual(key.id(), None)
-
-    def test_id_setter(self):
-        _DATASET = 'DATASET'
-        _NAMESPACE = 'NAMESPACE'
-        _KIND = 'KIND'
-        _ID_BEFORE = 1234
-        _ID_AFTER = 5678
-        _PATH = [{'kind': _KIND, 'id': _ID_BEFORE}]
-        key = self._makeOne(_PATH, _NAMESPACE, _DATASET)
-        after = key.id(_ID_AFTER)
-        self.assertFalse(after is key)
-        self.assertTrue(isinstance(after, self._getTargetClass()))
-        self.assertEqual(after._dataset_id, _DATASET)
-        self.assertEqual(after.namespace(), _NAMESPACE)
-        self.assertEqual(after.path(), [{'kind': _KIND, 'id': _ID_AFTER}])
+        self.assertEqual(key.id, None)
 
     def test_name_getter_empty_path(self):
         key = self._makeOne()
         key._path = ()  # edge case
-        self.assertEqual(key.name(), None)
-
-    def test_name_setter(self):
-        _DATASET = 'DATASET'
-        _NAMESPACE = 'NAMESPACE'
-        _KIND = 'KIND'
-        _NAME_BEFORE = 'NAME_BEFORE'
-        _NAME_AFTER = 'NAME_AFTER'
-        _PATH = [{'kind': _KIND, 'name': _NAME_BEFORE}]
-        key = self._makeOne(_PATH, _NAMESPACE, _DATASET)
-        after = key.name(_NAME_AFTER)
-        self.assertFalse(after is key)
-        self.assertTrue(isinstance(after, self._getTargetClass()))
-        self.assertEqual(after._dataset_id, _DATASET)
-        self.assertEqual(after.namespace(), _NAMESPACE)
-        self.assertEqual(after.path(), [{'kind': _KIND, 'name': _NAME_AFTER}])
+        self.assertEqual(key.name, None)
 
     def test_id_or_name_no_name_or_id(self):
         key = self._makeOne()
-        self.assertEqual(key.id_or_name(), None)
+        self.assertEqual(key.id_or_name, None)
 
     def test_id_or_name_no_name_or_id_child(self):
         _KIND = 'KIND'
@@ -220,14 +147,14 @@ class TestKey(unittest2.TestCase):
         _ID = 5678
         _PATH = [{'kind': _KIND, 'id': _ID, 'name': _NAME}, {'kind': ''}]
         key = self._makeOne(path=_PATH)
-        self.assertEqual(key.id_or_name(), None)
+        self.assertEqual(key.id_or_name, None)
 
     def test_id_or_name_w_id_only(self):
         _KIND = 'KIND'
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
         key = self._makeOne(path=_PATH)
-        self.assertEqual(key.id_or_name(), _ID)
+        self.assertEqual(key.id_or_name, _ID)
 
     def test_id_or_name_w_id_and_name(self):
         _KIND = 'KIND'
@@ -235,22 +162,22 @@ class TestKey(unittest2.TestCase):
         _NAME = 'NAME'
         _PATH = [{'kind': _KIND, 'id': _ID, 'name': _NAME}]
         key = self._makeOne(path=_PATH)
-        self.assertEqual(key.id_or_name(), _ID)
+        self.assertEqual(key.id_or_name, _ID)
 
     def test_id_or_name_w_name_only(self):
         _KIND = 'KIND'
         _NAME = 'NAME'
         _PATH = [{'kind': _KIND, 'name': _NAME}]
         key = self._makeOne(path=_PATH)
-        self.assertEqual(key.id_or_name(), _NAME)
+        self.assertEqual(key.id_or_name, _NAME)
 
     def test_parent_default(self):
         key = self._makeOne()
-        self.assertEqual(key.parent(), None)
+        self.assertEqual(key.parent, None)
 
     def test_parent_explicit_top_level(self):
         key = self._makeOne(path=[{'kind': 'abc', 'name': 'def'}])
-        self.assertEqual(key.parent(), None)
+        self.assertEqual(key.parent, None)
 
     def test_parent_explicit_nested(self):
         parent_part = {'kind': 'abc', 'name': 'def'}
@@ -258,4 +185,4 @@ class TestKey(unittest2.TestCase):
             parent_part,
             {'kind': 'ghi', 'id': 123},
         ])
-        self.assertEqual(key.parent().path(), [parent_part])
+        self.assertEqual(key.parent.path, [parent_part])

--- a/gcloud/datastore/test_query.py
+++ b/gcloud/datastore/test_query.py
@@ -336,7 +336,7 @@ class TestQuery(unittest2.TestCase):
             self.assertEqual(more_results, _MORE_RESULTS)
 
         self.assertEqual(len(entities), 1)
-        self.assertEqual(entities[0].key().path(),
+        self.assertEqual(entities[0].key().path,
                          [{'kind': _KIND, 'id': _ID}])
         limited_query = query
         if limit is not None:

--- a/gcloud/datastore/test_transaction.py
+++ b/gcloud/datastore/test_transaction.py
@@ -214,9 +214,8 @@ class _CommitResult(object):
 class _Key(object):
     _path = None
 
-    def path(self, path):
-        self._path = path
-        return self
+    def _clone(self):
+        return _Key()
 
 
 class _Entity(object):

--- a/gcloud/datastore/transaction.py
+++ b/gcloud/datastore/transaction.py
@@ -63,8 +63,8 @@ class Transaction(_implicit_environ._DatastoreBase):
          >>> with dataset.transaction():
          ...   entity = dataset.entity('Thing')
          ...   entity.save()
-         ...   assert entity.key().is_partial()  # There is no ID on this key.
-         >>> assert not entity.key().is_partial()  # There *is* an ID.
+         ...   assert entity.key().is_partial  # There is no ID on this key.
+         >>> assert not entity.key().is_partial  # There *is* an ID.
 
     .. warning:: If you're using the automatically generated ID
        functionality, it's important that you only use
@@ -235,7 +235,10 @@ class Transaction(_implicit_environ._DatastoreBase):
             for i, entity in enumerate(self._auto_id_entities):
                 key_pb = result.insert_auto_id_key[i]
                 key = helpers.key_from_protobuf(key_pb)
-                entity.key(entity.key().path(key.path()))
+                # This is a temporary hack. Will be addressed in 451 #6.
+                new_key = entity.key()._clone()
+                new_key._path = key.path
+                entity.key(key)
 
         # Tell the connection that the transaction is over.
         self.connection().transaction(None)

--- a/regression/clear_datastore.py
+++ b/regression/clear_datastore.py
@@ -45,7 +45,7 @@ def fetch_keys(dataset, kind, fetch_max=FETCH_MAX, query=None, cursor=None):
 
 def get_ancestors(entities):
     # NOTE: A key will always have at least one path element.
-    key_roots = [entity.key().path()[0] for entity in entities]
+    key_roots = [entity.key().path[0] for entity in entities]
     # Turn into hashable type so we can use set to get unique roots.
     # Also sorted the items() to ensure uniqueness.
     key_roots = [tuple(sorted(root.items())) for root in key_roots]

--- a/regression/datastore.py
+++ b/regression/datastore.py
@@ -48,9 +48,9 @@ class TestDatastoreAllocateIDs(TestDatastore):
 
         unique_ids = set()
         for key in allocated_keys:
-            unique_ids.add(key.id())
-            self.assertEqual(key.name(), None)
-            self.assertNotEqual(key.id(), None)
+            unique_ids.add(key.id)
+            self.assertEqual(key.name, None)
+            self.assertNotEqual(key.id, None)
 
         self.assertEqual(len(unique_ids), num_ids)
 
@@ -74,9 +74,9 @@ class TestDatastoreSave(TestDatastore):
         # Update the entity key.
         key = None
         if name is not None:
-            key = entity.key().name(name)
+            key = datastore.key.Key(path=[{'kind': 'Post', 'name': name}])
         if key_id is not None:
-            key = entity.key().id(key_id)
+            key = datastore.key.Key(path=[{'kind': 'Post', 'id': key_id}])
         if key is not None:
             entity.key(key)
 
@@ -90,14 +90,14 @@ class TestDatastoreSave(TestDatastore):
         self.case_entities_to_delete.append(entity)
 
         if name is not None:
-            self.assertEqual(entity.key().name(), name)
+            self.assertEqual(entity.key().name, name)
         if key_id is not None:
-            self.assertEqual(entity.key().id(), key_id)
+            self.assertEqual(entity.key().id, key_id)
         retrieved_entity = datastore.get_entity(entity.key())
         # Check the keys are the same.
-        self.assertEqual(retrieved_entity.key().path(), entity.key().path())
-        self.assertEqual(retrieved_entity.key().namespace(),
-                         entity.key().namespace())
+        self.assertEqual(retrieved_entity.key().path, entity.key().path)
+        self.assertEqual(retrieved_entity.key().namespace,
+                         entity.key().namespace)
 
         # Check the data is the same.
         retrieved_dict = dict(retrieved_entity.items())
@@ -162,8 +162,8 @@ class TestDatastoreSaveKeys(TestDatastore):
 
         stored_person = stored_persons[0]
         self.assertEqual(stored_person['fullName'], entity['fullName'])
-        self.assertEqual(stored_person.key().path(), key.path())
-        self.assertEqual(stored_person.key().namespace(), key.namespace())
+        self.assertEqual(stored_person.key().path, key.path)
+        self.assertEqual(stored_person.key().namespace, key.namespace)
 
 
 class TestDatastoreQuery(TestDatastore):
@@ -268,12 +268,12 @@ class TestDatastoreQuery(TestDatastore):
         # Check both Catelyn keys are the same.
         catelyn_stark_key = catelyn_stark_entity.key()
         catelyn_tully_key = catelyn_tully_entity.key()
-        self.assertEqual(catelyn_stark_key.path(), catelyn_tully_key.path())
-        self.assertEqual(catelyn_stark_key.namespace(),
-                         catelyn_tully_key.namespace())
-        # Also check the _dataset_id since both retrieved from datastore.
-        self.assertEqual(catelyn_stark_key._dataset_id,
-                         catelyn_tully_key._dataset_id)
+        self.assertEqual(catelyn_stark_key.path, catelyn_tully_key.path)
+        self.assertEqual(catelyn_stark_key.namespace,
+                         catelyn_tully_key.namespace)
+        # Also check the dataset_id since both retrieved from datastore.
+        self.assertEqual(catelyn_stark_key.dataset_id,
+                         catelyn_tully_key.dataset_id)
 
         sansa_entity = entities[8]
         sansa_dict = dict(sansa_entity.items())


### PR DESCRIPTION
Making all attributes on Key read-only and sorts out use of setters.

Addresses second part of #451. In some cases, since no valid
replacements for setters are implemented here, the functionality
is replaced with hacks using protected methods.

Also added a getter for Key._dataset_id and made the Key.path
property return a copy since a `list` of `dict`s is very much
mutable.

**NOTE**: This has #456 as a diffbase.
