### PR TITLE
Bigtable: plumb 'Client._channel' to GAPIC clients

### DIFF
--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -145,8 +145,7 @@ class Client(ClientWithProject):
         :rtype: str
         :returns: Return a fully-qualified project string.
         """
-        instance_client = self.instance_admin_client
-        return instance_client.project_path(self.project)
+        return self.instance_admin_client.project_path(self.project)
 
     @property
     def table_data_client(self):

--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -155,9 +155,15 @@ class Client(ClientWithProject):
         :returns: A BigtableClient object.
         """
         if self._table_data_client is None:
-            self._table_data_client = (
-                bigtable_v2.BigtableClient(credentials=self._credentials,
-                                           client_info=_CLIENT_INFO))
+
+            if self._channel is not None:
+                gapic_client = bigtable_v2.BigtableClient(
+                    channel=self._channel, client_info=_CLIENT_INFO)
+            else:
+                gapic_client = bigtable_v2.BigtableClient(
+                    credentials=self._credentials, client_info=_CLIENT_INFO)
+
+            self._table_data_client = gapic_client
 
         return self._table_data_client
 
@@ -172,11 +178,18 @@ class Client(ClientWithProject):
                  :meth:`start`-ed.
         """
         if self._table_admin_client is None:
+
             if not self._admin:
                 raise ValueError('Client is not an admin client.')
-            self._table_admin_client = (
-                bigtable_admin_v2.BigtableTableAdminClient(
-                    credentials=self._credentials, client_info=_CLIENT_INFO))
+
+            if self._channel is not None:
+                gapic_client = bigtable_admin_v2.BigtableTableAdminClient(
+                    channel=self._channel, client_info=_CLIENT_INFO)
+            else:
+                gapic_client = bigtable_admin_v2.BigtableTableAdminClient(
+                    credentials=self._credentials, client_info=_CLIENT_INFO)
+
+            self._table_admin_client = gapic_client
 
         return self._table_admin_client
 
@@ -191,11 +204,18 @@ class Client(ClientWithProject):
                  :meth:`start`-ed.
         """
         if self._instance_admin_client is None:
+
             if not self._admin:
                 raise ValueError('Client is not an admin client.')
-            self._instance_admin_client = (
-                bigtable_admin_v2.BigtableInstanceAdminClient(
-                    credentials=self._credentials, client_info=_CLIENT_INFO))
+
+            if self._channel is not None:
+                gapic_client = bigtable_admin_v2.BigtableInstanceAdminClient(
+                    channel=self._channel, client_info=_CLIENT_INFO)
+            else:
+                gapic_client = bigtable_admin_v2.BigtableInstanceAdminClient(
+                    credentials=self._credentials, client_info=_CLIENT_INFO)
+            self._instance_admin_client = gapic_client
+
         return self._instance_admin_client
 
     def instance(self, instance_id, display_name=None,

--- a/bigtable/tests/unit/test_client.py
+++ b/bigtable/tests/unit/test_client.py
@@ -122,8 +122,29 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=self.PROJECT, credentials=credentials)
 
         table_data_client = client.table_data_client
+
         self.assertIsInstance(table_data_client, BigtableClient)
         self.assertIs(client._table_data_client, table_data_client)
+
+    def test_table_data_client_not_initialized_w_channel(self):
+        import warnings
+        from google.cloud.bigtable_v2 import BigtableClient
+
+        credentials = _make_credentials()
+        channel = mock.Mock()
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=credentials,
+            channel=channel,
+        )
+
+        with warnings.catch_warnings():
+            table_data_client = client.table_data_client
+
+        self.assertIsInstance(table_data_client, BigtableClient)
+        self.assertIs(client._table_data_client, table_data_client)
+        stub = table_data_client.transport._stubs['bigtable_stub']
+        self.assertIs(stub.ReadRows, channel.unary_stream.return_value)
 
     def test_table_data_client_initialized(self):
         credentials = _make_credentials()
@@ -150,6 +171,26 @@ class TestClient(unittest.TestCase):
         table_admin_client = client.table_admin_client
         self.assertIsInstance(table_admin_client, BigtableTableAdminClient)
 
+    def test_table_admin_client_not_initialized_w_admin_flag_channel(self):
+        import warnings
+        from google.cloud.bigtable_admin_v2 import BigtableTableAdminClient
+
+        credentials = _make_credentials()
+        channel = mock.Mock()
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=credentials,
+            channel=channel,
+            admin=True,
+        )
+
+        with warnings.catch_warnings():
+            table_admin_client = client.table_admin_client
+
+        self.assertIsInstance(table_admin_client, BigtableTableAdminClient)
+        stub = table_admin_client.transport._stubs['bigtable_table_admin_stub']
+        self.assertIs(stub.CreateTable, channel.unary_unary.return_value)
+
     def test_table_admin_client_initialized(self):
         credentials = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=credentials,
@@ -175,6 +216,28 @@ class TestClient(unittest.TestCase):
         instance_admin_client = client.instance_admin_client
         self.assertIsInstance(
             instance_admin_client, BigtableInstanceAdminClient)
