### PR TITLE
BigQuery: fix IPython system test for new pytest

### DIFF
--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -1823,7 +1823,7 @@ def test_bigquery_magic():
     updates = list(filter(lambda x: bool(x) and x != '\x1b[2K', lines))
     assert re.match("Executing query with job ID: .*", updates[0])
     assert all(re.match("Query executing: .*s", line)
-                for line in updates[1:-1])
+               for line in updates[1:-1])
     assert re.match("Query complete after .*s", updates[-1])
     assert isinstance(result, pandas.DataFrame)
     assert len(result) == 10                      # verify row count


### PR DESCRIPTION
Pytest changes the way that marks and fixtures work in pytest 3.6.0 that
breaks when using unittest-style tests. Use pytest-style test for the
IPython system test so that the fixture gets used.

Pair-programmed with @alixhami 

Addresses https://github.com/GoogleCloudPlatform/google-cloud-python/issues/5003#issuecomment-392784415