### PR TITLE
Implementing more of `ndb` Property

### DIFF
--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -121,5 +121,8 @@ The primary differences come from:
   in some sense: the property name in the [protobuf definition][1] is a
   `string` (i.e. UTF-8 encoded text). However, there is a bit of a disconnect
   with other types that use property names, e.g. `FilterNode`.
+- There is a giant web of module interdependency, so runtime imports (to avoid
+  import cycles) are very common. For example `model.Property` depends on
+  `query` but `query` depends on `model`.
 
 [1]: https://github.com/googleapis/googleapis/blob/3afba2fd062df0c89ecd62d97f912192b8e0e0ae/google/datastore/v1/entity.proto#L203

--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -115,3 +115,11 @@ The primary differences come from:
   `RuntimeError` just it case it **is** actually reached.
 - For ``AND`` and ``OR`` to compare equal, the nodes must come in the
   same order. So ``AND(a > 7, b > 6)`` is not equal to ``AND(b > 6, a > 7)``.
+- The whole `bytes` vs. `str` issue needs to be considered package-wide.
+  For example, the `Property()` constructor always encoded Python 2 `unicode`
+  to a Python 2 `str` (i.e. `bytes`) with the `utf-8` encoding. This fits
+  in some sense: the property name in the [protobuf definition][1] is a
+  `string` (i.e. UTF-8 encoded text). However, there is a bit of a disconnect
+  with other types that use property names, e.g. `FilterNode`.
+
+[1]: https://github.com/googleapis/googleapis/blob/3afba2fd062df0c89ecd62d97f912192b8e0e0ae/google/datastore/v1/entity.proto#L203

--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -71,6 +71,9 @@ The primary differences come from:
   reasons. The first is the naive "performance" win and the second is that
   this will make it transparent whenever `ndb` users refer to non-existent
   "private" or "protected" instance attributes
+- I dropped `Property._positional` since keyword-only arguments are native
+  Python 3 syntax and converted `Property._attributes` into
+  `Property._positional_attributes` and `Property._keyword_attributes`
 
 ## Comments
 

--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -107,3 +107,5 @@ The primary differences come from:
   `RuntimeError` just it case it **is** actually reached.
 - For ``AND`` and ``OR`` to compare equal, the nodes must come in the
   same order. So ``AND(a > 7, b > 6)`` is not equal to ``AND(b > 6, a > 7)``.
+- Since we want "compatibility", suggestions in `TODO` comments have not been
+  implemented. However, that policy can be changed if desired.

--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -107,5 +107,8 @@ The primary differences come from:
   `RuntimeError` just it case it **is** actually reached.
 - For ``AND`` and ``OR`` to compare equal, the nodes must come in the
   same order. So ``AND(a > 7, b > 6)`` is not equal to ``AND(b > 6, a > 7)``.
-- Since we want "compatibility", suggestions in `TODO` comments have not been
-  implemented. However, that policy can be changed if desired.
+- It seems that `query.ConjunctionNode.__new__` had an unreachable line
+  that returned a `FalseNode`. This return has been changed to a
+  `RuntimeError` just it case it **is** actually reached.
+- For ``AND`` and ``OR`` to compare equal, the nodes must come in the
+  same order. So ``AND(a > 7, b > 6)`` is not equal to ``AND(b > 6, a > 7)``.

--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -72,8 +72,8 @@ The primary differences come from:
   this will make it transparent whenever `ndb` users refer to non-existent
   "private" or "protected" instance attributes
 - I dropped `Property._positional` since keyword-only arguments are native
-  Python 3 syntax and converted `Property._attributes` into
-  `Property._positional_attributes` and `Property._keyword_attributes`
+  Python 3 syntax and dropped `Property._attributes`  in favor of an
+  approach using `inspect.signature()`
 
 ## Comments
 

