### PR TITLE
[wip] Introduce to the `Blob` api extra headers as a way to use extensions (custom) http headers

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -965,13 +965,11 @@ class Blob(_PropertyMixin):
         if size is not None and size <= _MAX_MULTIPART_SIZE:
             response = self._do_multipart_upload(
                 client, stream, content_type,
-                size, num_retries, predefined_acl,
-                extra_headers=extra_headers)
+                size, num_retries, predefined_acl, extra_headers)
         else:
             response = self._do_resumable_upload(
                 client, stream, content_type, size,
-                num_retries, predefined_acl,
-                extra_headers=extra_headers)
+                num_retries, predefined_acl, extra_headers)
 
         return response.json()
 
@@ -1059,7 +1057,7 @@ class Blob(_PropertyMixin):
             created_json = self._do_upload(
                 client, file_obj, content_type,
                 size, num_retries, predefined_acl,
-                extra_headers=extra_headers)
+                extra_headers)
             self._set_properties(created_json)
         except resumable_media.InvalidResponse as exc:
             _raise_from_invalid_response(exc)

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -1038,7 +1038,8 @@ class Blob(_PropertyMixin):
 
         :type extra_headers: dict or ``NoneType``
         :param extra_headers: (Optional) Extension (Custom) http headers
-                              configurations
+                              configurations. See:
+                              https://cloud.google.com/storage/docs/json_api/v1/parameters
 
         :raises: :class:`~google.cloud.exceptions.GoogleCloudError`
                  if the upload response returns an error status.
@@ -1057,7 +1058,7 @@ class Blob(_PropertyMixin):
             created_json = self._do_upload(
                 client, file_obj, content_type,
                 size, num_retries, predefined_acl,
-                extra_headers)
+                extra_headers=extra_headers)
             self._set_properties(created_json)
         except resumable_media.InvalidResponse as exc:
             _raise_from_invalid_response(exc)
@@ -1103,7 +1104,8 @@ class Blob(_PropertyMixin):
 
         :type extra_headers: dict or ``NoneType``
         :param extra_headers: (Optional) Extension (Custom) http headers
-                              configurations
+                              configurations. See:
+                              https://cloud.google.com/storage/docs/json_api/v1/parameters
         """
         content_type = self._get_content_type(content_type, filename=filename)
 
@@ -1150,7 +1152,8 @@ class Blob(_PropertyMixin):
 
         :type extra_headers: dict or ``NoneType``
         :param extra_headers: (Optional) Extension (Custom) http headers
-                              configurations
+                              configurations. See:
+                              https://cloud.google.com/storage/docs/json_api/v1/parameters
         """
         data = _to_bytes(data, encoding='utf-8')
         string_buffer = BytesIO(data)

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -1251,8 +1251,7 @@ class Test_Blob(unittest.TestCase):
         self.assertGreater(size, len(data))
 
         with self.assertRaises(ValueError) as exc_info:
-            blob._do_multipart_upload(None, stream, None, size, None, None,
-                None)
+            blob._do_multipart_upload(None, stream, None, size, None, None, None)
 
         exc_contents = str(exc_info.exception)
         self.assertIn(
@@ -1294,8 +1293,8 @@ class Test_Blob(unittest.TestCase):
         content_type = u'text/plain'
         upload, transport = blob._initiate_resumable_upload(
             client, stream, content_type, size, num_retries,
-            extra_headers=extra_headers,
-            chunk_size=chunk_size, predefined_acl=predefined_acl)
+            chunk_size=chunk_size, predefined_acl=predefined_acl,
+            extra_headers=extra_headers)
 
         # Check the returned values.
         self.assertIsInstance(upload, ResumableUpload)
@@ -1625,14 +1624,14 @@ class Test_Blob(unittest.TestCase):
 
     def test_upload_from_file_success(self):
         stream = self._upload_from_file_helper(
-            predefined_acl='private', extra_headers={})
+            predefined_acl='private', extra_headers={'X-Goog-Testing': 'true'})
         assert stream.tell() == 2
 
     @mock.patch('warnings.warn')
     def test_upload_from_file_with_retries(self, mock_warn):
         from google.cloud.storage import blob as blob_module
 
-        self._upload_from_file_helper(num_retries=20, extra_headers={})
+        self._upload_from_file_helper(num_retries=20)
         mock_warn.assert_called_once_with(
             blob_module._NUM_RETRIES_MESSAGE, DeprecationWarning)
 
@@ -1665,7 +1664,7 @@ class Test_Blob(unittest.TestCase):
         mock_call = blob._do_upload.mock_calls[0]
         call_name, pos_args, kwargs = mock_call
         self.assertEqual(call_name, '')
-        self.assertEqual(len(pos_args), 6)
+        self.assertEqual(len(pos_args), 7)
         self.assertEqual(pos_args[0], client)
         self.assertEqual(pos_args[2], content_type)
         self.assertEqual(pos_args[3], size)


### PR DESCRIPTION
Fixing https://github.com/GoogleCloudPlatform/google-cloud-python/issues/5538

This is a proposition of feature that is adding support for setting `extra_headers` to `upload_from_file`, `upload_from_filename` and `upload_from_string`.

Those `extra_headers` options are being documented as part of the official GCS documentation at https://cloud.google.com/storage/docs/xml-api/reference-headers and used to be part of the cloudstorage api of Google App Engine.

Please note that we would probably want to also introduce those options for `delete` and functions of the `Blob` Api. We could maybe also think of adding it to the `Bucket` api.