### PR TITLE
BigQuery: expose 'to_api_repr' method for jobs.

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -949,7 +949,7 @@ class Client(ClientWithProject):
 
         job_ref = job._JobReference(job_id, project=project, location=location)
         load_job = job.LoadJob(job_ref, None, destination, self, job_config)
-        job_resource = load_job._build_resource()
+        job_resource = load_job.to_api_repr()
 
         if rewind:
             file_obj.seek(0, os.SEEK_SET)

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -519,9 +519,11 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
                            '["configuration"]["%s"]' % cls._JOB_TYPE)
         return job_id, resource['configuration']
 
-    def _build_resource(self):
-        """Helper:  Generate a resource for :meth:`_begin`."""
+    def to_api_repr(self):
+        """Generate a resource for the job."""
         raise NotImplementedError("Abstract")
+
+    _build_resource = to_api_repr  # backward-compatibility alias
 
     def _begin(self, client=None, retry=DEFAULT_RETRY):
         """API call:  begin the job via a POST request
@@ -549,7 +551,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         # job has an ID.
         api_response = client._call_api(
             retry,
-            method='POST', path=path, data=self._build_resource())
+            method='POST', path=path, data=self.to_api_repr())
         self._set_properties(api_response)
 
     def exists(self, client=None, retry=DEFAULT_RETRY):
@@ -1367,7 +1369,7 @@ class LoadJob(_AsyncJob):
         if statistics is not None:
             return int(statistics['load']['outputRows'])
 
-    def _build_resource(self):
+    def to_api_repr(self):
         """Generate a resource for :meth:`_begin`."""
         configuration = self._configuration.to_api_repr()
         if self.source_uris is not None:
@@ -1543,7 +1545,7 @@ class CopyJob(_AsyncJob):
         """
         return self._configuration.destination_encryption_configuration
 
-    def _build_resource(self):
+    def to_api_repr(self):
         """Generate a resource for :meth:`_begin`."""
 
         source_refs = [{
@@ -1761,7 +1763,7 @@ class ExtractJob(_AsyncJob):
             return [int(count) for count in counts]
         return None
 
-    def _build_resource(self):
+    def to_api_repr(self):
         """Generate a resource for :meth:`_begin`."""
 
         source_ref = {
@@ -2367,7 +2369,7 @@ class QueryJob(_AsyncJob):
         """
         return self._configuration.schema_update_options
 
-    def _build_resource(self):
+    def to_api_repr(self):
         """Generate a resource for :meth:`_begin`."""
         configuration = self._configuration.to_api_repr()
 

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -2214,7 +2214,7 @@ class TestClient(unittest.TestCase):
         config = LoadJobConfig()
         config.source_format = SourceFormat.CSV
         job = LoadJob(None, None, self.TABLE_REF, client, job_config=config)
-        metadata = job._build_resource()
+        metadata = job.to_api_repr()
         upload, transport = client._initiate_resumable_upload(
             stream, metadata, num_retries)
 
@@ -2279,7 +2279,7 @@ class TestClient(unittest.TestCase):
         config = LoadJobConfig()
         config.source_format = SourceFormat.CSV
         job = LoadJob(None, None, self.TABLE_REF, client, job_config=config)
-        metadata = job._build_resource()
+        metadata = job.to_api_repr()
         size = len(data)
         response = client._do_multipart_upload(
             stream, metadata, size, num_retries)

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -522,6 +522,12 @@ class Test_AsyncJob(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             job._build_resource()
 
+    def test_to_api_repr(self):
+        client = _make_client(project=self.PROJECT)
+        job = self._make_one(self.JOB_ID, client)
+        with self.assertRaises(NotImplementedError):
+            job.to_api_repr()
+
     def test__begin_already(self):
         job = self._set_properties_job()
         job._properties['status'] = {'state': 'WHATEVER'}
@@ -543,7 +549,7 @@ class Test_AsyncJob(unittest.TestCase):
             }
         }
         job = self._set_properties_job()
-        builder = job._build_resource = mock.Mock()
+        builder = job.to_api_repr = mock.Mock()
         builder.return_value = resource
         call_api = job._client._call_api = mock.Mock()
         call_api.return_value = resource
@@ -573,7 +579,7 @@ class Test_AsyncJob(unittest.TestCase):
             }
         }
         job = self._set_properties_job()
-        builder = job._build_resource = mock.Mock()
+        builder = job.to_api_repr = mock.Mock()
         builder.return_value = resource
         client = _make_client(project=other_project)
         call_api = client._call_api = mock.Mock()


### PR DESCRIPTION
Leave `_build_resource` behind as a backward-compatibility alias.

Closes #5866.