### PR TITLE
Adding all `Node` implementations for the `ndb.query` module

### DIFF
--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -98,3 +98,8 @@ The primary differences come from:
   be dropped or redesigned if possible.
 - Since we want "compatibility", suggestions in `TODO` comments have not been
   implemented. However, that policy can be changed if desired.
+- It seems that `query.ConjunctionNode.__new__` had an unreachable line
+  that returned a `FalseNode`. This return has been changed to a
+  `RuntimeError` just it case it **is** actually reached.
+- For ``AND`` and ``OR`` to compare equal, the nodes must come in the
+  same order. So ``AND(a > 7, b > 6)`` is not equal to ``AND(b > 6, a > 7)``.

--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -65,6 +65,8 @@ The primary differences come from:
   cases, the underlying representation of the class has changed (such as `Key`)
   due to newly available helper libraries or due to missing behavior from
   the legacy runtime.
+- `query.PostFilterNode.__eq__` compares `self.predicate` to `other.predicate`
+  rather than using `self.__dict__ == other.__dict__`
 
 ## Comments
 
@@ -94,3 +96,5 @@ The primary differences come from:
   import time, so this may not be an issue.
 - `ndb.model._BaseValue` for "wrapping" non-user values should probably
   be dropped or redesigned if possible.
+- Since we want "compatibility", suggestions in `TODO` comments have not been
+  implemented. However, that policy can be changed if desired.

--- a/ndb/src/google/cloud/ndb/exceptions.py
+++ b/ndb/src/google/cloud/ndb/exceptions.py
@@ -48,3 +48,7 @@ class Rollback(Error):
     Note that *any* exception raised by a transaction function will cause a
     rollback. Hence, this exception type is purely for convenience.
     """
+
+
+class BadQueryError(Error):
+    """Raised by Query when a query or query string is invalid."""

--- a/ndb/src/google/cloud/ndb/key.py
+++ b/ndb/src/google/cloud/ndb/key.py
@@ -261,7 +261,7 @@ class Key:
 
     def __new__(cls, *path_args, **kwargs):
         _constructor_handle_positional(path_args, kwargs)
-        self = super(Key, cls).__new__(cls)
+        instance = super(Key, cls).__new__(cls)
         if (
             "reference" in kwargs
             or "serialized" in kwargs
@@ -276,9 +276,9 @@ class Key:
                 "Key() cannot create a Key instance without arguments."
             )
 
-        self._key = ds_key
-        self._reference = reference
-        return self
+        instance._key = ds_key
+        instance._reference = reference
+        return instance
 
     @classmethod
     def _from_ds_key(cls, ds_key):

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -121,10 +121,10 @@ class IndexProperty:
     __slots__ = ("_name", "_direction")
 
     def __new__(cls, *, name, direction):
-        self = super(IndexProperty, cls).__new__(cls)
-        self._name = name
-        self._direction = direction
-        return self
+        instance = super(IndexProperty, cls).__new__(cls)
+        instance._name = name
+        instance._direction = direction
+        return instance
 
     @property
     def name(self):
@@ -162,11 +162,11 @@ class Index:
     __slots__ = ("_kind", "_properties", "_ancestor")
 
     def __new__(cls, *, kind, properties, ancestor):
-        self = super(Index, cls).__new__(cls)
-        self._kind = kind
-        self._properties = properties
-        self._ancestor = ancestor
-        return self
+        instance = super(Index, cls).__new__(cls)
+        instance._kind = kind
+        instance._properties = properties
+        instance._ancestor = ancestor
+        return instance
 
     @property
     def kind(self):
@@ -214,11 +214,11 @@ class IndexState:
     __slots__ = ("_definition", "_state", "_id")
 
     def __new__(cls, *, definition, state, id):
-        self = super(IndexState, cls).__new__(cls)
-        self._definition = definition
-        self._state = state
-        self._id = id
-        return self
+        instance = super(IndexState, cls).__new__(cls)
+        instance._definition = definition
+        instance._state = state
+        instance._id = id
+        return instance
 
     @property
     def definition(self):

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -406,11 +406,11 @@ class FilterNode(Node):
                 return nodes[0]
             return DisjunctionNode(*nodes)
 
-        self = super(FilterNode, cls).__new__(cls)
-        self._name = name
-        self._opsymbol = opsymbol
-        self._value = value
-        return self
+        instance = super(FilterNode, cls).__new__(cls)
+        instance._name = name
+        instance._opsymbol = opsymbol
+        instance._value = value
+        return instance
 
     def __getnewargs__(self):
         """Private API used to specify ``__new__`` arguments when unpickling.
