### PR TITLE
Only generate one documentation file per class.

### DIFF
--- a/third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/class.rst
+++ b/third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/class.rst
@@ -2,34 +2,35 @@
 
 .. currentmodule:: {{ module }}
 
+{% block methods %}
+{% if methods %}
+.. rubric:: Methods
+
+.. autosummary::
+{% for item in methods %}
+   {% if item != '__init__' %}
+   ~{{ name }}.{{ item }}
+   {% endif %}
+{%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block attributes %}
+{% if attributes %}
+.. rubric:: Attributes
+
+.. autosummary::
+{% for item in attributes %}
+   ~{{ name }}.{{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}
+
+.. raw:: html
+
+    <p>
+    <hr>
+    <p>
+
 .. autoclass:: {{ objname }}
-
-   {% block methods %}
-   .. automethod:: __init__
-
-   {% if methods %}
-   .. rubric:: Methods
-
-   {# Customized from original by adding toctree. This generates docs for the
-   listed functions. #}
-   .. autosummary::
-      :toctree: .
-   {% for item in methods %}
-      {% if item != '__init__' %}
-      ~{{ name }}.{{ item }}
-      {% endif %}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-   {% block attributes %}
-   {% if attributes %}
-   .. rubric:: Attributes
-
-   .. autosummary::
-      :toctree: .
-   {% for item in attributes %}
-      ~{{ name }}.{{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
+   :members:


### PR DESCRIPTION
Speeds up BigQuery documentation generation by only generating one file
per class instead of one file per method and attribute.

Closes #6144