--- a/ndb/src/google/cloud/ndb/exceptions.py
+++ b/ndb/src/google/cloud/ndb/exceptions.py
@@ -20,7 +20,13 @@ legacy Google App Engine runtime.
 """
 
 
-__all__ = ["Error", "BadValueError", "BadArgumentError", "Rollback"]
+__all__ = [
+    "Error",
+    "BadValueError",
+    "BadArgumentError",
+    "Rollback",
+    "BadFilterError",
+]
 
 
 class Error(Exception):
@@ -52,3 +58,16 @@ class Rollback(Error):
 
 class BadQueryError(Error):
     """Raised by Query when a query or query string is invalid."""
+
+
+class BadFilterError(Error):
+    """Indicates a filter value is invalid.
+
+    Raised by ``Query.__setitem__()`` and ``Query.Run()`` when a filter string
+    is invalid.
+    """
+
+    def __init__(self, filter):
+        self.filter = filter
+        message = "invalid filter: {}.".format(self.filter).encode("utf-8")
+        super(BadFilterError, self).__init__(message)

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -567,6 +567,34 @@ class Property(ModelAttribute):
             value = self._datastore_type(value)
         return query.FilterNode(self._name, op, value)
 
+    # Comparison operators on Property instances don't compare the
+    # properties; instead they return ``FilterNode``` instances that can be
+    # used in queries.
+
+    def __eq__(self, value):
+        """FilterNode: Represents the ``=`` comparison."""
+        return self._comparison("=", value)
+
+    def __ne__(self, value):
+        """FilterNode: Represents the ``!=`` comparison."""
+        return self._comparison("!=", value)
+
+    def __lt__(self, value):
+        """FilterNode: Represents the ``<`` comparison."""
+        return self._comparison("<", value)
+
+    def __le__(self, value):
+        """FilterNode: Represents the ``<=`` comparison."""
+        return self._comparison("<=", value)
+
+    def __gt__(self, value):
+        """FilterNode: Represents the ``>`` comparison."""
+        return self._comparison(">", value)
+
+    def __ge__(self, value):
+        """FilterNode: Represents the ``>=`` comparison."""
+        return self._comparison(">=", value)
+
 
 class ModelKey(Property):
     __slots__ = ()

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -15,6 +15,8 @@
 """Model classes for datastore objects and properties for models."""
 
 
+import inspect
+
 from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
 
@@ -346,18 +348,6 @@ class Property(ModelAttribute):
     _write_empty_list = False
     # Non-public class attributes.
     _CREATION_COUNTER = 0
-    # Attribute names, used only by ``repr()``.
-    _positional_attributes = ["_name"]
-    _keyword_attributes = [
-        "_indexed",
-        "_repeated",
-        "_required",
-        "_default",
-        "_choices",
-        "_validator",
-        "_verbose_name",
-        "_write_empty_list",
-    ]
 
     def __init__(
         self,
@@ -507,22 +497,20 @@ class Property(ModelAttribute):
         """
         args = []
         cls = self.__class__
-        combined_attributes = (
-            cls._positional_attributes + cls._keyword_attributes
-        )
-        for index, attr in enumerate(combined_attributes):
+        signature = inspect.signature(self.__init__)
+        for name, parameter in signature.parameters.items():
+            attr = "_{}".format(name)
             instance_val = getattr(self, attr)
             default_val = getattr(cls, attr)
+
             if instance_val is not default_val:
                 if isinstance(instance_val, type):
                     as_str = instance_val.__name__
                 else:
                     as_str = repr(instance_val)
 
-                if index >= len(cls._positional_attributes):
-                    if attr.startswith("_"):
-                        attr = attr[1:]
-                    as_str = "{}={}".format(attr, as_str)
+                if parameter.kind == inspect.Parameter.KEYWORD_ONLY:
+                    as_str = "{}={}".format(name, as_str)
                 args.append(as_str)
 
         return "{}({})".format(self.__class__.__name__, ", ".join(args))

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -346,6 +346,18 @@ class Property(ModelAttribute):
     _write_empty_list = False
     # Non-public class attributes.
     _CREATION_COUNTER = 0
+    # Attribute names, used only by ``repr()``.
+    _positional_attributes = ["_name"]
+    _keyword_attributes = [
+        "_indexed",
+        "_repeated",
+        "_required",
+        "_default",
+        "_choices",
+        "_validator",
+        "_verbose_name",
+        "_write_empty_list",
+    ]
 
     def __init__(
         self,
@@ -486,6 +498,33 @@ class Property(ModelAttribute):
             )
 
         return validator
