### PR TITLE
BigQuery: add destination table properties to 'LoadJobConfig'.

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -988,6 +988,25 @@ class LoadJobConfig(_JobConfig):
             self._del_sub_prop('destinationEncryptionConfiguration')
 
     @property
+    def destination_table_description(self):
+        """Union[str, None] name given to destination table.
+
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.destinationTableProperties.description
+        """
+        prop = self._get_sub_prop('destinationTableProperties')
+        if prop is not None:
+            return prop['description']
+
+    @destination_table_description.setter
+    def destination_table_description(self, value):
+        keys = [self._job_type, 'destinationTableProperties', 'description']
+        if value is not None:
+            _helpers._set_sub_prop(self._properties, keys, value)
+        else:
+            _helpers._del_sub_prop(self._properties, keys)
+
+    @property
     def encoding(self):
         """google.cloud.bigquery.job.Encoding: The character encoding of the
         data.

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1072,12 +1072,10 @@ class LoadJobConfig(_JobConfig):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.maxBadRecords
         """
-        # XXX: should this coerce from str, like 'skip_leading_rows' below?
-        return self._get_sub_prop('maxBadRecords')
+        return _helpers._int_or_none(self._get_sub_prop('maxBadRecords'))
 
     @max_bad_records.setter
     def max_bad_records(self, value):
-        # XXX: should this coerce to str, like 'skip_leading_rows' below?
         self._set_sub_prop('maxBadRecords', value)
 
     @property

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -981,10 +981,12 @@ class LoadJobConfig(_JobConfig):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.maxBadRecords
         """
+        # XXX: should this coerce from str, like 'skip_leading_rows' below?
         return self._get_sub_prop('maxBadRecords')
 
     @max_bad_records.setter
     def max_bad_records(self, value):
+        # XXX: should this coerce to str, like 'skip_leading_rows' below?
         self._set_sub_prop('maxBadRecords', value)
 
     @property

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -921,6 +921,34 @@ class LoadJobConfig(_JobConfig):
         self._set_sub_prop('autodetect', value)
 
     @property
+    def clustering_fields(self):
+        """Union[List[str], None]: Fields defining clustering for the table
+
+        (Defaults to :data:`None`).
+
+        Clustering fields are immutable after table creation.
+
+        .. note::
+
+           As of 2018-06-29, clustering fields cannot be set on a table
+           which does not also have time partioning defined.
+        """
+        prop = self._get_sub_prop('clustering')
+        if prop is not None:
+            return list(prop.get('fields', ()))
+
+    @clustering_fields.setter
+    def clustering_fields(self, value):
+        """Union[List[str], None]: Fields defining clustering for the table
+
+        (Defaults to :data:`None`).
+        """
+        if value is not None:
+            self._set_sub_prop('clustering', {'fields': value})
+        else:
+            self._del_sub_prop('clustering')
+
+    @property
     def create_disposition(self):
         """google.cloud.bigquery.job.CreateDisposition: Specifies behavior
         for creating tables.
@@ -933,6 +961,29 @@ class LoadJobConfig(_JobConfig):
     @create_disposition.setter
     def create_disposition(self, value):
         self._set_sub_prop('createDisposition', value)
+
+    @property
+    def destination_encryption_configuration(self):
+        """google.cloud.bigquery.table.EncryptionConfiguration: Custom
+        encryption configuration for the destination table.
+
+        Custom encryption configuration (e.g., Cloud KMS keys) or ``None``
+        if using default encryption.
+
+        See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.destinationEncryptionConfiguration
+        """
+        prop = self._get_sub_prop('destinationEncryptionConfiguration')
+        if prop is not None:
+            prop = EncryptionConfiguration.from_api_repr(prop)
+        return prop
+
+    @destination_encryption_configuration.setter
+    def destination_encryption_configuration(self, value):
+        api_repr = value
+        if value is not None:
+            api_repr = value.to_api_repr()
+        self._set_sub_prop('destinationEncryptionConfiguration', api_repr)
 
     @property
     def encoding(self):
@@ -1016,6 +1067,41 @@ class LoadJobConfig(_JobConfig):
         self._set_sub_prop('quote', value)
 
     @property
