### PR TITLE
Logging: add support for additional 'LogEntry' fields

### DIFF
--- a/logging/docs/entries.rst
+++ b/logging/docs/entries.rst
@@ -3,5 +3,5 @@ Entries
 
 .. automodule:: google.cloud.logging.entries
   :members:
-  :inherited-members:
+  :show-inheritance:
   :member-order: groupwise

--- a/logging/docs/entries.rst
+++ b/logging/docs/entries.rst
@@ -3,4 +3,5 @@ Entries
 
 .. automodule:: google.cloud.logging.entries
   :members:
-  :show-inheritance:
+  :inherited-members:
+  :member-order: groupwise

--- a/logging/google/cloud/logging/_helpers.py
+++ b/logging/google/cloud/logging/_helpers.py
@@ -16,7 +16,7 @@
 
 import requests
 
-from google.cloud.logging.entries import EmptyEntry
+from google.cloud.logging.entries import LogEntry
 from google.cloud.logging.entries import ProtobufEntry
 from google.cloud.logging.entries import StructEntry
 from google.cloud.logging.entries import TextEntry
@@ -54,7 +54,7 @@ def entry_from_resource(resource, client, loggers):
     if 'protoPayload' in resource:
         return ProtobufEntry.from_api_repr(resource, client, loggers)
 
-    return EmptyEntry.from_api_repr(resource, client, loggers)
+    return LogEntry.from_api_repr(resource, client, loggers)
 
 
 def retrieve_metadata_server(metadata_key):

--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -18,6 +18,7 @@ import collections
 import json
 import re
 
+from google.protobuf.any_pb2 import Any
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.json_format import Parse
 
@@ -341,7 +342,13 @@ class ProtobufEntry(_ProtobufEntryTuple, _ApiReprMixin):
 
     @property
     def payload_pb(self):
-        return self.payload
+        if isinstance(self.payload, Any):
+            return self.payload
+
+    @property
+    def payload_json(self):
+        if not isinstance(self.payload, Any):
+            return self.payload
 
     def parse_message(self, message):
         """Parse payload into a protobuf message.

--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -117,7 +117,7 @@ class _ApiReprMixin(object):
             monitored_resource = Resource._from_dict(monitored_resource_dict)
 
         inst = cls(
-            type_=cls._TYPE_NAME,
+            entry_type=cls._TYPE_NAME,
             log_name=logger_fullname,
             payload=payload,
             logger=logger,
@@ -141,11 +141,11 @@ class _ApiReprMixin(object):
     def to_api_repr(self):
         """API repr (JSON format) for entry.
         """
-        if self.type_ == 'text':
+        if self.entry_type == 'text':
             info = {'textPayload': self.payload}
-        elif self.type_ == 'struct':
+        elif self.entry_type == 'struct':
             info = {'jsonPayload': self.payload}
-        elif self.type_ == 'proto':
+        elif self.entry_type == 'proto':
             # NOTE: If ``self`` contains an ``Any`` field with an
             #       unknown type, this will fail with a ``TypeError``.
             #       However, since ``self`` was provided by a user in
@@ -185,7 +185,7 @@ class _ApiReprMixin(object):
 
 
 _LOG_ENTRY_FIELDS = (  # (name, default)
-    ('type_', None),
+    ('entry_type', None),
     ('log_name', None),
     ('payload', None),
     ('logger', None),
@@ -211,61 +211,61 @@ _LogEntryTuple.__new__.__defaults__ = tuple(
 
 
 _LOG_ENTRY_PARAM_DOCSTRING = """\
-:type logger: :class:`google.cloud.logging.logger.Logger`
-:param logger: the logger used to write the entry.
+    :type logger: :class:`google.cloud.logging.logger.Logger`
+    :param logger: the logger used to write the entry.
 
-:type log_name: str
-:param log_name: the name of the logger used to post the entry.
+    :type log_name: str
+    :param log_name: the name of the logger used to post the entry.
 
-:type labels: dict
-:param labels: (optional) mapping of labels for the entry
+    :type labels: dict
+    :param labels: (optional) mapping of labels for the entry
 
-:type insert_id: text
-:param insert_id: (optional) the ID used to identify an entry uniquely.
+    :type insert_id: text
+    :param insert_id: (optional) the ID used to identify an entry uniquely.
 
-:type severity: str
-:param severity: (optional) severity of event being logged.
+    :type severity: str
+    :param severity: (optional) severity of event being logged.
 
-:type http_request: dict
-:param http_request: (optional) info about HTTP request associated with
-                        the entry.
+    :type http_request: dict
+    :param http_request: (optional) info about HTTP request associated with
+                            the entry.
 
-:type timestamp: :class:`datetime.datetime`
-:param timestamp: (optional) timestamp for the entry
+    :type timestamp: :class:`datetime.datetime`
+    :param timestamp: (optional) timestamp for the entry
 
-:type resource: :class:`~google.cloud.logging.resource.Resource`
-:param resource: (Optional) Monitored resource of the entry
+    :type resource: :class:`~google.cloud.logging.resource.Resource`
+    :param resource: (Optional) Monitored resource of the entry
 
-:type trace: str
-:param trace: (optional) traceid to apply to the entry.
+    :type trace: str
+    :param trace: (optional) traceid to apply to the entry.
 
-:type span_id: str
-:param span_id: (optional) span_id within the trace for the log entry.
-                Specify the trace parameter if span_id is set.
+    :type span_id: str
+    :param span_id: (optional) span_id within the trace for the log entry.
+                    Specify the trace parameter if span_id is set.
 
-:type trace_sampled: bool
-:param trace_sampled: (optional) the sampling decision of the trace
-                        associated with the log entry.
+    :type trace_sampled: bool
+    :param trace_sampled: (optional) the sampling decision of the trace
+                          associated with the log entry.
 
-:type source_location: dict
-:param source_location: (optional) location in source code from which
-                        the entry was emitted.
+    :type source_location: dict
+    :param source_location: (optional) location in source code from which
+                            the entry was emitted.
 
-:type operation: dict
-:param operation: (optional) additional information about a potentially
-                  long-running operation with which a log entry is associated.
+    :type operation: dict
+    :param operation: (optional) additional information about a potentially
+                      long-running operation associated with the log entry.
 """
 
 
 class LogEntry(_LogEntryTuple, _ApiReprMixin):
     """Log entry.
 
-    :type type_: str
-    :param type_: one of 'empty', 'text', 'struct', or 'proto'. Indicates
-                    how the payload field is handled.
+    :type entry_type: str
+    :param entry_type: one of 'empty', 'text', 'struct', or 'proto'. Indicates
+                       how the payload field is handled.
 
     :type payload: None, str | unicode, dict, protobuf message
-    :param payload: payload for the message, based on 'type_'
+    :param payload: payload for the message, based on :attr:`entry_type`
     """ + _LOG_ENTRY_PARAM_DOCSTRING
 
 

--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -84,6 +84,8 @@ class _BaseEntry(object):
     :param span_id: (optional) span_id within the trace for the log entry.
                     Specify the trace parameter if span_id is set.
     """
+    received_timestamp = None
+
     def __init__(
         self,
         payload,
@@ -169,8 +171,6 @@ class _BaseEntry(object):
         received = resource.get('receiveTimestamp')
         if received is not None:
             inst.received_timestamp = _rfc3339_nanos_to_datetime(received)
-        else:
-            inst.received_timestamp = None
         return inst
 
 

--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -84,10 +84,19 @@ class _BaseEntry(object):
     :param span_id: (optional) span_id within the trace for the log entry.
                     Specify the trace parameter if span_id is set.
     """
-
-    def __init__(self, payload, logger, insert_id=None, timestamp=None,
-                 labels=None, severity=None, http_request=None, resource=None,
-                 trace=None, span_id=None):
+    def __init__(
+        self,
+        payload,
+        logger,
+        insert_id=None,
+        timestamp=None,
+        labels=None,
+        severity=None,
+        http_request=None,
+        resource=None,
+        trace=None,
+        span_id=None,
+    ):
         self.payload = payload
         self.logger = logger
         self.insert_id = insert_id
@@ -145,9 +154,24 @@ class _BaseEntry(object):
         if monitored_resource_dict is not None:
             monitored_resource = Resource._from_dict(monitored_resource_dict)
 
-        return cls(payload, logger, insert_id=insert_id, timestamp=timestamp,
-                   labels=labels, severity=severity, http_request=http_request,
-                   resource=monitored_resource, trace=trace, span_id=span_id)
+        inst = cls(
+            payload,
+            logger,
+            insert_id=insert_id,
+            timestamp=timestamp,
+            labels=labels,
+            severity=severity,
+            http_request=http_request,
+            resource=monitored_resource,
+            trace=trace,
+            span_id=span_id,
+        )
+        received = resource.get('receiveTimestamp')
+        if received is not None:
+            inst.received_timestamp = _rfc3339_nanos_to_datetime(received)
+        else:
+            inst.received_timestamp = None
+        return inst
 
 
 class EmptyEntry(_BaseEntry):

--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -83,6 +83,10 @@ class _BaseEntry(object):
     :type span_id: str
     :param span_id: (optional) span_id within the trace for the log entry.
                     Specify the trace parameter if span_id is set.
+
+    :type trace_sampled: bool
+    :param trace_sampled: (optional) the sampling decision of the trace
+                          associated with the log entry.
     """
     received_timestamp = None
 
@@ -98,6 +102,7 @@ class _BaseEntry(object):
         resource=None,
         trace=None,
         span_id=None,
+        trace_sampled=None,
     ):
         self.payload = payload
         self.logger = logger
@@ -109,6 +114,7 @@ class _BaseEntry(object):
         self.resource = resource
         self.trace = trace
         self.span_id = span_id
+        self.trace_sampled = trace_sampled
 
     @classmethod
     def from_api_repr(cls, resource, client, loggers=None):
@@ -150,6 +156,7 @@ class _BaseEntry(object):
         http_request = resource.get('httpRequest')
         trace = resource.get('trace')
         span_id = resource.get('spanId')
+        trace_sampled = resource.get('traceSampled')
 
         monitored_resource_dict = resource.get('resource')
         monitored_resource = None
@@ -167,6 +174,7 @@ class _BaseEntry(object):
             resource=monitored_resource,
             trace=trace,
             span_id=span_id,
+            trace_sampled=trace_sampled,
         )
         received = resource.get('receiveTimestamp')
         if received is not None:
@@ -241,16 +249,29 @@ class ProtobufEntry(_BaseEntry):
     :type span_id: str
     :param span_id: (optional) span_id within the trace for the log entry.
                     Specify the trace parameter if span_id is set.
+
+    :type trace_sampled: bool
+    :param trace_sampled: (optional) the sampling decision of the trace
+                          associated with the log entry.
     """
     _PAYLOAD_KEY = 'protoPayload'
 
     def __init__(self, payload, logger, insert_id=None, timestamp=None,
                  labels=None, severity=None, http_request=None, resource=None,
-                 trace=None, span_id=None):
+                 trace=None, span_id=None, trace_sampled=None):
         super(ProtobufEntry, self).__init__(
-            payload, logger, insert_id=insert_id, timestamp=timestamp,
-            labels=labels, severity=severity, http_request=http_request,
-            resource=resource, trace=trace, span_id=span_id)
+            payload,
+            logger,
+            insert_id=insert_id,
+            timestamp=timestamp,
+            labels=labels,
+            severity=severity,
+            http_request=http_request,
+            resource=resource,
+            trace=trace,
+            span_id=span_id,
+            trace_sampled=trace_sampled,
+        )
         if isinstance(self.payload, any_pb2.Any):
             self.payload_pb = self.payload
             self.payload = None

--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -81,8 +81,8 @@ class _ApiReprMixin(object):
             (Optional) A mapping of logger fullnames -> loggers.  If not
             passed, the entry will have a newly-created logger.
 
-        :rtype: :class:`google.cloud.logging.entries._BaseEntry`
-        :returns: Text entry parsed from ``resource``.
+        :rtype: :class:`google.cloud.logging.entries.LogEntry`
+        :returns: Log entry parsed from ``resource``.
         """
         if loggers is None:
             loggers = {}
@@ -204,13 +204,14 @@ _LOG_ENTRY_FIELDS = (  # (name, default)
 
 
 _LogEntryTuple = collections.namedtuple(
-        '_LogEntryTuple', (field for field, _ in _LOG_ENTRY_FIELDS))
+        'LogEntry', (field for field, _ in _LOG_ENTRY_FIELDS))
 
 _LogEntryTuple.__new__.__defaults__ = tuple(
     default for _, default in _LOG_ENTRY_FIELDS[1:])
 
 
 _LOG_ENTRY_PARAM_DOCSTRING = """\
+
     :type logger: :class:`google.cloud.logging.logger.Logger`
     :param logger: the logger used to write the entry.
 
@@ -254,11 +255,15 @@ _LOG_ENTRY_PARAM_DOCSTRING = """\
     :type operation: dict
     :param operation: (optional) additional information about a potentially
                       long-running operation associated with the log entry.
+
+    See:
+    https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
 """
 
 
 class LogEntry(_LogEntryTuple, _ApiReprMixin):
-    """Log entry.
+    __doc__ = """
+    Log entry.
 
     :type entry_type: str
     :param entry_type: one of 'empty', 'text', 'struct', or 'proto'. Indicates
@@ -270,13 +275,14 @@ class LogEntry(_LogEntryTuple, _ApiReprMixin):
 
 
 _EmptyEntryTuple = collections.namedtuple(
-        '_EmptyEntryTuple', (field for field, _ in _LOG_ENTRY_FIELDS))
+        'EmptyEntry', (field for field, _ in _LOG_ENTRY_FIELDS))
 _EmptyEntryTuple.__new__.__defaults__ = (
     ('empty',) + tuple(default for _, default in _LOG_ENTRY_FIELDS[1:]))
 
 
 class EmptyEntry(_EmptyEntryTuple, _ApiReprMixin):
-    """Log entry without payload.
+    __doc__ = """
+    Log entry without payload.
 
     """ + _LOG_ENTRY_PARAM_DOCSTRING
     _PAYLOAD_KEY = None
@@ -284,13 +290,14 @@ class EmptyEntry(_EmptyEntryTuple, _ApiReprMixin):
 
 
 _TextEntryTuple = collections.namedtuple(
-        '_TextEntryTuple', (field for field, _ in _LOG_ENTRY_FIELDS))
+        'TextEntry', (field for field, _ in _LOG_ENTRY_FIELDS))
 _TextEntryTuple.__new__.__defaults__ = (
     ('text',) + tuple(default for _, default in _LOG_ENTRY_FIELDS[1:]))
 
 
 class TextEntry(_TextEntryTuple, _ApiReprMixin):
-    """Log entry with text payload.
+    __doc__ = """
+    Log entry with text payload.
 
     :type payload: str | unicode
     :param payload: payload for the log entry.
@@ -300,13 +307,14 @@ class TextEntry(_TextEntryTuple, _ApiReprMixin):
 
 
 _StructEntryTuple = collections.namedtuple(
-        '_StructEntryTuple', (field for field, _ in _LOG_ENTRY_FIELDS))
+        'StructEntry', (field for field, _ in _LOG_ENTRY_FIELDS))
 _StructEntryTuple.__new__.__defaults__ = (
     ('struct',) + tuple(default for _, default in _LOG_ENTRY_FIELDS[1:]))
 
 
 class StructEntry(_StructEntryTuple, _ApiReprMixin):
-    """Log entry with JSON payload.
+    __doc__ = """
+    Log entry with JSON payload.
 
     :type payload: dict
     :param payload: payload for the log entry.
@@ -316,13 +324,14 @@ class StructEntry(_StructEntryTuple, _ApiReprMixin):
 
 
 _ProtobufEntryTuple = collections.namedtuple(
-        '_ProtobufEntryTuple', (field for field, _ in _LOG_ENTRY_FIELDS))
+        'ProtobufEntry', (field for field, _ in _LOG_ENTRY_FIELDS))
 _ProtobufEntryTuple.__new__.__defaults__ = (
     ('proto',) + tuple(default for _, default in _LOG_ENTRY_FIELDS[1:]))
 
 
 class ProtobufEntry(_ProtobufEntryTuple, _ApiReprMixin):
-    """Log entry with protobuf message payload.
+    __doc__ = """
+    Log entry with protobuf message payload.
 
     :type payload: protobuf message
     :param payload: payload for the log entry.

--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -109,6 +109,7 @@ class _ApiReprMixin(object):
         if source_location is not None:
             line = source_location.pop('line', None)
             source_location['line'] = _int_or_none(line)
+        operation = resource.get('operation')
 
         monitored_resource_dict = resource.get('resource')
         monitored_resource = None
@@ -130,6 +131,7 @@ class _ApiReprMixin(object):
             span_id=span_id,
             trace_sampled=trace_sampled,
             source_location=source_location,
+            operation=operation
         )
         received = resource.get('receiveTimestamp')
         if received is not None:
@@ -177,6 +179,8 @@ class _ApiReprMixin(object):
             source_location = self.source_location.copy()
             source_location['line'] = str(source_location.pop('line', 0))
             info['sourceLocation'] = source_location
+        if self.operation is not None:
+            info['operation'] = self.operation
         return info
 
 
@@ -195,6 +199,7 @@ _LOG_ENTRY_FIELDS = (  # (name, default)
     ('span_id', None),
     ('trace_sampled', None),
     ('source_location', None),
+    ('operation', None),
 )
 
 
