### PR TITLE
api_core: fix import order, appeasing lint.

### DIFF
--- a/api_core/tests/unit/test_bidi.py
+++ b/api_core/tests/unit/test_bidi.py
@@ -20,8 +20,8 @@ import mock
 import pytest
 from six.moves import queue
 
-from google.api_core import exceptions
 from google.api_core import bidi
+from google.api_core import exceptions
 
 
 class Test_RequestQueueGenerator(object):


### PR DESCRIPTION
Error left from PR #6211, when Kokoro was blithely skipping tests.

See: https://source.cloud.google.com/results/invocations/25ee204c-3118-4148-a530-0ad5e0fffc32/targets/cloud-devrel%2Fclient-libraries%2Fgoogle-cloud-python%2Fpresubmit%2Fapi_core/log