### PR TITLE
Adding `__slots__` throughout `ndb`.

### DIFF
--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -67,6 +67,10 @@ The primary differences come from:
   the legacy runtime.
 - `query.PostFilterNode.__eq__` compares `self.predicate` to `other.predicate`
   rather than using `self.__dict__ == other.__dict__`
+- `__slots__` have been added to most non-exception types for a number of
+  reasons. The first is the naive "performance" win and the second is that
+  this will make it transparent whenever `ndb` users refer to non-existent
+  "private" or "protected" instance attributes
 
 ## Comments
 

--- a/ndb/src/google/cloud/ndb/blobstore.py
+++ b/ndb/src/google/cloud/ndb/blobstore.py
@@ -68,6 +68,8 @@ class BlobFetchSizeTooLargeError:
 
 
 class BlobInfo:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -94,6 +96,8 @@ class BlobInfoParseError:
 
 
 class BlobKey:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -107,6 +111,8 @@ class BlobNotFoundError:
 
 
 class BlobReader:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/ndb/src/google/cloud/ndb/context.py
+++ b/ndb/src/google/cloud/ndb/context.py
@@ -25,16 +25,22 @@ __all__ = [
 
 
 class AutoBatcher:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class Context:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class ContextOptions:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -43,5 +49,7 @@ EVENTUAL_CONSISTENCY = 1
 
 
 class TransactionOptions:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError

--- a/ndb/src/google/cloud/ndb/django_middleware.py
+++ b/ndb/src/google/cloud/ndb/django_middleware.py
@@ -19,5 +19,7 @@ __all__ = ["NdbDjangoMiddleware"]
 
 
 class NdbDjangoMiddleware:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError

--- a/ndb/src/google/cloud/ndb/eventloop.py
+++ b/ndb/src/google/cloud/ndb/eventloop.py
@@ -35,6 +35,8 @@ def add_idle(*args, **kwargs):
 
 
 class EventLoop:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/ndb/src/google/cloud/ndb/metadata.py
+++ b/ndb/src/google/cloud/ndb/metadata.py
@@ -29,6 +29,8 @@ __all__ = [
 
 
 class EntityGroup:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -54,15 +56,21 @@ def get_representations_of_kind(*args, **kwargs):
 
 
 class Kind:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class Namespace:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class Property:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -265,6 +265,8 @@ class IndexState:
 
 
 class ModelAdapter:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -275,6 +277,8 @@ def make_connection(*args, **kwargs):
 
 class ModelAttribute:
     """Base for classes that implement a ``_fix_up()`` method."""
+
+    __slots__ = ()
 
     def _fix_up(self, cls, code_name):
         """Fix-up property name. To be implemented by subclasses.
@@ -485,111 +489,155 @@ class Property(ModelAttribute):
 
 
 class ModelKey(Property):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class BooleanProperty(Property):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class IntegerProperty(Property):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class FloatProperty(Property):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class BlobProperty(Property):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class TextProperty(BlobProperty):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class StringProperty(TextProperty):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class GeoPtProperty(Property):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class PickleProperty(BlobProperty):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class JsonProperty(BlobProperty):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class UserProperty(Property):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class KeyProperty(Property):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class BlobKeyProperty(Property):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class DateTimeProperty(Property):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class DateProperty(DateTimeProperty):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class TimeProperty(DateTimeProperty):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class StructuredProperty(Property):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class LocalStructuredProperty(BlobProperty):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class GenericProperty(Property):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class ComputedProperty(GenericProperty):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class MetaModel(type):
+    __slots__ = ()
+
     def __new__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class Model:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -605,6 +653,8 @@ class Model:
 
 
 class Expando(Model):
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/ndb/src/google/cloud/ndb/msgprop.py
+++ b/ndb/src/google/cloud/ndb/msgprop.py
@@ -19,10 +19,14 @@ __all__ = ["EnumProperty", "MessageProperty"]
 
 
 class EnumProperty:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class MessageProperty:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError

--- a/ndb/src/google/cloud/ndb/polymodel.py
+++ b/ndb/src/google/cloud/ndb/polymodel.py
@@ -19,5 +19,7 @@ __all__ = ["PolyModel"]
 
 
 class PolyModel:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -50,11 +50,15 @@ _OPS = frozenset([_EQ_OP, _NE_OP, _LT_OP, "<=", _GT_OP, ">=", _IN_OP])
 
 
 class QueryOptions:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class RepeatedStructuredPropertyPredicate:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -871,6 +875,8 @@ OR = DisjunctionNode
 
 
 class Query:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -880,5 +886,7 @@ def gql(*args, **kwargs):
 
 
 class QueryIterator:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError

--- a/ndb/src/google/cloud/ndb/stats.py
+++ b/ndb/src/google/cloud/ndb/stats.py
@@ -41,105 +41,147 @@ __all__ = [
 
 
 class BaseKindStatistic:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class BaseStatistic:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class GlobalStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class KindCompositeIndexStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class KindNonRootEntityStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class KindPropertyNamePropertyTypeStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class KindPropertyNameStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class KindPropertyTypeStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class KindRootEntityStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class KindStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class NamespaceGlobalStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class NamespaceKindCompositeIndexStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class NamespaceKindNonRootEntityStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class NamespaceKindPropertyNamePropertyTypeStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class NamespaceKindPropertyNameStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class NamespaceKindPropertyTypeStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class NamespaceKindRootEntityStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class NamespaceKindStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class NamespacePropertyTypeStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class NamespaceStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class PropertyTypeStat:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError

--- a/ndb/src/google/cloud/ndb/tasklets.py
+++ b/ndb/src/google/cloud/ndb/tasklets.py
@@ -44,6 +44,8 @@ def add_flow_exception(*args, **kwargs):
 
 
 class Future:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -65,16 +67,22 @@ def make_default_context(*args, **kwargs):
 
 
 class MultiFuture:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class QueueFuture:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class ReducingFuture:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -83,6 +91,8 @@ Return = StopIteration
 
 
 class SerialQueueFuture:
+    __slots__ = ()
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 


### PR DESCRIPTION
This is a spin-off of the discussion in #6258 with @theacodes and @tseaver.

I have added `__slots__` to **all** classes except for `Property`. The reason I didn't with `Property` is because the implementation actual depends on `'foo' in self.__dict__` (AFAICT just for `repr()`) to determine if a given attribute is the default (provided by the class) or set explicitly on the instance.

To see why `__slots__` don't work when a class uses a fallback:

```python
>>> class A:
...     __slots__ = ("a", "b")
...     a = 10
...     b = 11
...     def __init__(self, *, a=None, b=None):
...         if a is not None:
...             self.a = a
...         if b is not None:
...             self.b = b
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: 'a' in __slots__ conflicts with class variable
```