+    def schema(self):
+        """List[google.cloud.bigquery.schema.SchemaField]: Schema of the
+        destination table.
+
+        See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.schema
+        """
+        schema = _helpers._get_sub_prop(
+            self._properties, ['load', 'schema', 'fields'])
+        if schema is None:
+            return
+        return [SchemaField.from_api_repr(field) for field in schema]
+
+    @schema.setter
+    def schema(self, value):
+        if not all(hasattr(field, 'to_api_repr') for field in value):
+            raise ValueError('Schema items must be fields')
+        _helpers._set_sub_prop(
+            self._properties,
+            ['load', 'schema', 'fields'],
+            [field.to_api_repr() for field in value])
+
+    @property
+    def schema_update_options(self):
+        """List[google.cloud.bigquery.job.SchemaUpdateOption]: Specifies
+        updates to the destination table schema to allow as a side effect of
+        the load job.
+        """
+        return self._get_sub_prop('schemaUpdateOptions')
+
+    @schema_update_options.setter
+    def schema_update_options(self, values):
+        self._set_sub_prop('schemaUpdateOptions', values)
+
+    @property
     def skip_leading_rows(self):
         """int: Number of rows to skip when reading data (CSV only).
 
@@ -1042,66 +1128,6 @@ class LoadJobConfig(_JobConfig):
         self._set_sub_prop('sourceFormat', value)
 
     @property
-    def write_disposition(self):
-        """google.cloud.bigquery.job.WriteDisposition: Action that occurs if
-        the destination table already exists.
-
-        See
-        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.writeDisposition
-        """
-        return self._get_sub_prop('writeDisposition')
-
-    @write_disposition.setter
-    def write_disposition(self, value):
-        self._set_sub_prop('writeDisposition', value)
-
-    @property
-    def schema(self):
-        """List[google.cloud.bigquery.schema.SchemaField]: Schema of the
-        destination table.
-
-        See
-        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.schema
-        """
-        schema = _helpers._get_sub_prop(
-            self._properties, ['load', 'schema', 'fields'])
-        if schema is None:
-            return
-        return [SchemaField.from_api_repr(field) for field in schema]
-
-    @schema.setter
-    def schema(self, value):
-        if not all(hasattr(field, 'to_api_repr') for field in value):
-            raise ValueError('Schema items must be fields')
-        _helpers._set_sub_prop(
-            self._properties,
-            ['load', 'schema', 'fields'],
-            [field.to_api_repr() for field in value])
-
-    @property
-    def destination_encryption_configuration(self):
-        """google.cloud.bigquery.table.EncryptionConfiguration: Custom
-        encryption configuration for the destination table.
-
-        Custom encryption configuration (e.g., Cloud KMS keys) or ``None``
-        if using default encryption.
-
-        See
-        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.destinationEncryptionConfiguration
-        """
-        prop = self._get_sub_prop('destinationEncryptionConfiguration')
-        if prop is not None:
-            prop = EncryptionConfiguration.from_api_repr(prop)
-        return prop
-
-    @destination_encryption_configuration.setter
-    def destination_encryption_configuration(self, value):
-        api_repr = value
-        if value is not None:
-            api_repr = value.to_api_repr()
-        self._set_sub_prop('destinationEncryptionConfiguration', api_repr)
-
-    @property
     def time_partitioning(self):
         """google.cloud.bigquery.table.TimePartitioning: Specifies time-based
         partitioning for the destination table.
@@ -1121,44 +1147,18 @@ class LoadJobConfig(_JobConfig):
             self._del_sub_prop('timePartitioning')
 
     @property
-    def clustering_fields(self):
-        """Union[List[str], None]: Fields defining clustering for the table
+    def write_disposition(self):
+        """google.cloud.bigquery.job.WriteDisposition: Action that occurs if
+        the destination table already exists.
 
