### PR TITLE
Allow string in addition to DatasetReference / TableReference in Clie…

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -339,14 +339,14 @@ class Client(ClientWithProject):
         """Fetch the dataset referenced by ``dataset_ref``
 
         Args:
-            dataset_ref (Union[
-                :class:`google.cloud.bigquery.dataset.DatasetReference`,
-                str
+            dataset_ref (Union[ \
+                :class:`~google.cloud.bigquery.dataset.DatasetReference`, \
+                str, \
             ]):
                 A reference to the dataset to fetch from the BigQuery API.
                 If a string is passed in, this method attempts to create a
                 dataset reference from a string using
-                :func:`google.cloud.bigquery.dataset.DatasetReference.from_string`.
+                :func:`~google.cloud.bigquery.dataset.DatasetReference.from_string`.
             retry (:class:`google.api_core.retry.Retry`):
                 (Optional) How to retry the RPC.
 
@@ -366,9 +366,9 @@ class Client(ClientWithProject):
         """Fetch the table referenced by ``table_ref``.
 
         Args:
-            table_ref (Union[
-                :class:`google.cloud.bigquery.table.TableReference`,
-                str
+            table_ref (Union[ \
+                :class:`~google.cloud.bigquery.table.TableReference`, \
+                str, \
             ]):
                 A reference to the table to fetch from the BigQuery API.
                 If a string is passed in, this method attempts to create a
@@ -470,10 +470,10 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list
 
         Args:
-            dataset (Union[
-                :class:`google.cloud.bigquery.dataset.Dataset`,
-                :class:`google.cloud.bigquery.dataset.DatasetReference`,
-                str
+            dataset (Union[ \
+                :class:`~google.cloud.bigquery.dataset.Dataset`, \
+                :class:`~google.cloud.bigquery.dataset.DatasetReference`, \
+                str, \
             ]):
                 A reference to the dataset whose tables to list from the
                 BigQuery API. If a string is passed in, this method attempts
@@ -526,10 +526,10 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/delete
 
         Args
-            dataset (Union[
-                :class:`google.cloud.bigquery.dataset.Dataset`,
-                :class:`google.cloud.bigquery.dataset.DatasetReference`,
-                str
+            dataset (Union[ \
+                :class:`~google.cloud.bigquery.dataset.Dataset`, \
+                :class:`~google.cloud.bigquery.dataset.DatasetReference`, \
+                str, \
             ]):
                 A reference to the dataset to delete. If a string is passed
                 in, this method attempts to create a dataset reference from a
@@ -565,10 +565,10 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/delete
 
         Args:
-            table (Union[
-                :class:`google.cloud.bigquery.table.Table`,
-                :class:`google.cloud.bigquery.table.TableReference`,
-                str
+            table (Union[ \
+                :class:`~google.cloud.bigquery.table.Table`, \
+                :class:`~google.cloud.bigquery.table.TableReference`, \
+                str, \
             ]):
                 A reference to the table to delete. If a string is passed in,
                 this method attempts to create a table reference from a
@@ -830,9 +830,9 @@ class Client(ClientWithProject):
             source_uris (Union[str, Sequence[str]]):
                 URIs of data files to be loaded; in format
                 ``gs://<bucket_name>/<object_name_or_glob>``.
-            destination (Union[
-                google.cloud.bigquery.table.TableReference,
-                str,
+            destination (Union[ \
+                :class:`~google.cloud.bigquery.table.TableReference`, \
+                str, \
             ]):
                 Table into which data is to be loaded. If a string is passed
                 in, this method attempts to create a table reference from a
@@ -894,9 +894,9 @@ class Client(ClientWithProject):
 
         Arguments:
             file_obj (file): A file handle opened in binary mode for reading.
-            destination (Union[
-                google.cloud.bigquery.table.TableReference,
-                str,
+            destination (Union[ \
+                :class:`~google.cloud.bigquery.table.TableReference`, \
+                str, \
             ]):
                 Table into which data is to be loaded. If a string is passed
                 in, this method attempts to create a table reference from a
@@ -1154,15 +1154,16 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy
 
         Arguments:
-            sources (Union[
-                google.cloud.bigquery.table.TableReference,
-                str,
-                Sequence[google.cloud.bigquery.table.TableReference],
+            sources (Union[ \
+                :class:`~google.cloud.bigquery.table.TableReference`, \
+                str, \
+                Sequence[ \
+                    :class:`~google.cloud.bigquery.table.TableReference`], \
             ]):
                 Table or tables to be copied.
             destination (Union[
-                google.cloud.bigquery.table.TableReference,
-                str,
+                :class:`~google.cloud.bigquery.table.TableReference`, \
+                str, \
             ]):
                 Table into which data is to be copied.
 
@@ -1224,9 +1225,9 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.extract
 
         Arguments:
-            source (Union[
-                google.cloud.bigquery.table.TableReference,
-                src,
+            source (Union[ \
+                :class:`google.cloud.bigquery.table.TableReference`, \
+                src, \
             ]):
                 Table to be extracted.
             destination_uris (Union[str, Sequence[str]]):
@@ -1352,15 +1353,15 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll
 
         Args:
-            table (Union[
-                :class:`~google.cloud.bigquery.table.Table`,
-                :class:`~google.cloud.bigquery.table.TableReference`,
-                str,
+            table (Union[ \
+                :class:`~google.cloud.bigquery.table.Table`, \
+                :class:`~google.cloud.bigquery.table.TableReference`, \
+                str, \
             ]):
                 The destination table for the row data, or a reference to it.
-            rows (Union[
-                Sequence[Tuple],
-                Sequence[dict],
+            rows (Union[ \
+                Sequence[Tuple], \
+                Sequence[dict], \
             ]):
                 Row data to be inserted. If a list of tuples is given, each
                 tuple should contain data for each schema field on the
@@ -1368,8 +1369,8 @@ class Client(ClientWithProject):
                 a list of dictionaries is given, the keys must include all
                 required fields in the schema. Keys which do not correspond
                 to a field in the schema are ignored.
-            selected_fields (Sequence[
-                :class:`~google.cloud.bigquery.schema.SchemaField`,
+            selected_fields (Sequence[ \
+                :class:`~google.cloud.bigquery.schema.SchemaField`, \
             ]):
                 The fields to return. Required if ``table`` is a
                 :class:`~google.cloud.bigquery.table.TableReference`.
@@ -1426,10 +1427,10 @@ class Client(ClientWithProject):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll
 
-        table (Union[
-            :class:`~google.cloud.bigquery.table.Table`
-            :class:`~google.cloud.bigquery.table.TableReference`,
-            str,
+        table (Union[ \
+            :class:`~google.cloud.bigquery.table.Table` \
+            :class:`~google.cloud.bigquery.table.TableReference`, \
+            str, \
         ]):
             The destination table for the row data, or a reference to it.
         json_rows (Sequence[dict]):
@@ -1502,10 +1503,10 @@ class Client(ClientWithProject):
         """List the partitions in a table.
 
         Arguments:
-            table (Union[
-                google.cloud.bigquery.table.Table,
-                google.cloud.bigquery.table.TableReference,
-                str,
+            table (Union[ \
+                :class:`~google.cloud.bigquery.table.Table`, \
+                :class:`~google.cloud.bigquery.table.TableReference`, \
+                str, \
             ]):
                 The table or reference from which to get partition info
             retry (google.api_core.retry.Retry):
@@ -1546,14 +1547,14 @@ class Client(ClientWithProject):
            local copy of the schema is up-to-date, call ``client.get_table``.
 
         Args:
-            table (Union[
-                :class:`~google.cloud.bigquery.table.Table`,
-                :class:`~google.cloud.bigquery.table.TableReference`,
-                str,
+            table (Union[ \
+                :class:`~google.cloud.bigquery.table.Table`, \
+                :class:`~google.cloud.bigquery.table.TableReference`, \
+                str, \
             ]):
                 The table to list, or a reference to it.
-            selected_fields (Sequence[
-                :class:`~google.cloud.bigquery.schema.SchemaField`
+            selected_fields (Sequence[ \
+                :class:`~google.cloud.bigquery.schema.SchemaField` \
             ]):
                 The fields to return. Required if ``table`` is a
                 :class:`~google.cloud.bigquery.table.TableReference`.

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -338,34 +338,53 @@ class Client(ClientWithProject):
     def get_dataset(self, dataset_ref, retry=DEFAULT_RETRY):
         """Fetch the dataset referenced by ``dataset_ref``
 
-        :type dataset_ref:
-            :class:`google.cloud.bigquery.dataset.DatasetReference`
-        :param dataset_ref: the dataset to use.
+        Args:
+            dataset_ref (Union[
+                :class:`google.cloud.bigquery.dataset.DatasetReference`,
+                str
+            ]):
+                A reference to the dataset to fetch from the BigQuery API.
+                If a string is passed in, this method attempts to create a
+                dataset reference from a string using
+                :func:`google.cloud.bigquery.dataset.DatasetReference.from_string`.
+            retry (:class:`google.api_core.retry.Retry`):
+                (Optional) How to retry the RPC.
 
-        :type retry: :class:`google.api_core.retry.Retry`
-        :param retry: (Optional) How to retry the RPC.
-
-        :rtype: :class:`google.cloud.bigquery.dataset.Dataset`
-        :returns: a ``Dataset`` instance
+        Returns:
+            google.cloud.bigquery.dataset.Dataset:
+                A ``Dataset`` instance.
         """
-        api_response = self._call_api(retry,
-                                      method='GET',
-                                      path=dataset_ref.path)
+        if isinstance(dataset_ref, str):
+            dataset_ref = DatasetReference.from_string(
+                dataset_ref, default_project=self.project)
+
+        api_response = self._call_api(
+            retry, method='GET', path=dataset_ref.path)
         return Dataset.from_api_repr(api_response)
 
     def get_table(self, table_ref, retry=DEFAULT_RETRY):
-        """Fetch the table referenced by ``table_ref``
+        """Fetch the table referenced by ``table_ref``.
 
-        :type table_ref:
-            :class:`google.cloud.bigquery.table.TableReference`
-        :param table_ref: the table to use.
+        Args:
+            table_ref (Union[
+                :class:`google.cloud.bigquery.table.TableReference`,
+                str
+            ]):
+                A reference to the table to fetch from the BigQuery API.
+                If a string is passed in, this method attempts to create a
+                table reference from a string using
+                :func:`google.cloud.bigquery.table.TableReference.from_string`.
+            retry (:class:`google.api_core.retry.Retry`):
+                (Optional) How to retry the RPC.
 
-        :type retry: :class:`google.api_core.retry.Retry`
-        :param retry: (Optional) How to retry the RPC.
-
-        :rtype: :class:`google.cloud.bigquery.table.Table`
-        :returns: a ``Table`` instance
+        Returns:
+            google.cloud.bigquery.table.Table:
+                A ``Table`` instance.
         """
+        if isinstance(table_ref, str):
+            table_ref = TableReference.from_string(
+                table_ref, default_project=self.project)
+
         api_response = self._call_api(retry, method='GET', path=table_ref.path)
         return Table.from_api_repr(api_response)
 
@@ -450,34 +469,43 @@ class Client(ClientWithProject):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list
 
-        :type dataset: One of:
-                       :class:`~google.cloud.bigquery.dataset.Dataset`
-                       :class:`~google.cloud.bigquery.dataset.DatasetReference`
-        :param dataset: the dataset whose tables to list, or a reference to it.
+        Args:
+            dataset (Union[
+                :class:`google.cloud.bigquery.dataset.Dataset`,
+                :class:`google.cloud.bigquery.dataset.DatasetReference`,
+                str
+            ]):
+                A reference to the dataset whose tables to list from the
+                BigQuery API. If a string is passed in, this method attempts
+                to create a dataset reference from a string using
+                :func:`google.cloud.bigquery.dataset.DatasetReference.from_string`.
+            max_results (int):
+                (Optional) Maximum number of tables to return. If not passed,
+                defaults to a value set by the API.
+            page_token (str):
+                (Optional) Token representing a cursor into the tables. If
+                not passed, the API will return the first page of tables. The
+                token marks the beginning of the iterator to be returned and
+                the value of the ``page_token`` can be accessed at
+                ``next_page_token`` of the
+                :class:`~google.api_core.page_iterator.HTTPIterator`.
+            retry (:class:`google.api_core.retry.Retry`):
+                (Optional) How to retry the RPC.
 
-        :type max_results: int
-        :param max_results: (Optional) Maximum number of tables to return.
-                            If not passed, defaults to a value set by the API.
-
-        :type page_token: str
-        :param page_token:
-            (Optional) Token representing a cursor into the tables. If not
-            passed, the API will return the first page of tables. The
-            token marks the beginning of the iterator to be returned and
-            the value of the ``page_token`` can be accessed at
-            ``next_page_token`` of the
-            :class:`~google.api_core.page_iterator.HTTPIterator`.
-
-        :type retry: :class:`google.api_core.retry.Retry`
-        :param retry: (Optional) How to retry the RPC.
-
-        :rtype: :class:`~google.api_core.page_iterator.Iterator`
-        :returns:
-            Iterator of :class:`~google.cloud.bigquery.table.TableListItem`
-            contained within the current dataset.
+        Returns:
+            google.api_core.page_iterator.Iterator:
+                Iterator of
+                :class:`~google.cloud.bigquery.table.TableListItem` contained
+                within the requested dataset.
         """
+        if isinstance(dataset, str):
+            dataset = DatasetReference.from_string(
+                dataset, default_project=self.project)
+
         if not isinstance(dataset, (Dataset, DatasetReference)):
-            raise TypeError('dataset must be a Dataset or a DatasetReference')
+            raise TypeError(
+                'dataset must be a Dataset, DatasetReference, or string')
+
         path = '%s/tables' % dataset.path
         result = page_iterator.HTTPIterator(
             client=self,
@@ -497,19 +525,27 @@ class Client(ClientWithProject):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/delete
 
-        :type dataset: One of:
-                       :class:`~google.cloud.bigquery.dataset.Dataset`
-                       :class:`~google.cloud.bigquery.dataset.DatasetReference`
-        :param dataset: the dataset to delete, or a reference to it.
-
-        :type retry: :class:`google.api_core.retry.Retry`
-        :param retry: (Optional) How to retry the RPC.
-
-        :type delete_contents: boolean
-        :param delete_contents: (Optional) If True, delete all the tables
-             in the dataset. If False and the dataset contains tables, the
-             request will fail. Default is False
+        Args
+            dataset (Union[
+                :class:`google.cloud.bigquery.dataset.Dataset`,
+                :class:`google.cloud.bigquery.dataset.DatasetReference`,
+                str
+            ]):
+                A reference to the dataset to delete. If a string is passed
+                in, this method attempts to create a dataset reference from a
+                string using
+                :func:`google.cloud.bigquery.dataset.DatasetReference.from_string`.
+            retry (:class:`google.api_core.retry.Retry`):
+                (Optional) How to retry the RPC.
+            delete_contents (boolean):
+                (Optional) If True, delete all the tables in the dataset. If
+                False and the dataset contains tables, the request will fail.
+                Default is False.
         """
+        if isinstance(dataset, str):
+            dataset = DatasetReference.from_string(
+                dataset, default_project=self.project)
+
         if not isinstance(dataset, (Dataset, DatasetReference)):
             raise TypeError('dataset must be a Dataset or a DatasetReference')
 
@@ -528,14 +564,23 @@ class Client(ClientWithProject):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/delete
 
-        :type table: One of:
-                     :class:`~google.cloud.bigquery.table.Table`
-                     :class:`~google.cloud.bigquery.table.TableReference`
-        :param table: the table to delete, or a reference to it.
-
-        :type retry: :class:`google.api_core.retry.Retry`
-        :param retry: (Optional) How to retry the RPC.
+        Args:
+            table (Union[
+                :class:`google.cloud.bigquery.table.Table`,
+                :class:`google.cloud.bigquery.table.TableReference`,
+                str
+            ]):
+                A reference to the table to delete. If a string is passed in,
+                this method attempts to create a table reference from a
+                string using
+                :func:`google.cloud.bigquery.table.TableReference.from_string`.
+            retry (:class:`google.api_core.retry.Retry`):
+                (Optional) How to retry the RPC.
         """
+        if isinstance(table, str):
+            table = TableReference.from_string(
+                table, default_project=self.project)
+
         if not isinstance(table, (Table, TableReference)):
             raise TypeError('table must be a Table or a TableReference')
         self._call_api(retry, method='DELETE', path=table.path)
@@ -785,8 +830,14 @@ class Client(ClientWithProject):
             source_uris (Union[str, Sequence[str]]):
                 URIs of data files to be loaded; in format
                 ``gs://<bucket_name>/<object_name_or_glob>``.
-            destination (google.cloud.bigquery.table.TableReference):
-                Table into which data is to be loaded.
+            destination (Union[
+                google.cloud.bigquery.table.TableReference,
+                str,
+            ]):
+                Table into which data is to be loaded. If a string is passed
+                in, this method attempts to create a table reference from a
+                string using
+                :func:`google.cloud.bigquery.table.TableReference.from_string`.
 
         Keyword Arguments:
             job_id (str): (Optional) Name of the job.
@@ -821,6 +872,10 @@ class Client(ClientWithProject):
         if isinstance(source_uris, six.string_types):
             source_uris = [source_uris]
 
+        if isinstance(destination, str):
+            destination = TableReference.from_string(
+                destination, default_project=self.project)
+
         load_job = job.LoadJob(
             job_ref, source_uris, destination, self, job_config)
         load_job._begin(retry=retry)
@@ -839,8 +894,14 @@ class Client(ClientWithProject):
 
         Arguments:
             file_obj (file): A file handle opened in binary mode for reading.
-            destination (google.cloud.bigquery.table.TableReference):
-                Table into which data is to be loaded.
+            destination (Union[
+                google.cloud.bigquery.table.TableReference,
+                str,
+            ]):
+                Table into which data is to be loaded. If a string is passed
+                in, this method attempts to create a table reference from a
+                string using
+                :func:`google.cloud.bigquery.table.TableReference.from_string`.
 
         Keyword Arguments:
             rewind (bool):
@@ -882,6 +943,10 @@ class Client(ClientWithProject):
         if location is None:
             location = self.location
 
+        if isinstance(destination, str):
+            destination = TableReference.from_string(
+                destination, default_project=self.project)
+
         job_ref = job._JobReference(job_id, project=project, location=location)
         load_job = job.LoadJob(job_ref, None, destination, self, job_config)
         job_resource = load_job._build_resource()
@@ -922,6 +987,10 @@ class Client(ClientWithProject):
                 must match the schema of the destination table. If the table
                 does not yet exist, the schema is inferred from the
                 :class:`~pandas.DataFrame`.
+
+                If a string is passed in, this method attempts to create a
+                table reference from a string using
+                :func:`google.cloud.bigquery.table.TableReference.from_string`.
 
         Keyword Arguments:
             num_retries (int, optional): Number of upload retries.
@@ -1085,10 +1154,16 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy
 
         Arguments:
-            sources (Union[google.cloud.bigquery.table.TableReference, \
-            Sequence[google.cloud.bigquery.table.TableReference]]):
+            sources (Union[
+                google.cloud.bigquery.table.TableReference,
+                str,
+                Sequence[google.cloud.bigquery.table.TableReference],
+            ]):
                 Table or tables to be copied.
-            destination (google.cloud.bigquery.table.TableReference):
+            destination (Union[
+                google.cloud.bigquery.table.TableReference,
+                str,
+            ]):
                 Table into which data is to be copied.
 
         Keyword Arguments:
@@ -1121,6 +1196,14 @@ class Client(ClientWithProject):
 
         job_ref = job._JobReference(job_id, project=project, location=location)
 
+        if isinstance(sources, str):
+            sources = TableReference.from_string(
+                sources, default_project=self.project)
+
+        if isinstance(destination, str):
+            destination = TableReference.from_string(
+                destination, default_project=self.project)
+
         if not isinstance(sources, collections.Sequence):
             sources = [sources]
 
@@ -1141,7 +1224,10 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.extract
 
         Arguments:
-            source (google.cloud.bigquery.table.TableReference):
+            source (Union[
+                google.cloud.bigquery.table.TableReference,
+                src,
+            ]):
                 Table to be extracted.
             destination_uris (Union[str, Sequence[str]]):
                 URIs of Cloud Storage file(s) into which table data is to be
@@ -1180,6 +1266,10 @@ class Client(ClientWithProject):
             location = self.location
 
         job_ref = job._JobReference(job_id, project=project, location=location)
+
+        if isinstance(source, str):
+            source = TableReference.from_string(
+                source, default_project=self.project)
 
         if isinstance(destination_uris, six.string_types):
             destination_uris = [destination_uris]
@@ -1261,40 +1351,45 @@ class Client(ClientWithProject):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll
 
-        :type table: One of:
-                     :class:`~google.cloud.bigquery.table.Table`
-                     :class:`~google.cloud.bigquery.table.TableReference`
-        :param table: the destination table for the row data, or a reference
-                      to it.
+        Args:
+            table (Union[
+                :class:`~google.cloud.bigquery.table.Table`,
+                :class:`~google.cloud.bigquery.table.TableReference`,
+                str,
+            ]):
+                The destination table for the row data, or a reference to it.
+            rows (Union[
+                Sequence[Tuple],
+                Sequence[dict],
+            ]):
+                Row data to be inserted. If a list of tuples is given, each
+                tuple should contain data for each schema field on the
+                current table and in the same order as the schema fields. If
+                a list of dictionaries is given, the keys must include all
+                required fields in the schema. Keys which do not correspond
+                to a field in the schema are ignored.
+            selected_fields (Sequence[
+                :class:`~google.cloud.bigquery.schema.SchemaField`,
+            ]):
+                The fields to return. Required if ``table`` is a
+                :class:`~google.cloud.bigquery.table.TableReference`.
+            kwargs (dict):
+                Keyword arguments to
+                :meth:`~google.cloud.bigquery.client.Client.insert_rows_json`.
 
-        :type rows: One of:
-                    list of tuples
-                    list of dictionaries
-        :param rows: Row data to be inserted. If a list of tuples is given,
-                     each tuple should contain data for each schema field on
-                     the current table and in the same order as the schema
-                     fields.  If a list of dictionaries is given, the keys must
-                     include all required fields in the schema.  Keys which do
-                     not correspond to a field in the schema are ignored.
+        Returns:
+            Sequence[Mappings]:
+                One mapping per row with insert errors: the "index" key
+                identifies the row, and the "errors" key contains a list of
+                the mappings describing one or more problems with the row.
 
-        :type selected_fields:
-            list of :class:`~google.cloud.bigquery.schema.SchemaField`
-        :param selected_fields:
-            The fields to return. Required if ``table`` is a
-            :class:`~google.cloud.bigquery.table.TableReference`.
-
-        :type kwargs: dict
-        :param kwargs:
-            Keyword arguments to
-            :meth:`~google.cloud.bigquery.client.Client.insert_rows_json`
-
-        :rtype: list of mappings
-        :returns: One mapping per row with insert errors:  the "index" key
-                  identifies the row, and the "errors" key contains a list
-                  of the mappings describing one or more problems with the
-                  row.
-        :raises: ValueError if table's schema is not set
+        Raises:
+            ValueError: if table's schema is not set
         """
+        if isinstance(table, str):
+            table = TableReference.from_string(
+                table, default_project=self.project)
+
         if selected_fields is not None:
             schema = selected_fields
         elif isinstance(table, TableReference):
@@ -1331,51 +1426,44 @@ class Client(ClientWithProject):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll
 
-        :type table: One of:
-                     :class:`~google.cloud.bigquery.table.Table`
-                     :class:`~google.cloud.bigquery.table.TableReference`
-        :param table: the destination table for the row data, or a reference
-                      to it.
-
-        :type json_rows: list of dictionaries
-        :param json_rows: Row data to be inserted. Keys must match the table
-                          schema fields and values must be JSON-compatible
-                          representations.
-
-        :type row_ids: list of string
-        :param row_ids: (Optional)  Unique ids, one per row being inserted.
-                        If omitted, unique IDs are created.
-
-        :type skip_invalid_rows: bool
-        :param skip_invalid_rows: (Optional)  Insert all valid rows of a
-                                  request, even if invalid rows exist.
-                                  The default value is False, which causes
-                                  the entire request to fail if any invalid
-                                  rows exist.
-
-        :type ignore_unknown_values: bool
-        :param ignore_unknown_values: (Optional) Accept rows that contain
-                                      values that do not match the schema.
-                                      The unknown values are ignored. Default
-                                      is False, which treats unknown values as
-                                      errors.
-
-        :type template_suffix: str
-        :param template_suffix:
+        table (Union[
+            :class:`~google.cloud.bigquery.table.Table`
+            :class:`~google.cloud.bigquery.table.TableReference`,
+            str,
+        ]):
+            The destination table for the row data, or a reference to it.
+        json_rows (Sequence[dict]):
+            Row data to be inserted. Keys must match the table schema fields
+            and values must be JSON-compatible representations.
+        row_ids (Sequence[str]):
+            (Optional) Unique ids, one per row being inserted. If omitted,
+            unique IDs are created.
+        skip_invalid_rows (bool):
+            (Optional) Insert all valid rows of a request, even if invalid
+            rows exist. The default value is False, which causes the entire
+            request to fail if any invalid rows exist.
+        ignore_unknown_values (bool):
+            (Optional) Accept rows that contain values that do not match the
+            schema. The unknown values are ignored. Default is False, which
+            treats unknown values as errors.
+        template_suffix (str):
             (Optional) treat ``name`` as a template table and provide a suffix.
             BigQuery will create the table ``<name> + <template_suffix>`` based
             on the schema of the template table. See
             https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables
+        retry (:class:`google.api_core.retry.Retry`):
+            (Optional) How to retry the RPC.
 
-        :type retry: :class:`google.api_core.retry.Retry`
-        :param retry: (Optional) How to retry the RPC.
-
-        :rtype: list of mappings
-        :returns: One mapping per row with insert errors:  the "index" key
-                  identifies the row, and the "errors" key contains a list
-                  of the mappings describing one or more problems with the
-                  row.
+        Returns:
+            Sequence[Mappings]:
+                One mapping per row with insert errors: the "index" key
+                identifies the row, and the "errors" key contains a list of
+                the mappings describing one or more problems with the row.
         """
+        if isinstance(table, str):
+            table = TableReference.from_string(
+                table, default_project=self.project)
+
         rows_info = []
         data = {'rows': rows_info}
 
@@ -1414,8 +1502,11 @@ class Client(ClientWithProject):
         """List the partitions in a table.
 
         Arguments:
-            table (Union[google.cloud.bigquery.table.Table,
-                    google.cloud.bigquery.table.TableReference]):
+            table (Union[
+                google.cloud.bigquery.table.Table,
+                google.cloud.bigquery.table.TableReference,
+                str,
+            ]):
                 The table or reference from which to get partition info
             retry (google.api_core.retry.Retry):
                 (Optional) How to retry the RPC.
@@ -1424,6 +1515,10 @@ class Client(ClientWithProject):
             List[str]:
                 A list of the partition ids present in the partitioned table
         """
+        if isinstance(table, str):
+            table = TableReference.from_string(
+                table, default_project=self.project)
+
         meta_table = self.get_table(
             TableReference(
                 self.dataset(table.dataset_id, project=table.project),
@@ -1450,49 +1545,48 @@ class Client(ClientWithProject):
            identical, the values returned may be incomplete. To ensure that the
            local copy of the schema is up-to-date, call ``client.get_table``.
 
-        :type table: One of:
-                     :class:`~google.cloud.bigquery.table.Table`
-                     :class:`~google.cloud.bigquery.table.TableReference`
-        :param table: the table to list, or a reference to it.
+        Args:
+            table (Union[
+                :class:`~google.cloud.bigquery.table.Table`,
+                :class:`~google.cloud.bigquery.table.TableReference`,
+                str,
+            ]):
+                The table to list, or a reference to it.
+            selected_fields (Sequence[
+                :class:`~google.cloud.bigquery.schema.SchemaField`
+            ]):
+                The fields to return. Required if ``table`` is a
+                :class:`~google.cloud.bigquery.table.TableReference`.
+            max_results (int):
+                (Optional) maximum number of rows to return.
+            page_token (str):
+                (Optional) Token representing a cursor into the table's rows.
+                If not passed, the API will return the first page of the
+                rows. The token marks the beginning of the iterator to be
+                returned and the value of the ``page_token`` can be accessed
+                at ``next_page_token`` of the
+                :class:`~google.cloud.bigquery.table.RowIterator`.
+            start_index (int):
+                (Optional) The zero-based index of the starting row to read.
+            page_size (int):
+                (Optional) The maximum number of items to return per page in
+                the iterator.
+            retry (:class:`google.api_core.retry.Retry`):
+                (Optional) How to retry the RPC.
 
-        :type selected_fields:
-            list of :class:`~google.cloud.bigquery.schema.SchemaField`
-        :param selected_fields:
-            The fields to return. Required if ``table`` is a
-            :class:`~google.cloud.bigquery.table.TableReference`.
-
-        :type max_results: int
-        :param max_results: (Optional) maximum number of rows to return.
-
-        :type page_token: str
-        :param page_token: (Optional) Token representing a cursor into the
-                           table's rows. If not passed, the API will return
-                           the first page of the rows. The token marks the
-                           beginning of the iterator to be returned and the
-                           value of the ``page_token`` can be accessed at
-                           ``next_page_token`` of the
-                           :class:`~google.cloud.bigquery.table.RowIterator`.
-
-        :type start_index: int
-        :param start_index: (Optional) The zero-based index of the starting
-                           row to read.
-
-        :type page_size: int
-        :param page_size: (Optional) The maximum number of items to return
-                          per page in the iterator.
-
-        :type retry: :class:`google.api_core.retry.Retry`
-        :param retry: (Optional) How to retry the RPC.
-
-        :rtype: :class:`~google.cloud.bigquery.table.RowIterator`
-        :returns: Iterator of row data
-                  :class:`~google.cloud.bigquery.table.Row`-s. During each
-                  page, the iterator will have the ``total_rows`` attribute
-                  set, which counts the total number of rows **in the table**
-                  (this is distinct from the total number of rows in the
-                  current page: ``iterator.page.num_items``).
-
+        Returns:
+            google.cloud.bigquery.table.RowIterator:
+                Iterator of row data
+                :class:`~google.cloud.bigquery.table.Row`-s. During each
+                page, the iterator will have the ``total_rows`` attribute
+                set, which counts the total number of rows **in the table**
+                (this is distinct from the total number of rows in the
+                current page: ``iterator.page.num_items``).
         """
+        if isinstance(table, str):
+            table = TableReference.from_string(
+                table, default_project=self.project)
+
         if selected_fields is not None:
             schema = selected_fields
         elif isinstance(table, TableReference):

--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -211,18 +211,21 @@ class DatasetReference(object):
         return cls(project, dataset_id)
 
     @classmethod
-    def from_string(cls, full_dataset_id):
-        """Construct a dataset reference from fully-qualified dataset ID.
+    def from_string(cls, dataset_id, default_project=None):
+        """Construct a dataset reference from dataset ID string.
 
         Args:
-            full_dataset_id (str):
-                A fully-qualified dataset ID in standard SQL format. Must
-                included both the project ID and the dataset ID, separated by
-                ``.``.
+            dataset_id (str):
+                A dataset ID in standard SQL format. If ``default_project``
+                is not specified, this must included both the project ID and
+                the dataset ID, separated by ``.``.
+            default_project (str):
+                Optional. The project ID to use when ``dataset_id`` does not
+                include a project ID.
 
         Returns:
             DatasetReference:
-                Dataset reference parsed from ``full_dataset_id``.
+                Dataset reference parsed from ``dataset_id``.
 
         Examples:
             >>> DatasetReference.from_string('my-project-id.some_dataset')
@@ -230,16 +233,27 @@ class DatasetReference(object):
 
         Raises:
             ValueError:
-                If ``full_dataset_id`` is not a fully-qualified dataset ID in
+                If ``dataset_id`` is not a fully-qualified dataset ID in
                 standard SQL format.
         """
-        parts = full_dataset_id.split('.')
-        if len(parts) != 2:
+        output_dataset_id = dataset_id
+        output_project_id = default_project
+        parts = dataset_id.split('.')
+
+        if len(parts) == 1 and not default_project:
             raise ValueError(
-                'full_dataset_id must be a fully-qualified dataset ID in '
-                'standard SQL format. e.g. "project.dataset_id", got '
-                '{}'.format(full_dataset_id))
-        return cls(*parts)
+                'When default_project is not set, dataset_id must be a '
+                'fully-qualified dataset ID in standard SQL format. '
+                'e.g. "project.dataset_id", got {}'.format(dataset_id))
+        elif len(parts) == 2:
+            output_project_id, output_dataset_id = parts
+        elif len(parts) > 2:
+            raise ValueError(
+                'Too many parts in dataset_id. Expected a fully-qualified '
+                'dataset ID in standard SQL format. e.g. '
+                '"project.dataset_id", got {}'.format(dataset_id))
+
+        return cls(output_project_id, output_dataset_id)
 
     def to_api_repr(self):
         """Construct the API resource representation of this dataset reference

--- a/bigquery/tests/unit/test_dataset.py
+++ b/bigquery/tests/unit/test_dataset.py
@@ -187,6 +187,27 @@ class TestDatasetReference(unittest.TestCase):
         with self.assertRaises(ValueError):
             cls.from_string('string-project:string_dataset')
 
+    def test_from_string_not_fully_qualified(self):
+        cls = self._get_target_class()
+        with self.assertRaises(ValueError):
+            cls.from_string('string_dataset')
+        with self.assertRaises(ValueError):
+            cls.from_string('a.b.c')
+
+    def test_from_string_with_default_project(self):
+        cls = self._get_target_class()
+        got = cls.from_string(
+            'string_dataset', default_project='default-project')
+        self.assertEqual(got.project, 'default-project')
+        self.assertEqual(got.dataset_id, 'string_dataset')
+
+    def test_from_string_ignores_default_project(self):
+        cls = self._get_target_class()
+        got = cls.from_string(
+            'string-project.string_dataset', default_project='default-project')
+        self.assertEqual(got.project, 'string-project')
+        self.assertEqual(got.dataset_id, 'string_dataset')
+
     def test___eq___wrong_type(self):
         dataset = self._make_one('project_1', 'dataset_1')
         other = object()

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -149,7 +149,30 @@ class TestTableReference(unittest.TestCase):
     def test_from_string_not_fully_qualified(self):
         cls = self._get_target_class()
         with self.assertRaises(ValueError):
+            cls.from_string('string_table')
+
+        with self.assertRaises(ValueError):
             cls.from_string('string_dataset.string_table')
+
+        with self.assertRaises(ValueError):
+            cls.from_string('a.b.c.d')
+
+    def test_from_string_with_default_project(self):
+        cls = self._get_target_class()
+        got = cls.from_string(
+            'string_dataset.string_table', default_project='default-project')
+        self.assertEqual(got.project, 'default-project')
+        self.assertEqual(got.dataset_id, 'string_dataset')
+        self.assertEqual(got.table_id, 'string_table')
+
+    def test_from_string_ignores_default_project(self):
+        cls = self._get_target_class()
+        got = cls.from_string(
+            'string-project.string_dataset.string_table',
+            default_project='default-project')
+        self.assertEqual(got.project, 'string-project')
+        self.assertEqual(got.dataset_id, 'string_dataset')
+        self.assertEqual(got.table_id, 'string_table')
 
     def test___eq___wrong_type(self):
         from google.cloud.bigquery.dataset import DatasetReference


### PR DESCRIPTION
…nt methods.

Whereever a client method accepts a DatasetReference or TableReference,
it now also accepts a string. The project ID can be omitted from the
string and the Client's default project is used instead.

Also, to make it easier to share code across client methods for creating
XReference classes:

* Add default_project argument to DatasetReference.from_string
* Add default_project argument to TableReference.from_string

Towards #6055. Not closes because we should add similar logic to the `create_dataset` and `create_table` methods, but they need to be modified to also accept a reference. My thought there is that we can create an empty table/dataset resource when a string or reference is passed in.

@max-sixty Please take a look.