@@ -487,9 +487,9 @@ class PostFilterNode(Node):
     __slots__ = ("predicate",)
 
     def __new__(cls, predicate):
-        self = super(PostFilterNode, cls).__new__(cls)
-        self.predicate = predicate
-        return self
+        instance = super(PostFilterNode, cls).__new__(cls)
+        instance.predicate = predicate
+        return instance
 
     def __getnewargs__(self):
         """Private API used to specify ``__new__`` arguments when unpickling.
@@ -671,9 +671,9 @@ class ConjunctionNode(Node):
                 *[ConjunctionNode(*segment) for segment in clauses.or_parts]
             )
 
-        self = super(ConjunctionNode, cls).__new__(cls)
-        self._nodes = clauses.or_parts[0]
-        return self
+        instance = super(ConjunctionNode, cls).__new__(cls)
+        instance._nodes = clauses.or_parts[0]
+        return instance
 
     def __getnewargs__(self):
         """Private API used to specify ``__new__`` arguments when unpickling.
@@ -807,15 +807,15 @@ class DisjunctionNode(Node):
         elif len(nodes) == 1:
             return nodes[0]
 
-        self = super(DisjunctionNode, cls).__new__(cls)
-        self._nodes = []
+        instance = super(DisjunctionNode, cls).__new__(cls)
+        instance._nodes = []
 
         clauses = _BooleanClauses("DisjunctionNode", combine_or=True)
         for node in nodes:
             clauses.add_node(node)
 
-        self._nodes[:] = clauses.or_parts
-        return self
+        instance._nodes[:] = clauses.or_parts
+        return instance
 
     def __getnewargs__(self):
         """Private API used to specify ``__new__`` arguments when unpickling.

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -236,9 +236,7 @@ class FalseNode(Node):
         """
         if post:
             return None
-        raise _exceptions.BadQueryError(
-            "Cannot convert FalseNode to predicate"
-        )
+        raise exceptions.BadQueryError("Cannot convert FalseNode to predicate")
 
 
 class ParameterNode(Node):
