### PR TITLE
Bump minimum 'api_core' version to '1.4.1'.

### DIFF
--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -29,7 +29,7 @@ version = '0.38.0'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 4 - Beta'
 dependencies = [
-    'google-api-core[grpc] >= 1.1.0, < 2.0.0dev',
+    'google-api-core[grpc] >= 1.4.1, < 2.0.0dev',
     'grpc-google-iam-v1 >= 0.11.1, < 0.12dev',
     'enum34; python_version < "3.4"',
 ]


### PR DESCRIPTION
Closes #6128.

~~Blocked on merge of #6133 / release of `google.api_core 1.4.1`.~~