### PR TITLE
Restoring some `__new__()` constructors for `ndb`.

### DIFF
--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -58,6 +58,13 @@ The primary differences come from:
   the backend should enforce these limits, not the library.)
 - I renamed `Property.__creation_counter_global` to
   `Property._CREATION_COUNTER`.
+- `ndb` uses "private" instance attributes in many places, e.g. `Key.__app`.
+  The current implementation (for now) just uses "protected" attribute names,
+  e.g. `Key._key` (the implementation has changed in the rewrite). We may want
+  to keep the old "private" names around for compatibility. However, in some
+  cases, the underlying representation of the class has changed (such as `Key`)
+  due to newly available helper libraries or due to missing behavior from
+  the legacy runtime.
 
 ## Comments
 
@@ -72,14 +79,10 @@ The primary differences come from:
   and 4, during unpickling an instance will first be created via
   `Key.__new__()` and then `__setstate__` would be called on that instance.
   The addition of the `__getnewargs__` allows the (positional) arguments to be
-  stored in the pickled bytes. The original `ndb` implementation did **all** of
-  the work of the constructor in `__new__`, so the call to `__setstate__` was
-  redundant. In our implementation `__setstate__` is succifient and `__new__`
-  isn't implemented, hence `__getnewargs__` isn't needed.
-- Since we no longer use `__new__` as the constructor / utilize the
-  `__getnewargs__` value, the extra support for
-  `Key({"flat": ("a", "b"), ...})` as an alternative to
-  `Key(flat=("a", "b"), ...)` can be retired
+  stored in the pickled bytes. **All** of the work of the constructor happens
+  in `__new__`, so the call to `__setstate__` is redundant. In our
+  implementation `__setstate__` is sufficient, hence `__getnewargs__` isn't
+  needed.
 - Key parts (i.e. kind, string ID and / or integer ID) are verified when a
   `Reference` is created. However, this won't occur when the corresponding
   protobuf for the underlying `google.cloud.datastore.Key` is created. This

--- a/ndb/src/google/cloud/ndb/key.py
+++ b/ndb/src/google/cloud/ndb/key.py
@@ -259,14 +259,15 @@ class Key:
 
     __slots__ = ("_key", "_reference")
 
-    def __init__(self, *path_args, **kwargs):
+    def __new__(cls, *path_args, **kwargs):
         _constructor_handle_positional(path_args, kwargs)
+        self = super(Key, cls).__new__(cls)
         if (
             "reference" in kwargs
             or "serialized" in kwargs
             or "urlsafe" in kwargs
         ):
-            ds_key, reference = _parse_from_ref(type(self), **kwargs)
+            ds_key, reference = _parse_from_ref(cls, **kwargs)
         elif "pairs" in kwargs or "flat" in kwargs:
             ds_key = _parse_from_args(**kwargs)
             reference = None
@@ -277,6 +278,7 @@ class Key:
 
         self._key = ds_key
         self._reference = reference
+        return self
 
     @classmethod
     def _from_ds_key(cls, ds_key):
@@ -292,7 +294,7 @@ class Key:
         Returns:
             Key: The constructed :class:`Key`.
         """
-        key = cls.__new__(cls)
+        key = super(Key, cls).__new__(cls)
         key._key = ds_key
         key._reference = None
         return key

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -120,9 +120,11 @@ class IndexProperty:
 
     __slots__ = ("_name", "_direction")
 
-    def __init__(self, *, name, direction):
+    def __new__(cls, *, name, direction):
+        self = super(IndexProperty, cls).__new__(cls)
         self._name = name
         self._direction = direction
+        return self
 
     @property
     def name(self):
@@ -159,10 +161,12 @@ class Index:
 
     __slots__ = ("_kind", "_properties", "_ancestor")
 
-    def __init__(self, *, kind, properties, ancestor):
+    def __new__(cls, *, kind, properties, ancestor):
+        self = super(Index, cls).__new__(cls)
         self._kind = kind
         self._properties = properties
         self._ancestor = ancestor
+        return self
 
     @property
     def kind(self):
@@ -209,10 +213,12 @@ class IndexState:
 
     __slots__ = ("_definition", "_state", "_id")
 
-    def __init__(self, *, definition, state, id):
+    def __new__(cls, *, definition, state, id):
+        self = super(IndexState, cls).__new__(cls)
         self._definition = definition
         self._state = state
         self._id = id
+        return self
 
     @property
     def definition(self):


### PR DESCRIPTION
See the comment in `MIGRATION_NOTES.md` about the rampant use (and abuse) of `__new__()` rather than `__init__()` as a constructor.

Updated `MIGRATION_NOTES.md` to make a note about the difference in internal state between old and new versions of `ndb`. In particular, the new version has dropped usage of "private" (e.g. `self.__foo`) variables.

Removed `__slots__` from classes that didn't have them in the old implementation.

----

@theacodes and I discussed this and the conclusion was that "the old way" should be preserved as often as possible