### PR TITLE
Adding documentation for all `ndb` modules.

### DIFF
--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -31,7 +31,7 @@ The primary differences come from:
 ## Differences (between old and new implementations)
 
 - The "standard" exceptions from App Engine are no longer available. Instead,
-  we'll create "shims" for them in `google.cloud.ndb._exceptions` to match the
+  we'll create "shims" for them in `google.cloud.ndb.exceptions` to match the
   class names and emulate behavior.
 - There is no replacement for `google.appengine.api.namespace_manager` which is
   used to determine the default namespace when not passed in to `Key()`

--- a/ndb/docs/blobstore.rst
+++ b/ndb/docs/blobstore.rst
@@ -1,8 +1,8 @@
-###
-Key
-###
+#########
+Blobstore
+#########
 
-.. automodule:: google.cloud.ndb.key
+.. automodule:: google.cloud.ndb.blobstore
     :members:
     :inherited-members:
     :undoc-members:

--- a/ndb/docs/conf.py
+++ b/ndb/docs/conf.py
@@ -34,6 +34,10 @@ version = ".".join(release.split(".")[:2])
 # If your documentation needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'
+nitpicky = True
+nitpick_ignore = [
+    ("py:obj", "google.cloud.datastore._app_engine_key_pb2.Reference")
+]
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/ndb/docs/django-middleware.rst
+++ b/ndb/docs/django-middleware.rst
@@ -1,0 +1,9 @@
+#################
+Django Middleware
+#################
+
+.. automodule:: google.cloud.ndb.django_middleware
+    :members:
+    :inherited-members:
+    :undoc-members:
+    :show-inheritance:

--- a/ndb/docs/exceptions.rst
+++ b/ndb/docs/exceptions.rst
@@ -1,0 +1,8 @@
+##########
+Exceptions
+##########
+
+.. automodule:: google.cloud.ndb.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/ndb/docs/index.rst
+++ b/ndb/docs/index.rst
@@ -6,7 +6,16 @@
    :hidden:
    :maxdepth: 2
 
-   Key <key>
-   Model <model>
+   key
+   model
+   query
+   exceptions
+   polymodel
+   django-middleware
+   msgprop
+   blobstore
+   metadata
+   stats
 
-Placeholder.
+.. automodule:: google.cloud.ndb
+    :no-members:

--- a/ndb/docs/metadata.rst
+++ b/ndb/docs/metadata.rst
@@ -1,9 +1,9 @@
 ##################
-Model and Property
+Datastore Metadata
 ##################
 
-.. automodule:: google.cloud.ndb.model
+.. automodule:: google.cloud.ndb.metadata
     :members:
-    :exclude-members: Key, Rollback
+    :inherited-members:
     :undoc-members:
     :show-inheritance:

--- a/ndb/docs/msgprop.rst
+++ b/ndb/docs/msgprop.rst
@@ -1,0 +1,9 @@
+###########################
+ProtoRPC Message Properties
+###########################
+
+.. automodule:: google.cloud.ndb.msgprop
+    :members:
+    :inherited-members:
+    :undoc-members:
+    :show-inheritance:

--- a/ndb/docs/polymodel.rst
+++ b/ndb/docs/polymodel.rst
@@ -1,0 +1,9 @@
+##############################
+Polymorphic Models and Queries
+##############################
+
+.. automodule:: google.cloud.ndb.polymodel
+    :members:
+    :inherited-members:
+    :undoc-members:
+    :show-inheritance:

--- a/ndb/docs/query.rst
+++ b/ndb/docs/query.rst
@@ -1,8 +1,8 @@
-###
-Key
-###
+#####
+Query
+#####
 
-.. automodule:: google.cloud.ndb.key
+.. automodule:: google.cloud.ndb.query
     :members:
     :inherited-members:
     :undoc-members:

--- a/ndb/docs/stats.rst
+++ b/ndb/docs/stats.rst
@@ -1,0 +1,9 @@
+####################
+Datastore Statistics
+####################
+
+.. automodule:: google.cloud.ndb.stats
+    :members:
+    :inherited-members:
+    :undoc-members:
+    :show-inheritance:

--- a/ndb/src/google/cloud/ndb/__init__.py
+++ b/ndb/src/google/cloud/ndb/__init__.py
@@ -16,9 +16,13 @@
 
 It was originally included in the Google App Engine runtime as a "new"
 version of the ``db`` API (hence ``ndb``).
+
+.. autodata:: __version__
+.. autodata:: __all__
 """
 
 __version__ = "0.0.1.dev1"
+"""Current ``ndb`` version."""
 __all__ = [
     "AutoBatcher",
     "Context",
@@ -115,6 +119,7 @@ __all__ = [
     "tasklet",
     "toplevel",
 ]
+"""All top-level exported names."""
 
 from google.cloud.ndb.context import AutoBatcher
 from google.cloud.ndb.context import Context

--- a/ndb/src/google/cloud/ndb/exceptions.py
+++ b/ndb/src/google/cloud/ndb/exceptions.py
@@ -20,7 +20,7 @@ legacy Google App Engine runtime.
 """
 
 
-__all__ = []
+__all__ = ["Error", "BadValueError", "BadArgumentError", "Rollback"]
 
 
 class Error(Exception):

--- a/ndb/src/google/cloud/ndb/key.py
+++ b/ndb/src/google/cloud/ndb/key.py
@@ -92,7 +92,7 @@ from google.cloud.datastore import _app_engine_key_pb2
 from google.cloud.datastore import key as _key_module
 import google.cloud.datastore
 
-from google.cloud.ndb import _exceptions
+from google.cloud.ndb import exceptions
 
 
 __all__ = ["Key"]
