### PR TITLE
Implementing `model._BaseValue` for `ndb`.

### DIFF
--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -285,6 +285,50 @@ class ModelAttribute:
         """
 
 
+class _BaseValue:
+    """A marker object wrapping a "base type" value.
+
+    This is used to be able to tell whether ``entity._values[name]`` is a
+    user value (i.e. of a type that the Python code understands) or a
+    base value (i.e of a type that serialization understands).
+    User values are unwrapped; base values are wrapped in a
+    :class:`_BaseValue` instance.
+
+    Args:
+        b_val (Any): The base value to be wrapped.
+
+    Raises:
+        TypeError: If ``b_val`` is :data:`None`.
+        TypeError: If ``b_val`` is a list.
+    """
+
+    __slots__ = ("b_val",)
+
+    def __init__(self, b_val):
+        if b_val is None:
+            raise TypeError("Cannot wrap None")
+        if isinstance(b_val, list):
+            raise TypeError("Lists cannot be wrapped. Received", b_val)
+        self.b_val = b_val
+
+    def __repr__(self):
+        return "_BaseValue({!r})".format(self.b_val)
+
+    def __eq__(self, other):
+        """Compare two :class:`_BaseValue` instances."""
+        if not isinstance(other, _BaseValue):
+            return NotImplemented
+
+        return self.b_val == other.b_val
+
+    def __ne__(self, other):
+        """Inequality comparison operation."""
+        return not self == other
+
+    def __hash__(self):
+        raise TypeError("_BaseValue is not immutable")
+
+
 class Property(ModelAttribute):
     # Instance default fallbacks provided by class.
     _name = None

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -284,6 +284,49 @@ class TestModelAttribute:
         assert attr._fix_up(model.Model, "birthdate") is None
 
 
+class Test_BaseValue:
+    @staticmethod
+    def test_constructor():
+        wrapped = model._BaseValue(17)
+        assert wrapped.b_val == 17
+
+    @staticmethod
+    def test_constructor_invalid_input():
+        with pytest.raises(TypeError):
+            model._BaseValue(None)
+        with pytest.raises(TypeError):
+            model._BaseValue([1, 2])
+
+    @staticmethod
+    def test___repr__():
+        wrapped = model._BaseValue(b"abc")
+        assert repr(wrapped) == "_BaseValue(b'abc')"
+
+    @staticmethod
+    def test___eq__():
+        wrapped1 = model._BaseValue("one val")
+        wrapped2 = model._BaseValue(25.5)
+        wrapped3 = unittest.mock.sentinel.base_value
+        assert wrapped1 == wrapped1
+        assert not wrapped1 == wrapped2
+        assert not wrapped1 == wrapped3
+
+    @staticmethod
+    def test___ne__():
+        wrapped1 = model._BaseValue("one val")
+        wrapped2 = model._BaseValue(25.5)
+        wrapped3 = unittest.mock.sentinel.base_value
+        assert not wrapped1 != wrapped1
+        assert wrapped1 != wrapped2
+        assert wrapped1 != wrapped3
+
+    @staticmethod
+    def test___hash__():
+        wrapped = model._BaseValue((11, 12, 88))
+        with pytest.raises(TypeError):
+            hash(wrapped)
+
+
 @pytest.fixture
 def zero_prop_counter():
     counter_val = model.Property._CREATION_COUNTER


### PR DESCRIPTION
This is used to wrap values returned from the datastore so that they can be differentiated by values set by the user.

Worth noting: It's unclear if this would be needed by the "best" implementation, but I think it's "best" to leave it in for now.