### PR TITLE
Address fifth part of 451: Implement Key.complete_key for auto_id on partial keys.

### DIFF
--- a/gcloud/datastore/dataset.py
+++ b/gcloud/datastore/dataset.py
@@ -196,5 +196,5 @@ class Dataset(object):
             self.id(), incomplete_key_pbs)
         allocated_ids = [allocated_key_pb.path_element[-1].id
                          for allocated_key_pb in allocated_key_pbs]
-        return [incomplete_key.complete_key(allocated_id)
+        return [incomplete_key.completed_key(allocated_id)
                 for allocated_id in allocated_ids]

--- a/gcloud/datastore/key.py
+++ b/gcloud/datastore/key.py
@@ -127,7 +127,7 @@ class Key(object):
         """
         return copy.deepcopy(self)
 
-    def complete_key(self, id_or_name):
+    def completed_key(self, id_or_name):
         """Creates new key from existing partial key by adding final ID/name.
 
         :rtype: :class:`gcloud.datastore.key.Key`

--- a/gcloud/datastore/test_key.py
+++ b/gcloud/datastore/test_key.py
@@ -62,29 +62,29 @@ class TestKey(unittest2.TestCase):
         self.assertEqual(clone.kind, _KIND)
         self.assertEqual(clone.path, _PATH)
 
-    def test_complete_key_on_partial_w_id(self):
+    def test_completed_key_on_partial_w_id(self):
         key = self._makeOne('KIND')
         _ID = 1234
-        new_key = key.complete_key(_ID)
+        new_key = key.completed_key(_ID)
         self.assertFalse(key is new_key)
         self.assertEqual(new_key.id, _ID)
         self.assertEqual(new_key.name, None)
 
-    def test_complete_key_on_partial_w_name(self):
+    def test_completed_key_on_partial_w_name(self):
         key = self._makeOne('KIND')
         _NAME = 'NAME'
-        new_key = key.complete_key(_NAME)
+        new_key = key.completed_key(_NAME)
         self.assertFalse(key is new_key)
         self.assertEqual(new_key.id, None)
         self.assertEqual(new_key.name, _NAME)
 
-    def test_complete_key_on_partial_w_invalid(self):
+    def test_completed_key_on_partial_w_invalid(self):
         key = self._makeOne('KIND')
-        self.assertRaises(ValueError, key.complete_key, object())
+        self.assertRaises(ValueError, key.completed_key, object())
 
-    def test_complete_key_on_complete(self):
+    def test_completed_key_on_complete(self):
         key = self._makeOne('KIND', 1234)
-        self.assertRaises(ValueError, key.complete_key, 5678)
+        self.assertRaises(ValueError, key.completed_key, 5678)
 
     def test_to_protobuf_defaults(self):
         from gcloud.datastore.datastore_v1_pb2 import Key as KeyPB

--- a/regression/datastore.py
+++ b/regression/datastore.py
@@ -74,9 +74,9 @@ class TestDatastoreSave(TestDatastore):
         # Update the entity key.
         key = None
         if name is not None:
-            key = entity.key().complete_key(name)
+            key = entity.key().completed_key(name)
         if key_id is not None:
-            key = entity.key().complete_key(key_id)
+            key = entity.key().completed_key(key_id)
         if key is not None:
             entity.key(key)
 


### PR DESCRIPTION
Addresses fifth part of #451.

**NOTE**: This has #460 as a diffbase.