@@ -310,7 +308,7 @@ class ParameterNode(Node):
             .BadArgumentError: Always. This is because this node represents
             a parameter, i.e. no value exists to be filtered on.
         """
-        raise _exceptions.BadArgumentError(
+        raise exceptions.BadArgumentError(
             "Parameter :{} is not bound.".format(self._param.key)
         )
 

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -205,8 +205,33 @@ class Node:
 
 
 class FalseNode(Node):
-    def __init__(self, *args, **kwargs):
-        raise NotImplementedError
+    """Tree node for an always-failing filter."""
+
+    def __eq__(self, other):
+        """Equality check.
+
+        An instance will always equal another :class:`FalseNode` instance. This
+        is because they hold no state.
+        """
+        if not isinstance(other, FalseNode):
+            return NotImplemented
+        return True
+
+    def _to_filter(self, post=False):
+        """(Attempt to) convert to a low-level filter instance.
+
+        Args:
+            post (bool): Indicates if this is a post-filter node.
+
+        Raises:
+            .BadQueryError: If ``post`` is :data:`False`, because there's no
+                point submitting a query that will never return anything.
+        """
+        if post:
+            return None
+        raise _exceptions.BadQueryError(
+            "Cannot convert FalseNode to predicate"
+        )
 
 
 class ParameterNode(Node):

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -15,6 +15,7 @@
 """High-level wrapper for datastore queries."""
 
 from google.cloud.ndb import exceptions
+from google.cloud.ndb import model
 
 
 __all__ = [
@@ -40,6 +41,8 @@ __all__ = [
 
 
 Cursor = NotImplemented  # From `google.appengine.datastore.datastore_query`
+_IN_OP = "in"
+_OPS = frozenset(["=", "!=", "<", "<=", ">", ">=", _IN_OP])
 
 
 class QueryOptions:
@@ -235,8 +238,94 @@ class FalseNode(Node):
 
 
 class ParameterNode(Node):
-    def __init__(self, *args, **kwargs):
-        raise NotImplementedError
+    """Tree node for a parameterized filter.
+
+    Args:
+        prop (.Property): A property describing a value type.
+        op (str): The comparison operator. One of ``=``, ``!=``, ``<``, ``<=``,
+            ``>``, ``>=`` or ``in``.
+        param (ParameterizedThing): The parameter corresponding to the node.
+
+    Raises:
+        TypeError: If ``prop`` is not a :class:`.Property`.
+        TypeError: If ``op`` is not one of the accepted operators.
+        TypeError: If ``param`` is not a :class:`.Parameter` or
+            :class:`.ParameterizedFunction`.
+    """
+
+    def __new__(cls, prop, op, param):
+        if not isinstance(prop, model.Property):
+            raise TypeError("Expected a Property, got {!r}".format(prop))
+        if op not in _OPS:
+            raise TypeError("Expected a valid operator, got {!r}".format(op))
+        if not isinstance(param, ParameterizedThing):
+            raise TypeError(
+                "Expected a ParameterizedThing, got {!r}".format(param)
+            )
+        obj = super(ParameterNode, cls).__new__(cls)
+        obj._prop = prop
+        obj._op = op
+        obj._param = param
+        return obj
+
+    def __getnewargs__(self):
+        """Private API used to specify ``__new__`` arguments when unpickling.
+
+        .. note::
+
+            This method only applies if the ``pickle`` protocol is 2 or
+            greater.
+
+        Returns:
+            Tuple[.Property, str, .ParameterizedThing]: A tuple containing the
+            internal state: the property, operation and parameter.
+        """
+        return self._prop, self._op, self._param
+
+    def __repr__(self):
+        return "ParameterNode({!r}, {!r}, {!r})".format(
+            self._prop, self._op, self._param
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, ParameterNode):
+            return NotImplemented
+        return (
+            self._prop._name == other._prop._name
+            and self._op == other._op
+            and self._param == other._param
+        )
+
+    def _to_filter(self, post=False):
+        """Helper to convert to low-level filter, or :data:`None`.
+
+        Args:
+            post (bool): Indicates if this is a post-filter node.
+
+        Raises:
+            .BadArgumentError: Always. This is because this node represents
+            a parameter, i.e. no value exists to be filtered on.
+        """
+        raise _exceptions.BadArgumentError(
+            "Parameter :{} is not bound.".format(self._param.key)
+        )
+
+    def resolve(self, bindings, used):
+        """Return a node with parameters replaced by the selected values.
+
+        Args:
+            bindings (dict): A mapping of parameter bindings.
+            used (Dict[Union[str, int], bool]): A mapping of already used
+                parameters.
+
+        Raises:
+            NotImplementedError: Always. This is because the implementation
+                will rely on as-yet-unimplemented features in
+                :class:`Property`.
+        """
+        raise NotImplementedError(
+            "Some features of Property need to be implemented first"
+        )
 
 
 class FilterNode(Node):

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -243,13 +243,15 @@ class ParameterNode(Node):
     """Tree node for a parameterized filter.
 
     Args:
-        prop (.Property): A property describing a value type.
+        prop (~google.cloud.ndb.model.Property): A property describing a value
+            type.
         op (str): The comparison operator. One of ``=``, ``!=``, ``<``, ``<=``,
             ``>``, ``>=`` or ``in``.
         param (ParameterizedThing): The parameter corresponding to the node.
 
     Raises:
