### PR TITLE
Docs: Add / fix badges for PyPI / versions.

### DIFF
--- a/api_core/README.rst
+++ b/api_core/README.rst
@@ -7,8 +7,8 @@ This library is not meant to stand-alone. Instead it defines
 common helpers used by all Google API clients. For more information, see the
 `documentation`_.
 
-.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-core.svg
-   :target: https://pypi.org/project/google-cloud-core/
-.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-core.svg
-   :target: https://pypi.org/project/google-cloud-core/
+.. |pypi| image:: https://img.shields.io/pypi/v/google-api_core.svg
+   :target: https://pypi.org/project/google-api_core/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-api_core.svg
+   :target: https://pypi.org/project/google-api_core/
 .. _documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/core/

--- a/asset/README.rst
+++ b/asset/README.rst
@@ -1,12 +1,18 @@
 Python Client for Cloud Asset API (`Alpha`_)
 ============================================
 
+|pypi| |versions|
+
 `Cloud Asset API`_: The cloud asset API manages the history and inventory of cloud resources.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-asset.svg
+   :target: https://pypi.org/project/google-cloud-asset/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-asset.svg
+   :target: https://pypi.org/project/google-cloud-asset/
 .. _Cloud Asset API: https://cloud.google.com/cloudasset
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/asset/index.html
 .. _Product Documentation:  https://cloud.google.com/cloudasset

--- a/automl/README.rst
+++ b/automl/README.rst
@@ -1,6 +1,8 @@
 Python Client for Cloud AutoML API (`Alpha`_)
 =============================================
 
+|pypi| |versions|
+
 The `Cloud AutoML API`_ is a suite of machine learning products that enables
 developers with limited machine learning expertise to train high-quality models
 specific to their business needs, by leveraging Google’s state-of-the-art
@@ -10,6 +12,10 @@ transfer learning, and Neural Architecture Search technology.
 - `Product Documentation`_
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-automl.svg
+   :target: https://pypi.org/project/google-cloud-automl/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-automl.svg
+   :target: https://pypi.org/project/google-cloud-automl/
 .. _Cloud AutoML API: https://cloud.google.com/automl
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/automl/index.html
 .. _Product Documentation:  https://cloud.google.com/automl

--- a/core/README.rst
+++ b/core/README.rst
@@ -1,14 +1,19 @@
 Core Helpers for Google Cloud Python Client Library
 ===================================================
 
+|pypi| |versions|
+
 This library is not meant to stand-alone. Instead it defines
 common helpers (e.g. base ``Client`` classes) used by all of the
 ``google-cloud-*`` packages.
 
-|pypi| |versions|
 
 -  `Documentation`_
 
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-core.svg
+   :target: https://pypi.org/project/google-cloud-core/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-core.svg
+   :target: https://pypi.org/project/google-cloud-core/
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/core/index.html
 
 Quick Start
@@ -24,7 +29,3 @@ to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 
-.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-core.svg
-   :target: https://pypi.org/project/google-cloud-core/
-.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-core.svg
-   :target: https://pypi.org/project/google-cloud-core/

--- a/dlp/README.rst
+++ b/dlp/README.rst
@@ -1,6 +1,8 @@
 Python Client for Cloud Data Loss Prevention (DLP) API (`Alpha`_)
 =================================================================
 
+|pypi| |versions|
+
 `Cloud Data Loss Prevention (DLP) API`_: Provides methods for detection, risk analysis, and de-identification of
 privacy-sensitive fragments in text, images, and Google Cloud Platform
 storage repositories.
@@ -9,6 +11,10 @@ storage repositories.
 - `Product Documentation`_
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-dlp.svg
+   :target: https://pypi.org/project/google-cloud-dlp/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dlp.svg
+   :target: https://pypi.org/project/google-cloud-dlp/
 .. _Cloud Data Loss Prevention (DLP) API: https://cloud.google.com/dlp
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/dlp/index.html
 .. _Product Documentation:  https://cloud.google.com/dlp
@@ -89,12 +95,7 @@ DlpServiceClient
 Next Steps
 ~~~~~~~~~~
 
--  Read the `Client Library Documentation`_ for Cloud Data Loss Prevention (DLP) API
-   API to see other available methods on the client.
--  Read the `Cloud Data Loss Prevention (DLP) API Product documentation`_ to learn
-   more about the product and see How-to Guides.
--  View this `repository’s main README`_ to see the full list of Cloud
-   APIs that we cover.
-
-.. _Cloud Data Loss Prevention (DLP) API Product documentation:  https://cloud.google.com/dlp
-.. _repository’s main README: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+-  Read the `Client Library Documentation`_ for Cloud Data Loss Prevention
+   (DLP) API to see other available methods on the client.
+-  Read the `Product documentation`_ to
+   learn more about the product and see How-to Guides.

--- a/dns/README.rst
+++ b/dns/README.rst
@@ -1,11 +1,10 @@
 Python Client for Google Cloud DNS
 ==================================
 
+|pypi| |versions|
+
 The `Google Cloud DNS`_ API provides methods that you can use to
 manage DNS for your applications.