-        (Defaults to :data:`None`).
-
-        Clustering fields are immutable after table creation.
-
-        .. note::
-
-           As of 2018-06-29, clustering fields cannot be set on a table
-           which does not also have time partioning defined.
+        See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.writeDisposition
         """
-        prop = self._get_sub_prop('clustering')
-        if prop is not None:
-            return list(prop.get('fields', ()))
+        return self._get_sub_prop('writeDisposition')
 
-    @clustering_fields.setter
-    def clustering_fields(self, value):
-        """Union[List[str], None]: Fields defining clustering for the table
-
-        (Defaults to :data:`None`).
-        """
-        if value is not None:
-            self._set_sub_prop('clustering', {'fields': value})
-        else:
-            self._del_sub_prop('clustering')
-
-    @property
-    def schema_update_options(self):
-        """List[google.cloud.bigquery.job.SchemaUpdateOption]: Specifies
-        updates to the destination table schema to allow as a side effect of
-        the load job.
-        """
-        return self._get_sub_prop('schemaUpdateOptions')
-
-    @schema_update_options.setter
-    def schema_update_options(self, values):
-        self._set_sub_prop('schemaUpdateOptions', values)
+    @write_disposition.setter
+    def write_disposition(self, value):
+        self._set_sub_prop('writeDisposition', value)
 
 
 class LoadJob(_AsyncJob):

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -983,7 +983,9 @@ class LoadJobConfig(_JobConfig):
         api_repr = value
         if value is not None:
             api_repr = value.to_api_repr()
-        self._set_sub_prop('destinationEncryptionConfiguration', api_repr)
+            self._set_sub_prop('destinationEncryptionConfiguration', api_repr)
+        else:
+            self._del_sub_prop('destinationEncryptionConfiguration')
 
     @property
     def encoding(self):

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1116,7 +1116,9 @@ class LoadJobConfig(_JobConfig):
         api_repr = value
         if value is not None:
             api_repr = value.to_api_repr()
-        self._set_sub_prop('timePartitioning', api_repr)
+            self._set_sub_prop('timePartitioning', api_repr)
+        else:
+            self._del_sub_prop('timePartitioning')
 
     @property
     def clustering_fields(self):

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1007,6 +1007,25 @@ class LoadJobConfig(_JobConfig):
             _helpers._del_sub_prop(self._properties, keys)
 
     @property
+    def destination_table_friendly_name(self):
+        """Union[str, None] name given to destination table.
+
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.destinationTableProperties.friendlyName
+        """
+        prop = self._get_sub_prop('destinationTableProperties')
+        if prop is not None:
+            return prop['friendlyName']
+
+    @destination_table_friendly_name.setter
+    def destination_table_friendly_name(self, value):
+        keys = [self._job_type, 'destinationTableProperties', 'friendlyName']
+        if value is not None:
+            _helpers._set_sub_prop(self._properties, keys, value)
+        else:
+            _helpers._del_sub_prop(self._properties, keys)
+
+    @property
     def encoding(self):
         """google.cloud.bigquery.job.Encoding: The character encoding of the
         data.

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1356,6 +1356,24 @@ class TimePartitioning(object):
         """
         return self._properties
 
+    def _key(self):
+        return tuple(sorted(self._properties.items()))
+
+    def __eq__(self, other):
+        if not isinstance(other, TimePartitioning):
+            return NotImplemented
+        return self._key() == other._key()
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __hash__(self):
+        return hash(self._key())
+
+    def __repr__(self):
+        key_vals = ['{}={}'.format(key, val) for key, val in self._key()]
+        return 'TimePartitioning({})'.format(','.join(key_vals))
+
 
 def _item_to_row(iterator, resource):
     """Convert a JSON row to the native object.

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -132,6 +132,20 @@ class EncryptionConfiguration(object):
         """
         return copy.deepcopy(self._properties)
 
+    def __eq__(self, other):
+        if not isinstance(other, EncryptionConfiguration):
+            return NotImplemented
+        return self.kms_key_name == other.kms_key_name
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __hash__(self):
+        return hash(self.kms_key_name)
+
+    def __repr__(self):
+        return 'EncryptionConfiguration({})'.format(self.kms_key_name)
+
 
 class TableReference(object):
     """TableReferences are pointers to tables.

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1358,6 +1358,27 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
             # XXX: Should this really be a str?
             str(skip_leading_rows))
 
+    def test_source_format_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.source_format)
+
+    def test_source_format_hit(self):
+        from google.cloud.bigquery.job import SourceFormat
+
+        source_format = SourceFormat.CSV
+        config = self._get_target_class()()
+        config._properties['load']['sourceFormat'] = source_format
+        self.assertEqual(config.source_format, source_format)
+
+    def test_source_format_setter(self):
+        from google.cloud.bigquery.job import SourceFormat
+
+        source_format = SourceFormat.CSV
+        config = self._get_target_class()()
+        config.source_format = source_format
+        self.assertEqual(
+            config._properties['load']['sourceFormat'], source_format)
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1147,21 +1147,6 @@ class _Base(object):
 class TestLoadJobConfig(unittest.TestCase, _Base):
     JOB_TYPE = 'load'
 
-    def _make_resource(self, started=False, ended=False):
-        resource = super(TestLoadJobConfig, self)._make_resource(
-            started, ended)
-        config = resource['configuration']['load']
-        config['sourceUris'] = [self.SOURCE1]
-        config['destinationTable'] = {
-            'projectId': self.PROJECT,
-            'datasetId': self.DS_ID,
-            'tableId': self.TABLE_ID,
-        }
-        config['destinationEncryptionConfiguration'] = {
-            'kmsKeyName': self.KMS_KEY_NAME}
-
-        return resource
-
     @staticmethod
     def _get_target_class():
         from google.cloud.bigquery.job import LoadJobConfig
@@ -1289,6 +1274,17 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertEqual(
             config._properties['load']['destinationEncryptionConfiguration'],
             expected)
