### PR TITLE
Firestore: block calling 'DocumentRef.get()' with a single string.

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/document.py
+++ b/firestore/google/cloud/firestore_v1beta1/document.py
@@ -14,8 +14,9 @@
 
 """Classes for representing documents for the Google Cloud Firestore API."""
 
-
 import copy
+
+import six
 
 from google.cloud.firestore_v1beta1 import _helpers
 
@@ -418,6 +419,9 @@ class DocumentReference(object):
                 `update_time`, and `create_time` attributes will all be
                 `None` and `exists` will be `False`.
         """
+        if isinstance(field_paths, six.string_types):
+            raise ValueError(
+                "'field_paths' must be a sequence of paths, not a string.")
         snapshot_generator = self._client.get_all(
             [self], field_paths=field_paths, transaction=transaction)
         return _consume_single_get(snapshot_generator)

--- a/firestore/tests/unit/test_document.py
+++ b/firestore/tests/unit/test_document.py
@@ -449,6 +449,13 @@ class TestDocumentReference(unittest.TestCase):
         )
         self._delete_helper(last_update_time=timestamp_pb)
 
+    def test_get_w_single_field_path(self):
+        client = mock.Mock(spec=[])
+
+        document = self._make_one('yellow', 'mellow', client=client)
+        with self.assertRaises(ValueError):
+            document.get('foo')
+
     def test_get_success(self):
         # Create a minimal fake client with a dummy response.
         response_iterator = iter([mock.sentinel.snapshot])


### PR DESCRIPTION
Closes #6203.