### PR TITLE
Add --params option to %%bigquery magic

### DIFF
--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -40,8 +40,9 @@
         query is finished. By default, this information will be displayed but
         will be cleared after the query is finished.
     * ``--params <params dictionary>`` (optional, line argument):
-        If present, the argument must be a parsable JSON string. This dictionary
-        will be used to format values preceded by ``@`` in the query.
+        If present, the argument must be a parsable JSON string or a reference to dictionary
+        which is serializable to JSON (preceding the dictionary with $).
+        This dictionary will be used to format values preceded by ``@`` in the query.
     * ``<query>`` (required, cell argument):
         SQL query to run.
 
@@ -102,13 +103,6 @@
         In [5]: %%bigquery df --params {"num": 17}
            ...: SELECT @num AS num
         Out[5]:
-           ...:    num
-           ...: 0   17
-        In [6]: # Expand a dictionary instead of writing it's string value
-        In [6]: params = {"num": 17}
-        In [7]: %%bigquery df --params $params
-           ...: SELECT @num AS num
-        Out[7]:
            ...:    num
            ...: 0   17
 """

--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -40,7 +40,7 @@
         query is finished. By default, this information will be displayed but
         will be cleared after the query is finished.
     * ``--params <params dictionary>`` (optional, line argument):
-        If present, the argument will be parsed into a dictionary. This dictionary
+        If present, the argument must be a parsable JSON string. This dictionary
         will be used to format values enclosed within {} in the query.
     * ``<query>`` (required, cell argument):
         SQL query to run.

--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -103,10 +103,9 @@
 
 from __future__ import print_function
 
-import json
+import ast
 import time
 from concurrent import futures
-from json import JSONDecodeError
 
 try:
     import IPython
@@ -256,6 +255,7 @@ def _run_query(client, query, job_config=None):
           'cleared after the query is finished.'))
 @magic_arguments.argument(
     '--params',
+    nargs='+',
     default=None,
     help=('Parameters to format the query string. If present, it should be a '
           'parsable JSON string. The parsed dictionary will be used for string'
@@ -278,9 +278,9 @@ def _cell_magic(line, query):
 
     if args.params is not None:
         try:
-            params = json.loads(args.params)
-        except JSONDecodeError as e:
-            raise JSONDecodeError('--params is not a correctly formatted JSON string', e.doc, e.pos)
+            params = ast.literal_eval(''.join(args.params))
+        except Exception:
+            raise SyntaxError('--params is not a correctly formatted JSON string')
 
         query = query.format(**params)
 

--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -41,7 +41,7 @@
         will be cleared after the query is finished.
     * ``--params <params dictionary>`` (optional, line argument):
         If present, the argument must be a parsable JSON string. This dictionary
-        will be used to format values enclosed within {} in the query.
+        will be used to format values preceded by ``@`` in the query.
     * ``<query>`` (required, cell argument):
         SQL query to run.
 
@@ -99,6 +99,18 @@
            ...: 1    Patricia  1568495
            ...: 2   Elizabeth  1519946
 
+        In [5]: %%bigquery df --params {"num": 17}
+           ...: SELECT @num AS num
+        Out[5]:
+           ...:    num
+           ...: 0   17
+        In [6]: # Expand a dictionary instead of writing it's string value
+        In [6]: params = {"num": 17}
+        In [7]: %%bigquery df --params $params
+           ...: SELECT @num AS num
+        Out[7]:
+           ...:    num
+           ...: 0   17
 """
 
 from __future__ import print_function
@@ -116,7 +128,7 @@ except ImportError:  # pragma: NO COVER
 
 import google.auth
 from google.cloud import bigquery
-from google.cloud.bigquery.dbapi._helpers import to_query_parameters
+from google.cloud.bigquery.dbapi import _helpers
 
 
 class Context(object):
@@ -280,7 +292,7 @@ def _cell_magic(line, query):
     params = []
     if args.params is not None:
         try:
-            params = to_query_parameters(ast.literal_eval(''.join(args.params)))
+            params = _helpers.to_query_parameters(ast.literal_eval(''.join(args.params)))
         except Exception:
             raise SyntaxError('--params is not a correctly formatted JSON string')
 

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -263,7 +263,7 @@ def test_bigquery_magic_with_project():
 
 @pytest.mark.usefixtures('ipython_interactive')
 @pytest.mark.skipif(pandas is None, reason='Requires `pandas`')