+
+    def test_destination_encryption_configuration_setter_w_none(self):
+        kms_key_name = 'kms-key-name'
+        config = self._get_target_class()()
+        config._properties['load']['destinationEncryptionConfiguration'] = {
+            'kmsKeyName': kms_key_name,
+        }
+        config.destination_encryption_configuration = None
+        self.assertIsNone(config.destination_encryption_configuration)
+        self.assertNotIn(
+            'destinationEncryptionConfiguration', config._properties['load'])
 
     def test_encoding_missing(self):
         config = self._get_target_class()()
@@ -1598,40 +1594,6 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         config.write_disposition = write_disposition
         self.assertEqual(
             config._properties['load']['writeDisposition'], write_disposition)
-
-    def test_from_api_repr(self):
-        resource = self._make_resource()
-        config = self._get_target_class().from_api_repr(resource)
-        self.assertEqual(config.to_api_repr(), resource)
-
-    def test_to_api_repr_with_encryption(self):
-        from google.cloud.bigquery.table import EncryptionConfiguration
-
-        config = self._make_one()
-        config.destination_encryption_configuration = EncryptionConfiguration(
-            kms_key_name=self.KMS_KEY_NAME)
-        resource = config.to_api_repr()
-        self.assertEqual(
-            resource,
-            {
-                'load': {
-                    'destinationEncryptionConfiguration': {
-                        'kmsKeyName': self.KMS_KEY_NAME,
-                    },
-                },
-            })
-
-    def test_to_api_repr_with_encryption_none(self):
-        config = self._make_one()
-        config.destination_encryption_configuration = None
-        resource = config.to_api_repr()
-        self.assertEqual(
-            resource,
-            {
-                'load': {
-                    'destinationEncryptionConfiguration': None,
-                },
-            })
 
 
 class TestLoadJob(unittest.TestCase, _Base):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1316,6 +1316,23 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertEqual(
             config._properties['load']['nullMarker'], null_marker)
 
+    def test_quote_character_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.quote_character)
+
+    def test_quote_character_hit(self):
+        quote_character = "'"
+        config = self._get_target_class()()
+        config._properties['load']['quote'] = quote_character
+        self.assertEqual(config.quote_character, quote_character)
+
+    def test_quote_character_setter(self):
+        quote_character = "'"
+        config = self._get_target_class()()
+        config.quote_character = quote_character
+        self.assertEqual(
+            config._properties['load']['quote'], quote_character)
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1379,6 +1379,27 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertEqual(
             config._properties['load']['sourceFormat'], source_format)
 
+    def test_write_disposition_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.write_disposition)
+
+    def test_write_disposition_hit(self):
+        from google.cloud.bigquery.job import WriteDisposition
+
+        write_disposition = WriteDisposition.WRITE_TRUNCATE
+        config = self._get_target_class()()
+        config._properties['load']['writeDisposition'] = write_disposition
+        self.assertEqual(config.write_disposition, write_disposition)
+
+    def test_write_disposition_setter(self):
+        from google.cloud.bigquery.job import WriteDisposition
+
+        write_disposition = WriteDisposition.WRITE_TRUNCATE
+        config = self._get_target_class()()
+        config.write_disposition = write_disposition
+        self.assertEqual(
+            config._properties['load']['writeDisposition'], write_disposition)
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1268,6 +1268,20 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertEqual(
             config._properties['load']['fieldDelimiter'], field_delimiter)
 
+    def test_ignore_unknown_values_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.ignore_unknown_values)
+
+    def test_ignore_unknown_values_hit(self):
+        config = self._get_target_class()()
+        config._properties['load']['ignoreUnknownValues'] = True
+        self.assertTrue(config.ignore_unknown_values)
+
+    def test_ignore_unknown_values_setter(self):
+        config = self._get_target_class()()
+        config.ignore_unknown_values = True
+        self.assertTrue(config._properties['load']['ignoreUnknownValues'])
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1251,6 +1251,23 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertEqual(
             config._properties['load']['encoding'], encoding)
 
+    def test_field_delimiter_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.field_delimiter)
+
+    def test_field_delimiter_hit(self):
+        field_delimiter = '|'
+        config = self._get_target_class()()
+        config._properties['load']['fieldDelimiter'] = field_delimiter
+        self.assertEqual(config.field_delimiter, field_delimiter)
+
+    def test_field_delimiter_setter(self):
+        field_delimiter = '|'
+        config = self._get_target_class()()
+        config.field_delimiter = field_delimiter
+        self.assertEqual(
+            config._properties['load']['fieldDelimiter'], field_delimiter)
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1286,6 +1286,59 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertNotIn(
             'destinationEncryptionConfiguration', config._properties['load'])
 