-
-
-|pypi| |versions|
 
 - `Client Library Documentation`_
 - `Product Documentation`_

--- a/iot/README.rst
+++ b/iot/README.rst
@@ -1,13 +1,19 @@
 Python Client for Cloud IoT API (`Alpha`_)
 ==========================================
 
-`Cloud IoT API`_: Registers and manages IoT (Internet of Things) devices that connect to the
-Google Cloud Platform.
+|pypi| |versions|
+
+`Cloud IoT API`_: Registers and manages IoT (Internet of Things) devices that
+connect to the Google Cloud Platform.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-iot.svg
+   :target: https://pypi.org/project/google-cloud-iot/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-iot.svg
+   :target: https://pypi.org/project/google-cloud-iot/
 .. _Cloud IoT API: https://cloud.google.com/iot
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/iot/index.html
 .. _Product Documentation:  https://cloud.google.com/iot
@@ -92,11 +98,6 @@ Next Steps
 ~~~~~~~~~~
 
 -  Read the `Client Library Documentation`_ for Cloud IoT API
-   API to see other available methods on the client.
--  Read the `Cloud IoT API Product documentation`_ to learn
+   to see other available methods on the client.
+-  Read the `Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository’s main README`_ to see the full list of Cloud
-   APIs that we cover.
-
-.. _Cloud IoT API Product documentation:  https://cloud.google.com/iot
-.. _repository’s main README: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst

--- a/kms/README.rst
+++ b/kms/README.rst
@@ -3,20 +3,21 @@ Python Client for Cloud Key Management Service (KMS) API (`Alpha`_)
 
 |pypi| |versions|
 
-`Cloud Key Management Service (KMS) API`_: Manages keys and performs cryptographic operations in a central cloud
-service, for direct use by other cloud resources and applications.
+`Cloud Key Management Service (KMS) API`_: Manages keys and performs
+cryptographic operations in a central cloud service, for direct use by other
+cloud resources and applications.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-kms.svg
+   :target: https://pypi.org/project/google-cloud-kms/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-kms.svg
+   :target: https://pypi.org/project/google-cloud-kms/
 .. _Cloud Key Management Service (KMS) API: https://cloud.google.com/kms
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/kms/index.html
 .. _Product Documentation:  https://cloud.google.com/kms
-.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-datastore.svg
-   :target: https://pypi.org/project/google-cloud-datastore/
-.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datastore.svg
-   :target: https://pypi.org/project/google-cloud-datastore/
 
 Quick Start
 -----------

--- a/oslogin/README.rst
+++ b/oslogin/README.rst
@@ -1,5 +1,7 @@
-Python Client for Google Cloud OS Login API (`Alpha`_)
-======================================================
+Python Client for Google Cloud OS Login API (unreleased)
+========================================================
+
+|pypi| |versions|
 
 `Google Cloud OS Login API`_: Manages OS login configuration for Google account users.
 
@@ -7,6 +9,10 @@ Python Client for Google Cloud OS Login API (`Alpha`_)
 - `Product Documentation`_
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-oslogin.svg
+   :target: https://pypi.org/project/google-cloud-oslogin/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-oslogin.svg
+   :target: https://pypi.org/project/google-cloud-oslogin/
 .. _Google Cloud OS Login API: https://cloud.google.com/os-login
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/oslogin/index.html
 .. _Product Documentation:  https://cloud.google.com/os-login
@@ -65,11 +71,6 @@ Next Steps
 ~~~~~~~~~~
 
 -  Read the `Client Library Documentation`_ for Google Cloud OS Login API
-   API to see other available methods on the client.
--  Read the `Google Cloud OS Login API Product documentation`_ to learn
+   to see other available methods on the client.
+-  Read the `Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository’s main README`_ to see the full list of Cloud
-   APIs that we cover.
-
-.. _Google Cloud OS Login API Product documentation:  https://cloud.google.com/os-login
-.. _repository’s main README: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst

--- a/redis/README.rst
+++ b/redis/README.rst
@@ -1,13 +1,20 @@
 Python Client for Google Cloud Memorystore for Redis API (`Alpha`_)
 ===================================================================
 
-`Google Cloud Memorystore for Redis API`_: The Google Cloud Memorystore for Redis API is used for creating and managing
-Redis instances on the Google Cloud Platform.
+|pypi| |versions|
+
+`Google Cloud Memorystore for Redis API`_: The Google Cloud Memorystore for
+Redis API is used for creating and managing Redis instances on the Google
+Cloud Platform.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-redis.svg
+   :target: https://pypi.org/project/google-cloud-redis/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-redis.svg
+   :target: https://pypi.org/project/google-cloud-redis/
 .. _Google Cloud Memorystore for Redis API: https://cloud.google.com/memorystore/
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/redis/index.html
 .. _Product Documentation:  https://cloud.google.com/memorystore/
@@ -65,12 +72,7 @@ Windows
 Next Steps
 ~~~~~~~~~~
 
