### PR TITLE
Fix branch coverage for un-called callbacks.

### DIFF
--- a/api_core/tests/unit/test_bidi.py
+++ b/api_core/tests/unit/test_bidi.py
@@ -280,7 +280,9 @@ class CallStub(object):
 
 class TestResumableBidiRpc(object):
     def test_initial_state(self):
-        bidi_rpc = bidi.ResumableBidiRpc(None, lambda _: True)
+        callback = mock.Mock()
+        callback.return_value = True
+        bidi_rpc = bidi.ResumableBidiRpc(None, callback)
 
         assert bidi_rpc.is_active is False
 
@@ -380,7 +382,9 @@ class TestResumableBidiRpc(object):
             grpc.StreamStreamMultiCallable,
             instance=True,
             side_effect=[call_1, call_2])
-        bidi_rpc = bidi.ResumableBidiRpc(start_rpc, lambda _: True)
+        callback = mock.Mock()
+        callback.return_value = True
+        bidi_rpc = bidi.ResumableBidiRpc(start_rpc, callback)
 
         bidi_rpc.open()
 


### PR DESCRIPTION
Use `mock.Mock()` w/ `return_value` True, rather than inlining `lambda _: True` in cases where the callback doesn't get called.