### PR TITLE
BigQuery: fix swallowed error message

### DIFF
--- a/bigquery/google/cloud/bigquery/dbapi/cursor.py
+++ b/bigquery/google/cloud/bigquery/dbapi/cursor.py
@@ -153,8 +153,8 @@ class Cursor(object):
         # Wait for the query to finish.
         try:
             self._query_job.result()
-        except google.cloud.exceptions.GoogleCloudError as e:
-            raise exceptions.DatabaseError(self._query_job.errors or e)
+        except google.cloud.exceptions.GoogleCloudError as exc:
+            raise exceptions.DatabaseError(exc)
 
         query_results = self._query_job._query_results
         self._set_rowcount(query_results)

--- a/bigquery/google/cloud/bigquery/dbapi/cursor.py
+++ b/bigquery/google/cloud/bigquery/dbapi/cursor.py
@@ -153,8 +153,8 @@ class Cursor(object):
         # Wait for the query to finish.
         try:
             self._query_job.result()
-        except google.cloud.exceptions.GoogleCloudError:
-            raise exceptions.DatabaseError(self._query_job.errors)
+        except google.cloud.exceptions.GoogleCloudError as e:
+            raise exceptions.DatabaseError(self._query_job.errors or e)
 
         query_results = self._query_job._query_results
         self._set_rowcount(query_results)


### PR DESCRIPTION
When getting a `Cannot query over table (...) without a filter over
column(s) (...)`, the re-raising happening gobbles up the error message
and the context is lost.

This may or may not be the right fix, but clearly highlights the issue
of `self._query_job.errors` being `None` in that particular context.
When that is the case, the only context available is that of
`DatabaseError` without any details which clearly isn't enough detail.

```
After this fix is applied (wrapping the exception into another exception) both stack traces are shown:
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/cloud/bigquery/job.py", line 2685, in result
    super(QueryJob, self).result(timeout=timeout)
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/cloud/bigquery/job.py", line 697, in result
    return super(_AsyncJob, self).result(timeout=timeout)
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/api_core/future/polling.py", line 115, in result
    self._blocking_poll(timeout=timeout)
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/cloud/bigquery/job.py", line 2659, in _blocking_poll
    super(QueryJob, self)._blocking_poll(timeout=timeout)
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/api_core/future/polling.py", line 94, in _blocking_poll
    retry_(self._done_or_raise)()
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/api_core/retry.py", line 260, in retry_wrapped_func
    on_error=on_error,
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/api_core/retry.py", line 177, in retry_target
    return target()
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/api_core/future/polling.py", line 73, in _done_or_raise
    if not self.done():
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/cloud/bigquery/job.py", line 2647, in done
    location=self.location)
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/cloud/bigquery/client.py", line 584, in _get_query_results
    retry, method='GET', path=path, query_params=extra_params)
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/cloud/bigquery/client.py", line 336, in _call_api
    return call()
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/api_core/retry.py", line 260, in retry_wrapped_func
    on_error=on_error,
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/api_core/retry.py", line 177, in retry_target
    return target()
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/cloud/_http.py", line 293, in api_request
    raise exceptions.from_http_response(response)
google.api_core.exceptions.BadRequest: 400 GET https://www.googleapis.com/bigquery/v2/projects/fsql-production/queries/6ed337a4-e23c-4634-ba94-15254648bdfb?maxResults=0&location=US: Cannot query over table 'fsql-production.records.routes_stream' without a filter over column(s) 'created_at' that can be used for partition elimination

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mbeauchemin/incubator-superset/superset/sql_lab.py", line 185, in execute_sql
    db_engine_spec.execute(cursor, query.executed_sql, async_=True)
  File "/home/mbeauchemin/incubator-superset/superset/db_engine_specs.py", line 376, in execute
    cursor.execute(query)
  File "/home/mbeauchemin/incubator-superset/env/lib/python3.4/site-packages/google/cloud/bigquery/dbapi/cursor.py", line 157, in execute
    raise exceptions.DatabaseError(self._query_job.errors or e)
google.cloud.bigquery.dbapi.exceptions.DatabaseError: 400 GET https://www.googleapis.com/bigquery/v2/projects/fsql-production/queries/6ed337a4-e23c-4634-ba94-15254648bdfb?maxResults=0&location=US: Cannot query over table 'fsql-production.records.routes_stream' without a filter over column(s) 'created_at' that can be used for partition elimination
```

