### PR TITLE
Bigtable: Add retry parameter to 'Table.read_rows()'.

### DIFF
--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -338,8 +338,10 @@ class PartialRowsData(object):
     :param retry: (Optional) Retry delay and deadline arguments. To override,
                   the default value :attr:`DEFAULT_RETRY_READ_ROWS` can be
                   used and modified with the
-                  :meth:`~google.api_core.retry.Retry.with_delay` method or the
-                  :meth:`~google.api_core.retry.Retry.with_deadline` method.
+                  .. :meth::`~google.api_core.retry.Retry.with_delay` method
+                  or the
+                  .. :meth::`~google.api_core.retry.Retry.with_deadline`
+                  method.
     """
 
     NEW_ROW = 'New row'  # No cells yet complete for row

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -314,8 +314,8 @@ DEFAULT_RETRY_READ_ROWS = retry.Retry(
 )
 """The default retry strategy to be used on retry-able errors.
 
-Used by :meth:`~google.cloud.bigtable.row_data.PartialRowsData.
-                                            _read_next_response`.
+Used by
+:meth:`~google.cloud.bigtable.row_data.PartialRowsData._read_next_response`.
 """
 
 
@@ -338,10 +338,9 @@ class PartialRowsData(object):
     :param retry: (Optional) Retry delay and deadline arguments. To override,
                   the default value :attr:`DEFAULT_RETRY_READ_ROWS` can be
                   used and modified with the
-                  .. :meth::`~google.api_core.retry.Retry.with_delay` method
+                  :meth:`~google.api_core.retry.Retry.with_delay` method
                   or the
-                  .. :meth::`~google.api_core.retry.Retry.with_deadline`
-                  method.
+                  :meth:`~google.api_core.retry.Retry.with_deadline` method.
     """
 
     NEW_ROW = 'New row'  # No cells yet complete for row

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -31,6 +31,7 @@ from google.cloud.bigtable.row import AppendRow
 from google.cloud.bigtable.row import ConditionalRow
 from google.cloud.bigtable.row import DirectRow
 from google.cloud.bigtable.row_data import PartialRowsData
+from google.cloud.bigtable.row_data import DEFAULT_RETRY_READ_ROWS
 from google.cloud.bigtable.row_set import RowSet
 from google.cloud.bigtable.row_set import RowRange
 from google.cloud.bigtable import enums
@@ -60,7 +61,7 @@ DEFAULT_RETRY = Retry(
     multiplier=2.0,
     deadline=120.0,  # 2 minutes
 )
-"""The default retry stategy to be used on retry-able errors.
+"""The default retry strategy to be used on retry-able errors.
 
 Used by :meth:`~google.cloud.bigtable.table.Table.mutate_rows`.
 """
@@ -298,7 +299,8 @@ class Table(object):
         return row
 
     def read_rows(self, start_key=None, end_key=None, limit=None,
-                  filter_=None, end_inclusive=False, row_set=None):
+                  filter_=None, end_inclusive=False, row_set=None,
+                  retry=DEFAULT_RETRY_READ_ROWS):
         """Read rows from this table.
 
         :type start_key: bytes
@@ -329,6 +331,14 @@ class Table(object):
         :param filter_: (Optional) The row set containing multiple row keys and
                         row_ranges.
 
+        :type retry: :class:`~google.api_core.retry.Retry`
+        :param retry:
+            (Optional) Retry delay and deadline arguments. To override, the
+            default value :attr:`DEFAULT_RETRY_READ_ROWS` can be used and
+            modified with the :meth:`~google.api_core.retry.Retry.with_delay`
+            method or the :meth:`~google.api_core.retry.Retry.with_deadline`
+            method.
+
         :rtype: :class:`.PartialRowsData`
         :returns: A :class:`.PartialRowsData` a generator for consuming
                   the streamed results.
@@ -340,7 +350,7 @@ class Table(object):
         data_client = self._instance._client.table_data_client
         return PartialRowsData(
             data_client.transport.read_rows,
-            request_pb)
+            request_pb, retry)
 
     def yield_rows(self, **kwargs):
         """Read rows from this table.

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -14,9 +14,9 @@
 
 
 import unittest
-import grpc
 import mock
 
+from google.api_core.exceptions import DeadlineExceeded
 from ._testing import _make_credentials
 from google.cloud.bigtable.row_set import RowRange
 from google.cloud.bigtable_v2.proto import (
@@ -1189,20 +1189,10 @@ class _MockCancellableIterator(object):
     __next__ = next
 
 
-class DeadlineExceeded(grpc.RpcError, grpc.Call):
-            """ErrorDeadlineExceeded exception"""
-
-            def code(self):
-                return grpc.StatusCode.DEADLINE_EXCEEDED
-
-            def details(self):
-                return "Failed to read from server"
-
-
 class _MockFailureIterator_1(object):
 
     def next(self):
-        raise DeadlineExceeded()
+        raise DeadlineExceeded("Failed to read from server")
 
     __next__ = next
 

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -15,9 +15,9 @@
 
 import unittest
 
-import grpc
 import mock
 from ._testing import _make_credentials
+from google.api_core.exceptions import DeadlineExceeded
 
 
 class Test___mutate_rows_request(unittest.TestCase):
@@ -1778,20 +1778,10 @@ class _MockReadRowsIterator(object):
     __next__ = next
 
 
-class DeadlineExceeded(grpc.RpcError, grpc.Call):
-            """ErrorDeadlineExceeded exception"""
-
-            def code(self):
-                return grpc.StatusCode.DEADLINE_EXCEEDED
-
-            def details(self):
-                return "Failed to read from server"
-
-
 class _MockFailureIterator_1(object):
 
     def next(self):
-        raise DeadlineExceeded()
+        raise DeadlineExceeded("Failed to read from server")
 
     __next__ = next
 
@@ -1807,7 +1797,7 @@ class _MockFailureIterator_2(object):
         if self.calls == 1:
             return self.iter_values[0]
         else:
-            raise DeadlineExceeded()
+            raise DeadlineExceeded("Failed to read from server")
 
     __next__ = next
 


### PR DESCRIPTION
Closes #6186 