@@ -245,6 +250,10 @@ _LOG_ENTRY_PARAM_DOCSTRING = """\
 :type source_location: dict
 :param source_location: (optional) location in source code from which
                         the entry was emitted.
+
+:type operation: dict
+:param operation: (optional) additional information about a potentially
+                  long-running operation with which a log entry is associated.
 """
 
 

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -14,7 +14,7 @@
 
 """Define API Loggers."""
 
-from google.cloud.logging.entries import EmptyEntry
+from google.cloud.logging.entries import LogEntry
 from google.cloud.logging.entries import ProtobufEntry
 from google.cloud.logging.entries import StructEntry
 from google.cloud.logging.entries import TextEntry
@@ -145,7 +145,7 @@ class Logger(object):
         :param kw: (optional) additional keyword arguments for the entry.
                    See :class:`~google.cloud.logging.entries.LogEntry`.
         """
-        self._do_log(client, EmptyEntry, **kw)
+        self._do_log(client, LogEntry, **kw)
 
     def log_text(self, text, client=None, **kw):
         """API call:  log a text message via a POST request
@@ -304,7 +304,7 @@ class Batch(object):
         :param kw: (optional) additional keyword arguments for the entry.
                    See :class:`~google.cloud.logging.entries.LogEntry`.
         """
-        self.entries.append(EmptyEntry(**kw))
+        self.entries.append(LogEntry(**kw))
 
     def log_text(self, text, **kw):
         """Add a text entry to be logged during :meth:`commit`.

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -41,6 +41,49 @@ _OUTBOUND_ENTRY_FIELDS = (  # (name, default)
 
 class OutboundEntry(collections.namedtuple(
         'OutboundEntry', (field for field, _ in _OUTBOUND_ENTRY_FIELDS))):
+    """Outbound log entry.
+
+    :type type_: str
+    :param type_: one of 'empty', 'text', 'struct', or 'proto'. Indicates
+                  how the payload field is handled.
+
+    :type payload: None, str | unicode, dict, protobuf message
+    :param payload: payload for the message, based on 'type_'
+
+    :type labels: dict
+    :param labels: (optional) mapping of labels for the entry
+
+    :type insert_id: text
+    :param insert_id: (optional) the ID used to identify an entry uniquely.
+
+    :type severity: str
+    :param severity: (optional) severity of event being logged.
+
+    :type http_request: dict
+    :param http_request: (optional) info about HTTP request associated with
+                         the entry.
+
+    :type timestamp: :class:`datetime.datetime`
+    :param timestamp: (optional) timestamp for the entry
+
+    :type resource: :class:`~google.cloud.logging.resource.Resource`
+    :param resource: (Optional) Monitored resource of the entry
+
+    :type trace: str
+    :param trace: (optional) traceid to apply to the entry.
+
+    :type span_id: str
+    :param span_id: (optional) span_id within the trace for the log entry.
+                    Specify the trace parameter if span_id is set.
+
+    :type trace_sampled: bool
+    :param trace_sampled: (optional) the sampling decision of the trace
+                          associated with the log entry.
+
+    :type source_location: dict
+    :param source_location: (optional) location in source code from which
+                            the entry was emitted.
+    """
     def to_api_repr(self):
         """API repr (JSON format) for entry.
         """

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -35,6 +35,7 @@ _OUTBOUND_ENTRY_FIELDS = (  # (name, default)
     ('trace', None),
     ('span_id', None),
     ('trace_sampled', None),
+    ('source_location', None),
 )
 
 
@@ -75,6 +76,10 @@ class OutboundEntry(collections.namedtuple(
             info['spanId'] = self.span_id
         if self.trace_sampled is not None:
             info['traceSampled'] = self.trace_sampled
+        if self.source_location is not None:
+            source_location = self.source_location.copy()
+            source_location['line'] = str(source_location.pop('line', 0))
+            info['sourceLocation'] = source_location
         return info
 
 

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -106,6 +106,7 @@ class Logger(object):
         resource=_GLOBAL_RESOURCE,
         trace=None,
         span_id=None,
+        trace_sampled=None,
     ):
         """Return a log entry resource of the appropriate type.
 
@@ -147,6 +148,10 @@ class Logger(object):
         :type span_id: str
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
+
+        :type trace_sampled: bool
+        :param trace_sampled: (optional) the sampling decision of the trace
+                              associated with the log entry.
 
         :rtype: dict
         :returns: The JSON resource created.
@@ -195,6 +200,9 @@ class Logger(object):
         if span_id is not None:
             entry['spanId'] = span_id
 
+        if trace_sampled is not None:
+            entry['traceSampled'] = trace_sampled
+
         return entry
 
     def log_empty(
@@ -208,6 +216,7 @@ class Logger(object):
         resource=_GLOBAL_RESOURCE,
         trace=None,
         span_id=None,
+        trace_sampled=None,
     ):
         """API call:  log an empty message via a POST request
 
@@ -245,6 +254,10 @@ class Logger(object):
         :type span_id: str
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
+
+        :type trace_sampled: bool
+        :param trace_sampled: (optional) the sampling decision of the trace
+                              associated with the log entry.
         """
         client = self._require_client(client)
         entry_resource = self._make_entry_resource(
@@ -256,6 +269,7 @@ class Logger(object):
             resource=resource,
             trace=trace,
             span_id=span_id,
+            trace_sampled=trace_sampled,
         )
         client.logging_api.write_entries([entry_resource])
 
@@ -271,6 +285,7 @@ class Logger(object):
         resource=_GLOBAL_RESOURCE,
         trace=None,
         span_id=None,
+        trace_sampled=None,
     ):
         """API call:  log a text message via a POST request
 
@@ -311,6 +326,10 @@ class Logger(object):
         :type span_id: str
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
+
+        :type trace_sampled: bool
+        :param trace_sampled: (optional) the sampling decision of the trace
+                              associated with the log entry.
         """
         client = self._require_client(client)
         entry_resource = self._make_entry_resource(
@@ -323,6 +342,7 @@ class Logger(object):
             resource=resource,
             trace=trace,
             span_id=span_id,
+            trace_sampled=trace_sampled,
         )
         client.logging_api.write_entries([entry_resource])
 
@@ -338,6 +358,7 @@ class Logger(object):
         resource=_GLOBAL_RESOURCE,
         trace=None,
         span_id=None,
+        trace_sampled=None,
     ):
         """API call:  log a structured message via a POST request
 
@@ -378,6 +399,10 @@ class Logger(object):
         :type span_id: str
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
+
+        :type trace_sampled: bool
+        :param trace_sampled: (optional) the sampling decision of the trace
+                              associated with the log entry.
         """
         client = self._require_client(client)
         entry_resource = self._make_entry_resource(
@@ -390,6 +415,7 @@ class Logger(object):
             resource=resource,
             trace=trace,
             span_id=span_id,
+            trace_sampled=trace_sampled,
         )
         client.logging_api.write_entries([entry_resource])
 
@@ -405,6 +431,7 @@ class Logger(object):
         resource=_GLOBAL_RESOURCE,
         trace=None,
         span_id=None,
+        trace_sampled=None,
     ):
         """API call:  log a protobuf message via a POST request
 
@@ -445,6 +472,10 @@ class Logger(object):
         :type span_id: str
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
+
+        :type trace_sampled: bool
+        :param trace_sampled: (optional) the sampling decision of the trace
+                              associated with the log entry.
         """
         client = self._require_client(client)
         entry_resource = self._make_entry_resource(
@@ -457,6 +488,7 @@ class Logger(object):
             resource=resource,
             trace=trace,
             span_id=span_id,
+            trace_sampled=trace_sampled,
         )
         client.logging_api.write_entries([entry_resource])
 
@@ -561,6 +593,7 @@ class Batch(object):
         resource=_GLOBAL_RESOURCE,
         trace=None,
         span_id=None,
+        trace_sampled=None,
     ):
         """Add a text entry to be logged during :meth:`commit`.
 
@@ -596,6 +629,10 @@ class Batch(object):
         :type span_id: str
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
+
+        :type trace_sampled: bool
+        :param trace_sampled: (optional) the sampling decision of the trace
+                              associated with the log entry.
         """
         self.entries.append((
             'text',
@@ -608,6 +645,7 @@ class Batch(object):
             resource,
             trace,
             span_id,
+            trace_sampled,
         ))
 
     def log_struct(
@@ -621,6 +659,7 @@ class Batch(object):
         resource=_GLOBAL_RESOURCE,
         trace=None,
         span_id=None,
+        trace_sampled=None,
     ):
         """Add a struct entry to be logged during :meth:`commit`.
 
@@ -656,6 +695,10 @@ class Batch(object):
         :type span_id: str
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
+
+        :type trace_sampled: bool
+        :param trace_sampled: (optional) the sampling decision of the trace
+                              associated with the log entry.
         """
         self.entries.append((
             'struct',
@@ -668,6 +711,7 @@ class Batch(object):
             resource,
             trace,
             span_id,
+            trace_sampled,
         ))
 
     def log_proto(
@@ -681,6 +725,7 @@ class Batch(object):
         resource=_GLOBAL_RESOURCE,
         trace=None,
         span_id=None,
+        trace_sampled=None,
     ):
         """Add a protobuf entry to be logged during :meth:`commit`.
 
@@ -716,6 +761,10 @@ class Batch(object):
         :type span_id: str
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
+
+        :type trace_sampled: bool
+        :param trace_sampled: (optional) the sampling decision of the trace
+                              associated with the log entry.
         """
         self.entries.append((
             'proto',
@@ -728,6 +777,7 @@ class Batch(object):
             resource,
             trace,
             span_id,
+            trace_sampled,
         ))
 
     def commit(self, client=None):
@@ -751,8 +801,19 @@ class Batch(object):
             kwargs['labels'] = self.logger.labels
 
         entries = []
-        for (entry_type, entry, labels, iid, severity, http_req,
-             timestamp, resource, trace, span_id) in self.entries:
+        for (
+            entry_type,
+            entry,
+            labels,
+            iid,
+            severity,
+            http_req,
+            timestamp,
+            resource,
+            trace,
+            span_id,
+            trace_sampled,
+        ) in self.entries:
             if entry_type == 'text':
                 info = {'textPayload': entry}
             elif entry_type == 'struct':
@@ -783,6 +844,8 @@ class Batch(object):
                 info['trace'] = trace
             if span_id is not None:
                 info['spanId'] = span_id
+            if trace_sampled is not None:
+                info['traceSampled'] = trace_sampled
             entries.append(info)
 
         client.logging_api.write_entries(entries, **kwargs)

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -93,11 +93,20 @@ class Logger(object):
         client = self._require_client(client)
         return Batch(self, client)
 
-    def _make_entry_resource(self, text=None, info=None, message=None,
-                             labels=None, insert_id=None, severity=None,
-                             http_request=None, timestamp=None,
-                             resource=_GLOBAL_RESOURCE, trace=None,
-                             span_id=None):
+    def _make_entry_resource(
+        self,
+        text=None,
+        info=None,
+        message=None,
+        labels=None,
+        insert_id=None,
+        severity=None,
+        http_request=None,
+        timestamp=None,
+        resource=_GLOBAL_RESOURCE,
+        trace=None,
+        span_id=None,
+    ):
         """Return a log entry resource of the appropriate type.
 
         Helper for :meth:`log_text`, :meth:`log_struct`, and :meth:`log_proto`.
@@ -188,9 +197,18 @@ class Logger(object):
 
         return entry
 
-    def log_empty(self, client=None, labels=None, insert_id=None,
-                  severity=None, http_request=None, timestamp=None,
-                  resource=_GLOBAL_RESOURCE, trace=None, span_id=None):
+    def log_empty(
+        self,
+        client=None,
+        labels=None,
+        insert_id=None,
+        severity=None,
+        http_request=None,
+        timestamp=None,
+        resource=_GLOBAL_RESOURCE,
+        trace=None,
+        span_id=None,
+    ):
         """API call:  log an empty message via a POST request
 
         See
@@ -230,14 +248,30 @@ class Logger(object):
         """
         client = self._require_client(client)
         entry_resource = self._make_entry_resource(
-            labels=labels, insert_id=insert_id, severity=severity,
-            http_request=http_request, timestamp=timestamp, resource=resource,
-            trace=trace, span_id=span_id)
+            labels=labels,
+            insert_id=insert_id,
+            severity=severity,
+            http_request=http_request,
+            timestamp=timestamp,
+            resource=resource,
+            trace=trace,
+            span_id=span_id,
+        )
         client.logging_api.write_entries([entry_resource])
 
-    def log_text(self, text, client=None, labels=None, insert_id=None,
-                 severity=None, http_request=None, timestamp=None,
-                 resource=_GLOBAL_RESOURCE, trace=None, span_id=None):
+    def log_text(
+        self,
+        text,
+        client=None,
+        labels=None,
+        insert_id=None,
+        severity=None,
+        http_request=None,
+        timestamp=None,
+        resource=_GLOBAL_RESOURCE,
+        trace=None,
+        span_id=None,
+    ):
         """API call:  log a text message via a POST request
 
         See
@@ -280,14 +314,31 @@ class Logger(object):
         """
         client = self._require_client(client)
         entry_resource = self._make_entry_resource(
-            text=text, labels=labels, insert_id=insert_id, severity=severity,
-            http_request=http_request, timestamp=timestamp, resource=resource,
-            trace=trace, span_id=span_id)
+            text=text,
+            labels=labels,
+            insert_id=insert_id,
+            severity=severity,
+            http_request=http_request,
+            timestamp=timestamp,
+            resource=resource,
+            trace=trace,
+            span_id=span_id,
+        )
         client.logging_api.write_entries([entry_resource])
 
-    def log_struct(self, info, client=None, labels=None, insert_id=None,
-                   severity=None, http_request=None, timestamp=None,
-                   resource=_GLOBAL_RESOURCE, trace=None, span_id=None):
+    def log_struct(
+        self,
+        info,
+        client=None,
+        labels=None,
+        insert_id=None,
+        severity=None,
+        http_request=None,
+        timestamp=None,
+        resource=_GLOBAL_RESOURCE,
+        trace=None,
+        span_id=None,
+    ):
         """API call:  log a structured message via a POST request
 
         See
@@ -330,14 +381,31 @@ class Logger(object):
         """
         client = self._require_client(client)
         entry_resource = self._make_entry_resource(
-            info=info, labels=labels, insert_id=insert_id, severity=severity,
-            http_request=http_request, timestamp=timestamp, resource=resource,
-            trace=trace, span_id=span_id)
+            info=info,
+            labels=labels,
+            insert_id=insert_id,
+            severity=severity,
+            http_request=http_request,
+            timestamp=timestamp,
+            resource=resource,
+            trace=trace,
+            span_id=span_id,
+        )
         client.logging_api.write_entries([entry_resource])
 
-    def log_proto(self, message, client=None, labels=None, insert_id=None,
-                  severity=None, http_request=None, timestamp=None,
-                  resource=_GLOBAL_RESOURCE, trace=None, span_id=None):
+    def log_proto(
+        self,
+        message,
+        client=None,
+        labels=None,
+        insert_id=None,
+        severity=None,
+        http_request=None,
+        timestamp=None,
+        resource=_GLOBAL_RESOURCE,
+        trace=None,
+        span_id=None,
+    ):
         """API call:  log a protobuf message via a POST request
 
         See
@@ -380,9 +448,16 @@ class Logger(object):
         """
         client = self._require_client(client)
         entry_resource = self._make_entry_resource(
-            message=message, labels=labels, insert_id=insert_id,
-            severity=severity, http_request=http_request, timestamp=timestamp,
-            resource=resource, trace=trace, span_id=span_id)
+            message=message,
+            labels=labels,
+            insert_id=insert_id,
+            severity=severity,
+            http_request=http_request,
+            timestamp=timestamp,
+            resource=resource,
+            trace=trace,
+            span_id=span_id,
+        )
         client.logging_api.write_entries([entry_resource])
 
     def delete(self, client=None):
@@ -475,9 +550,18 @@ class Batch(object):
         if exc_type is None:
             self.commit()
 
-    def log_text(self, text, labels=None, insert_id=None, severity=None,
-                 http_request=None, timestamp=None, resource=_GLOBAL_RESOURCE,
-                 trace=None, span_id=None):
+    def log_text(
+        self,
+        text,
+        labels=None,
+        insert_id=None,
+        severity=None,
+        http_request=None,
+        timestamp=None,
+        resource=_GLOBAL_RESOURCE,
+        trace=None,
+        span_id=None,
+    ):
         """Add a text entry to be logged during :meth:`commit`.
 
         :type text: str
@@ -513,13 +597,31 @@ class Batch(object):
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
         """
-        self.entries.append(
-            ('text', text, labels, insert_id, severity, http_request,
-             timestamp, resource, trace, span_id))
+        self.entries.append((
+            'text',
+            text,
+            labels,
+            insert_id,
+            severity,
+            http_request,
+            timestamp,
+            resource,
+            trace,
+            span_id,
+        ))
 
-    def log_struct(self, info, labels=None, insert_id=None, severity=None,
-                   http_request=None, timestamp=None,
-                   resource=_GLOBAL_RESOURCE, trace=None, span_id=None):
+    def log_struct(
+        self,
+        info,
+        labels=None,
+        insert_id=None,
+        severity=None,
+        http_request=None,
+        timestamp=None,
+        resource=_GLOBAL_RESOURCE,
+        trace=None,
+        span_id=None,
+    ):
         """Add a struct entry to be logged during :meth:`commit`.
 
         :type info: dict
@@ -555,13 +657,31 @@ class Batch(object):
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
         """
-        self.entries.append(
-            ('struct', info, labels, insert_id, severity, http_request,
-             timestamp, resource, trace, span_id))
+        self.entries.append((
+            'struct',
+            info,
+            labels,
+            insert_id,
+            severity,
+            http_request,
+            timestamp,
+            resource,
+            trace,
+            span_id,
+        ))
 
