### PR TITLE
Docs: fix 'CallOptions' examples

### DIFF
--- a/bigquery_datatransfer/README.rst
+++ b/bigquery_datatransfer/README.rst
@@ -88,7 +88,7 @@ DataTransferServiceClient
         pass
 
     # Or iterate over results one page at a time
-    for page in client.list_data_sources(parent, options=CallOptions(page_token=INITIAL_PAGE)):
+    for page in client.list_data_sources(parent).pages:
         for element in page:
             # process element
             pass

--- a/dataproc/README.rst
+++ b/dataproc/README.rst
@@ -87,7 +87,7 @@ Example Usage
         pass
 
     # Or iterate over results one page at a time
-    for page in client.list_clusters(project_id, region, options=CallOptions(page_token=INITIAL_PAGE)):
+    for page in client.list_clusters(project_id, region).pages:
         for element in page:
             # process element
             pass

--- a/iot/README.rst
+++ b/iot/README.rst
@@ -90,7 +90,7 @@ DeviceManagerClient
         pass
 
     # Or iterate over results one page at a time
-    for page in client.list_device_registries(parent, options=CallOptions(page_token=INITIAL_PAGE)):
+    for page in client.list_device_registries(parent).pages:
         for element in page:
             # process element
             pass

--- a/monitoring/README.rst
+++ b/monitoring/README.rst
@@ -90,7 +90,7 @@ MetricServiceClient
         pass
 
     # Or iterate over results one page at a time
-    for page in client.list_monitored_resource_descriptors(name, options=CallOptions(page_token=INITIAL_PAGE)):
+    for page in client.list_monitored_resource_descriptors(name).pages:
         for element in page:
             # process element
             pass

--- a/vision/google/cloud/vision_helpers/__init__.py
+++ b/vision/google/cloud/vision_helpers/__init__.py
@@ -40,8 +40,12 @@ class VisionHelpers(object):
 
         Args:
             request (:class:`~.vision_v1.types.AnnotateImageRequest`)
-            options (:class:`google.gax.CallOptions`): Overrides the default
-                settings for this call, e.g, timeout, retries, etc.
+            retry (Optional[google.api_core.retry.Retry]):  A retry object used
+                to retry requests. If ``None`` is specified, requests will not
+                be retried.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
 
         Returns:
             :class:`~.vision_v1.types.AnnotateImageResponse` The API response.


### PR DESCRIPTION
In package `README.rst` files, where `CallOptions` was being shown as a way to trigger paged iteration, usse idiomatic `pages` attribute of iterators

For `VisionHelper.annotate_image`, update docstring to reflect the actual signature, which takes `retry` and `timeout` rather than `options`.

Closes #5560.

Other elements of that bug will be fixed in [`gapic-generator`](googleapis/gapic-generator#2388) and propagated via autosynth.