-def test_bigquery_magic_with_formatting_params_with_string():
+def test_bigquery_magic_with_string_params():
     ip = IPython.get_ipython()
     ip.extension_manager.load_extension('google.cloud.bigquery')
     magics.context.credentials = mock.create_autospec(
@@ -294,7 +294,7 @@ def test_bigquery_magic_with_formatting_params_with_string():
 
 @pytest.mark.usefixtures('ipython_interactive')
 @pytest.mark.skipif(pandas is None, reason='Requires `pandas`')
-def test_bigquery_magic_with_formatting_params_with_expanded_dict():
+def test_bigquery_magic_with_dict_params():
     ip = IPython.get_ipython()
     ip.extension_manager.load_extension('google.cloud.bigquery')
     magics.context.credentials = mock.create_autospec(
@@ -323,3 +323,18 @@ def test_bigquery_magic_with_formatting_params_with_expanded_dict():
     df = ip.user_ns['params_dict_df']
     assert len(df) == len(result)          # verify row count
     assert list(df) == list(result)        # verify column names
+
+
+@pytest.mark.usefixtures('ipython_interactive')
+@pytest.mark.skipif(pandas is None, reason='Requires `pandas`')
+def test_bigquery_magic_with_improperly_formatted_params():
+    ip = IPython.get_ipython()
+    ip.extension_manager.load_extension('google.cloud.bigquery')
+    magics.context.credentials = mock.create_autospec(
+        google.auth.credentials.Credentials, instance=True)
+
+    sql = 'SELECT @num AS num'
+
+    with pytest.raises(SyntaxError):
+        ip.run_cell_magic(
+            'bigquery', '--params {17}', sql)

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -282,8 +282,10 @@ def test_bigquery_magic_with_formatting_params():
         run_query_mock.return_value = query_job_mock
 
         ip.run_cell_magic('bigquery', 'df --params {"num":17}', sql)
+        run_query_mock.assert_called_once_with(mock.ANY, sql.format(num=17), mock.ANY)
 
     assert 'df' in ip.user_ns        # verify that variable exists
     df = ip.user_ns['df']
     assert len(df) == len(result)    # verify row count
     assert list(df) == list(result)  # verify column names
+

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -281,13 +281,15 @@ def test_bigquery_magic_with_formatting_params_with_string():
     with run_query_patch as run_query_mock:
         run_query_mock.return_value = query_job_mock
 
-        ip.run_cell_magic('bigquery', 'params_string_df --params {"num":17}', sql)
-        run_query_mock.assert_called_once_with(mock.ANY, sql.format(num=17), mock.ANY)
+        ip.run_cell_magic(
+            'bigquery', 'params_string_df --params {"num":17}', sql)
+        run_query_mock.assert_called_once_with(
+            mock.ANY, sql.format(num=17), mock.ANY)
 
-    assert 'params_string_df' in ip.user_ns        # verify that variable exists
+    assert 'params_string_df' in ip.user_ns  # verify that the variable exists
     df = ip.user_ns['params_string_df']
-    assert len(df) == len(result)    # verify row count
-    assert list(df) == list(result)  # verify column names
+    assert len(df) == len(result)            # verify row count
+    assert list(df) == list(result)          # verify column names
 
 
 @pytest.mark.usefixtures('ipython_interactive')
@@ -314,9 +316,10 @@ def test_bigquery_magic_with_formatting_params_with_expanded_dict():
         # Insert dictionary into user namespace so that it can be expanded
         ip.user_ns['params'] = params
         ip.run_cell_magic('bigquery', 'params_dict_df --params $params', sql)
-        run_query_mock.assert_called_once_with(mock.ANY, sql.format(num=17), mock.ANY)
+        run_query_mock.assert_called_once_with(
+            mock.ANY, sql.format(num=17), mock.ANY)
 
-    assert 'params_dict_df' in ip.user_ns        # verify that variable exists
+    assert 'params_dict_df' in ip.user_ns  # verify that the variable exists
     df = ip.user_ns['params_dict_df']
-    assert len(df) == len(result)    # verify row count
-    assert list(df) == list(result)  # verify column names
+    assert len(df) == len(result)          # verify row count
+    assert list(df) == list(result)        # verify column names

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -269,7 +269,7 @@ def test_bigquery_magic_with_formatting_params():
     magics.context.credentials = mock.create_autospec(
         google.auth.credentials.Credentials, instance=True)
 
-    sql = 'SELECT {num} AS num'
+    sql = 'SELECT @num AS num'
     result = pandas.DataFrame([17], columns=['num'])
     assert 'myvariable' not in ip.user_ns
 


### PR DESCRIPTION
Often it is useful to be able to parametrize query strings. While there is the option of parametrizing queries [using the raw sdk](https://cloud.google.com/bigquery/docs/parameterized-queries), there is no option to do so using the `%%bigquery` magic in Jupyter notebooks. 

This is useful for several reasons, specially when the same parameter appears several times in the query. This could be for example a cutoff date appearing in several `JOIN` conditions.

This PR adds the option `--params` to the `%%bigquery` magic for Jupyter notebooks. `--params` accepts a JSON string that will be used to format the string contained in the query. 

An example of how this would work:
```
%%bigquery df --params {"max_question_length":300,"limit":10}

SELECT
      posts.id AS post_id,
      posts.creation_date AS post_creation_date,
      posts.body AS question
FROM
  `bigquery-public-data.stackoverflow.posts_questions` posts
WHERE
  LENGTH(posts.body) < {max_question_length}
LIMIT {limit}
```