+    def test_destination_table_description_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.destination_table_description)
+
+    def test_destination_table_description_hit(self):
+        description = 'Description'
+        config = self._get_target_class()()
+        config._properties['load']['destinationTableProperties'] = {
+            'description': description,
+        }
+        self.assertEqual(
+            config.destination_table_description, description)
+
+    def test_destination_table_description_setter(self):
+        description = 'Description'
+        config = self._get_target_class()()
+        config.destination_table_description = description
+        expected = {
+            'description': description,
+        }
+        self.assertEqual(
+            config._properties['load']['destinationTableProperties'], expected)
+
+    def test_destination_table_description_setter_w_fn_already(self):
+        description = 'Description'
+        friendly_name = 'Friendly Name'
+        config = self._get_target_class()()
+        config._properties['load']['destinationTableProperties'] = {
+            'friendlyName': friendly_name,
+        }
+        config.destination_table_description = description
+        expected = {
+            'friendlyName': friendly_name,
+            'description': description,
+        }
+        self.assertEqual(
+            config._properties['load']['destinationTableProperties'], expected)
+
+    def test_destination_table_description_w_none(self):
+        description = 'Description'
+        friendly_name = 'Friendly Name'
+        config = self._get_target_class()()
+        config._properties['load']['destinationTableProperties'] = {
+            'description': description,
+            'friendlyName': friendly_name,
+        }
+        config.destination_table_description = None
+        expected = {
+            'friendlyName': friendly_name,
+        }
+        self.assertEqual(
+            config._properties['load']['destinationTableProperties'], expected)
+
     def test_encoding_missing(self):
         config = self._get_target_class()()
         self.assertIsNone(config.encoding)

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1339,6 +1339,59 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertEqual(
             config._properties['load']['destinationTableProperties'], expected)
 
+    def test_destination_table_friendly_name_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.destination_table_friendly_name)
+
+    def test_destination_table_friendly_name_hit(self):
+        friendly_name = 'Friendly Name'
+        config = self._get_target_class()()
+        config._properties['load']['destinationTableProperties'] = {
+            'friendlyName': friendly_name,
+        }
+        self.assertEqual(
+            config.destination_table_friendly_name, friendly_name)
+
+    def test_destination_table_friendly_name_setter(self):
+        friendly_name = 'Friendly Name'
+        config = self._get_target_class()()
+        config.destination_table_friendly_name = friendly_name
+        expected = {
+            'friendlyName': friendly_name,
+        }
+        self.assertEqual(
+            config._properties['load']['destinationTableProperties'], expected)
+
+    def test_destination_table_friendly_name_setter_w_descr_already(self):
+        friendly_name = 'Friendly Name'
+        description = 'Description'
+        config = self._get_target_class()()
+        config._properties['load']['destinationTableProperties'] = {
+            'description': description,
+        }
+        config.destination_table_friendly_name = friendly_name
+        expected = {
+            'friendlyName': friendly_name,
+            'description': description,
+        }
+        self.assertEqual(
+            config._properties['load']['destinationTableProperties'], expected)
+
+    def test_destination_table_friendly_name_w_none(self):
+        friendly_name = 'Friendly Name'
+        description = 'Description'
+        config = self._get_target_class()()
+        config._properties['load']['destinationTableProperties'] = {
+            'description': description,
+            'friendlyName': friendly_name,
+        }
+        config.destination_table_friendly_name = None
+        expected = {
+            'description': description,
+        }
+        self.assertEqual(
+            config._properties['load']['destinationTableProperties'], expected)
+
     def test_encoding_missing(self):
         config = self._get_target_class()()
         self.assertIsNone(config.encoding)

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1195,6 +1195,20 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         config.allow_quoted_newlines = True
         self.assertTrue(config._properties['load']['allowQuotedNewlines'])
 
+    def test_autodetect_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.autodetect)
+
+    def test_autodetect_hit(self):
+        config = self._get_target_class()()
+        config._properties['load']['autodetect'] = True
+        self.assertTrue(config.autodetect)
+
+    def test_autodetect_setter(self):
+        config = self._get_target_class()()
+        config.autodetect = True
+        self.assertTrue(config._properties['load']['autodetect'])
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1209,6 +1209,27 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         config.autodetect = True
         self.assertTrue(config._properties['load']['autodetect'])
 