+
+    def __repr__(self):
+        """Return a compact unambiguous string representation of a property.
+
+        This
+        """
+        args = []
+        cls = self.__class__
+        combined_attributes = (
+            cls._positional_attributes + cls._keyword_attributes
+        )
+        for index, attr in enumerate(combined_attributes):
+            instance_val = getattr(self, attr)
+            default_val = getattr(cls, attr)
+            if instance_val is not default_val:
+                if isinstance(instance_val, type):
+                    as_str = instance_val.__name__
+                else:
+                    as_str = repr(instance_val)
+
+                if index >= len(cls._positional_attributes):
+                    if attr.startswith("_"):
+                        attr = attr[1:]
+                    as_str = "{}={}".format(attr, as_str)
+                args.append(as_str)
+
+        return "{}({})".format(self.__class__.__name__, ", ".join(args))
 
 
 class ModelKey(Property):

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -505,7 +505,7 @@ class Property(ModelAttribute):
 
             if instance_val is not default_val:
                 if isinstance(instance_val, type):
-                    as_str = instance_val.__name__
+                    as_str = instance_val.__qualname__
                 else:
                     as_str = repr(instance_val)
 

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -502,7 +502,8 @@ class Property(ModelAttribute):
     def __repr__(self):
         """Return a compact unambiguous string representation of a property.
 
-        This
+        This cycles through all stored attributes and displays the ones that
+        differ from the default values.
         """
         args = []
         cls = self.__class__

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -339,14 +339,17 @@ class ParameterNode(Node):
             used (Dict[Union[str, int], bool]): A mapping of already used
                 parameters.
 