+
+    def test_instance_admin_client_not_initialized_w_admin_flag_channel(self):
+        import warnings
+        from google.cloud.bigtable_admin_v2 import BigtableInstanceAdminClient
+
+        credentials = _make_credentials()
+        channel = mock.Mock()
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=credentials,
+            channel=channel,
+            admin=True,
+        )
+
+        with warnings.catch_warnings():
+            instance_admin_client = client.instance_admin_client
+
+        self.assertIsInstance(
+            instance_admin_client, BigtableInstanceAdminClient)
+        stub = instance_admin_client.transport._stubs[
+            'bigtable_instance_admin_stub']
+        self.assertIs(stub.CreateInstance, channel.unary_unary.return_value)
 
     def test_instance_admin_client_initialized(self):
         credentials = _make_credentials()

--- a/bigtable/tests/unit/test_client.py
+++ b/bigtable/tests/unit/test_client.py
@@ -115,47 +115,6 @@ class TestClient(unittest.TestCase):
         project_name = 'projects/' + project
         self.assertEqual(client.project_path, project_name)
 
-    def test_instance_factory_defaults(self):
-        from google.cloud.bigtable.instance import Instance
-
-        PROJECT = 'PROJECT'
-        INSTANCE_ID = 'instance-id'
-        credentials = _make_credentials()
-        client = self._make_one(
-            project=PROJECT, credentials=credentials)
-
-        instance = client.instance(INSTANCE_ID)
-
-        self.assertIsInstance(instance, Instance)
-        self.assertEqual(instance.instance_id, INSTANCE_ID)
-        self.assertEqual(instance.display_name, INSTANCE_ID)
-        self.assertIsNone(instance.type_)
-        self.assertIsNone(instance.labels)
-        self.assertIs(instance._client, client)
-
-    def test_instance_factory_non_defaults(self):
-        from google.cloud.bigtable.instance import Instance
-        from google.cloud.bigtable import enums
-
-        PROJECT = 'PROJECT'
-        INSTANCE_ID = 'instance-id'
-        DISPLAY_NAME = 'display-name'
-        instance_type = enums.Instance.Type.DEVELOPMENT
-        labels = {'foo': 'bar'}
-        credentials = _make_credentials()
-        client = self._make_one(
-            project=PROJECT, credentials=credentials)
-
-        instance = client.instance(INSTANCE_ID, display_name=DISPLAY_NAME,
-                                   instance_type=instance_type, labels=labels)
-
-        self.assertIsInstance(instance, Instance)
-        self.assertEqual(instance.instance_id, INSTANCE_ID)
-        self.assertEqual(instance.display_name, DISPLAY_NAME)
-        self.assertEqual(instance.type_, instance_type)
-        self.assertEqual(instance.labels, labels)
-        self.assertIs(instance._client, client)
-
     def test_table_data_client_not_initialized(self):
         from google.cloud.bigtable_v2 import BigtableClient
 
@@ -224,6 +183,47 @@ class TestClient(unittest.TestCase):
 
         already = client._instance_admin_client = object()
         self.assertIs(client.instance_admin_client, already)
+
+    def test_instance_factory_defaults(self):
+        from google.cloud.bigtable.instance import Instance
+
+        PROJECT = 'PROJECT'
+        INSTANCE_ID = 'instance-id'
+        credentials = _make_credentials()
+        client = self._make_one(
+            project=PROJECT, credentials=credentials)
+
+        instance = client.instance(INSTANCE_ID)
+
+        self.assertIsInstance(instance, Instance)
+        self.assertEqual(instance.instance_id, INSTANCE_ID)
+        self.assertEqual(instance.display_name, INSTANCE_ID)
+        self.assertIsNone(instance.type_)
+        self.assertIsNone(instance.labels)
+        self.assertIs(instance._client, client)
+
+    def test_instance_factory_non_defaults(self):
+        from google.cloud.bigtable.instance import Instance
+        from google.cloud.bigtable import enums
+
+        PROJECT = 'PROJECT'
+        INSTANCE_ID = 'instance-id'
+        DISPLAY_NAME = 'display-name'
+        instance_type = enums.Instance.Type.DEVELOPMENT
+        labels = {'foo': 'bar'}
+        credentials = _make_credentials()
+        client = self._make_one(
+            project=PROJECT, credentials=credentials)
+
+        instance = client.instance(INSTANCE_ID, display_name=DISPLAY_NAME,
+                                   instance_type=instance_type, labels=labels)
+
+        self.assertIsInstance(instance, Instance)
+        self.assertEqual(instance.instance_id, INSTANCE_ID)
+        self.assertEqual(instance.display_name, DISPLAY_NAME)
+        self.assertEqual(instance.type_, instance_type)
+        self.assertEqual(instance.labels, labels)
+        self.assertIs(instance._client, client)
 
     def test_list_instances(self):
         from google.cloud.bigtable_admin_v2.proto import (


### PR DESCRIPTION
See: #6278 

Alternative strategy to the deprecation of `channel` in #6279.