+    def test_create_disposition_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.create_disposition)
+
+    def test_create_disposition_hit(self):
+        from google.cloud.bigquery.job import CreateDisposition
+
+        disposition = CreateDisposition.CREATE_IF_NEEDED
+        config = self._get_target_class()()
+        config._properties['load']['createDisposition'] = disposition
+        self.assertEqual(config.create_disposition, disposition)
+
+    def test_create_disposition_setter(self):
+        from google.cloud.bigquery.job import CreateDisposition
+
+        disposition = CreateDisposition.CREATE_IF_NEEDED
+        config = self._get_target_class()()
+        config.create_disposition = disposition
+        self.assertEqual(
+            config._properties['load']['createDisposition'], disposition)
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1230,6 +1230,27 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertEqual(
             config._properties['load']['createDisposition'], disposition)
 
+    def test_encoding_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.encoding)
+
+    def test_encoding_hit(self):
+        from google.cloud.bigquery.job import Encoding
+
+        encoding = Encoding.UTF_8
+        config = self._get_target_class()()
+        config._properties['load']['encoding'] = encoding
+        self.assertEqual(config.encoding, encoding)
+
+    def test_encoding_setter(self):
+        from google.cloud.bigquery.job import Encoding
+
+        encoding = Encoding.UTF_8
+        config = self._get_target_class()()
+        config.encoding = encoding
+        self.assertEqual(
+            config._properties['load']['encoding'], encoding)
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1299,6 +1299,23 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertEqual(
             config._properties['load']['maxBadRecords'], max_bad_records)
 
+    def test_null_marker_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.null_marker)
+
+    def test_null_marker_hit(self):
+        null_marker = 'XXX'
+        config = self._get_target_class()()
+        config._properties['load']['nullMarker'] = null_marker
+        self.assertEqual(config.null_marker, null_marker)
+
+    def test_null_marker_setter(self):
+        null_marker = 'XXX'
+        config = self._get_target_class()()
+        config.null_marker = null_marker
+        self.assertEqual(
+            config._properties['load']['nullMarker'], null_marker)
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1592,7 +1592,6 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         config.skip_leading_rows = skip_leading_rows
         self.assertEqual(
             config._properties['load']['skipLeadingRows'],
-            # XXX: Should this really be a str?
             str(skip_leading_rows))
 
     def test_source_format_missing(self):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1167,6 +1167,20 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         from google.cloud.bigquery.job import LoadJobConfig
         return LoadJobConfig
 
+    def test_allow_jagged_rows_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.allow_jagged_rows)
+
+    def test_allow_jagged_rows_hit(self):
+        config = self._get_target_class()()
+        config._properties['load']['allowJaggedRows'] = True
+        self.assertTrue(config.allow_jagged_rows)
+
+    def test_allow_jagged_rows_setter(self):
+        config = self._get_target_class()()
+        config.allow_jagged_rows = True
+        self.assertTrue(config._properties['load']['allowJaggedRows'])
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1572,7 +1572,34 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertIsNone(config.clustering_fields)
         self.assertNotIn('clustering', config._properties['load'])
 
-    def test_api_repr(self):
+    def test_schema_update_options_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.schema_update_options)
+
+    def test_schema_update_options_hit(self):
+        from google.cloud.bigquery.job import SchemaUpdateOption
+
+        options = [
+            SchemaUpdateOption.ALLOW_FIELD_ADDITION,
+            SchemaUpdateOption.ALLOW_FIELD_RELAXATION,
+        ]
+        config = self._get_target_class()()
+        config._properties['load']['schemaUpdateOptions'] = options
+        self.assertEqual(config.schema_update_options, options)
+
+    def test_schema_update_options_setter(self):
+        from google.cloud.bigquery.job import SchemaUpdateOption
+
+        options = [
+            SchemaUpdateOption.ALLOW_FIELD_ADDITION,
+            SchemaUpdateOption.ALLOW_FIELD_RELAXATION,
+        ]
+        config = self._get_target_class()()
+        config.schema_update_options = options
+        self.assertEqual(
+            config._properties['load']['schemaUpdateOptions'], options)
+
+    def test_from_api_repr(self):
         resource = self._make_resource()
         config = self._get_target_class().from_api_repr(resource)
         self.assertEqual(config.to_api_repr(), resource)

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1448,6 +1448,37 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
             config._properties['load']['schema'],
             {'fields': [full_name_repr, age_repr]})
 