-    def log_proto(self, message, labels=None, insert_id=None, severity=None,
-                  http_request=None, timestamp=None,
-                  resource=_GLOBAL_RESOURCE, trace=None, span_id=None):
+    def log_proto(
+        self,
+        message,
+        labels=None,
+        insert_id=None,
+        severity=None,
+        http_request=None,
+        timestamp=None,
+        resource=_GLOBAL_RESOURCE,
+        trace=None,
+        span_id=None,
+    ):
         """Add a protobuf entry to be logged during :meth:`commit`.
 
         :type message: protobuf message
@@ -597,9 +717,18 @@ class Batch(object):
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
         """
-        self.entries.append(
-            ('proto', message, labels, insert_id, severity, http_request,
-             timestamp, resource, trace, span_id))
+        self.entries.append((
+            'proto',
+            message,
+            labels,
+            insert_id,
+            severity,
+            http_request,
+            timestamp,
+            resource,
+            trace,
+            span_id,
+        ))
 
     def commit(self, client=None):
         """Send saved log entries as a single API call.

--- a/logging/tests/system/test_system.py
+++ b/logging/tests/system/test_system.py
@@ -157,6 +157,8 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(entries[0].payload, TEXT_PAYLOAD)
 
     def test_log_text_with_timestamp(self):
+        import datetime
+
         text_payload = 'System test: test_log_text_with_timestamp'
         logger = Config.CLIENT.logger(self._logger_name('log_text_ts'))
         now = datetime.datetime.utcnow()
@@ -168,6 +170,7 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0].payload, text_payload)
         self.assertEqual(entries[0].timestamp, now.replace(tzinfo=UTC))
+        self.assertIsInstance(entries[0].received_timestamp, datetime.datetime)
 
     def test_log_text_with_resource(self):
         text_payload = 'System test: test_log_text_with_timestamp'

--- a/logging/tests/system/test_system.py
+++ b/logging/tests/system/test_system.py
@@ -140,12 +140,12 @@ class TestLogging(unittest.TestCase):
 
         self.assertIsInstance(protobuf_entry, entries.ProtobufEntry)
         if Config.CLIENT._use_grpc:
-            self.assertIsNone(protobuf_entry.payload)
+            self.assertIsNone(protobuf_entry.payload_json)
             self.assertIsInstance(protobuf_entry.payload_pb, any_pb2.Any)
             self.assertEqual(protobuf_entry.payload_pb.type_url, type_url)
         else:
             self.assertIsNone(protobuf_entry.payload_pb)
-            self.assertEqual(protobuf_entry.payload['@type'], type_url)
+            self.assertEqual(protobuf_entry.payload_json['@type'], type_url)
 
     def test_log_text(self):
         TEXT_PAYLOAD = 'System test: test_log_text'

--- a/logging/tests/unit/test__helpers.py
+++ b/logging/tests/unit/test__helpers.py
@@ -44,7 +44,7 @@ class Test_entry_from_resource(unittest.TestCase):
         self.assertEqual(mock_class.called, (resource, client, loggers))
 
     def test_wo_payload(self):
-        self._payload_helper(None, 'EmptyEntry')
+        self._payload_helper(None, 'LogEntry')
 
     def test_text_payload(self):
         self._payload_helper('textPayload', 'TextEntry')

--- a/logging/tests/unit/test_entries.py
+++ b/logging/tests/unit/test_entries.py
@@ -450,7 +450,7 @@ class TestLogEntry(unittest.TestCase):
             'operation': OPERATION,
         }
         entry = self._make_one(
-            type_='empty',
+            entry_type='empty',
             log_name=LOG_NAME,
             labels=LABELS,
             insert_id=IID,
@@ -544,7 +544,7 @@ class TestLogEntry(unittest.TestCase):
             'operation': OPERATION,
         }
         entry = self._make_one(
-            type_='text',
+            entry_type='text',
             log_name=LOG_NAME,
             payload=TEXT,
             labels=LABELS,
@@ -639,7 +639,7 @@ class TestLogEntry(unittest.TestCase):
             'operation': OPERATION,
         }
         entry = self._make_one(
-            type_='struct',
+            entry_type='struct',
             log_name=LOG_NAME,
             payload=JSON_PAYLOAD,
             labels=LABELS,
@@ -742,7 +742,7 @@ class TestLogEntry(unittest.TestCase):
         }
 
         entry = self._make_one(
-            type_='proto',
+            entry_type='proto',
             log_name=LOG_NAME,
             payload=message,
             labels=LABELS,

--- a/logging/tests/unit/test_entries.py
+++ b/logging/tests/unit/test_entries.py
@@ -97,6 +97,7 @@ class TestLogEntry(unittest.TestCase):
         self.assertIsNone(entry.span_id)
         self.assertIsNone(entry.trace_sampled)
         self.assertIsNone(entry.source_location)
+        self.assertIsNone(entry.operation)
 
     def test_ctor_explicit(self):
         import datetime
@@ -126,6 +127,14 @@ class TestLogEntry(unittest.TestCase):
             'line': LINE_NO,
             'function': FUNCTION,
         }
+        OP_ID = 'OP_ID'
+        PRODUCER = 'PRODUCER'
+        OPERATION = {
+            'id': OP_ID,
+            'producer': PRODUCER,
+            'first': True,
+            'last': False,
+        }
         logger = _Logger(self.LOGGER_NAME, self.PROJECT)
 
         entry = self._make_one(
@@ -141,6 +150,7 @@ class TestLogEntry(unittest.TestCase):
             span_id=SPANID,
             trace_sampled=True,
             source_location=SOURCE_LOCATION,
+            operation=OPERATION,
         )
 
         self.assertEqual(entry.payload, PAYLOAD)
@@ -161,6 +171,8 @@ class TestLogEntry(unittest.TestCase):
         self.assertEqual(source_location['file'], FILE)
         self.assertEqual(source_location['line'], LINE_NO)
         self.assertEqual(source_location['function'], FUNCTION)
+
+        self.assertEqual(entry.operation, OPERATION)
 
     def test_from_api_repr_no_payload_missing_data_no_loggers(self):
         client = _Client(self.PROJECT)
@@ -185,6 +197,7 @@ class TestLogEntry(unittest.TestCase):
         self.assertIsNone(entry.span_id)
         self.assertIsNone(entry.trace_sampled)
         self.assertIsNone(entry.source_location)
+        self.assertIsNone(entry.operation)
         self.assertIs(logger.client, client)
 
     def test_from_api_repr_w_loggers_no_logger_match(self):
@@ -224,6 +237,14 @@ class TestLogEntry(unittest.TestCase):
             'line': str(LINE_NO),
             'function': FUNCTION,
         }
+        OP_ID = 'OP_ID'
+        PRODUCER = 'PRODUCER'
+        OPERATION = {
+            'id': OP_ID,
+            'producer': PRODUCER,
+            'first': True,
+            'last': False,
+        }
         API_REPR = {
             'dummyPayload': PAYLOAD,
             'logName': LOG_NAME,
@@ -241,6 +262,7 @@ class TestLogEntry(unittest.TestCase):
             'spanId': SPANID,
             'traceSampled': True,
             'sourceLocation': SOURCE_LOCATION,
+            'operation': OPERATION,
         }
         loggers = {}
 
@@ -272,6 +294,8 @@ class TestLogEntry(unittest.TestCase):
         self.assertEqual(source_location['line'], LINE_NO)
         self.assertEqual(source_location['function'], FUNCTION)
 
+        self.assertEqual(entry.operation, OPERATION)
+
     def test_from_api_repr_w_loggers_w_logger_match(self):
         from datetime import datetime
         from datetime import timedelta
@@ -296,6 +320,14 @@ class TestLogEntry(unittest.TestCase):
             'line': str(LINE_NO),
             'function': FUNCTION,
         }
+        OP_ID = 'OP_ID'
+        PRODUCER = 'PRODUCER'
+        OPERATION = {
+            'id': OP_ID,
+            'producer': PRODUCER,
+            'first': True,
+            'last': False,
+        }
         API_REPR = {
             'dummyPayload': PAYLOAD,
             'logName': LOG_NAME,
@@ -307,6 +339,7 @@ class TestLogEntry(unittest.TestCase):
             'spanId': SPANID,
             'traceSampled': True,
             'sourceLocation': SOURCE_LOCATION,
+            'operation': OPERATION,
         }
         LOGGER = object()
         loggers = {LOG_NAME: LOGGER}
@@ -329,6 +362,8 @@ class TestLogEntry(unittest.TestCase):
         self.assertEqual(source_location['file'], FILE)
         self.assertEqual(source_location['line'], LINE_NO)
         self.assertEqual(source_location['function'], FUNCTION)
+
+        self.assertEqual(entry.operation, OPERATION)
 
     def test_to_api_repr_empty_w_source_location_no_line(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
@@ -388,6 +423,14 @@ class TestLogEntry(unittest.TestCase):
             'line': LINE,
             'function': FUNCTION,
         }
+        OP_ID = 'OP_ID'
+        PRODUCER = 'PRODUCER'
+        OPERATION = {
+            'id': OP_ID,
+            'producer': PRODUCER,
+            'first': True,
+            'last': False,
+        }
         expected = {
             'logName': LOG_NAME,
             'labels': LABELS,
@@ -404,6 +447,7 @@ class TestLogEntry(unittest.TestCase):
                 'line': str(LINE),
                 'function': FUNCTION,
             },
+            'operation': OPERATION,
         }
         entry = self._make_one(
             type_='empty',
@@ -418,6 +462,7 @@ class TestLogEntry(unittest.TestCase):
             span_id=SPANID,
             trace_sampled=True,
             source_location=SOURCE_LOCATION,
+            operation=OPERATION,
         )
 
         self.assertEqual(entry.to_api_repr(), expected)
@@ -471,6 +516,14 @@ class TestLogEntry(unittest.TestCase):
             'line': LINE,
             'function': FUNCTION,
         }
+        OP_ID = 'OP_ID'
+        PRODUCER = 'PRODUCER'
+        OPERATION = {
+            'id': OP_ID,
+            'producer': PRODUCER,
+            'first': True,
+            'last': False,
+        }
         expected = {
             'logName': LOG_NAME,
             'textPayload': TEXT,
@@ -488,6 +541,7 @@ class TestLogEntry(unittest.TestCase):
                 'line': str(LINE),
                 'function': FUNCTION,
             },
+            'operation': OPERATION,
         }
         entry = self._make_one(
             type_='text',
@@ -503,6 +557,7 @@ class TestLogEntry(unittest.TestCase):
             span_id=SPANID,
             trace_sampled=True,
             source_location=SOURCE_LOCATION,
+            operation=OPERATION,
         )
 
         self.assertEqual(entry.to_api_repr(), expected)
@@ -556,6 +611,14 @@ class TestLogEntry(unittest.TestCase):
             'line': LINE,
             'function': FUNCTION,
         }
+        OP_ID = 'OP_ID'
+        PRODUCER = 'PRODUCER'
+        OPERATION = {
+            'id': OP_ID,
+            'producer': PRODUCER,
+            'first': True,
+            'last': False,
+        }
         expected = {
             'logName': LOG_NAME,
             'jsonPayload': JSON_PAYLOAD,
@@ -573,6 +636,7 @@ class TestLogEntry(unittest.TestCase):
                 'line': str(LINE),
                 'function': FUNCTION,
             },
+            'operation': OPERATION,
         }
         entry = self._make_one(
             type_='struct',
@@ -588,6 +652,7 @@ class TestLogEntry(unittest.TestCase):
             span_id=SPANID,
             trace_sampled=True,
             source_location=SOURCE_LOCATION,
+            operation=OPERATION,
         )
 
         self.assertEqual(entry.to_api_repr(), expected)
@@ -648,6 +713,14 @@ class TestLogEntry(unittest.TestCase):
             'line': LINE,
             'function': FUNCTION,
         }
+        OP_ID = 'OP_ID'
+        PRODUCER = 'PRODUCER'
+        OPERATION = {
+            'id': OP_ID,
+            'producer': PRODUCER,
+            'first': True,
+            'last': False,
+        }
         expected = {
             'logName': LOG_NAME,
             'protoPayload': MessageToDict(message),
@@ -665,6 +738,7 @@ class TestLogEntry(unittest.TestCase):
                 'line': str(LINE),
                 'function': FUNCTION,
             },
+            'operation': OPERATION,
         }
 
         entry = self._make_one(
@@ -681,6 +755,7 @@ class TestLogEntry(unittest.TestCase):
             span_id=SPANID,
             trace_sampled=True,
             source_location=SOURCE_LOCATION,
+            operation=OPERATION,
         )
 
         self.assertEqual(entry.to_api_repr(), expected)

--- a/logging/tests/unit/test_entries.py
+++ b/logging/tests/unit/test_entries.py
@@ -781,7 +781,8 @@ class TestProtobufEntry(unittest.TestCase):
         pb_entry = self._make_one(payload=payload, logger=mock.sentinel.logger)
 
         self.assertIs(pb_entry.payload, payload)
-        self.assertIs(pb_entry.payload_pb, payload)
+        self.assertIsNone(pb_entry.payload_pb)
+        self.assertIs(pb_entry.payload_json, payload)
         self.assertIs(pb_entry.logger, mock.sentinel.logger)
         self.assertIsNone(pb_entry.insert_id)
         self.assertIsNone(pb_entry.timestamp)
@@ -802,6 +803,7 @@ class TestProtobufEntry(unittest.TestCase):
 
         self.assertIs(pb_entry.payload, payload)
         self.assertIs(pb_entry.payload_pb, payload)
+        self.assertIsNone(pb_entry.payload_json)
         self.assertIs(pb_entry.logger, mock.sentinel.logger)
         self.assertIsNone(pb_entry.insert_id)
         self.assertIsNone(pb_entry.timestamp)
@@ -811,7 +813,7 @@ class TestProtobufEntry(unittest.TestCase):
         self.assertIsNone(pb_entry.trace)
         self.assertIsNone(pb_entry.span_id)
         self.assertIsNone(pb_entry.trace_sampled)
-        self.assertIsNone(pb_entry.trace_sampled)
+        self.assertIsNone(pb_entry.source_location)
 
     def test_parse_message(self):
         import json

--- a/logging/tests/unit/test_entries.py
+++ b/logging/tests/unit/test_entries.py
@@ -70,6 +70,7 @@ class Test_BaseEntry(unittest.TestCase):
         self.assertIsNone(entry.resource)
         self.assertIsNone(entry.trace)
         self.assertIsNone(entry.span_id)
+        self.assertIsNone(entry.trace_sampled)
 
     def test_ctor_explicit(self):
         import datetime
@@ -93,15 +94,19 @@ class Test_BaseEntry(unittest.TestCase):
         SPANID = '000000000000004a'
 
         logger = _Logger(self.LOGGER_NAME, self.PROJECT)
-        entry = self._make_one(PAYLOAD, logger,
-                               insert_id=IID,
-                               timestamp=TIMESTAMP,
-                               labels=LABELS,
-                               severity=SEVERITY,
-                               http_request=REQUEST,
-                               resource=resource,
-                               trace=TRACE,
-                               span_id=SPANID)
+        entry = self._make_one(
+            PAYLOAD,
+            logger,
+            insert_id=IID,
+            timestamp=TIMESTAMP,
+            labels=LABELS,
+            severity=SEVERITY,
+            http_request=REQUEST,
+            resource=resource,
+            trace=TRACE,
+            span_id=SPANID,
+            trace_sampled=True,
+        )
         self.assertEqual(entry.payload, PAYLOAD)
         self.assertIs(entry.logger, logger)
         self.assertEqual(entry.insert_id, IID)
@@ -114,6 +119,7 @@ class Test_BaseEntry(unittest.TestCase):
         self.assertEqual(entry.resource, resource)
         self.assertEqual(entry.trace, TRACE)
         self.assertEqual(entry.span_id, SPANID)
+        self.assertTrue(entry.trace_sampled)
 
     def test_from_api_repr_no_payload_missing_data_no_loggers(self):
         client = _Client(self.PROJECT)
@@ -130,6 +136,7 @@ class Test_BaseEntry(unittest.TestCase):
         self.assertIsNone(entry.http_request)
         self.assertIsNone(entry.trace)
         self.assertIsNone(entry.span_id)
+        self.assertIsNone(entry.trace_sampled)
         logger = entry.logger
         self.assertIsInstance(logger, _Logger)
         self.assertIs(logger.client, client)
@@ -178,7 +185,8 @@ class Test_BaseEntry(unittest.TestCase):
             },
             'resource': RESOURCE._to_dict(),
             'trace': TRACE,
-            'spanId': SPANID
+            'spanId': SPANID,
+            'traceSampled': True,
         }
         loggers = {}
         entry = klass.from_api_repr(API_REPR, client, loggers=loggers)
@@ -199,6 +207,7 @@ class Test_BaseEntry(unittest.TestCase):
         self.assertEqual(entry.resource, RESOURCE)
         self.assertEqual(entry.trace, TRACE)
         self.assertEqual(entry.span_id, SPANID)
+        self.assertTrue(entry.trace_sampled)
 
     def test_from_api_repr_w_loggers_w_logger_match(self):
         from datetime import datetime
@@ -224,7 +233,8 @@ class Test_BaseEntry(unittest.TestCase):
             'receiveTimestamp': RECEIVED,
             'labels': LABELS,
             'trace': TRACE,
-            'spanId': SPANID
+            'spanId': SPANID,
+            'traceSampled': True,
         }
         LOGGER = object()
         loggers = {LOG_NAME: LOGGER}
@@ -237,6 +247,7 @@ class Test_BaseEntry(unittest.TestCase):
         self.assertEqual(entry.labels, LABELS)
         self.assertEqual(entry.trace, TRACE)
         self.assertEqual(entry.span_id, SPANID)
+        self.assertTrue(entry.trace_sampled)
         self.assertIs(entry.logger, LOGGER)
 
 
@@ -267,6 +278,7 @@ class TestProtobufEntry(unittest.TestCase):
         self.assertIsNone(pb_entry.http_request)
         self.assertIsNone(pb_entry.trace)
         self.assertIsNone(pb_entry.span_id)
+        self.assertIsNone(pb_entry.trace_sampled)
 
     def test_constructor_with_any(self):
         from google.protobuf.any_pb2 import Any
@@ -283,6 +295,7 @@ class TestProtobufEntry(unittest.TestCase):
         self.assertIsNone(pb_entry.http_request)
         self.assertIsNone(pb_entry.trace)
         self.assertIsNone(pb_entry.span_id)
+        self.assertIsNone(pb_entry.trace_sampled)
 
     def test_parse_message(self):
         import json

--- a/logging/tests/unit/test_entries.py
+++ b/logging/tests/unit/test_entries.py
@@ -185,6 +185,7 @@ class Test_BaseEntry(unittest.TestCase):
         self.assertEqual(entry.payload, PAYLOAD)
         self.assertEqual(entry.insert_id, IID)
         self.assertEqual(entry.timestamp, NOW)
+        self.assertIsNone(entry.received_timestamp)
         self.assertEqual(entry.labels, LABELS)
         self.assertEqual(entry.severity, SEVERITY)
         self.assertEqual(entry.http_request['requestMethod'], METHOD)
@@ -201,13 +202,16 @@ class Test_BaseEntry(unittest.TestCase):
 
     def test_from_api_repr_w_loggers_w_logger_match(self):
         from datetime import datetime
+        from datetime import timedelta
         from google.cloud._helpers import UTC
 
         client = _Client(self.PROJECT)
         PAYLOAD = 'PAYLOAD'
         IID = 'IID'
         NOW = datetime.utcnow().replace(tzinfo=UTC)
+        LATER = NOW + timedelta(seconds=1)
         TIMESTAMP = _datetime_to_rfc3339_w_nanos(NOW)
+        RECEIVED = _datetime_to_rfc3339_w_nanos(LATER)
         LOG_NAME = 'projects/%s/logs/%s' % (self.PROJECT, self.LOGGER_NAME)
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         TRACE = '12345678-1234-5678-1234-567812345678'
@@ -217,6 +221,7 @@ class Test_BaseEntry(unittest.TestCase):
             'logName': LOG_NAME,
             'insertId': IID,
             'timestamp': TIMESTAMP,
+            'receiveTimestamp': RECEIVED,
             'labels': LABELS,
             'trace': TRACE,
             'spanId': SPANID
@@ -228,6 +233,7 @@ class Test_BaseEntry(unittest.TestCase):
         self.assertEqual(entry.payload, PAYLOAD)
         self.assertEqual(entry.insert_id, IID)
         self.assertEqual(entry.timestamp, NOW)
+        self.assertEqual(entry.received_timestamp, LATER)
         self.assertEqual(entry.labels, LABELS)
         self.assertEqual(entry.trace, TRACE)
         self.assertEqual(entry.span_id, SPANID)

--- a/logging/tests/unit/test_logger.py
+++ b/logging/tests/unit/test_logger.py
@@ -144,9 +144,15 @@ class TestLogger(unittest.TestCase):
         logger = self._make_one(self.LOGGER_NAME, client=client1,
                                 labels=DEFAULT_LABELS)
 
-        logger.log_empty(client=client2, labels=LABELS,
-                         insert_id=IID, severity=SEVERITY,
-                         http_request=REQUEST, trace=TRACE, span_id=SPANID)
+        logger.log_empty(
+            client=client2,
+            labels=LABELS,
+            insert_id=IID,
+            severity=SEVERITY,
+            http_request=REQUEST,
+            trace=TRACE,
+            span_id=SPANID,
+        )
 
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
@@ -301,9 +307,16 @@ class TestLogger(unittest.TestCase):
         logger = self._make_one(self.LOGGER_NAME, client=client1,
                                 labels=DEFAULT_LABELS)
 
-        logger.log_text(TEXT, client=client2, labels=LABELS,
-                        insert_id=IID, severity=SEVERITY, http_request=REQUEST,
-                        trace=TRACE, span_id=SPANID)
+        logger.log_text(
+            TEXT,
+            client=client2,
+            labels=LABELS,
+            insert_id=IID,
+            severity=SEVERITY,
+            http_request=REQUEST,
+            trace=TRACE,
+            span_id=SPANID,
+        )
 
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
@@ -388,9 +401,16 @@ class TestLogger(unittest.TestCase):
         logger = self._make_one(self.LOGGER_NAME, client=client1,
                                 labels=DEFAULT_LABELS)
 
-        logger.log_struct(STRUCT, client=client2, labels=LABELS,
-                          insert_id=IID, severity=SEVERITY,
-                          http_request=REQUEST, trace=TRACE, span_id=SPANID)
+        logger.log_struct(
+            STRUCT,
+            client=client2,
+            labels=LABELS,
+            insert_id=IID,
+            severity=SEVERITY,
+            http_request=REQUEST,
+            trace=TRACE,
+            span_id=SPANID,
+        )
 
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
@@ -558,9 +578,16 @@ class TestLogger(unittest.TestCase):
         logger = self._make_one(self.LOGGER_NAME, client=client1,
                                 labels=DEFAULT_LABELS)
 
-        logger.log_proto(message, client=client2, labels=LABELS,
-                         insert_id=IID, severity=SEVERITY,
-                         http_request=REQUEST, trace=TRACE, span_id=SPANID)
+        logger.log_proto(
+            message,
+            client=client2,
+            labels=LABELS,
+            insert_id=IID,
+            severity=SEVERITY,
+            http_request=REQUEST,
+            trace=TRACE,
+            span_id=SPANID,
+        )
 
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
@@ -804,9 +831,17 @@ class TestBatch(unittest.TestCase):
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
-        batch.log_text(TEXT, labels=LABELS, insert_id=IID, severity=SEVERITY,
-                       http_request=REQUEST, timestamp=TIMESTAMP,
-                       resource=RESOURCE, trace=TRACE, span_id=SPANID)
+        batch.log_text(
+            TEXT,
+            labels=LABELS,
+            insert_id=IID,
+            severity=SEVERITY,
+            http_request=REQUEST,
+            timestamp=TIMESTAMP,
+            resource=RESOURCE,
+            trace=TRACE,
+            span_id=SPANID,
+        )
         self.assertEqual(
             batch.entries,
             [('text', TEXT, LABELS, IID, SEVERITY, REQUEST, TIMESTAMP,
@@ -854,10 +889,17 @@ class TestBatch(unittest.TestCase):
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
-        batch.log_struct(STRUCT, labels=LABELS, insert_id=IID,
-                         severity=SEVERITY, http_request=REQUEST,
-                         timestamp=TIMESTAMP, resource=RESOURCE, trace=TRACE,
-                         span_id=SPANID)
+        batch.log_struct(
+            STRUCT,
+            labels=LABELS,
+            insert_id=IID,
+            severity=SEVERITY,
+            http_request=REQUEST,
+            timestamp=TIMESTAMP,
+            resource=RESOURCE,
+            trace=TRACE,
+            span_id=SPANID,
+        )
         self.assertEqual(
             batch.entries,
             [('struct', STRUCT, LABELS, IID, SEVERITY, REQUEST, TIMESTAMP,
@@ -908,10 +950,17 @@ class TestBatch(unittest.TestCase):
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
-        batch.log_proto(message, labels=LABELS, insert_id=IID,
-                        severity=SEVERITY, http_request=REQUEST,
-                        timestamp=TIMESTAMP, resource=RESOURCE, trace=TRACE,
-                        span_id=SPANID)
+        batch.log_proto(
+            message,
+            labels=LABELS,
+            insert_id=IID,
+            severity=SEVERITY,
+            http_request=REQUEST,
+            timestamp=TIMESTAMP,
+            resource=RESOURCE,
+            trace=TRACE,
+            span_id=SPANID,
+        )
         self.assertEqual(
             batch.entries,
             [('proto', message, LABELS, IID, SEVERITY, REQUEST, TIMESTAMP,
@@ -998,12 +1047,26 @@ class TestBatch(unittest.TestCase):
         logger = _Logger()
         batch = self._make_one(logger, client=client)
 
-        batch.log_text(TEXT, insert_id=IID1, timestamp=TIMESTAMP1,
-                       trace=TRACE1, span_id=SPANID1)
-        batch.log_struct(STRUCT, insert_id=IID2, timestamp=TIMESTAMP2,
-                         trace=TRACE2, span_id=SPANID2)
-        batch.log_proto(message, insert_id=IID3, timestamp=TIMESTAMP3,
-                        trace=TRACE3, span_id=SPANID3)
+        batch.log_text(
+            TEXT,
+            insert_id=IID1,
+            timestamp=TIMESTAMP1,
+            trace=TRACE1,
+            span_id=SPANID1,
+        )
+        batch.log_struct(
+            STRUCT,
+            insert_id=IID2,
+            timestamp=TIMESTAMP2,
+            trace=TRACE2,
+            span_id=SPANID2,
+        )
+        batch.log_proto(
+            message,
+            insert_id=IID3,
+            timestamp=TIMESTAMP3,
+            trace=TRACE3, span_id=SPANID3,
+        )
         batch.commit()
 
         self.assertEqual(list(batch.entries), [])

--- a/logging/tests/unit/test_logger.py
+++ b/logging/tests/unit/test_logger.py
@@ -906,7 +906,7 @@ class TestBatch(unittest.TestCase):
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         api = client.logging_api = _DummyLoggingAPI()
         batch = self._make_one(logger, client)
-        batch.entries.append(LogEntry(type_='bogus', severity='blah'))
+        batch.entries.append(LogEntry(entry_type='bogus', severity='blah'))
         ENTRY = {
             'severity': 'blah',
             'resource': _GLOBAL_RESOURCE._to_dict(),

--- a/logging/tests/unit/test_logger.py
+++ b/logging/tests/unit/test_logger.py
@@ -624,10 +624,9 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(len(batch.entries), 0)
 
     def test_log_empty_defaults(self):
-        from google.cloud.logging.entries import _GLOBAL_RESOURCE
-        from google.cloud.logging.entries import EmptyEntry
+        from google.cloud.logging.entries import LogEntry
 
-        ENTRY = EmptyEntry(resource=_GLOBAL_RESOURCE)
+        ENTRY = LogEntry()
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
@@ -637,7 +636,7 @@ class TestBatch(unittest.TestCase):
     def test_log_empty_explicit(self):
         import datetime
         from google.cloud.logging.resource import Resource
-        from google.cloud.logging.entries import EmptyEntry
+        from google.cloud.logging.entries import LogEntry
 
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         IID = 'IID'
@@ -660,7 +659,7 @@ class TestBatch(unittest.TestCase):
         )
         TRACE = '12345678-1234-5678-1234-567812345678'
         SPANID = '000000000000004a'
-        ENTRY = EmptyEntry(
+        ENTRY = LogEntry(
             labels=LABELS,
             insert_id=IID,
             severity=SEVERITY,
@@ -906,7 +905,7 @@ class TestBatch(unittest.TestCase):
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         api = client.logging_api = _DummyLoggingAPI()
         batch = self._make_one(logger, client)
-        batch.entries.append(LogEntry(entry_type='bogus', severity='blah'))
+        batch.entries.append(LogEntry(severity='blah'))
         ENTRY = {
             'severity': 'blah',
             'resource': _GLOBAL_RESOURCE._to_dict(),

--- a/logging/tests/unit/test_logger.py
+++ b/logging/tests/unit/test_logger.py
@@ -37,14 +37,17 @@ class TestOutboundEntry(unittest.TestCase):
     def test_to_api_repr_empty_w_source_location_no_line(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
+        LOG_NAME = 'test.log'
         FILE = 'my_file.py'
         FUNCTION = 'my_function'
         SOURCE_LOCATION = {
             'file': FILE,
             'function': FUNCTION,
         }
-        entry = self._make_one('empty', source_location=SOURCE_LOCATION)
+        entry = self._make_one(
+            'empty', LOG_NAME, source_location=SOURCE_LOCATION)
         expected = {
+            'logName': LOG_NAME,
             'resource': _GLOBAL_RESOURCE._to_dict(),
             'sourceLocation': {
                 'file': FILE,
@@ -59,6 +62,7 @@ class TestOutboundEntry(unittest.TestCase):
         from google.cloud.logging.resource import Resource
         from google.cloud._helpers import _datetime_to_rfc3339
 
+        LOG_NAME = 'test.log'
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         IID = 'IID'
         SEVERITY = 'CRITICAL'
@@ -89,6 +93,7 @@ class TestOutboundEntry(unittest.TestCase):
             'function': FUNCTION,
         }
         expected = {
+            'logName': LOG_NAME,
             'labels': LABELS,
             'insertId': IID,
             'severity': SEVERITY,
@@ -106,6 +111,7 @@ class TestOutboundEntry(unittest.TestCase):
         }
         entry = self._make_one(
             type_='empty',
+            log_name=LOG_NAME,
             labels=LABELS,
             insert_id=IID,
             severity=SEVERITY,
@@ -123,9 +129,12 @@ class TestOutboundEntry(unittest.TestCase):
     def test_to_api_repr_text_defaults(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
-        entry = self._make_one('text', 'TESTING')
+        LOG_NAME = 'test.log'
+        TEXT = 'TESTING'
+        entry = self._make_one('text', LOG_NAME, TEXT)
         expected = {
-            'textPayload': 'TESTING',
+            'logName': LOG_NAME,
+            'textPayload': TEXT,
             'resource': _GLOBAL_RESOURCE._to_dict(),
         }
         self.assertEqual(entry.to_api_repr(), expected)
@@ -135,6 +144,7 @@ class TestOutboundEntry(unittest.TestCase):
         from google.cloud.logging.resource import Resource
         from google.cloud._helpers import _datetime_to_rfc3339
 
+        LOG_NAME = 'test.log'
         TEXT = 'This is the entry text'
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         IID = 'IID'
@@ -166,6 +176,7 @@ class TestOutboundEntry(unittest.TestCase):
             'function': FUNCTION,
         }
         expected = {
+            'logName': LOG_NAME,
             'textPayload': TEXT,
             'labels': LABELS,
             'insertId': IID,
@@ -184,6 +195,7 @@ class TestOutboundEntry(unittest.TestCase):
         }
         entry = self._make_one(
             type_='text',
+            log_name=LOG_NAME,
             payload=TEXT,
             labels=LABELS,
             insert_id=IID,
@@ -202,9 +214,11 @@ class TestOutboundEntry(unittest.TestCase):
     def test_to_api_repr_struct_defaults(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
+        LOG_NAME = 'test.log'
         JSON_PAYLOAD = {'key': 'value'}
-        entry = self._make_one('struct', JSON_PAYLOAD)
+        entry = self._make_one('struct', LOG_NAME, JSON_PAYLOAD)
         expected = {
+            'logName': LOG_NAME,
             'jsonPayload': JSON_PAYLOAD,
             'resource': _GLOBAL_RESOURCE._to_dict(),
         }
@@ -215,6 +229,7 @@ class TestOutboundEntry(unittest.TestCase):
         from google.cloud.logging.resource import Resource
         from google.cloud._helpers import _datetime_to_rfc3339
 
+        LOG_NAME = 'test.log'
         JSON_PAYLOAD = {'key': 'value'}
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         IID = 'IID'
@@ -246,6 +261,7 @@ class TestOutboundEntry(unittest.TestCase):
             'function': FUNCTION,
         }
         expected = {
+            'logName': LOG_NAME,
             'jsonPayload': JSON_PAYLOAD,
             'labels': LABELS,
             'insertId': IID,
@@ -264,6 +280,7 @@ class TestOutboundEntry(unittest.TestCase):
         }
         entry = self._make_one(
             type_='struct',
+            log_name=LOG_NAME,
             payload=JSON_PAYLOAD,
             labels=LABELS,
             insert_id=IID,
@@ -285,10 +302,12 @@ class TestOutboundEntry(unittest.TestCase):
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
 
+        LOG_NAME = 'test.log'
         message = Struct(fields={'foo': Value(bool_value=True)})
 
-        entry = self._make_one('proto', message)
+        entry = self._make_one('proto', LOG_NAME, message)
         expected = {
+            'logName': LOG_NAME,
             'protoPayload': MessageToDict(message),
             'resource': _GLOBAL_RESOURCE._to_dict(),
         }
@@ -302,6 +321,7 @@ class TestOutboundEntry(unittest.TestCase):
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
 
+        LOG_NAME = 'test.log'
         message = Struct(fields={'foo': Value(bool_value=True)})
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         IID = 'IID'
@@ -333,6 +353,7 @@ class TestOutboundEntry(unittest.TestCase):
             'function': FUNCTION,
         }
         expected = {
+            'logName': LOG_NAME,
             'protoPayload': MessageToDict(message),
             'labels': LABELS,
             'insertId': IID,
@@ -351,8 +372,9 @@ class TestOutboundEntry(unittest.TestCase):
         }
 
         entry = self._make_one(
-            'proto',
-            message,
+            type_='proto',
+            log_name=LOG_NAME,
+            payload=message,
             labels=LABELS,
             insert_id=IID,
             severity=SEVERITY,
@@ -458,6 +480,7 @@ class TestLogger(unittest.TestCase):
         import datetime
         from google.cloud.logging.resource import Resource
 
+        ALT_LOG_NAME = 'projects/foo/logs/alt.log.name'
         DEFAULT_LABELS = {'foo': 'spam'}
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         IID = 'IID'
@@ -481,8 +504,7 @@ class TestLogger(unittest.TestCase):
             }
         )
         ENTRIES = [{
-            'logName': 'projects/%s/logs/%s' % (
-                self.PROJECT, self.LOGGER_NAME),
+            'logName': ALT_LOG_NAME,
             'labels': LABELS,
             'insertId': IID,
             'severity': SEVERITY,
@@ -500,6 +522,7 @@ class TestLogger(unittest.TestCase):
                                 labels=DEFAULT_LABELS)
 
         logger.log_empty(
+            log_name=ALT_LOG_NAME,
             client=client2,
             labels=LABELS,
             insert_id=IID,
@@ -562,6 +585,7 @@ class TestLogger(unittest.TestCase):
         import datetime
         from google.cloud.logging.resource import Resource
 
+        ALT_LOG_NAME = 'projects/foo/logs/alt.log.name'
         TEXT = 'TEXT'
         DEFAULT_LABELS = {'foo': 'spam'}
         LABELS = {'foo': 'bar', 'baz': 'qux'}
@@ -586,8 +610,7 @@ class TestLogger(unittest.TestCase):
             }
         )
         ENTRIES = [{
-            'logName': 'projects/%s/logs/%s' % (
-                self.PROJECT, self.LOGGER_NAME),
+            'logName': ALT_LOG_NAME,
             'textPayload': TEXT,
             'labels': LABELS,
             'insertId': IID,
@@ -607,6 +630,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_text(
             TEXT,
+            log_name=ALT_LOG_NAME,
             client=client2,
             labels=LABELS,
             insert_id=IID,
@@ -669,6 +693,7 @@ class TestLogger(unittest.TestCase):
         import datetime
         from google.cloud.logging.resource import Resource
 
+        ALT_LOG_NAME = 'projects/foo/logs/alt.log.name'
         STRUCT = {'message': 'MESSAGE', 'weather': 'cloudy'}
         DEFAULT_LABELS = {'foo': 'spam'}
         LABELS = {'foo': 'bar', 'baz': 'qux'}
@@ -693,8 +718,7 @@ class TestLogger(unittest.TestCase):
             }
         )
         ENTRIES = [{
-            'logName': 'projects/%s/logs/%s' % (
-                self.PROJECT, self.LOGGER_NAME),
+            'logName': ALT_LOG_NAME,
             'jsonPayload': STRUCT,
             'labels': LABELS,
             'insertId': IID,
@@ -714,6 +738,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_struct(
             STRUCT,
+            log_name=ALT_LOG_NAME,
             client=client2,
             labels=LABELS,
             insert_id=IID,
@@ -789,6 +814,7 @@ class TestLogger(unittest.TestCase):
         from google.cloud.logging.resource import Resource
 
         message = Struct(fields={'foo': Value(bool_value=True)})
+        ALT_LOG_NAME = 'projects/foo/logs/alt.log.name'
         DEFAULT_LABELS = {'foo': 'spam'}
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         IID = 'IID'
@@ -812,8 +838,7 @@ class TestLogger(unittest.TestCase):
             }
         )
         ENTRIES = [{
-            'logName': 'projects/%s/logs/%s' % (
-                self.PROJECT, self.LOGGER_NAME),
+            'logName': ALT_LOG_NAME,
             'protoPayload': json.loads(MessageToJson(message)),
             'labels': LABELS,
             'insertId': IID,
@@ -833,6 +858,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_proto(
             message,
+            log_name=ALT_LOG_NAME,
             client=client2,
             labels=LABELS,
             insert_id=IID,
@@ -1254,7 +1280,7 @@ class TestBatch(unittest.TestCase):
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         api = client.logging_api = _DummyLoggingAPI()
         batch = self._make_one(logger, client)
-        batch.entries.append(OutboundEntry('bogus', 'BOGUS', severity='blah'))
+        batch.entries.append(OutboundEntry('bogus', severity='blah'))
         ENTRY = {
             'severity': 'blah',
             'resource': _GLOBAL_RESOURCE._to_dict(),

--- a/logging/tests/unit/test_logger.py
+++ b/logging/tests/unit/test_logger.py
@@ -34,6 +34,92 @@ class TestOutboundEntry(unittest.TestCase):
     def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
+    def test_to_api_repr_empty_w_source_location_no_line(self):
+        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+
+        FILE = 'my_file.py'
+        FUNCTION = 'my_function'
+        SOURCE_LOCATION = {
+            'file': FILE,
+            'function': FUNCTION,
+        }
+        entry = self._make_one('empty', source_location=SOURCE_LOCATION)
+        expected = {
+            'resource': _GLOBAL_RESOURCE._to_dict(),
+            'sourceLocation': {
+                'file': FILE,
+                'line': '0',
+                'function': FUNCTION,
+            }
+        }
+        self.assertEqual(entry.to_api_repr(), expected)
+
+    def test_to_api_repr_empty_explicit(self):
+        import datetime
+        from google.cloud.logging.resource import Resource
+        from google.cloud._helpers import _datetime_to_rfc3339
+
+        LABELS = {'foo': 'bar', 'baz': 'qux'}
+        IID = 'IID'
+        SEVERITY = 'CRITICAL'
+        METHOD = 'POST'
+        URI = 'https://api.example.com/endpoint'
+        STATUS = '500'
+        REQUEST = {
+            'requestMethod': METHOD,
+            'requestUrl': URI,
+            'status': STATUS,
+        }
+        TIMESTAMP = datetime.datetime(2016, 12, 31, 0, 1, 2, 999999)
+        RESOURCE = Resource(
+            type='gae_app',
+            labels={
+                'module_id': 'default',
+                'version_id': 'test'
+            }
+        )
+        TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
+        FILE = 'my_file.py'
+        LINE = 123
+        FUNCTION = 'my_function'
+        SOURCE_LOCATION = {
+            'file': FILE,
+            'line': LINE,
+            'function': FUNCTION,
+        }
+        expected = {
+            'labels': LABELS,
+            'insertId': IID,
+            'severity': SEVERITY,
+            'httpRequest': REQUEST,
+            'timestamp': _datetime_to_rfc3339(TIMESTAMP),
+            'resource': RESOURCE._to_dict(),
+            'trace': TRACE,
+            'spanId': SPANID,
+            'traceSampled': True,
+            'sourceLocation': {
+                'file': FILE,
+                'line': str(LINE),
+                'function': FUNCTION,
+            },
+        }
+        entry = self._make_one(
+            type_='empty',
+            labels=LABELS,
+            insert_id=IID,
+            severity=SEVERITY,
+            http_request=REQUEST,
+            timestamp=TIMESTAMP,
+            resource=RESOURCE,
+            trace=TRACE,
+            span_id=SPANID,
+            trace_sampled=True,
+            source_location=SOURCE_LOCATION,
+        )
+
+        self.assertEqual(entry.to_api_repr(), expected)
+
     def test_to_api_repr_text_defaults(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
@@ -71,6 +157,14 @@ class TestOutboundEntry(unittest.TestCase):
         )
         TRACE = '12345678-1234-5678-1234-567812345678'
         SPANID = '000000000000004a'
+        FILE = 'my_file.py'
+        LINE = 123
+        FUNCTION = 'my_function'
+        SOURCE_LOCATION = {
+            'file': FILE,
+            'line': LINE,
+            'function': FUNCTION,
+        }
         expected = {
             'textPayload': TEXT,
             'labels': LABELS,
@@ -82,6 +176,11 @@ class TestOutboundEntry(unittest.TestCase):
             'trace': TRACE,
             'spanId': SPANID,
             'traceSampled': True,
+            'sourceLocation': {
+                'file': FILE,
+                'line': str(LINE),
+                'function': FUNCTION,
+            },
         }
         entry = self._make_one(
             type_='text',
@@ -95,6 +194,7 @@ class TestOutboundEntry(unittest.TestCase):
             trace=TRACE,
             span_id=SPANID,
             trace_sampled=True,
+            source_location=SOURCE_LOCATION,
         )
 
         self.assertEqual(entry.to_api_repr(), expected)
@@ -137,6 +237,14 @@ class TestOutboundEntry(unittest.TestCase):
         )
         TRACE = '12345678-1234-5678-1234-567812345678'
         SPANID = '000000000000004a'
+        FILE = 'my_file.py'
+        LINE = 123
+        FUNCTION = 'my_function'
+        SOURCE_LOCATION = {
+            'file': FILE,
+            'line': LINE,
+            'function': FUNCTION,
+        }
         expected = {
             'jsonPayload': JSON_PAYLOAD,
             'labels': LABELS,
@@ -148,6 +256,11 @@ class TestOutboundEntry(unittest.TestCase):
             'trace': TRACE,
             'spanId': SPANID,
             'traceSampled': True,
+            'sourceLocation': {
+                'file': FILE,
+                'line': str(LINE),
+                'function': FUNCTION,
+            },
         }
         entry = self._make_one(
             type_='struct',
@@ -161,6 +274,7 @@ class TestOutboundEntry(unittest.TestCase):
             trace=TRACE,
             span_id=SPANID,
             trace_sampled=True,
+            source_location=SOURCE_LOCATION,
         )
 
         self.assertEqual(entry.to_api_repr(), expected)
@@ -210,6 +324,14 @@ class TestOutboundEntry(unittest.TestCase):
         )
         TRACE = '12345678-1234-5678-1234-567812345678'
         SPANID = '000000000000004a'
+        FILE = 'my_file.py'
+        LINE = 123
+        FUNCTION = 'my_function'
+        SOURCE_LOCATION = {
+            'file': FILE,
+            'line': LINE,
+            'function': FUNCTION,
+        }
         expected = {
             'protoPayload': MessageToDict(message),
             'labels': LABELS,
@@ -221,6 +343,11 @@ class TestOutboundEntry(unittest.TestCase):
             'trace': TRACE,
             'spanId': SPANID,
             'traceSampled': True,
+            'sourceLocation': {
+                'file': FILE,
+                'line': str(LINE),
+                'function': FUNCTION,
+            },
         }
 
         entry = self._make_one(
@@ -235,6 +362,7 @@ class TestOutboundEntry(unittest.TestCase):
             trace=TRACE,
             span_id=SPANID,
             trace_sampled=True,
+            source_location=SOURCE_LOCATION,
         )
 
         self.assertEqual(entry.to_api_repr(), expected)
@@ -1348,7 +1476,6 @@ class TestBatch(unittest.TestCase):
         import datetime
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
         from google.cloud.logging.logger import TextOutboundEntry
         from google.cloud.logging.logger import StructOutboundEntry
         from google.cloud.logging.logger import ProtoOutboundEntry

--- a/logging/tests/unit/test_logger.py
+++ b/logging/tests/unit/test_logger.py
@@ -136,7 +136,8 @@ class TestLogger(unittest.TestCase):
             'severity': SEVERITY,
             'httpRequest': REQUEST,
             'trace': TRACE,
-            'spanId': SPANID
+            'spanId': SPANID,
+            'traceSampled': True,
         }]
         client1 = _Client(self.PROJECT)
         client2 = _Client(self.PROJECT)
@@ -152,6 +153,7 @@ class TestLogger(unittest.TestCase):
             http_request=REQUEST,
             trace=TRACE,
             span_id=SPANID,
+            trace_sampled=True,
         )
 
         self.assertEqual(api._write_entries_called_with,
@@ -224,32 +226,10 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
 
-    def test_log_text_w_trace(self):
+    def test_log_text_w_trace_span_trace_sampled(self):
 
         TEXT = 'TEXT'
         TRACE = '12345678-1234-5678-1234-567812345678'
-        ENTRIES = [{
-            'logName': 'projects/%s/logs/%s' % (
-                self.PROJECT, self.LOGGER_NAME),
-            'textPayload': TEXT,
-            'resource': {
-                'type': 'global',
-                'labels': {},
-            },
-            'trace': TRACE
-        }]
-        client = _Client(self.PROJECT)
-        api = client.logging_api = _DummyLoggingAPI()
-        logger = self._make_one(self.LOGGER_NAME, client=client)
-
-        logger.log_text(TEXT, trace=TRACE)
-
-        self.assertEqual(api._write_entries_called_with,
-                         (ENTRIES, None, None, None))
-
-    def test_log_text_w_span(self):
-
-        TEXT = 'TEXT'
         SPANID = '000000000000004a'
         ENTRIES = [{
             'logName': 'projects/%s/logs/%s' % (
@@ -259,13 +239,15 @@ class TestLogger(unittest.TestCase):
                 'type': 'global',
                 'labels': {},
             },
-            'spanId': SPANID
+            'trace': TRACE,
+            'spanId': SPANID,
+            'traceSampled': True,
         }]
         client = _Client(self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
         logger = self._make_one(self.LOGGER_NAME, client=client)
 
-        logger.log_text(TEXT, span_id=SPANID)
+        logger.log_text(TEXT, trace=TRACE, span_id=SPANID, trace_sampled=True)
 
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
@@ -299,7 +281,8 @@ class TestLogger(unittest.TestCase):
             'severity': SEVERITY,
             'httpRequest': REQUEST,
             'trace': TRACE,
-            'spanId': SPANID
+            'spanId': SPANID,
+            'traceSampled': True,
         }]
         client1 = _Client(self.PROJECT)
         client2 = _Client(self.PROJECT)
@@ -316,6 +299,7 @@ class TestLogger(unittest.TestCase):
             http_request=REQUEST,
             trace=TRACE,
             span_id=SPANID,
+            trace_sampled=True,
         )
 
         self.assertEqual(api._write_entries_called_with,
@@ -393,7 +377,8 @@ class TestLogger(unittest.TestCase):
             'severity': SEVERITY,
             'httpRequest': REQUEST,
             'trace': TRACE,
-            'spanId': SPANID
+            'spanId': SPANID,
+            'traceSampled': True,
         }]
         client1 = _Client(self.PROJECT)
         client2 = _Client(self.PROJECT)
@@ -410,6 +395,7 @@ class TestLogger(unittest.TestCase):
             http_request=REQUEST,
             trace=TRACE,
             span_id=SPANID,
+            trace_sampled=True,
         )
 
         self.assertEqual(api._write_entries_called_with,
@@ -439,32 +425,10 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
 
-    def test_log_struct_w_trace(self):
+    def test_log_struct_w_trace_span_trace_sampled(self):
 
         STRUCT = {'message': 'MESSAGE', 'weather': 'cloudy'}
         TRACE = '12345678-1234-5678-1234-567812345678'
-        ENTRIES = [{
-            'logName': 'projects/%s/logs/%s' % (
-                self.PROJECT, self.LOGGER_NAME),
-            'jsonPayload': STRUCT,
-            'resource': {
-                'type': 'global',
-                'labels': {},
-            },
-            'trace': TRACE
-        }]
-        client = _Client(self.PROJECT)
-        api = client.logging_api = _DummyLoggingAPI()
-        logger = self._make_one(self.LOGGER_NAME, client=client)
-
-        logger.log_struct(STRUCT, trace=TRACE)
-
-        self.assertEqual(api._write_entries_called_with,
-                         (ENTRIES, None, None, None))
-
-    def test_log_struct_w_span(self):
-
-        STRUCT = {'message': 'MESSAGE', 'weather': 'cloudy'}
         SPANID = '000000000000004a'
         ENTRIES = [{
             'logName': 'projects/%s/logs/%s' % (
@@ -474,13 +438,16 @@ class TestLogger(unittest.TestCase):
                 'type': 'global',
                 'labels': {},
             },
-            'spanId': SPANID
+            'trace': TRACE,
+            'spanId': SPANID,
+            'traceSampled': True,
         }]
         client = _Client(self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
         logger = self._make_one(self.LOGGER_NAME, client=client)
 
-        logger.log_struct(STRUCT, span_id=SPANID)
+        logger.log_struct(
+            STRUCT, trace=TRACE, span_id=SPANID, trace_sampled=True)
 
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
@@ -570,7 +537,8 @@ class TestLogger(unittest.TestCase):
             'severity': SEVERITY,
             'httpRequest': REQUEST,
             'trace': TRACE,
-            'spanId': SPANID
+            'spanId': SPANID,
+            'traceSampled': True,
         }]
         client1 = _Client(self.PROJECT)
         client2 = _Client(self.PROJECT)
@@ -587,6 +555,7 @@ class TestLogger(unittest.TestCase):
             http_request=REQUEST,
             trace=TRACE,
             span_id=SPANID,
+            trace_sampled=True,
         )
 
         self.assertEqual(api._write_entries_called_with,
@@ -620,7 +589,7 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
 
-    def test_log_proto_w_trace(self):
+    def test_log_proto_w_trace_span_trace_sampled(self):
         import json
         from google.protobuf.json_format import MessageToJson
         from google.protobuf.struct_pb2 import Struct
@@ -628,32 +597,6 @@ class TestLogger(unittest.TestCase):
 
         message = Struct(fields={'foo': Value(bool_value=True)})
         TRACE = '12345678-1234-5678-1234-567812345678'
-        ENTRIES = [{
-            'logName': 'projects/%s/logs/%s' % (
-                self.PROJECT, self.LOGGER_NAME),
-            'protoPayload': json.loads(MessageToJson(message)),
-            'resource': {
-                'type': 'global',
-                'labels': {},
-            },
-            'trace': TRACE
-        }]
-        client = _Client(self.PROJECT)
-        api = client.logging_api = _DummyLoggingAPI()
-        logger = self._make_one(self.LOGGER_NAME, client=client)
-
-        logger.log_proto(message, trace=TRACE)
-
-        self.assertEqual(api._write_entries_called_with,
-                         (ENTRIES, None, None, None))
-
-    def test_log_proto_w_span(self):
-        import json
-        from google.protobuf.json_format import MessageToJson
-        from google.protobuf.struct_pb2 import Struct
-        from google.protobuf.struct_pb2 import Value
-
-        message = Struct(fields={'foo': Value(bool_value=True)})
         SPANID = '000000000000004a'
         ENTRIES = [{
             'logName': 'projects/%s/logs/%s' % (
@@ -663,13 +606,16 @@ class TestLogger(unittest.TestCase):
                 'type': 'global',
                 'labels': {},
             },
-            'spanId': SPANID
+            'trace': TRACE,
+            'spanId': SPANID,
+            'traceSampled': True,
         }]
         client = _Client(self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
         logger = self._make_one(self.LOGGER_NAME, client=client)
 
-        logger.log_proto(message, span_id=SPANID)
+        logger.log_proto(
+            message, trace=TRACE, span_id=SPANID, trace_sampled=True)
 
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
@@ -797,9 +743,20 @@ class TestBatch(unittest.TestCase):
         logger = _Logger()
         batch = self._make_one(logger, client=client)
         batch.log_text(TEXT)
-        self.assertEqual(batch.entries,
-                         [('text', TEXT, None, None, None, None, None,
-                           _GLOBAL_RESOURCE, None, None)])
+        ENTRY = (
+            'text',
+            TEXT,
+            None,
+            None,
+            None,
+            None,
+            None,
+            _GLOBAL_RESOURCE,
+            None,
+            None,
+            None,
+        )
+        self.assertEqual(batch.entries, [ENTRY])
 
     def test_log_text_explicit(self):
         import datetime
@@ -827,6 +784,19 @@ class TestBatch(unittest.TestCase):
         )
         TRACE = '12345678-1234-5678-1234-567812345678'
         SPANID = '000000000000004a'
+        ENTRY = (
+            'text',
+            TEXT,
+            LABELS,
+            IID,
+            SEVERITY,
+            REQUEST,
+            TIMESTAMP,
+            RESOURCE,
+            TRACE,
+            SPANID,
+            True,
+        )
 
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
@@ -841,23 +811,31 @@ class TestBatch(unittest.TestCase):
             resource=RESOURCE,
             trace=TRACE,
             span_id=SPANID,
+            trace_sampled=True,
         )
-        self.assertEqual(
-            batch.entries,
-            [('text', TEXT, LABELS, IID, SEVERITY, REQUEST, TIMESTAMP,
-              RESOURCE, TRACE, SPANID)])
+        self.assertEqual(batch.entries, [ENTRY])
 
     def test_log_struct_defaults(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
         STRUCT = {'message': 'Message text', 'weather': 'partly cloudy'}
+        ENTRY = (
+            'struct',
+            STRUCT,
+            None,
+            None,
+            None,
+            None,
+            None,
+            _GLOBAL_RESOURCE,
+            None,
+            None,
+            None,
+        )
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
         batch.log_struct(STRUCT)
-        self.assertEqual(
-            batch.entries,
-            [('struct', STRUCT, None, None, None, None, None,
-              _GLOBAL_RESOURCE, None, None)])
+        self.assertEqual(batch.entries, [ENTRY])
 
     def test_log_struct_explicit(self):
         import datetime
@@ -885,6 +863,19 @@ class TestBatch(unittest.TestCase):
                 'version_id': 'test',
             }
         )
+        ENTRY = (
+            'struct',
+            STRUCT,
+            LABELS,
+            IID,
+            SEVERITY,
+            REQUEST,
+            TIMESTAMP,
+            RESOURCE,
+            TRACE,
+            SPANID,
+            True,
+        )
 
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
@@ -899,11 +890,9 @@ class TestBatch(unittest.TestCase):
             resource=RESOURCE,
             trace=TRACE,
             span_id=SPANID,
+            trace_sampled=True,
         )
-        self.assertEqual(
-            batch.entries,
-            [('struct', STRUCT, LABELS, IID, SEVERITY, REQUEST, TIMESTAMP,
-              RESOURCE, TRACE, SPANID)])
+        self.assertEqual(batch.entries, [ENTRY])
 
     def test_log_proto_defaults(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
@@ -911,13 +900,24 @@ class TestBatch(unittest.TestCase):
         from google.protobuf.struct_pb2 import Value
 
         message = Struct(fields={'foo': Value(bool_value=True)})
+        ENTRY = (
+            'proto',
+            message,
+            None,
+            None,
+            None,
+            None,
+            None,
+            _GLOBAL_RESOURCE,
+            None,
+            None,
+            None,
+        )
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
         batch.log_proto(message)
-        self.assertEqual(batch.entries,
-                         [('proto', message, None, None, None, None, None,
-                           _GLOBAL_RESOURCE, None, None)])
+        self.assertEqual(batch.entries, [ENTRY])
 
     def test_log_proto_explicit(self):
         import datetime
@@ -947,6 +947,19 @@ class TestBatch(unittest.TestCase):
                 'version_id': 'test',
             }
         )
+        ENTRY = (
+            'proto',
+            message,
+            LABELS,
+            IID,
+            SEVERITY,
+            REQUEST,
+            TIMESTAMP,
+            RESOURCE,
+            TRACE,
+            SPANID,
+            True,
+        )
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
@@ -960,18 +973,16 @@ class TestBatch(unittest.TestCase):
             resource=RESOURCE,
             trace=TRACE,
             span_id=SPANID,
+            trace_sampled=True,
         )
-        self.assertEqual(
-            batch.entries,
-            [('proto', message, LABELS, IID, SEVERITY, REQUEST, TIMESTAMP,
-              RESOURCE, TRACE, SPANID)])
+        self.assertEqual(batch.entries, [ENTRY])
 
     def test_commit_w_invalid_entry_type(self):
         logger = _Logger()
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         batch = self._make_one(logger, client)
         batch.entries.append(('bogus', 'BOGUS', None, None, None, None, None,
-                              None, None, None))
+                              None, None, None, None))
         with self.assertRaises(ValueError):
             batch.commit()
 
@@ -1027,21 +1038,31 @@ class TestBatch(unittest.TestCase):
         SPANID1 = '000000000000004a'
         SPANID2 = '000000000000004b'
         SPANID3 = '000000000000004c'
-        ENTRIES = [
-            {'textPayload': TEXT, 'insertId': IID1,
-             'timestamp': _datetime_to_rfc3339(TIMESTAMP1),
-             'resource': _GLOBAL_RESOURCE._to_dict(), 'trace': TRACE1,
-             'spanId': SPANID1},
-            {'jsonPayload': STRUCT, 'insertId': IID2,
-             'timestamp': _datetime_to_rfc3339(TIMESTAMP2),
-             'resource': _GLOBAL_RESOURCE._to_dict(), 'trace': TRACE2,
-             'spanId': SPANID2},
-            {'protoPayload': json.loads(MessageToJson(message)),
-             'insertId': IID3,
-             'timestamp': _datetime_to_rfc3339(TIMESTAMP3),
-             'resource': _GLOBAL_RESOURCE._to_dict(), 'trace': TRACE3,
-             'spanId': SPANID3},
-        ]
+        ENTRIES = [{
+            'textPayload': TEXT,
+            'insertId': IID1,
+            'timestamp': _datetime_to_rfc3339(TIMESTAMP1),
+            'resource': _GLOBAL_RESOURCE._to_dict(),
+            'trace': TRACE1,
+            'spanId': SPANID1,
+            'traceSampled': True,
+        }, {
+            'jsonPayload': STRUCT,
+            'insertId': IID2,
+            'timestamp': _datetime_to_rfc3339(TIMESTAMP2),
+            'resource': _GLOBAL_RESOURCE._to_dict(),
+            'trace': TRACE2,
+            'spanId': SPANID2,
+            'traceSampled': False,
+        }, {
+            'protoPayload': json.loads(MessageToJson(message)),
+            'insertId': IID3,
+            'timestamp': _datetime_to_rfc3339(TIMESTAMP3),
+            'resource': _GLOBAL_RESOURCE._to_dict(),
+            'trace': TRACE3,
+            'spanId': SPANID3,
+            'traceSampled': True,
+        }]
         client = _Client(project=self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
         logger = _Logger()
@@ -1053,6 +1074,7 @@ class TestBatch(unittest.TestCase):
             timestamp=TIMESTAMP1,
             trace=TRACE1,
             span_id=SPANID1,
+            trace_sampled=True,
         )
         batch.log_struct(
             STRUCT,
@@ -1060,12 +1082,15 @@ class TestBatch(unittest.TestCase):
             timestamp=TIMESTAMP2,
             trace=TRACE2,
             span_id=SPANID2,
+            trace_sampled=False,
         )
         batch.log_proto(
             message,
             insert_id=IID3,
             timestamp=TIMESTAMP3,
-            trace=TRACE3, span_id=SPANID3,
+            trace=TRACE3,
+            span_id=SPANID3,
+            trace_sampled=True,
         )
         batch.commit()
 
@@ -1193,11 +1218,11 @@ class TestBatch(unittest.TestCase):
         logger = _Logger()
         UNSENT = [
             ('text', TEXT, None, IID, None, None, TIMESTAMP,
-             _GLOBAL_RESOURCE, None, None),
+             _GLOBAL_RESOURCE, None, None, None),
             ('struct', STRUCT, None, None, SEVERITY, None, None,
-             _GLOBAL_RESOURCE, None, None),
+             _GLOBAL_RESOURCE, None, None, None),
             ('proto', message, LABELS, None, None, REQUEST, None,
-             _GLOBAL_RESOURCE, None, None),
+             _GLOBAL_RESOURCE, None, None, None),
         ]
         batch = self._make_one(logger, client=client)
 

--- a/logging/tests/unit/test_logger.py
+++ b/logging/tests/unit/test_logger.py
@@ -1349,6 +1349,9 @@ class TestBatch(unittest.TestCase):
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
+        from google.cloud.logging.logger import TextOutboundEntry
+        from google.cloud.logging.logger import StructOutboundEntry
+        from google.cloud.logging.logger import ProtoOutboundEntry
 
         TEXT = 'This is the entry text'
         STRUCT = {'message': TEXT, 'weather': 'partly cloudy'}
@@ -1369,12 +1372,12 @@ class TestBatch(unittest.TestCase):
         api = client.logging_api = _DummyLoggingAPI()
         logger = _Logger()
         UNSENT = [
-            ('text', TEXT, None, IID, None, None, TIMESTAMP,
-             _GLOBAL_RESOURCE, None, None, None),
-            ('struct', STRUCT, None, None, SEVERITY, None, None,
-             _GLOBAL_RESOURCE, None, None, None),
-            ('proto', message, LABELS, None, None, REQUEST, None,
-             _GLOBAL_RESOURCE, None, None, None),
+            TextOutboundEntry._replace(
+                payload=TEXT, insert_id=IID, timestamp=TIMESTAMP),
+            StructOutboundEntry._replace(
+                payload=STRUCT, severity=SEVERITY),
+            ProtoOutboundEntry._replace(
+                payload=message, labels=LABELS, http_request=REQUEST),
         ]
         batch = self._make_one(logger, client=client)
 

--- a/logging/tests/unit/test_logger.py
+++ b/logging/tests/unit/test_logger.py
@@ -23,373 +23,6 @@ def _make_credentials():
     return mock.Mock(spec=google.auth.credentials.Credentials)
 
 
-class TestOutboundEntry(unittest.TestCase):
-
-    @staticmethod
-    def _get_target_class():
-        from google.cloud.logging.logger import OutboundEntry
-
-        return OutboundEntry
-
-    def _make_one(self, *args, **kwargs):
-        return self._get_target_class()(*args, **kwargs)
-
-    def test_to_api_repr_empty_w_source_location_no_line(self):
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
-
-        LOG_NAME = 'test.log'
-        FILE = 'my_file.py'
-        FUNCTION = 'my_function'
-        SOURCE_LOCATION = {
-            'file': FILE,
-            'function': FUNCTION,
-        }
-        entry = self._make_one(
-            'empty', LOG_NAME, source_location=SOURCE_LOCATION)
-        expected = {
-            'logName': LOG_NAME,
-            'resource': _GLOBAL_RESOURCE._to_dict(),
-            'sourceLocation': {
-                'file': FILE,
-                'line': '0',
-                'function': FUNCTION,
-            }
-        }
-        self.assertEqual(entry.to_api_repr(), expected)
-
-    def test_to_api_repr_empty_explicit(self):
-        import datetime
-        from google.cloud.logging.resource import Resource
-        from google.cloud._helpers import _datetime_to_rfc3339
-
-        LOG_NAME = 'test.log'
-        LABELS = {'foo': 'bar', 'baz': 'qux'}
-        IID = 'IID'
-        SEVERITY = 'CRITICAL'
-        METHOD = 'POST'
-        URI = 'https://api.example.com/endpoint'
-        STATUS = '500'
-        REQUEST = {
-            'requestMethod': METHOD,
-            'requestUrl': URI,
-            'status': STATUS,
-        }
-        TIMESTAMP = datetime.datetime(2016, 12, 31, 0, 1, 2, 999999)
-        RESOURCE = Resource(
-            type='gae_app',
-            labels={
-                'module_id': 'default',
-                'version_id': 'test'
-            }
-        )
-        TRACE = '12345678-1234-5678-1234-567812345678'
-        SPANID = '000000000000004a'
-        FILE = 'my_file.py'
-        LINE = 123
-        FUNCTION = 'my_function'
-        SOURCE_LOCATION = {
-            'file': FILE,
-            'line': LINE,
-            'function': FUNCTION,
-        }
-        expected = {
-            'logName': LOG_NAME,
-            'labels': LABELS,
-            'insertId': IID,
-            'severity': SEVERITY,
-            'httpRequest': REQUEST,
-            'timestamp': _datetime_to_rfc3339(TIMESTAMP),
-            'resource': RESOURCE._to_dict(),
-            'trace': TRACE,
-            'spanId': SPANID,
-            'traceSampled': True,
-            'sourceLocation': {
-                'file': FILE,
-                'line': str(LINE),
-                'function': FUNCTION,
-            },
-        }
-        entry = self._make_one(
-            type_='empty',
-            log_name=LOG_NAME,
-            labels=LABELS,
-            insert_id=IID,
-            severity=SEVERITY,
-            http_request=REQUEST,
-            timestamp=TIMESTAMP,
-            resource=RESOURCE,
-            trace=TRACE,
-            span_id=SPANID,
-            trace_sampled=True,
-            source_location=SOURCE_LOCATION,
-        )
-
-        self.assertEqual(entry.to_api_repr(), expected)
-
-    def test_to_api_repr_text_defaults(self):
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
-
-        LOG_NAME = 'test.log'
-        TEXT = 'TESTING'
-        entry = self._make_one('text', LOG_NAME, TEXT)
-        expected = {
-            'logName': LOG_NAME,
-            'textPayload': TEXT,
-            'resource': _GLOBAL_RESOURCE._to_dict(),
-        }
-        self.assertEqual(entry.to_api_repr(), expected)
-
-    def test_to_api_repr_text_explicit(self):
-        import datetime
-        from google.cloud.logging.resource import Resource
-        from google.cloud._helpers import _datetime_to_rfc3339
-
-        LOG_NAME = 'test.log'
-        TEXT = 'This is the entry text'
-        LABELS = {'foo': 'bar', 'baz': 'qux'}
-        IID = 'IID'
-        SEVERITY = 'CRITICAL'
-        METHOD = 'POST'
-        URI = 'https://api.example.com/endpoint'
-        STATUS = '500'
-        REQUEST = {
-            'requestMethod': METHOD,
-            'requestUrl': URI,
-            'status': STATUS,
-        }
-        TIMESTAMP = datetime.datetime(2016, 12, 31, 0, 1, 2, 999999)
-        RESOURCE = Resource(
-            type='gae_app',
-            labels={
-                'module_id': 'default',
-                'version_id': 'test'
-            }
-        )
-        TRACE = '12345678-1234-5678-1234-567812345678'
-        SPANID = '000000000000004a'
-        FILE = 'my_file.py'
-        LINE = 123
-        FUNCTION = 'my_function'
-        SOURCE_LOCATION = {
-            'file': FILE,
-            'line': LINE,
-            'function': FUNCTION,
-        }
-        expected = {
-            'logName': LOG_NAME,
-            'textPayload': TEXT,
-            'labels': LABELS,
-            'insertId': IID,
-            'severity': SEVERITY,
-            'httpRequest': REQUEST,
-            'timestamp': _datetime_to_rfc3339(TIMESTAMP),
-            'resource': RESOURCE._to_dict(),
-            'trace': TRACE,
-            'spanId': SPANID,
-            'traceSampled': True,
-            'sourceLocation': {
-                'file': FILE,
-                'line': str(LINE),
-                'function': FUNCTION,
-            },
-        }
-        entry = self._make_one(
-            type_='text',
-            log_name=LOG_NAME,
-            payload=TEXT,
-            labels=LABELS,
-            insert_id=IID,
-            severity=SEVERITY,
-            http_request=REQUEST,
-            timestamp=TIMESTAMP,
-            resource=RESOURCE,
-            trace=TRACE,
-            span_id=SPANID,
-            trace_sampled=True,
-            source_location=SOURCE_LOCATION,
-        )
-
-        self.assertEqual(entry.to_api_repr(), expected)
-
-    def test_to_api_repr_struct_defaults(self):
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
-
-        LOG_NAME = 'test.log'
-        JSON_PAYLOAD = {'key': 'value'}
-        entry = self._make_one('struct', LOG_NAME, JSON_PAYLOAD)
-        expected = {
-            'logName': LOG_NAME,
-            'jsonPayload': JSON_PAYLOAD,
-            'resource': _GLOBAL_RESOURCE._to_dict(),
-        }
-        self.assertEqual(entry.to_api_repr(), expected)
-
-    def test_to_api_repr_struct_explicit(self):
-        import datetime
-        from google.cloud.logging.resource import Resource
-        from google.cloud._helpers import _datetime_to_rfc3339
-
-        LOG_NAME = 'test.log'
-        JSON_PAYLOAD = {'key': 'value'}
-        LABELS = {'foo': 'bar', 'baz': 'qux'}
-        IID = 'IID'
-        SEVERITY = 'CRITICAL'
-        METHOD = 'POST'
-        URI = 'https://api.example.com/endpoint'
-        STATUS = '500'
-        REQUEST = {
-            'requestMethod': METHOD,
-            'requestUrl': URI,
-            'status': STATUS,
-        }
-        TIMESTAMP = datetime.datetime(2016, 12, 31, 0, 1, 2, 999999)
-        RESOURCE = Resource(
-            type='gae_app',
-            labels={
-                'module_id': 'default',
-                'version_id': 'test'
-            }
-        )
-        TRACE = '12345678-1234-5678-1234-567812345678'
-        SPANID = '000000000000004a'
-        FILE = 'my_file.py'
-        LINE = 123
-        FUNCTION = 'my_function'
-        SOURCE_LOCATION = {
-            'file': FILE,
-            'line': LINE,
-            'function': FUNCTION,
-        }
-        expected = {
-            'logName': LOG_NAME,
-            'jsonPayload': JSON_PAYLOAD,
-            'labels': LABELS,
-            'insertId': IID,
-            'severity': SEVERITY,
-            'httpRequest': REQUEST,
-            'timestamp': _datetime_to_rfc3339(TIMESTAMP),
-            'resource': RESOURCE._to_dict(),
-            'trace': TRACE,
-            'spanId': SPANID,
-            'traceSampled': True,
-            'sourceLocation': {
-                'file': FILE,
-                'line': str(LINE),
-                'function': FUNCTION,
-            },
-        }
-        entry = self._make_one(
-            type_='struct',
-            log_name=LOG_NAME,
-            payload=JSON_PAYLOAD,
-            labels=LABELS,
-            insert_id=IID,
-            severity=SEVERITY,
-            http_request=REQUEST,
-            timestamp=TIMESTAMP,
-            resource=RESOURCE,
-            trace=TRACE,
-            span_id=SPANID,
-            trace_sampled=True,
-            source_location=SOURCE_LOCATION,
-        )
-
-        self.assertEqual(entry.to_api_repr(), expected)
-
-    def test_to_api_repr_proto_defaults(self):
-        from google.protobuf.json_format import MessageToDict
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
-        from google.protobuf.struct_pb2 import Struct
-        from google.protobuf.struct_pb2 import Value
-
-        LOG_NAME = 'test.log'
-        message = Struct(fields={'foo': Value(bool_value=True)})
-
-        entry = self._make_one('proto', LOG_NAME, message)
-        expected = {
-            'logName': LOG_NAME,
-            'protoPayload': MessageToDict(message),
-            'resource': _GLOBAL_RESOURCE._to_dict(),
-        }
-        self.assertEqual(entry.to_api_repr(), expected)
-
-    def test_to_api_repr_proto_explicit(self):
-        import datetime
-        from google.protobuf.json_format import MessageToDict
-        from google.cloud.logging.resource import Resource
-        from google.cloud._helpers import _datetime_to_rfc3339
-        from google.protobuf.struct_pb2 import Struct
-        from google.protobuf.struct_pb2 import Value
-
-        LOG_NAME = 'test.log'
-        message = Struct(fields={'foo': Value(bool_value=True)})
-        LABELS = {'foo': 'bar', 'baz': 'qux'}
-        IID = 'IID'
-        SEVERITY = 'CRITICAL'
-        METHOD = 'POST'
-        URI = 'https://api.example.com/endpoint'
-        STATUS = '500'
-        REQUEST = {
-            'requestMethod': METHOD,
-            'requestUrl': URI,
-            'status': STATUS,
-        }
-        TIMESTAMP = datetime.datetime(2016, 12, 31, 0, 1, 2, 999999)
-        RESOURCE = Resource(
-            type='gae_app',
-            labels={
-                'module_id': 'default',
-                'version_id': 'test'
-            }
-        )
-        TRACE = '12345678-1234-5678-1234-567812345678'
-        SPANID = '000000000000004a'
-        FILE = 'my_file.py'
-        LINE = 123
-        FUNCTION = 'my_function'
-        SOURCE_LOCATION = {
-            'file': FILE,
-            'line': LINE,
-            'function': FUNCTION,
-        }
-        expected = {
-            'logName': LOG_NAME,
-            'protoPayload': MessageToDict(message),
-            'labels': LABELS,
-            'insertId': IID,
-            'severity': SEVERITY,
-            'httpRequest': REQUEST,
-            'timestamp': _datetime_to_rfc3339(TIMESTAMP),
-            'resource': RESOURCE._to_dict(),
-            'trace': TRACE,
-            'spanId': SPANID,
-            'traceSampled': True,
-            'sourceLocation': {
-                'file': FILE,
-                'line': str(LINE),
-                'function': FUNCTION,
-            },
-        }
-
-        entry = self._make_one(
-            type_='proto',
-            log_name=LOG_NAME,
-            payload=message,
-            labels=LABELS,
-            insert_id=IID,
-            severity=SEVERITY,
-            http_request=REQUEST,
-            timestamp=TIMESTAMP,
-            resource=RESOURCE,
-            trace=TRACE,
-            span_id=SPANID,
-            trace_sampled=True,
-            source_location=SOURCE_LOCATION,
-        )
-
-        self.assertEqual(entry.to_api_repr(), expected)
-
-
 class TestLogger(unittest.TestCase):
 
     PROJECT = 'test-project'
@@ -991,10 +624,10 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(len(batch.entries), 0)
 
     def test_log_empty_defaults(self):
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
-        from google.cloud.logging.logger import EmptyOutboundEntry
+        from google.cloud.logging.entries import _GLOBAL_RESOURCE
+        from google.cloud.logging.entries import EmptyEntry
 
-        ENTRY = EmptyOutboundEntry._replace(resource=_GLOBAL_RESOURCE)
+        ENTRY = EmptyEntry(resource=_GLOBAL_RESOURCE)
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
@@ -1004,7 +637,7 @@ class TestBatch(unittest.TestCase):
     def test_log_empty_explicit(self):
         import datetime
         from google.cloud.logging.resource import Resource
-        from google.cloud.logging.logger import EmptyOutboundEntry
+        from google.cloud.logging.entries import EmptyEntry
 
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         IID = 'IID'
@@ -1027,7 +660,7 @@ class TestBatch(unittest.TestCase):
         )
         TRACE = '12345678-1234-5678-1234-567812345678'
         SPANID = '000000000000004a'
-        ENTRY = EmptyOutboundEntry._replace(
+        ENTRY = EmptyEntry(
             labels=LABELS,
             insert_id=IID,
             severity=SEVERITY,
@@ -1056,12 +689,11 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(batch.entries, [ENTRY])
 
     def test_log_text_defaults(self):
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
-        from google.cloud.logging.logger import TextOutboundEntry
+        from google.cloud.logging.entries import _GLOBAL_RESOURCE
+        from google.cloud.logging.entries import TextEntry
 
         TEXT = 'This is the entry text'
-        ENTRY = TextOutboundEntry._replace(
-            payload=TEXT, resource=_GLOBAL_RESOURCE)
+        ENTRY = TextEntry(payload=TEXT, resource=_GLOBAL_RESOURCE)
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
@@ -1071,7 +703,7 @@ class TestBatch(unittest.TestCase):
     def test_log_text_explicit(self):
         import datetime
         from google.cloud.logging.resource import Resource
-        from google.cloud.logging.logger import TextOutboundEntry
+        from google.cloud.logging.entries import TextEntry
 
         TEXT = 'This is the entry text'
         LABELS = {'foo': 'bar', 'baz': 'qux'}
@@ -1095,7 +727,7 @@ class TestBatch(unittest.TestCase):
         )
         TRACE = '12345678-1234-5678-1234-567812345678'
         SPANID = '000000000000004a'
-        ENTRY = TextOutboundEntry._replace(
+        ENTRY = TextEntry(
             payload=TEXT,
             labels=LABELS,
             insert_id=IID,
@@ -1126,14 +758,11 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(batch.entries, [ENTRY])
 
     def test_log_struct_defaults(self):
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
-        from google.cloud.logging.logger import StructOutboundEntry
+        from google.cloud.logging.entries import _GLOBAL_RESOURCE
+        from google.cloud.logging.entries import StructEntry
 
         STRUCT = {'message': 'Message text', 'weather': 'partly cloudy'}
-        ENTRY = StructOutboundEntry._replace(
-            payload=STRUCT,
-            resource=_GLOBAL_RESOURCE,
-        )
+        ENTRY = StructEntry(payload=STRUCT, resource=_GLOBAL_RESOURCE)
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
@@ -1143,7 +772,7 @@ class TestBatch(unittest.TestCase):
     def test_log_struct_explicit(self):
         import datetime
         from google.cloud.logging.resource import Resource
-        from google.cloud.logging.logger import StructOutboundEntry
+        from google.cloud.logging.entries import StructEntry
 
         STRUCT = {'message': 'Message text', 'weather': 'partly cloudy'}
         LABELS = {'foo': 'bar', 'baz': 'qux'}
@@ -1167,7 +796,7 @@ class TestBatch(unittest.TestCase):
                 'version_id': 'test',
             }
         )
-        ENTRY = StructOutboundEntry._replace(
+        ENTRY = StructEntry(
             payload=STRUCT,
             labels=LABELS,
             insert_id=IID,
@@ -1198,16 +827,13 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(batch.entries, [ENTRY])
 
     def test_log_proto_defaults(self):
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
-        from google.cloud.logging.logger import ProtoOutboundEntry
+        from google.cloud.logging.entries import _GLOBAL_RESOURCE
+        from google.cloud.logging.entries import ProtobufEntry
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
 
         message = Struct(fields={'foo': Value(bool_value=True)})
-        ENTRY = ProtoOutboundEntry._replace(
-            payload=message,
-            resource=_GLOBAL_RESOURCE,
-        )
+        ENTRY = ProtobufEntry(payload=message, resource=_GLOBAL_RESOURCE)
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
@@ -1217,7 +843,7 @@ class TestBatch(unittest.TestCase):
     def test_log_proto_explicit(self):
         import datetime
         from google.cloud.logging.resource import Resource
-        from google.cloud.logging.logger import ProtoOutboundEntry
+        from google.cloud.logging.entries import ProtobufEntry
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
 
@@ -1243,7 +869,7 @@ class TestBatch(unittest.TestCase):
                 'version_id': 'test',
             }
         )
-        ENTRY = ProtoOutboundEntry._replace(
+        ENTRY = ProtobufEntry(
             payload=message,
             labels=LABELS,
             insert_id=IID,
@@ -1273,14 +899,14 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(batch.entries, [ENTRY])
 
     def test_commit_w_unknown_entry_type(self):
-        from google.cloud.logging.logger import OutboundEntry
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+        from google.cloud.logging.entries import _GLOBAL_RESOURCE
+        from google.cloud.logging.entries import LogEntry
 
         logger = _Logger()
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         api = client.logging_api = _DummyLoggingAPI()
         batch = self._make_one(logger, client)
-        batch.entries.append(OutboundEntry('bogus', severity='blah'))
+        batch.entries.append(LogEntry(type_='bogus', severity='blah'))
         ENTRY = {
             'severity': 'blah',
             'resource': _GLOBAL_RESOURCE._to_dict(),
@@ -1293,7 +919,7 @@ class TestBatch(unittest.TestCase):
                          ([ENTRY], logger.full_name, None, None))
 
     def test_commit_w_resource_specified(self):
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+        from google.cloud.logging.entries import _GLOBAL_RESOURCE
         from google.cloud.logging.resource import Resource
 
         logger = _Logger()
@@ -1327,7 +953,7 @@ class TestBatch(unittest.TestCase):
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
         from google.cloud._helpers import _datetime_to_rfc3339
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+        from google.cloud.logging.entries import _GLOBAL_RESOURCE
 
         TEXT = 'This is the entry text'
         STRUCT = {'message': TEXT, 'weather': 'partly cloudy'}
@@ -1410,7 +1036,7 @@ class TestBatch(unittest.TestCase):
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
         from google.cloud.logging.logger import Logger
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+        from google.cloud.logging.entries import _GLOBAL_RESOURCE
 
         TEXT = 'This is the entry text'
         STRUCT = {'message': TEXT, 'weather': 'partly cloudy'}
@@ -1459,7 +1085,7 @@ class TestBatch(unittest.TestCase):
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
         from google.cloud.logging.logger import Logger
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+        from google.cloud.logging.entries import _GLOBAL_RESOURCE
 
         TEXT = 'This is the entry text'
         STRUCT = {'message': TEXT, 'weather': 'partly cloudy'}
@@ -1502,9 +1128,9 @@ class TestBatch(unittest.TestCase):
         import datetime
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
-        from google.cloud.logging.logger import TextOutboundEntry
-        from google.cloud.logging.logger import StructOutboundEntry
-        from google.cloud.logging.logger import ProtoOutboundEntry
+        from google.cloud.logging.entries import TextEntry
+        from google.cloud.logging.entries import StructEntry
+        from google.cloud.logging.entries import ProtobufEntry
 
         TEXT = 'This is the entry text'
         STRUCT = {'message': TEXT, 'weather': 'partly cloudy'}
@@ -1525,11 +1151,9 @@ class TestBatch(unittest.TestCase):
         api = client.logging_api = _DummyLoggingAPI()
         logger = _Logger()
         UNSENT = [
-            TextOutboundEntry._replace(
-                payload=TEXT, insert_id=IID, timestamp=TIMESTAMP),
-            StructOutboundEntry._replace(
-                payload=STRUCT, severity=SEVERITY),
-            ProtoOutboundEntry._replace(
+            TextEntry(payload=TEXT, insert_id=IID, timestamp=TIMESTAMP),
+            StructEntry(payload=STRUCT, severity=SEVERITY),
+            ProtobufEntry(
                 payload=message, labels=LABELS, http_request=REQUEST),
         ]
         batch = self._make_one(logger, client=client)

--- a/logging/tests/unit/test_logger.py
+++ b/logging/tests/unit/test_logger.py
@@ -23,6 +23,223 @@ def _make_credentials():
     return mock.Mock(spec=google.auth.credentials.Credentials)
 
 
+class TestOutboundEntry(unittest.TestCase):
+
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.logging.logger import OutboundEntry
+
+        return OutboundEntry
+
+    def _make_one(self, *args, **kwargs):
+        return self._get_target_class()(*args, **kwargs)
+
+    def test_to_api_repr_text_defaults(self):
+        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+
+        entry = self._make_one('text', 'TESTING')
+        expected = {
+            'textPayload': 'TESTING',
+            'resource': _GLOBAL_RESOURCE._to_dict(),
+        }
+        self.assertEqual(entry.to_api_repr(), expected)
+
+    def test_to_api_repr_text_explicit(self):
+        import datetime
+        from google.cloud.logging.resource import Resource
+        from google.cloud._helpers import _datetime_to_rfc3339
+
+        TEXT = 'This is the entry text'
+        LABELS = {'foo': 'bar', 'baz': 'qux'}
+        IID = 'IID'
+        SEVERITY = 'CRITICAL'
+        METHOD = 'POST'
+        URI = 'https://api.example.com/endpoint'
+        STATUS = '500'
+        REQUEST = {
+            'requestMethod': METHOD,
+            'requestUrl': URI,
+            'status': STATUS,
+        }
+        TIMESTAMP = datetime.datetime(2016, 12, 31, 0, 1, 2, 999999)
+        RESOURCE = Resource(
+            type='gae_app',
+            labels={
+                'module_id': 'default',
+                'version_id': 'test'
+            }
+        )
+        TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
+        expected = {
+            'textPayload': TEXT,
+            'labels': LABELS,
+            'insertId': IID,
+            'severity': SEVERITY,
+            'httpRequest': REQUEST,
+            'timestamp': _datetime_to_rfc3339(TIMESTAMP),
+            'resource': RESOURCE._to_dict(),
+            'trace': TRACE,
+            'spanId': SPANID,
+            'traceSampled': True,
+        }
+        entry = self._make_one(
+            type_='text',
+            payload=TEXT,
+            labels=LABELS,
+            insert_id=IID,
+            severity=SEVERITY,
+            http_request=REQUEST,
+            timestamp=TIMESTAMP,
+            resource=RESOURCE,
+            trace=TRACE,
+            span_id=SPANID,
+            trace_sampled=True,
+        )
+
+        self.assertEqual(entry.to_api_repr(), expected)
+
+    def test_to_api_repr_struct_defaults(self):
+        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+
+        JSON_PAYLOAD = {'key': 'value'}
+        entry = self._make_one('struct', JSON_PAYLOAD)
+        expected = {
+            'jsonPayload': JSON_PAYLOAD,
+            'resource': _GLOBAL_RESOURCE._to_dict(),
+        }
+        self.assertEqual(entry.to_api_repr(), expected)
+
+    def test_to_api_repr_struct_explicit(self):
+        import datetime
+        from google.cloud.logging.resource import Resource
+        from google.cloud._helpers import _datetime_to_rfc3339
+
+        JSON_PAYLOAD = {'key': 'value'}
+        LABELS = {'foo': 'bar', 'baz': 'qux'}
+        IID = 'IID'
+        SEVERITY = 'CRITICAL'
+        METHOD = 'POST'
+        URI = 'https://api.example.com/endpoint'
+        STATUS = '500'
+        REQUEST = {
+            'requestMethod': METHOD,
+            'requestUrl': URI,
+            'status': STATUS,
+        }
+        TIMESTAMP = datetime.datetime(2016, 12, 31, 0, 1, 2, 999999)
+        RESOURCE = Resource(
+            type='gae_app',
+            labels={
+                'module_id': 'default',
+                'version_id': 'test'
+            }
+        )
+        TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
+        expected = {
+            'jsonPayload': JSON_PAYLOAD,
+            'labels': LABELS,
+            'insertId': IID,
+            'severity': SEVERITY,
+            'httpRequest': REQUEST,
+            'timestamp': _datetime_to_rfc3339(TIMESTAMP),
+            'resource': RESOURCE._to_dict(),
+            'trace': TRACE,
+            'spanId': SPANID,
+            'traceSampled': True,
+        }
+        entry = self._make_one(
+            type_='struct',
+            payload=JSON_PAYLOAD,
+            labels=LABELS,
+            insert_id=IID,
+            severity=SEVERITY,
+            http_request=REQUEST,
+            timestamp=TIMESTAMP,
+            resource=RESOURCE,
+            trace=TRACE,
+            span_id=SPANID,
+            trace_sampled=True,
+        )
+
+        self.assertEqual(entry.to_api_repr(), expected)
+
+    def test_to_api_repr_proto_defaults(self):
+        from google.protobuf.json_format import MessageToDict
+        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
+        message = Struct(fields={'foo': Value(bool_value=True)})
+
+        entry = self._make_one('proto', message)
+        expected = {
+            'protoPayload': MessageToDict(message),
+            'resource': _GLOBAL_RESOURCE._to_dict(),
+        }
+        self.assertEqual(entry.to_api_repr(), expected)
+
+    def test_to_api_repr_proto_explicit(self):
+        import datetime
+        from google.protobuf.json_format import MessageToDict
+        from google.cloud.logging.resource import Resource
+        from google.cloud._helpers import _datetime_to_rfc3339
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
+        message = Struct(fields={'foo': Value(bool_value=True)})
+        LABELS = {'foo': 'bar', 'baz': 'qux'}
+        IID = 'IID'
+        SEVERITY = 'CRITICAL'
+        METHOD = 'POST'
+        URI = 'https://api.example.com/endpoint'
+        STATUS = '500'
+        REQUEST = {
+            'requestMethod': METHOD,
+            'requestUrl': URI,
+            'status': STATUS,
+        }
+        TIMESTAMP = datetime.datetime(2016, 12, 31, 0, 1, 2, 999999)
+        RESOURCE = Resource(
+            type='gae_app',
+            labels={
+                'module_id': 'default',
+                'version_id': 'test'
+            }
+        )
+        TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
+        expected = {
+            'protoPayload': MessageToDict(message),
+            'labels': LABELS,
+            'insertId': IID,
+            'severity': SEVERITY,
+            'httpRequest': REQUEST,
+            'timestamp': _datetime_to_rfc3339(TIMESTAMP),
+            'resource': RESOURCE._to_dict(),
+            'trace': TRACE,
+            'spanId': SPANID,
+            'traceSampled': True,
+        }
+
+        entry = self._make_one(
+            'proto',
+            message,
+            labels=LABELS,
+            insert_id=IID,
+            severity=SEVERITY,
+            http_request=REQUEST,
+            timestamp=TIMESTAMP,
+            resource=RESOURCE,
+            trace=TRACE,
+            span_id=SPANID,
+            trace_sampled=True,
+        )
+
+        self.assertEqual(entry.to_api_repr(), expected)
+
+
 class TestLogger(unittest.TestCase):
 
     PROJECT = 'test-project'
@@ -715,223 +932,6 @@ class TestLogger(unittest.TestCase):
         })
 
 
-class Test_BatchEntry(unittest.TestCase):
-
-    @staticmethod
-    def _get_target_class():
-        from google.cloud.logging.logger import _BatchEntry
-
-        return _BatchEntry
-
-    def _make_one(self, *args, **kwargs):
-        return self._get_target_class()(*args, **kwargs)
-
-    def test_to_api_repr_text_defaults(self):
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
-
-        entry = self._make_one('text', 'TESTING')
-        expected = {
-            'textPayload': 'TESTING',
-            'resource': _GLOBAL_RESOURCE._to_dict(),
-        }
-        self.assertEqual(entry.to_api_repr(), expected)
-
-    def test_to_api_repr_text_explicit(self):
-        import datetime
-        from google.cloud.logging.resource import Resource
-        from google.cloud._helpers import _datetime_to_rfc3339
-
-        TEXT = 'This is the entry text'
-        LABELS = {'foo': 'bar', 'baz': 'qux'}
-        IID = 'IID'
-        SEVERITY = 'CRITICAL'
-        METHOD = 'POST'
-        URI = 'https://api.example.com/endpoint'
-        STATUS = '500'
-        REQUEST = {
-            'requestMethod': METHOD,
-            'requestUrl': URI,
-            'status': STATUS,
-        }
-        TIMESTAMP = datetime.datetime(2016, 12, 31, 0, 1, 2, 999999)
-        RESOURCE = Resource(
-            type='gae_app',
-            labels={
-                'module_id': 'default',
-                'version_id': 'test'
-            }
-        )
-        TRACE = '12345678-1234-5678-1234-567812345678'
-        SPANID = '000000000000004a'
-        expected = {
-            'textPayload': TEXT,
-            'labels': LABELS,
-            'insertId': IID,
-            'severity': SEVERITY,
-            'httpRequest': REQUEST,
-            'timestamp': _datetime_to_rfc3339(TIMESTAMP),
-            'resource': RESOURCE._to_dict(),
-            'trace': TRACE,
-            'spanId': SPANID,
-            'traceSampled': True,
-        }
-        entry = self._make_one(
-            type_='text',
-            payload=TEXT,
-            labels=LABELS,
-            insert_id=IID,
-            severity=SEVERITY,
-            http_request=REQUEST,
-            timestamp=TIMESTAMP,
-            resource=RESOURCE,
-            trace=TRACE,
-            span_id=SPANID,
-            trace_sampled=True,
-        )
-
-        self.assertEqual(entry.to_api_repr(), expected)
-
-    def test_to_api_repr_struct_defaults(self):
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
-
-        JSON_PAYLOAD = {'key': 'value'}
-        entry = self._make_one('struct', JSON_PAYLOAD)
-        expected = {
-            'jsonPayload': JSON_PAYLOAD,
-            'resource': _GLOBAL_RESOURCE._to_dict(),
-        }
-        self.assertEqual(entry.to_api_repr(), expected)
-
-    def test_to_api_repr_struct_explicit(self):
-        import datetime
-        from google.cloud.logging.resource import Resource
-        from google.cloud._helpers import _datetime_to_rfc3339
-
-        JSON_PAYLOAD = {'key': 'value'}
-        LABELS = {'foo': 'bar', 'baz': 'qux'}
-        IID = 'IID'
-        SEVERITY = 'CRITICAL'
-        METHOD = 'POST'
-        URI = 'https://api.example.com/endpoint'
-        STATUS = '500'
-        REQUEST = {
-            'requestMethod': METHOD,
-            'requestUrl': URI,
-            'status': STATUS,
-        }
-        TIMESTAMP = datetime.datetime(2016, 12, 31, 0, 1, 2, 999999)
-        RESOURCE = Resource(
-            type='gae_app',
-            labels={
-                'module_id': 'default',
-                'version_id': 'test'
-            }
-        )
-        TRACE = '12345678-1234-5678-1234-567812345678'
-        SPANID = '000000000000004a'
-        expected = {
-            'jsonPayload': JSON_PAYLOAD,
-            'labels': LABELS,
-            'insertId': IID,
-            'severity': SEVERITY,
-            'httpRequest': REQUEST,
-            'timestamp': _datetime_to_rfc3339(TIMESTAMP),
-            'resource': RESOURCE._to_dict(),
-            'trace': TRACE,
-            'spanId': SPANID,
-            'traceSampled': True,
-        }
-        entry = self._make_one(
-            type_='struct',
-            payload=JSON_PAYLOAD,
-            labels=LABELS,
-            insert_id=IID,
-            severity=SEVERITY,
-            http_request=REQUEST,
-            timestamp=TIMESTAMP,
-            resource=RESOURCE,
-            trace=TRACE,
-            span_id=SPANID,
-            trace_sampled=True,
-        )
-
-        self.assertEqual(entry.to_api_repr(), expected)
-
-    def test_to_api_repr_proto_defaults(self):
-        from google.protobuf.json_format import MessageToDict
-        from google.cloud.logging.logger import _GLOBAL_RESOURCE
-        from google.protobuf.struct_pb2 import Struct
-        from google.protobuf.struct_pb2 import Value
-
-        message = Struct(fields={'foo': Value(bool_value=True)})
-
-        entry = self._make_one('proto', message)
-        expected = {
-            'protoPayload': MessageToDict(message),
-            'resource': _GLOBAL_RESOURCE._to_dict(),
-        }
-        self.assertEqual(entry.to_api_repr(), expected)
-
-    def test_to_api_repr_proto_explicit(self):
-        import datetime
-        from google.protobuf.json_format import MessageToDict
-        from google.cloud.logging.resource import Resource
-        from google.cloud._helpers import _datetime_to_rfc3339
-        from google.protobuf.struct_pb2 import Struct
-        from google.protobuf.struct_pb2 import Value
-
-        message = Struct(fields={'foo': Value(bool_value=True)})
-        LABELS = {'foo': 'bar', 'baz': 'qux'}
-        IID = 'IID'
-        SEVERITY = 'CRITICAL'
-        METHOD = 'POST'
-        URI = 'https://api.example.com/endpoint'
-        STATUS = '500'
-        REQUEST = {
-            'requestMethod': METHOD,
-            'requestUrl': URI,
-            'status': STATUS,
-        }
-        TIMESTAMP = datetime.datetime(2016, 12, 31, 0, 1, 2, 999999)
-        RESOURCE = Resource(
-            type='gae_app',
-            labels={
-                'module_id': 'default',
-                'version_id': 'test'
-            }
-        )
-        TRACE = '12345678-1234-5678-1234-567812345678'
-        SPANID = '000000000000004a'
-        expected = {
-            'protoPayload': MessageToDict(message),
-            'labels': LABELS,
-            'insertId': IID,
-            'severity': SEVERITY,
-            'httpRequest': REQUEST,
-            'timestamp': _datetime_to_rfc3339(TIMESTAMP),
-            'resource': RESOURCE._to_dict(),
-            'trace': TRACE,
-            'spanId': SPANID,
-            'traceSampled': True,
-        }
-
-        entry = self._make_one(
-            'proto',
-            message,
-            labels=LABELS,
-            insert_id=IID,
-            severity=SEVERITY,
-            http_request=REQUEST,
-            timestamp=TIMESTAMP,
-            resource=RESOURCE,
-            trace=TRACE,
-            span_id=SPANID,
-            trace_sampled=True,
-        )
-
-        self.assertEqual(entry.to_api_repr(), expected)
-
-
 class TestBatch(unittest.TestCase):
 
     PROJECT = 'test-project'
@@ -955,9 +955,9 @@ class TestBatch(unittest.TestCase):
 
     def test_log_empty_defaults(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
-        from google.cloud.logging.logger import _EmptyBatchEntry
+        from google.cloud.logging.logger import EmptyOutboundEntry
 
-        ENTRY = _EmptyBatchEntry._replace(resource=_GLOBAL_RESOURCE)
+        ENTRY = EmptyOutboundEntry._replace(resource=_GLOBAL_RESOURCE)
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
@@ -967,7 +967,7 @@ class TestBatch(unittest.TestCase):
     def test_log_empty_explicit(self):
         import datetime
         from google.cloud.logging.resource import Resource
-        from google.cloud.logging.logger import _EmptyBatchEntry
+        from google.cloud.logging.logger import EmptyOutboundEntry
 
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         IID = 'IID'
@@ -990,7 +990,7 @@ class TestBatch(unittest.TestCase):
         )
         TRACE = '12345678-1234-5678-1234-567812345678'
         SPANID = '000000000000004a'
-        ENTRY = _EmptyBatchEntry._replace(
+        ENTRY = EmptyOutboundEntry._replace(
             labels=LABELS,
             insert_id=IID,
             severity=SEVERITY,
@@ -1020,10 +1020,10 @@ class TestBatch(unittest.TestCase):
 
     def test_log_text_defaults(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
-        from google.cloud.logging.logger import _TextBatchEntry
+        from google.cloud.logging.logger import TextOutboundEntry
 
         TEXT = 'This is the entry text'
-        ENTRY = _TextBatchEntry._replace(
+        ENTRY = TextOutboundEntry._replace(
             payload=TEXT, resource=_GLOBAL_RESOURCE)
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
@@ -1034,7 +1034,7 @@ class TestBatch(unittest.TestCase):
     def test_log_text_explicit(self):
         import datetime
         from google.cloud.logging.resource import Resource
-        from google.cloud.logging.logger import _TextBatchEntry
+        from google.cloud.logging.logger import TextOutboundEntry
 
         TEXT = 'This is the entry text'
         LABELS = {'foo': 'bar', 'baz': 'qux'}
@@ -1058,7 +1058,7 @@ class TestBatch(unittest.TestCase):
         )
         TRACE = '12345678-1234-5678-1234-567812345678'
         SPANID = '000000000000004a'
-        ENTRY = _TextBatchEntry._replace(
+        ENTRY = TextOutboundEntry._replace(
             payload=TEXT,
             labels=LABELS,
             insert_id=IID,
@@ -1090,10 +1090,10 @@ class TestBatch(unittest.TestCase):
 
     def test_log_struct_defaults(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
-        from google.cloud.logging.logger import _StructBatchEntry
+        from google.cloud.logging.logger import StructOutboundEntry
 
         STRUCT = {'message': 'Message text', 'weather': 'partly cloudy'}
-        ENTRY = _StructBatchEntry._replace(
+        ENTRY = StructOutboundEntry._replace(
             payload=STRUCT,
             resource=_GLOBAL_RESOURCE,
         )
@@ -1106,7 +1106,7 @@ class TestBatch(unittest.TestCase):
     def test_log_struct_explicit(self):
         import datetime
         from google.cloud.logging.resource import Resource
-        from google.cloud.logging.logger import _StructBatchEntry
+        from google.cloud.logging.logger import StructOutboundEntry
 
         STRUCT = {'message': 'Message text', 'weather': 'partly cloudy'}
         LABELS = {'foo': 'bar', 'baz': 'qux'}
@@ -1130,7 +1130,7 @@ class TestBatch(unittest.TestCase):
                 'version_id': 'test',
             }
         )
-        ENTRY = _StructBatchEntry._replace(
+        ENTRY = StructOutboundEntry._replace(
             payload=STRUCT,
             labels=LABELS,
             insert_id=IID,
@@ -1162,12 +1162,12 @@ class TestBatch(unittest.TestCase):
 
     def test_log_proto_defaults(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
-        from google.cloud.logging.logger import _ProtoBatchEntry
+        from google.cloud.logging.logger import ProtoOutboundEntry
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
 
         message = Struct(fields={'foo': Value(bool_value=True)})
-        ENTRY = _ProtoBatchEntry._replace(
+        ENTRY = ProtoOutboundEntry._replace(
             payload=message,
             resource=_GLOBAL_RESOURCE,
         )
@@ -1180,7 +1180,7 @@ class TestBatch(unittest.TestCase):
     def test_log_proto_explicit(self):
         import datetime
         from google.cloud.logging.resource import Resource
-        from google.cloud.logging.logger import _ProtoBatchEntry
+        from google.cloud.logging.logger import ProtoOutboundEntry
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
 
@@ -1206,7 +1206,7 @@ class TestBatch(unittest.TestCase):
                 'version_id': 'test',
             }
         )
-        ENTRY = _ProtoBatchEntry._replace(
+        ENTRY = ProtoOutboundEntry._replace(
             payload=message,
             labels=LABELS,
             insert_id=IID,
@@ -1236,14 +1236,14 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(batch.entries, [ENTRY])
 
     def test_commit_w_unknown_entry_type(self):
-        from google.cloud.logging.logger import _BatchEntry
+        from google.cloud.logging.logger import OutboundEntry
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
         logger = _Logger()
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         api = client.logging_api = _DummyLoggingAPI()
         batch = self._make_one(logger, client)
-        batch.entries.append(_BatchEntry('bogus', 'BOGUS', severity='blah'))
+        batch.entries.append(OutboundEntry('bogus', 'BOGUS', severity='blah'))
         ENTRY = {
             'severity': 'blah',
             'resource': _GLOBAL_RESOURCE._to_dict(),


### PR DESCRIPTION
/cc @salrashid123.

Note that this PR refactors the log entry implementation pretty heavily:  log entry classes are now based on named tuples, and should be a) smaller, b) faster, and c) better documented.

Closes #5601 (includes its commits).

Closes #6094.