### PR TITLE
fix usage docs example for entity extraction

### DIFF
--- a/language/docs/usage.rst
+++ b/language/docs/usage.rst
@@ -94,7 +94,7 @@ returns a :class:`~.language_v1.types.AnalyzeEntitiesResponse`.
      >>> for entity in response.entities:
      ...     print('=' * 20)
      ...     print('         name: {0}'.format(entity.name))
-     ...     print('         type: {0}'.format(entity.entity_type))
+     ...     print('         type: {0}'.format(entity.type))
      ...     print('     metadata: {0}'.format(entity.metadata))
      ...     print('     salience: {0}'.format(entity.salience))
      ====================


### PR DESCRIPTION
entities no longer have `entity_type`, just `type`.