--  Read the `Client Library Documentation`_ for Google Cloud Memorystore for Redis API
-   API to see other available methods on the client.
--  Read the `Google Cloud Memorystore for Redis API Product documentation`_ to learn
-   more about the product and see How-to Guides.
--  View this `repository’s main README`_ to see the full list of Cloud
-   APIs that we cover.
-
-.. _Google Cloud Memorystore for Redis API Product documentation:  https://cloud.google.com/memorystore/
-.. _repository’s main README: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+-  Read the `Client Library Documentation`_ for Google Cloud Memorystore for
+   Redis API to see other available methods on the client.
+-  Read the `Product documentation`_ to learn more about the product and see
+   How-to Guides.

--- a/speech/README.rst
+++ b/speech/README.rst
@@ -1,6 +1,8 @@
 Python Client for Cloud Speech API (`Beta`_)
 =============================================
 
+|pypi| |versions|
+
 The `Cloud Speech API`_ enables developers to convert audio to text by applying
 powerful neural network models.  The API recognizes over 80 languages and
 variants, to support your global user base.
@@ -9,6 +11,10 @@ variants, to support your global user base.
 - `Product Documentation`_
 
 .. _Beta: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-speech.svg
+   :target: https://pypi.org/project/google-cloud-speech/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-speech.svg
+   :target: https://pypi.org/project/google-cloud-speech/
 .. _Cloud Speech API: https://cloud.google.com/speech
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/speech/index.html
 .. _Product Documentation:  https://cloud.google.com/speech

--- a/tasks/README.rst
+++ b/tasks/README.rst
@@ -1,12 +1,19 @@
 Python Client for Cloud Tasks API (`Alpha`_)
 ============================================
 
-`Cloud Tasks API`_: Manages the execution of large numbers of distributed requests.
+|pypi| |versions|
+
+`Cloud Tasks API`_: Manages the execution of large numbers of distributed
+requests.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-tasks.svg
+   :target: https://pypi.org/project/google-cloud-tasks/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-tasks.svg
+   :target: https://pypi.org/project/google-cloud-tasks/
 .. _Cloud Tasks API: https://cloud.google.com/tasks
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/tasks/index.html
 .. _Product Documentation:  https://cloud.google.com/tasks
@@ -68,8 +75,5 @@ Next Steps
    API to see other available methods on the client.
 -  Read the `Cloud Tasks API Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository’s main README`_ to see the full list of Cloud
-   APIs that we cover.
 
 .. _Cloud Tasks API Product documentation:  https://cloud.google.com/tasks
-.. _repository’s main README: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst

--- a/texttospeech/README.rst
+++ b/texttospeech/README.rst
@@ -1,13 +1,19 @@
 Python Client for Cloud Text-to-Speech API (`Alpha`_)
 =====================================================
 
-`Cloud Text-to-Speech API`_: Synthesizes natural-sounding speech by applying powerful neural network
-models.
+|pypi| |versions|
+
+`Cloud Text-to-Speech API`_: Synthesizes natural-sounding speech by applying
+powerful neural network models.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-texttospeech.svg
+   :target: https://pypi.org/project/google-cloud-texttospeech/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-texttospeech.svg
+   :target: https://pypi.org/project/google-cloud-texttospeech/
 .. _Cloud Text-to-Speech API: https://cloud.google.com/texttospeech
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/texttospeech/api.html
 .. _Product Documentation: https://cloud.google.com/texttospeech
@@ -69,8 +75,6 @@ Next Steps
    API to see other available methods on the client.
 -  Read the `Cloud Text-to-Speech API Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository’s main README`_ to see the full list of Cloud
    APIs that we cover.
 
 .. _Cloud Text-to-Speech API Product documentation:  https://cloud.google.com/texttospeech
-.. _repository’s main README: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst

--- a/websecurityscanner/README.rst
+++ b/websecurityscanner/README.rst
@@ -1,11 +1,17 @@
 Python Client for Web Security Scanner API (`Alpha`_)
 =====================================================
 
+|pypi| |versions|
+
 `Web Security Scanner API`_: Web Security Scanner API (under development).
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-websecurityscanner.svg
+   :target: https://pypi.org/project/google-cloud-websecurityscanner/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-websecurityscanner.svg
+   :target: https://pypi.org/project/google-cloud-websecurityscanner/
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _Web Security Scanner API: https://cloud.google.com/security-scanner
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/websecurityscanner/index.html
@@ -66,10 +72,5 @@ Next Steps
 
 -  Read the `Client Library Documentation`_ for Web Security Scanner API
    API to see other available methods on the client.
--  Read the `Web Security Scanner API Product documentation`_ to learn
+-  Read the `Product documentation`_ to learn
    more about the product and see How-to Guides.
--  View this `repository’s main README`_ to see the full list of Cloud
-   APIs that we cover.
-
-.. _Web Security Scanner API Product documentation:  https://cloud.google.com/security-scanner
-.. _repository’s main README: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst


### PR DESCRIPTION
We could still do with another normalization pass (e.g., standardize on use of `|alpha|` / `|beta|` badges).

~~Note that the change to `asset/README.rst` will have broken badges until we land a release of `google-cloud-asset` (vs. `google-cloud-cloudasset`, see #6154).~~  `oslogin/README.rst` is likewise going to show broken badges, because it has never been released.