-        Raises:
-            NotImplementedError: Always. This is because the implementation
-                will rely on as-yet-unimplemented features in
-                :class:`~google.cloud.ndb.model.Property`.
+        Returns:
+            Union[~google.cloud.ndb.query.DisjunctionNode, \
+                ~google.cloud.ndb.query.FilterNode, \
+                ~google.cloud.ndb.query.FalseNode]: A node corresponding to
+            the value substituted.
         """
-        raise NotImplementedError(
-            "Some features of Property need to be implemented first"
-        )
+        value = self._param.resolve(bindings, used)
+        if self._op == _IN_OP:
+            return self._prop._IN(value)
+        else:
+            return self._prop._comparison(self._op, value)
 
 
 class FilterNode(Node):

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -442,14 +442,12 @@ class TestProperty:
     @staticmethod
     def test_repr_subclass():
         class SimpleProperty(model.Property):
-            _positional_attributes = []
-            _keyword_attributes = ["_foo_type", "bar"]
             _foo_type = None
-            bar = "eleventy"
+            _bar = "eleventy"
 
             def __init__(self, *, foo_type, bar):
                 self._foo_type = foo_type
-                self.bar = bar
+                self._bar = bar
 
         prop = SimpleProperty(foo_type=list, bar="nope")
         assert repr(prop) == "SimpleProperty(foo_type=list, bar='nope')"

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -463,23 +463,89 @@ class TestProperty:
     @staticmethod
     def test__comparison_indexed():
         prop = model.Property("color", indexed=False)
-        assert not prop._indexed
         with pytest.raises(exceptions.BadFilterError):
             prop._comparison("!=", "red")
 
     @staticmethod
     def test__comparison():
-        prop = model.Property("sentiment")
-        assert prop._indexed
+        prop = model.Property("sentiment", indexed=True)
         filter_node = prop._comparison(">=", 0.0)
         assert filter_node == query.FilterNode(b"sentiment", ">=", 0.0)
 
     @staticmethod
     def test__comparison_empty_value():
-        prop = model.Property("height")
-        assert prop._indexed
+        prop = model.Property("height", indexed=True)
         filter_node = prop._comparison("=", None)
         assert filter_node == query.FilterNode(b"height", "=", None)
+
+    @staticmethod
+    def test___eq__():
+        prop = model.Property("name", indexed=True)
+        value = 1337
+        expected = query.FilterNode(b"name", "=", value)
+
+        filter_node_left = prop == value
+        assert filter_node_left == expected
+        filter_node_right = value == prop
+        assert filter_node_right == expected
+
+    @staticmethod
+    def test___ne__():
+        prop = model.Property("name", indexed=True)
+        value = 7.0
+        expected = query.DisjunctionNode(
+            query.FilterNode(b"name", "<", value),
+            query.FilterNode(b"name", ">", value),
+        )
+
+        or_node_left = prop != value
+        assert or_node_left == expected
+        or_node_right = value != prop
+        assert or_node_right == expected
+
+    @staticmethod
+    def test___lt__():
+        prop = model.Property("name", indexed=True)
+        value = 2.0
+        expected = query.FilterNode(b"name", "<", value)
+
+        filter_node_left = prop < value
+        assert filter_node_left == expected
+        filter_node_right = value > prop
+        assert filter_node_right == expected
+
+    @staticmethod
+    def test___le__():
+        prop = model.Property("name", indexed=True)
+        value = 20.0
+        expected = query.FilterNode(b"name", "<=", value)
+
+        filter_node_left = prop <= value
+        assert filter_node_left == expected
+        filter_node_right = value >= prop
+        assert filter_node_right == expected
+
+    @staticmethod
+    def test___gt__():
+        prop = model.Property("name", indexed=True)
+        value = "new"
+        expected = query.FilterNode(b"name", ">", value)
+
+        filter_node_left = prop > value
+        assert filter_node_left == expected
+        filter_node_right = value < prop
+        assert filter_node_right == expected
+
+    @staticmethod
+    def test___ge__():
+        prop = model.Property("name", indexed=True)
+        value = "old"
+        expected = query.FilterNode(b"name", ">=", value)
+
+        filter_node_left = prop >= value
+        assert filter_node_left == expected
+        filter_node_right = value <= prop
+        assert filter_node_right == expected
 
 
 class TestModelKey:

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -416,6 +416,42 @@ class TestProperty:
         # Check that the creation counter was not updated.
         assert model.Property._CREATION_COUNTER == 0
 
+    def test_repr(self):
+        prop = model.Property(
+            "val",
+            indexed=False,
+            repeated=False,
+            required=True,
+            default="zorp",
+            choices=("zorp", "zap", "zip"),
+            validator=self._example_validator,
+            verbose_name="VALUE FOR READING",
+            write_empty_list=False,
+        )
+        expected = (
+            "Property(b'val', indexed=False, required=True, "
+            "default='zorp', choices={}, validator={}, "
+            "verbose_name='VALUE FOR READING')".format(
+                prop._choices, prop._validator
+            )
+        )
+        assert repr(prop) == expected
+
+    @staticmethod
+    def test_repr_subclass():
+        class SimpleProperty(model.Property):
+            _positional_attributes = []
+            _keyword_attributes = ["_foo_type", "bar"]
+            _foo_type = None
+            bar = "eleventy"
+
+            def __init__(self, *, foo_type, bar):
+                self._foo_type = foo_type
+                self.bar = bar
+
+        prop = SimpleProperty(foo_type=list, bar="nope")
+        assert repr(prop) == "SimpleProperty(foo_type=list, bar='nope')"
+
 
 class TestModelKey:
     @staticmethod

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -547,6 +547,43 @@ class TestProperty:
         filter_node_right = value <= prop
         assert filter_node_right == expected
 
+    @staticmethod
+    def test__IN_not_indexed():
+        prop = model.Property("name", indexed=False)
+        with pytest.raises(exceptions.BadFilterError):
+            prop._IN([10, 20, 81])
+
+    @staticmethod
+    def test__IN_wrong_container():
+        prop = model.Property("name", indexed=True)
+        with pytest.raises(exceptions.BadArgumentError):
+            prop._IN({1: "a", 11: "b"})
+
+    @staticmethod
+    def test__IN():
+        prop = model.Property("name", indexed=True)
+        or_node = prop._IN(["a", None, "xy"])
+        expected = query.DisjunctionNode(
+            query.FilterNode(b"name", "=", "a"),
+            query.FilterNode(b"name", "=", None),
+            query.FilterNode(b"name", "=", "xy"),
+        )
+        assert or_node == expected
+        # Also verify the alias
+        assert or_node == prop.IN(["a", None, "xy"])
+
+    @staticmethod
+    def test___neg__():
+        prop = model.Property("name")
+        with pytest.raises(NotImplementedError):
+            -prop
+
+    @staticmethod
+    def test___pos__():
+        prop = model.Property("name")
+        with pytest.raises(NotImplementedError):
+            +prop
+
 
 class TestModelKey:
     @staticmethod

--- a/ndb/tests/unit/test_query.py
+++ b/ndb/tests/unit/test_query.py
@@ -322,6 +322,20 @@ class TestParameterNode:
         )
         assert used == {"replace": True}
 
+    @staticmethod
+    def test_resolve_in_empty_container():
+        prop = model.Property(name="val")
+        param = query.Parameter("replace")
+        parameter_node = query.ParameterNode(prop, "in", param)
+
+        value = ()
+        bindings = {"replace": value}
+        used = {}
+        resolved_node = parameter_node.resolve(bindings, used)
+
+        assert resolved_node == query.FalseNode()
+        assert used == {"replace": True}
+
 
 class TestFilterNode:
     @staticmethod

--- a/ndb/tests/unit/test_query.py
+++ b/ndb/tests/unit/test_query.py
@@ -338,15 +338,13 @@ class TestFilterNode:
             query.FilterNode("name", "=", key)
 
     @staticmethod
-    @unittest.mock.patch("google.cloud.ndb.query.DisjunctionNode")
-    def test_constructor_in(disjunction_node):
+    def test_constructor_in():
         or_node = query.FilterNode("a", "in", ("x", "y", "z"))
-        assert or_node is disjunction_node.return_value
 
         filter_node1 = query.FilterNode("a", "=", "x")
         filter_node2 = query.FilterNode("a", "=", "y")
         filter_node3 = query.FilterNode("a", "=", "z")
-        disjunction_node.assert_called_once_with(
+        assert or_node == query.DisjunctionNode(
             filter_node1, filter_node2, filter_node3
         )
 
@@ -369,14 +367,12 @@ class TestFilterNode:
             query.FilterNode("a", "in", {})
 
     @staticmethod
-    @unittest.mock.patch("google.cloud.ndb.query.DisjunctionNode")
-    def test_constructor_ne(disjunction_node):
+    def test_constructor_ne():
         or_node = query.FilterNode("a", "!=", 2.5)
-        assert or_node is disjunction_node.return_value
 
         filter_node1 = query.FilterNode("a", "<", 2.5)
         filter_node2 = query.FilterNode("a", ">", 2.5)
-        disjunction_node.assert_called_once_with(filter_node1, filter_node2)
+        assert or_node == query.DisjunctionNode(filter_node1, filter_node2)
 
     @staticmethod
     def test_pickling():

--- a/ndb/tests/unit/test_query.py
+++ b/ndb/tests/unit/test_query.py
@@ -291,15 +291,36 @@ class TestParameterNode:
             parameter_node._to_filter()
 
     @staticmethod
-    def test_resolve():
+    def test_resolve_simple():
         prop = model.Property(name="val")
         param = query.Parameter("abc")
         parameter_node = query.ParameterNode(prop, "=", param)
 
+        value = 67
+        bindings = {"abc": value}
         used = {}
-        with pytest.raises(NotImplementedError):
-            parameter_node.resolve({}, used)
-        assert used == {}
+        resolved_node = parameter_node.resolve(bindings, used)
+
+        assert resolved_node == query.FilterNode(b"val", "=", value)
+        assert used == {"abc": True}
+
+    @staticmethod
+    def test_resolve_with_in():
+        prop = model.Property(name="val")
+        param = query.Parameter("replace")
+        parameter_node = query.ParameterNode(prop, "in", param)
+
+        value = (19, 20, 28)
+        bindings = {"replace": value}
+        used = {}
+        resolved_node = parameter_node.resolve(bindings, used)
+
+        assert resolved_node == query.DisjunctionNode(
+            query.FilterNode(b"val", "=", 19),
+            query.FilterNode(b"val", "=", 20),
+            query.FilterNode(b"val", "=", 28),
+        )
+        assert used == {"replace": True}
 
 
 class TestFilterNode:


### PR DESCRIPTION
~~**NOTE**: This has #6250 as diffbase (since `Property.__eq__` relies on `query.Node` implementations)~~

This is still incomplete, it's a very large class.

In particular, this implements:

- `Property.__repr__`
- `Property._comparison`, which provides the nifty ORM feature that makes `MyModel.foo == 10` spit out a filter
- `Property.__eq__` and friends (all just call `_comparison`)
- `Property.IN`
- `+Property` and `-Property` (this is just a stub, but they **should** create `Order` objects)
- `Property._datastore_type` (used to convert from Python types to protobuf types when needed)
- Completes the implementation of `query.ParameterNode.resolve()`