+    def test_destination_encryption_configuration_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.destination_encryption_configuration)
+
+    def test_destination_encryption_configuration_hit(self):
+        from google.cloud.bigquery.table import EncryptionConfiguration
+
+        kms_key_name = 'kms-key-name'
+        encryption_configuration = EncryptionConfiguration(kms_key_name)
+        config = self._get_target_class()()
+        config._properties['load']['destinationEncryptionConfiguration'] = {
+            'kmsKeyName': kms_key_name,
+        }
+        self.assertEqual(
+            config.destination_encryption_configuration,
+            encryption_configuration)
+
+    def test_destination_encryption_configuration_setter(self):
+        from google.cloud.bigquery.table import EncryptionConfiguration
+
+        kms_key_name = 'kms-key-name'
+        encryption_configuration = EncryptionConfiguration(kms_key_name)
+        config = self._get_target_class()()
+        config.destination_encryption_configuration = encryption_configuration
+        expected = {
+            'kmsKeyName': kms_key_name,
+        }
+        self.assertEqual(
+            config._properties['load']['destinationEncryptionConfiguration'],
+            expected)
+
     def test_time_partitioning(self):
         from google.cloud.bigquery import table
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1543,6 +1543,35 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertIsNone(config.time_partitioning)
         self.assertNotIn('timePartitioning', config._properties['load'])
 
+    def test_clustering_fields_miss(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.clustering_fields)
+
+    def test_clustering_fields_hit(self):
+        config = self._get_target_class()()
+        fields = ['email', 'postal_code']
+        config._properties['load']['clustering'] = {
+            'fields': fields,
+        }
+        self.assertEqual(config.clustering_fields, fields)
+
+    def test_clustering_fields_setter(self):
+        fields = ['email', 'postal_code']
+        config = self._get_target_class()()
+        config.clustering_fields = fields
+        self.assertEqual(
+            config._properties['load']['clustering'], {'fields': fields})
+
+    def test_clustering_fields_setter_w_none(self):
+        config = self._get_target_class()()
+        fields = ['email', 'postal_code']
+        config._properties['load']['clustering'] = {
+            'fields': fields,
+        }
+        config.clustering_fields = None
+        self.assertIsNone(config.clustering_fields)
+        self.assertNotIn('clustering', config._properties['load'])
+
     def test_api_repr(self):
         resource = self._make_resource()
         config = self._get_target_class().from_api_repr(resource)

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1400,13 +1400,53 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertEqual(
             config._properties['load']['writeDisposition'], write_disposition)
 
-    def test_schema(self):
+    def test_schema_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.schema)
+
+    def test_schema_hit(self):
         from google.cloud.bigquery.schema import SchemaField
+
+        config = self._get_target_class()()
+        all_props_repr = {
+            'mode': 'REQUIRED',
+            'name': 'foo',
+            'type': 'INTEGER',
+            'description':  'Foo',
+        }
+        minimal_repr = {
+            'name': 'bar',
+            'type': 'STRING',
+        }
+        config._properties['load']['schema'] = {
+            'fields': [all_props_repr, minimal_repr],
+        }
+        all_props, minimal = config.schema
+        self.assertEqual(all_props, SchemaField.from_api_repr(all_props_repr))
+        self.assertEqual(minimal, SchemaField.from_api_repr(minimal_repr))
+
+    def test_schema_setter(self):
+        from google.cloud.bigquery.schema import SchemaField
+
         config = self._get_target_class()()
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         config.schema = [full_name, age]
-        self.assertEqual(config.schema, [full_name, age])
+        full_name_repr = {
+            'name': 'full_name',
+            'type': 'STRING',
+            'mode': 'REQUIRED',
+            'description': None,
+        }
+        age_repr = {
+            'name': 'age',
+            'type': 'INTEGER',
+            'mode': 'REQUIRED',
+            'description': None,
+        }
+        self.assertEqual(
+            config._properties['load']['schema'],
+            {'fields': [full_name_repr, age_repr]})
 
     def test_time_partitioning(self):
         from google.cloud.bigquery import table

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1282,6 +1282,23 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         config.ignore_unknown_values = True
         self.assertTrue(config._properties['load']['ignoreUnknownValues'])
 
+    def test_max_bad_records_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.max_bad_records)
+
+    def test_max_bad_records_hit(self):
+        max_bad_records = 13
+        config = self._get_target_class()()
+        config._properties['load']['maxBadRecords'] = max_bad_records
+        self.assertEqual(config.max_bad_records, max_bad_records)
+
+    def test_max_bad_records_setter(self):
+        max_bad_records = 13
+        config = self._get_target_class()()
+        config.max_bad_records = max_bad_records
+        self.assertEqual(
+            config._properties['load']['maxBadRecords'], max_bad_records)
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1541,7 +1541,7 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         }
         config.time_partitioning = None
         self.assertIsNone(config.time_partitioning)
-        self.assertIsNone(config._properties['load']['timePartitioning'])
+        self.assertNotIn('timePartitioning', config._properties['load'])
 
     def test_api_repr(self):
         resource = self._make_resource()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1333,6 +1333,31 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertEqual(
             config._properties['load']['quote'], quote_character)
 
