### PR TITLE
Clarify GCS URL signing limitations on GCE

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -278,9 +278,10 @@ class Blob(_PropertyMixin):
         .. note::
 
             If you are on Google Compute Engine, you can't generate a signed
-            URL using GCE service account. Follow `Issue 50`_ for updates on this. If you'd like to
-            be able to generate a signed URL from GCE, you can use a standard
-            service account from a JSON file rather than a GCE service account.
+            URL using GCE service account. Follow `Issue 50`_ for updates on this.
+            If you'd like to be able to generate a signed URL from GCE, you can
+            use a standard service account from a JSON file rather than a GCE
+            service account.
 
         .. _Issue 50: https://github.com/GoogleCloudPlatform/\
                       google-auth-library-python/issues/50

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -278,10 +278,10 @@ class Blob(_PropertyMixin):
         .. note::
 
             If you are on Google Compute Engine, you can't generate a signed
-            URL using GCE service account. Follow `Issue 50`_ for updates on this.
-            If you'd like to be able to generate a signed URL from GCE, you can
-            use a standard service account from a JSON file rather than a GCE
-            service account.
+            URL using GCE service account. Follow `Issue 50`_ for updates on
+            this. If you'd like to be able to generate a signed URL from GCE,
+            you can use a standard service account from a JSON file rather
+            than a GCE service account.
 
         .. _Issue 50: https://github.com/GoogleCloudPlatform/\
                       google-auth-library-python/issues/50

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -278,7 +278,7 @@ class Blob(_PropertyMixin):
         .. note::
 
             If you are on Google Compute Engine, you can't generate a signed
-            URL. Follow `Issue 50`_ for updates on this. If you'd like to
+            URL using GCE service account. Follow `Issue 50`_ for updates on this. If you'd like to
             be able to generate a signed URL from GCE, you can use a standard
             service account from a JSON file rather than a GCE service account.
 


### PR DESCRIPTION
The line 'If you are on Google Compute Engine, you can't generate a signed URL' wrongly implies URL generation is impossible from GCE. Adding clarification that this line only holds true when GCE is using GCE service account.