@@ -1075,7 +1075,7 @@ def _parse_from_args(
     else:
         project = _project_from_app(app, allow_empty=True)
         if not isinstance(parent, Key):
-            raise _exceptions.BadValueError(
+            raise exceptions.BadValueError(
                 "Expected Key instance, got {!r}".format(parent)
             )
         # Offload verification of parent to ``google.cloud.datastore.Key()``.
@@ -1163,7 +1163,7 @@ def _clean_flat_path(flat):
         id_ = flat[i + 1]
         if id_ is None:
             if i + 2 < len(flat):
-                raise _exceptions.BadArgumentError(
+                raise exceptions.BadArgumentError(
                     "Incomplete Key entry must be last"
                 )
         elif not isinstance(id_, (str, int)):

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -15,7 +15,7 @@
 """Model classes for datastore objects and properties for models."""
 
 
-from google.cloud.ndb import _exceptions
+from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
 
 
@@ -81,17 +81,17 @@ __all__ = [
 Key = key_module.Key
 BlobKey = NotImplemented  # From `google.appengine.api.datastore_types`
 GeoPt = NotImplemented  # From `google.appengine.api.datastore_types`
-Rollback = _exceptions.Rollback
+Rollback = exceptions.Rollback
 
 
-class KindError(_exceptions.BadValueError):
+class KindError(exceptions.BadValueError):
     """Raised when an implementation for a kind can't be found.
 
     May also be raised when the kind is not a byte string.
     """
 
 
-class InvalidPropertyError(_exceptions.Error):
+class InvalidPropertyError(exceptions.Error):
     """Raised when a property is not applicable to a given use.
 
     For example, a property must exist and be indexed to be used in a query's
@@ -103,11 +103,11 @@ BadProjectionError = InvalidPropertyError
 """This alias for :class:`InvalidPropertyError` is for legacy support."""
 
 
-class UnprojectedPropertyError(_exceptions.Error):
+class UnprojectedPropertyError(exceptions.Error):
     """Raised when getting a property value that's not in the projection."""
 
 
-class ReadonlyPropertyError(_exceptions.Error):
+class ReadonlyPropertyError(exceptions.Error):
     """Raised when attempting to set a property value that is read-only."""
 
 
@@ -268,7 +268,7 @@ def make_connection(*args, **kwargs):
 
 
 class ModelAttribute:
-    """Base for :meth:`_fix_up` implementing classes."""
+    """Base for classes that implement a ``_fix_up()`` method."""
 
     def _fix_up(self, cls, code_name):
         """Fix-up property name. To be implemented by subclasses.

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -14,7 +14,7 @@
 
 """High-level wrapper for datastore queries."""
 
-from google.cloud.ndb import _exceptions
+from google.cloud.ndb import exceptions
 
 
 __all__ = [
@@ -71,7 +71,7 @@ class Parameter(ParameterizedThing):
     ``Parameter(1)`` corresponds to a slot labeled ``:1`` in a GQL query.
     ``Parameter('xyz')`` corresponds to a slot labeled ``:xyz``.
 
-    The value must be set (bound) separately by calling :meth:`set`.
+    The value must be set (bound) separately.
 
     Args:
         key (Union[str, int]): The parameter key.
@@ -120,7 +120,7 @@ class Parameter(ParameterizedThing):
         """
         key = self._key
         if key not in bindings:
-            raise _exceptions.BadArgumentError(
+            raise exceptions.BadArgumentError(
                 "Parameter :{} is not bound.".format(key)
             )
         value = bindings[key]

--- a/ndb/tests/unit/test_key.py
+++ b/ndb/tests/unit/test_key.py
@@ -20,7 +20,7 @@ from google.cloud.datastore import _app_engine_key_pb2
 import google.cloud.datastore
 import pytest
 
-from google.cloud.ndb import _exceptions
+from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
 from google.cloud.ndb import model
 import tests.unit.utils
@@ -66,7 +66,7 @@ class TestKey:
     def test_constructor_invalid_id_type():
         with pytest.raises(TypeError):
             key_module.Key("Kind", object())
-        with pytest.raises(_exceptions.BadArgumentError):
+        with pytest.raises(exceptions.BadArgumentError):
             key_module.Key("Kind", None, "Also", 10)
 
     @staticmethod
@@ -186,7 +186,7 @@ class TestKey:
 
     def test_constructor_with_parent_bad_type(self):
         parent = unittest.mock.sentinel.parent
-        with pytest.raises(_exceptions.BadValueError):
+        with pytest.raises(exceptions.BadValueError):
             key_module.Key("Zip", 10, parent=parent)
 
     @staticmethod

--- a/ndb/tests/unit/test_query.py
+++ b/ndb/tests/unit/test_query.py
@@ -16,7 +16,7 @@ import unittest.mock
 
 import pytest
 
-from google.cloud.ndb import _exceptions
+from google.cloud.ndb import exceptions
 from google.cloud.ndb import query
 import tests.unit.utils
 
@@ -111,7 +111,7 @@ class TestParameter:
     def test_resolve_missing_key():
         parameter = query.Parameter(9000)
         used = {}
-        with pytest.raises(_exceptions.BadArgumentError):
+        with pytest.raises(exceptions.BadArgumentError):
             parameter.resolve({}, used)
 
         assert used == {}


### PR DESCRIPTION
In the process also:

- Renaming `_exceptions` module to `exceptions` so that it could be documented
- Adding the package (`google.cloud.ndb`) documentation to `index.rst` and making sure only `__all__` and `__version__` get documented
- Adding `nitpicky = True` to `docs/conf.py` to make sure all references are valid
- Excluding `Rollback` from `model.rst` since it is a borrowed type from `exceptions`
- Populating `__all__` for `exceptions` module
- Removing references to non-existent `query.Parameter.set()` and to undocumented `model.ModelAttribute._fix_up` (these were found by nitpicky)