+    def test_skip_leading_rows_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.skip_leading_rows)
+
+    def test_skip_leading_rows_hit_w_str(self):
+        skip_leading_rows = 1
+        config = self._get_target_class()()
+        config._properties['load']['skipLeadingRows'] = str(skip_leading_rows)
+        self.assertEqual(config.skip_leading_rows, skip_leading_rows)
+
+    def test_skip_leading_rows_hit_w_integer(self):
+        skip_leading_rows = 1
+        config = self._get_target_class()()
+        config._properties['load']['skipLeadingRows'] = skip_leading_rows
+        self.assertEqual(config.skip_leading_rows, skip_leading_rows)
+
+    def test_skip_leading_rows_setter(self):
+        skip_leading_rows = 1
+        config = self._get_target_class()()
+        config.skip_leading_rows = skip_leading_rows
+        self.assertEqual(
+            config._properties['load']['skipLeadingRows'],
+            # XXX: Should this really be a str?
+            str(skip_leading_rows))
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1181,6 +1181,20 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         config.allow_jagged_rows = True
         self.assertTrue(config._properties['load']['allowJaggedRows'])
 
+    def test_allow_quoted_newlines_missing(self):
+        config = self._get_target_class()()
+        self.assertIsNone(config.allow_quoted_newlines)
+
+    def test_allow_quoted_newlines_hit(self):
+        config = self._get_target_class()()
+        config._properties['load']['allowQuotedNewlines'] = True
+        self.assertTrue(config.allow_quoted_newlines)
+
+    def test_allow_quoted_newlines_setter(self):
+        config = self._get_target_class()()
+        config.allow_quoted_newlines = True
+        self.assertTrue(config._properties['load']['allowQuotedNewlines'])
+
     def test_schema(self):
         from google.cloud.bigquery.schema import SchemaField
         config = self._get_target_class()()

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -84,6 +84,59 @@ class TestEncryptionConfiguration(unittest.TestCase):
                 'kmsKeyName': self.KMS_KEY_NAME,
             })
 
+    def test___eq___wrong_type(self):
+        encryption_config = self._make_one()
+        other = object()
+        self.assertNotEqual(encryption_config, other)
+        self.assertEqual(encryption_config, mock.ANY)
+
+    def test___eq___kms_key_name_mismatch(self):
+        encryption_config = self._make_one()
+        other = self._make_one(self.KMS_KEY_NAME)
+        self.assertNotEqual(encryption_config, other)
+
+    def test___eq___hit(self):
+        encryption_config = self._make_one(self.KMS_KEY_NAME)
+        other = self._make_one(self.KMS_KEY_NAME)
+        self.assertEqual(encryption_config, other)
+
+    def test___ne___wrong_type(self):
+        encryption_config = self._make_one()
+        other = object()
+        self.assertNotEqual(encryption_config, other)
+        self.assertEqual(encryption_config, mock.ANY)
+
+    def test___ne___same_value(self):
+        encryption_config1 = self._make_one(self.KMS_KEY_NAME)
+        encryption_config2 = self._make_one(self.KMS_KEY_NAME)
+        # unittest ``assertEqual`` uses ``==`` not ``!=``.
+        comparison_val = (encryption_config1 != encryption_config2)
+        self.assertFalse(comparison_val)
+
+    def test___ne___different_values(self):
+        encryption_config1 = self._make_one()
+        encryption_config2 = self._make_one(self.KMS_KEY_NAME)
+        self.assertNotEqual(encryption_config1, encryption_config2)
+
+    def test___hash__set_equality(self):
+        encryption_config1 = self._make_one(self.KMS_KEY_NAME)
+        encryption_config2 = self._make_one(self.KMS_KEY_NAME)
+        set_one = {encryption_config1, encryption_config2}
+        set_two = {encryption_config1, encryption_config2}
+        self.assertEqual(set_one, set_two)
+
+    def test___hash__not_equals(self):
+        encryption_config1 = self._make_one()
+        encryption_config2 = self._make_one(self.KMS_KEY_NAME)
+        set_one = {encryption_config1}
+        set_two = {encryption_config2}
+        self.assertNotEqual(set_one, set_two)
+
+    def test___repr__(self):
+        encryption_config = self._make_one(self.KMS_KEY_NAME)
+        expected = "EncryptionConfiguration({})".format(self.KMS_KEY_NAME)
+        self.assertEqual(repr(encryption_config), expected)
+
 
 class TestTableReference(unittest.TestCase):
 


### PR DESCRIPTION
Closes #5093.

This PR includes a bunch of new explicit unit test cases / assertions for `LoadJobConfig`, and reorders the properties alphabetically, to make it easier to match up with the docs.

/cc @yiga2.