-        TypeError: If ``prop`` is not a :class:`.Property`.
+        TypeError: If ``prop`` is not a
+            :class:`~google.cloud.ndb.model.Property`.
         TypeError: If ``op`` is not one of the accepted operators.
         TypeError: If ``param`` is not a :class:`.Parameter` or
             :class:`.ParameterizedFunction`.
@@ -279,8 +281,9 @@ class ParameterNode(Node):
             greater.
 
         Returns:
-            Tuple[.Property, str, .ParameterizedThing]: A tuple containing the
-            internal state: the property, operation and parameter.
+            Tuple[~google.cloud.ndb.model.Property, str, ParameterizedThing]:
+            A tuple containing the internal state: the property, operation and
+            parameter.
         """
         return self._prop, self._op, self._param
 
@@ -323,7 +326,7 @@ class ParameterNode(Node):
         Raises:
             NotImplementedError: Always. This is because the implementation
                 will rely on as-yet-unimplemented features in
-                :class:`Property`.
+                :class:`~google.cloud.ndb.model.Property`.
         """
         raise NotImplementedError(
             "Some features of Property need to be implemented first"
@@ -361,7 +364,7 @@ class FilterNode(Node):
 
     Raises:
         TypeError: If ``opsymbol`` is ``"in"`` but ``value`` is not a
-            basic container (:class:`list`, :func:`tuple`, :class:`set` or
+            basic container (:class:`list`, :class:`tuple`, :class:`set` or
             :class:`frozenset`)
     """
 
@@ -662,7 +665,7 @@ class ConjunctionNode(Node):
 
         Returns:
             Tuple[Node, ...]: The list of stored nodes, converted to a
-            :func:`tuple`.
+            :class:`tuple`.
         """
         return tuple(self._nodes)
 
@@ -765,7 +768,7 @@ class DisjunctionNode(Node):
 
     .. warning::
 
-        This constructor may not always return a :class:`DisjuctionNode`.
+        This constructor may not always return a :class:`DisjunctionNode`.
         If the passed in ``nodes`` has only one entry, that single node
         will be returned by the constructor.
 
@@ -802,7 +805,7 @@ class DisjunctionNode(Node):
 
         Returns:
             Tuple[Node, ...]: The list of stored nodes, converted to a
-            :func:`tuple`.
+            :class:`tuple`.
         """
         return tuple(self._nodes)
 

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -134,8 +134,74 @@ class ParameterizedFunction(ParameterizedThing):
 
 
 class Node:
-    def __init__(self, *args, **kwargs):
+    """Base class for filter expression tree nodes.
+
+    Tree nodes are considered immutable, even though they can contain
+    Parameter instances, which are not.  In particular, two identical
+    trees may be represented by the same Node object in different
+    contexts.
+
+    Raises:
+        TypeError: Always, only subclasses are allowed.
+    """
+
+    def __new__(cls):
+        if cls is Node:
+            raise TypeError("Cannot instantiate Node, only a subclass.")
+        return super(Node, cls).__new__(cls)
+
+    def __eq__(self, other):
         raise NotImplementedError
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __le__(self, unused_other):
+        raise TypeError("Nodes cannot be ordered")
+
+    def __lt__(self, unused_other):
+        raise TypeError("Nodes cannot be ordered")
+
+    def __ge__(self, unused_other):
+        raise TypeError("Nodes cannot be ordered")
+
+    def __gt__(self, unused_other):
+        raise TypeError("Nodes cannot be ordered")
+
+    def _to_filter(self, post=False):
+        """Helper to convert to low-level filter, or :data:`None`.
+
+        Raises:
+            NotImplementedError: Always. This method is virtual.
+        """
+        raise NotImplementedError
+
+    def _post_filters(self):
+        """Helper to extract post-filter nodes, if any.
+
+        Returns:
+            None: Always. Because this is the base implementation.
+        """
+        return None
+
+    def resolve(self, bindings, used):
+        """Return a node with parameters replaced by the selected values.
+
+        .. note::
+
+            Both ``bindings`` and ``used`` are unused by this base class
+            implementation.
+
+        Args:
+            bindings (dict): A mapping of parameter bindings.
+            used (Dict[Union[str, int], bool]): A mapping of already used
+                parameters. This will be modified if the current parameter
+                is in ``bindings``.
+
+        Returns:
+            Node: The current node.
+        """
+        return self
 
 
 class FalseNode(Node):

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -65,6 +65,8 @@ class ParameterizedThing:
     This exists purely for :func:`isinstance` checks.
     """
 
+    __slots__ = ()
+
     def __eq__(self, other):
         raise NotImplementedError
 
@@ -86,6 +88,8 @@ class Parameter(ParameterizedThing):
     Raises:
         TypeError: If the ``key`` is not a string or integer.
     """
+
+    __slots__ = ("_key",)
 
     def __init__(self, key):
         if not isinstance(key, (int, str, bytes)):
@@ -136,6 +140,8 @@ class Parameter(ParameterizedThing):
 
 
 class ParameterizedFunction(ParameterizedThing):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -151,6 +157,8 @@ class Node:
     Raises:
         TypeError: Always, only subclasses are allowed.
     """
+
+    __slots__ = ()
 
     def __new__(cls):
         if cls is Node:
@@ -214,6 +222,8 @@ class Node:
 class FalseNode(Node):
     """Tree node for an always-failing filter."""
 
+    __slots__ = ()
+
     def __eq__(self, other):
         """Equality check.
 
@@ -256,6 +266,8 @@ class ParameterNode(Node):
         TypeError: If ``param`` is not a :class:`.Parameter` or
             :class:`.ParameterizedFunction`.
     """
+
+    __slots__ = ("_prop", "_op", "_param")
 
     def __new__(cls, prop, op, param):
         if not isinstance(prop, model.Property):
@@ -368,6 +380,8 @@ class FilterNode(Node):
             :class:`frozenset`)
     """
 
+    __slots__ = ("_name", "_opsymbol", "_value")
+
     def __new__(cls, name, opsymbol, value):
         if isinstance(value, model.Key):
             value = value.to_old_key()
@@ -470,6 +484,8 @@ class PostFilterNode(Node):
             the given filter.
     """
 
+    __slots__ = ("predicate",)
+
     def __new__(cls, predicate):
         self = super(PostFilterNode, cls).__new__(cls)
         self.predicate = predicate
@@ -539,6 +555,8 @@ class _BooleanClauses:
         combine_or (bool): Indicates if new nodes will be combined
             with the current boolean expression via ``AND`` or ``OR``.
     """
+
+    __slots__ = ("name", "combine_or", "or_parts")
 
     def __init__(self, name, combine_or):
         self.name = name
@@ -630,6 +648,8 @@ class ConjunctionNode(Node):
         RuntimeError: If the ``nodes`` combine to an "empty" boolean
             expression.
     """
+
+    __slots__ = ("_nodes",)
 
     def __new__(cls, *nodes):
         if not nodes:
@@ -778,6 +798,8 @@ class DisjunctionNode(Node):
     Raises:
         TypeError: If ``nodes`` is empty.
     """
+
+    __slots__ = ("_nodes",)
 
     def __new__(cls, *nodes):
         if not nodes:

--- a/ndb/tests/unit/test_query.py
+++ b/ndb/tests/unit/test_query.py
@@ -127,8 +127,68 @@ class TestParameterizedFunction:
 class TestNode:
     @staticmethod
     def test_constructor():
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             query.Node()
+
+    @staticmethod
+    def _make_one():
+        # Bypass the intentionally broken constructor.
+        node = object.__new__(query.Node)
+        assert isinstance(node, query.Node)
+        return node
+
+    def test___eq__(self):
+        node = self._make_one()
+        with pytest.raises(NotImplementedError):
+            node == None
+
+    def test___ne__(self):
+        node = self._make_one()
+        with pytest.raises(NotImplementedError):
+            node != None
+
+    def test___le__(self):
+        node = self._make_one()
+        with pytest.raises(TypeError) as exc_info:
+            node <= None
+
+        assert exc_info.value.args == ("Nodes cannot be ordered",)
+
+    def test___lt__(self):
+        node = self._make_one()
+        with pytest.raises(TypeError) as exc_info:
+            node < None
+
+        assert exc_info.value.args == ("Nodes cannot be ordered",)
+
+    def test___ge__(self):
+        node = self._make_one()
+        with pytest.raises(TypeError) as exc_info:
+            node >= None
+
+        assert exc_info.value.args == ("Nodes cannot be ordered",)
+
+    def test___gt__(self):
+        node = self._make_one()
+        with pytest.raises(TypeError) as exc_info:
+            node > None
+
+        assert exc_info.value.args == ("Nodes cannot be ordered",)
+
+    def test__to_filter(self):
+        node = self._make_one()
+        with pytest.raises(NotImplementedError):
+            node._to_filter()
+
+    def test__post_filters(self):
+        node = self._make_one()
+        assert node._post_filters() is None
+
+    def test_resolve(self):
+        node = self._make_one()
+        used = {}
+        assert node.resolve({}, used) is node
+        assert used == {}
 
 
 class TestFalseNode:

--- a/ndb/tests/unit/test_query.py
+++ b/ndb/tests/unit/test_query.py
@@ -649,11 +649,10 @@ class TestConjunctionNode:
 
     @staticmethod
     def test__to_filter_single():
-        node1 = query.FilterNode("a", "=", 7)
-        node1._to_filter = unittest.mock.Mock(spec=())
+        node1 = unittest.mock.Mock(spec=query.FilterNode)
         node2 = query.PostFilterNode("predicate")
-        node3 = query.FilterNode("a", "=", 7)
-        node3._to_filter = unittest.mock.Mock(spec=(), return_value=False)
+        node3 = unittest.mock.Mock(spec=query.FilterNode)
+        node3._to_filter.return_value = False
         and_node = query.ConjunctionNode(node1, node2, node3)
 
         as_filter = and_node._to_filter()
@@ -723,10 +722,10 @@ class TestConjunctionNode:
 
     @staticmethod
     def test_resolve_changed():
-        node1 = query.FilterNode("a", "=", 7)
+        node1 = unittest.mock.Mock(spec=query.FilterNode)
         node2 = query.FilterNode("b", ">", 77)
         node3 = query.FilterNode("c", "=", 7)
-        node1.resolve = unittest.mock.Mock(spec=(), return_value=node3)
+        node1.resolve.return_value = node3
         and_node = query.ConjunctionNode(node1, node2)
 
         bindings = {}
@@ -821,10 +820,10 @@ class TestDisjunctionNode:
 
     @staticmethod
     def test_resolve_changed():
-        node1 = query.FilterNode("a", "=", 7)
+        node1 = unittest.mock.Mock(spec=query.FilterNode)
         node2 = query.FilterNode("b", ">", 77)
         node3 = query.FilterNode("c", "=", 7)
-        node1.resolve = unittest.mock.Mock(spec=(), return_value=node3)
+        node1.resolve.return_value = node3
         or_node = query.DisjunctionNode(node1, node2)
 
         bindings = {}

--- a/ndb/tests/unit/test_query.py
+++ b/ndb/tests/unit/test_query.py
@@ -207,7 +207,7 @@ class TestFalseNode:
     @staticmethod
     def test__to_filter():
         false_node = query.FalseNode()
-        with pytest.raises(_exceptions.BadQueryError):
+        with pytest.raises(exceptions.BadQueryError):
             false_node._to_filter()
 
     @staticmethod
@@ -287,7 +287,7 @@ class TestParameterNode:
         prop = model.Property(name="val")
         param = query.Parameter("abc")
         parameter_node = query.ParameterNode(prop, "=", param)
-        with pytest.raises(_exceptions.BadArgumentError):
+        with pytest.raises(exceptions.BadArgumentError):
             parameter_node._to_filter()
 
     @staticmethod

--- a/ndb/tests/unit/test_query.py
+++ b/ndb/tests/unit/test_query.py
@@ -193,9 +193,24 @@ class TestNode:
 
 class TestFalseNode:
     @staticmethod
-    def test_constructor():
-        with pytest.raises(NotImplementedError):
-            query.FalseNode()
+    def test___eq__():
+        false_node1 = query.FalseNode()
+        false_node2 = query.FalseNode()
+        false_node3 = unittest.mock.sentinel.false_node
+        assert false_node1 == false_node1
+        assert false_node1 == false_node2
+        assert not false_node1 == false_node3
+
+    @staticmethod
+    def test__to_filter():
+        false_node = query.FalseNode()
+        with pytest.raises(_exceptions.BadQueryError):
+            false_node._to_filter()
+
+    @staticmethod
+    def test__to_filter_post():
+        false_node = query.FalseNode()
+        assert false_node._to_filter(post=True) is None
 
 
 class TestParameterNode:

--- a/ndb/tests/unit/test_query.py
+++ b/ndb/tests/unit/test_query.py
@@ -405,8 +405,47 @@ class TestFilterNode:
 class TestPostFilterNode:
     @staticmethod
     def test_constructor():
-        with pytest.raises(NotImplementedError):
-            query.PostFilterNode()
+        predicate = unittest.mock.sentinel.predicate
+        post_filter_node = query.PostFilterNode(predicate)
+        assert post_filter_node.predicate is predicate
+
+    @staticmethod
+    def test_pickling():
+        predicate = "must-be-pickle-able"
+        post_filter_node = query.PostFilterNode(predicate)
+
+        pickled = pickle.dumps(post_filter_node)
+        unpickled = pickle.loads(pickled)
+        assert post_filter_node == unpickled
+
+    @staticmethod
+    def test___repr__():
+        predicate = "predicate-not-repr"
+        post_filter_node = query.PostFilterNode(predicate)
+        assert repr(post_filter_node) == "PostFilterNode(predicate-not-repr)"
+
+    @staticmethod
+    def test___eq__():
+        predicate1 = unittest.mock.sentinel.predicate1
+        post_filter_node1 = query.PostFilterNode(predicate1)
+        predicate2 = unittest.mock.sentinel.predicate2
+        post_filter_node2 = query.PostFilterNode(predicate2)
+        post_filter_node3 = unittest.mock.sentinel.post_filter_node
+        assert post_filter_node1 == post_filter_node1
+        assert not post_filter_node1 == post_filter_node2
+        assert not post_filter_node1 == post_filter_node3
+
+    @staticmethod
+    def test__to_filter_post():
+        predicate = unittest.mock.sentinel.predicate
+        post_filter_node = query.PostFilterNode(predicate)
+        assert post_filter_node._to_filter(post=True) is predicate
+
+    @staticmethod
+    def test__to_filter():
+        predicate = unittest.mock.sentinel.predicate
+        post_filter_node = query.PostFilterNode(predicate)
+        assert post_filter_node._to_filter() is None
 
 
 class TestConjunctionNode:


### PR DESCRIPTION
In particular

- `query.Node`
- `query.FalseNode`
- Most of `query.ParameterNode`. The remaining part (`ParameterNode.resolve()`) depends on as-yet-unimplemented features of `model.Property`.
- Most of `query.FilterNode`. With two "missing" parts.
  - `FilterNode._to_filter` raises `NotImplementedError` instead of creating a filter object. This is because the old implementation relies on the `google.appengine.datastore.datastore_query` module for low-level filters. At some point we'll need to replace that with the new protobuf [Filter][1]
  - If `value` is a `model.Key`, this just does what the original implementation did: call `Key.to_old_key`. This must be changed to actual convert it to a protobuf `Key` for the new proto API
- `query.PostFilterNode`. I slightly modified the `__eq__` implementation and made a note about this in `MIGRATION_NOTES.md`.
- `query.AND` and `query.OR` (named `ConjunctionFilter` and `DisjunctionFilter`); `ConjunctionFilter._to_filter()` is only partially implemented because it relies on `datastore_query` to create a low-level `Filter` protobuf

[1]: https://github.com/googleapis/googleapis/blob/ddb39a21778579122d6edf505bda0092c8066a65/google/datastore/v1/query.proto#L154