### PR TITLE
Allow turning on JSON Detection in StackDriver

### DIFF
--- a/logging/google/cloud/logging/handlers/transports/background_thread.py
+++ b/logging/google/cloud/logging/handlers/transports/background_thread.py
@@ -92,10 +92,10 @@ class _Worker(object):
         than the grace_period. This means this is effectively the longest
         amount of time the background thread will hold onto log entries
         before sending them to the server.
-        
+
     :type includer_logger_name: bool
     :param include_logger_name: (optional) Include python_logger field in
-        jsonPayload. Turn this off to enable json detection in log messages.      
+        jsonPayload. Turn this off to enable json detection in log messages.
     """
 
     def __init__(self, cloud_logger, grace_period=_DEFAULT_GRACE_PERIOD,
@@ -259,7 +259,7 @@ class _Worker(object):
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
         """
-        
+
         log_record = {
             'info': {
                 'message': message,
@@ -270,11 +270,10 @@ class _Worker(object):
             'trace': trace,
             'span_id': span_id,
         }
-        
+
         if self._include_logger_name:
-            log_record['info']['python_logger'] = record.name 
+            log_record['info']['python_logger'] = record.name
         self._queue.put_nowait(log_record)
-        
 
     def flush(self):
         """Submit any pending log records."""
@@ -304,11 +303,11 @@ class BackgroundThreadTransport(Transport):
         than the grace_period. This means this is effectively the longest
         amount of time the background thread will hold onto log entries
         before sending them to the server.
-        
+
     :type includer_logger_name: bool
     :param include_logger_name: (optional) Include python_logger field in
                                 jsonPayload. Turn this off to enable jso
-                                detection in log messages.      
+                                detection in log messages.
     """
 
     def __init__(self, client, name, grace_period=_DEFAULT_GRACE_PERIOD,

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -296,7 +296,9 @@ class Test_Worker(unittest.TestCase):
         worker._thread_main()
 
         self.assertEqual(len(worker._cloud_logger._batch.all_entries), 1)
-        self.assertFalse('python_logger' in worker._cloud_logger._batch.all_entries[0])
+        self.assertFalse(
+            'python_logger' in worker._cloud_logger._batch.all_entries[0]
+        )
 
     def test__thread_main_error(self):
         from google.cloud.logging.handlers.transports import background_thread

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -166,17 +166,16 @@ class Test_Worker(unittest.TestCase):
         grace_period = 50
         max_batch_size = 50
         max_latency = 0.1
-        include_logger_name = True
 
         worker = self._make_one(
             logger, grace_period=grace_period, max_batch_size=max_batch_size,
-            max_latency=max_latency, include_logger_name=include_logger_name)
+            max_latency=max_latency)
 
         self.assertEqual(worker._cloud_logger, logger)
         self.assertEqual(worker._grace_period, grace_period)
         self.assertEqual(worker._max_batch_size, max_batch_size)
         self.assertEqual(worker._max_latency, max_latency)
-        self.assertEqual(worker._include_logger_name, include_logger_name)
+        self.assertTrue(worker._include_logger_name)
         self.assertFalse(worker.is_alive)
         self.assertIsNone(worker._thread)
 
@@ -288,6 +287,7 @@ class Test_Worker(unittest.TestCase):
         from google.cloud.logging.handlers.transports import background_thread
 
         worker = self._make_one(_Logger(self.NAME), include_logger_name=False)
+        self.assertFalse(worker._include_logger_name)
 
         # Enqueue one record and the termination signal.
         self._enqueue_record(worker, '1')


### PR DESCRIPTION
To enable JSON detection in StackDriver, `jsonPayload` should
have no fields other than `message`. This patch lets clients
opt-in to this behavior, by creating a custom Transport.

Fixes https://github.com/googleapis/google-cloud-python/issues/5799