### PR TITLE
Bigtable: WIP / spike for opencensus integration

### DIFF
--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -173,8 +173,11 @@ class Client(ClientWithProject):
         """
         if self._table_data_client is None:
             self._table_data_client = (
-                bigtable_v2.BigtableClient(credentials=self._credentials,
-                                           client_info=_CLIENT_INFO))
+                bigtable_v2.BigtableClient(
+                    credentials=self._credentials,
+                    client_info=_CLIENT_INFO,
+                    grpc_interceptors=self.grpc_interceptors,
+                ))
 
         return self._table_data_client
 
@@ -193,7 +196,10 @@ class Client(ClientWithProject):
                 raise ValueError('Client is not an admin client.')
             self._table_admin_client = (
                 bigtable_admin_v2.BigtableTableAdminClient(
-                    credentials=self._credentials, client_info=_CLIENT_INFO))
+                    credentials=self._credentials,
+                    client_info=_CLIENT_INFO,
+                    grpc_interceptors=self.grpc_interceptors,
+                ))
 
         return self._table_admin_client
 
@@ -212,7 +218,10 @@ class Client(ClientWithProject):
                 raise ValueError('Client is not an admin client.')
             self._instance_admin_client = (
                 bigtable_admin_v2.BigtableInstanceAdminClient(
-                    credentials=self._credentials, client_info=_CLIENT_INFO))
+                    credentials=self._credentials,
+                    client_info=_CLIENT_INFO,
+                    grpc_interceptors=self.grpc_interceptors,
+                ))
         return self._instance_admin_client
 
     def instance(self, instance_id, display_name=None,

--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -86,6 +86,9 @@ class Client(ClientWithProject):
                   interact with the Instance Admin or Table Admin APIs. This
                   requires the :const:`ADMIN_SCOPE`. Defaults to :data:`False`.
 
+    :type grpc_interceptors: list of GRPC channel interceptors.
+    :param grpc_interceptors: (Optional) interceptors used to wrap GRPC calls.
+
     :type channel: :instance: grpc.Channel
     :param channel (grpc.Channel): (Optional) DEPRECATED:
             A ``Channel`` instance through which to make calls.
@@ -99,8 +102,15 @@ class Client(ClientWithProject):
     _table_admin_client = None
     _instance_admin_client = None
 
-    def __init__(self, project=None, credentials=None,
-                 read_only=False, admin=False, channel=None):
+    def __init__(
+        self,
+        project=None,
+        credentials=None,
+        read_only=False,
+        admin=False,
+        grpc_interceptors=(),
+        channel=None,
+    ):
         if read_only and admin:
             raise ValueError('A read-only client cannot also perform'
                              'administrative actions.')
@@ -117,6 +127,7 @@ class Client(ClientWithProject):
 
         self._channel = channel
         self.SCOPE = self._get_scopes()
+        self.grpc_interceptors = grpc_interceptors
         super(Client, self).__init__(project=project, credentials=credentials)
 
     def _get_scopes(self):

--- a/bigtable/google/cloud/bigtable_admin_v2/gapic/bigtable_instance_admin_client.py
+++ b/bigtable/google/cloud/bigtable_admin_v2/gapic/bigtable_instance_admin_client.py
@@ -132,6 +132,7 @@ class BigtableInstanceAdminClient(object):
                  transport=None,
                  channel=None,
                  credentials=None,
+                 grpc_interceptors=(),
                  client_config=bigtable_instance_admin_client_config.config,
                  client_info=None):
         """Constructor.
@@ -156,6 +157,8 @@ class BigtableInstanceAdminClient(object):
                 This argument is mutually exclusive with providing a
                 transport instance to ``transport``; doing so will raise
                 an exception.
+            grpc_interceptors (Optional[Sequence[grpc.*ClientInterceptor])]:
+                Interceptors to be applied to the GRPC channel.
             client_config (dict): DEPRECATED. A dictionary of call options for
                 each method. If not specified, the default configuration is used.
             client_info (google.api_core.gapic_v1.client_info.ClientInfo):
@@ -194,6 +197,7 @@ class BigtableInstanceAdminClient(object):
                 address=self.SERVICE_ADDRESS,
                 channel=channel,
                 credentials=credentials,
+                grpc_interceptors=grpc_interceptors,
             )
 
         if client_info is None:

--- a/bigtable/google/cloud/bigtable_admin_v2/gapic/bigtable_table_admin_client.py
+++ b/bigtable/google/cloud/bigtable_admin_v2/gapic/bigtable_table_admin_client.py
@@ -133,6 +133,7 @@ class BigtableTableAdminClient(object):
                  transport=None,
                  channel=None,
                  credentials=None,
+                 grpc_interceptors=(),
                  client_config=bigtable_table_admin_client_config.config,
                  client_info=None):
         """Constructor.
@@ -157,6 +158,8 @@ class BigtableTableAdminClient(object):
                 This argument is mutually exclusive with providing a
                 transport instance to ``transport``; doing so will raise
                 an exception.
+            grpc_interceptors (Optional[Sequence[grpc.*ClientInterceptor])]:
+                Interceptors to be applied to the GRPC channel.
             client_config (dict): DEPRECATED. A dictionary of call options for
                 each method. If not specified, the default configuration is used.
             client_info (google.api_core.gapic_v1.client_info.ClientInfo):
@@ -195,6 +198,7 @@ class BigtableTableAdminClient(object):
                 address=self.SERVICE_ADDRESS,
                 channel=channel,
                 credentials=credentials,
+                grpc_interceptors=grpc_interceptors,
             )
 
         if client_info is None:

--- a/bigtable/google/cloud/bigtable_admin_v2/gapic/transports/bigtable_instance_admin_grpc_transport.py
+++ b/bigtable/google/cloud/bigtable_admin_v2/gapic/transports/bigtable_instance_admin_grpc_transport.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import grpc
 import google.api_core.grpc_helpers
 import google.api_core.operations_v1
 
@@ -45,7 +46,8 @@ class BigtableInstanceAdminGrpcTransport(object):
     def __init__(self,
                  channel=None,
                  credentials=None,
-                 address='bigtableadmin.googleapis.com:443'):
+                 address='bigtableadmin.googleapis.com:443',
+                 grpc_interceptors=()):
         """Instantiate the transport class.
 
         Args:
@@ -58,6 +60,8 @@ class BigtableInstanceAdminGrpcTransport(object):
                 are specified, the client will attempt to ascertain the
                 credentials from the environment.
             address (str): The address where the service is hosted.
+            grpc_interceptors (Optional[Sequence[grpc.*ClientInterceptor])]:
+                Interceptors to be applied when creating a GRPC channel.
         """
         # If both `channel` and `credentials` are specified, raise an
         # exception (channels come with credentials baked in already).
@@ -72,6 +76,8 @@ class BigtableInstanceAdminGrpcTransport(object):
                 address=address,
                 credentials=credentials,
             )
+            for interceptor in grpc_interceptors:
+                channel = grpc.intercept_channel(channel, interceptor)
 
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.

--- a/bigtable/google/cloud/bigtable_admin_v2/gapic/transports/bigtable_table_admin_grpc_transport.py
+++ b/bigtable/google/cloud/bigtable_admin_v2/gapic/transports/bigtable_table_admin_grpc_transport.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import grpc
 import google.api_core.grpc_helpers
 import google.api_core.operations_v1
 
@@ -45,7 +46,8 @@ class BigtableTableAdminGrpcTransport(object):
     def __init__(self,
                  channel=None,
                  credentials=None,
-                 address='bigtableadmin.googleapis.com:443'):
+                 address='bigtableadmin.googleapis.com:443',
+                 grpc_interceptors=()):
         """Instantiate the transport class.
 
         Args:
@@ -58,6 +60,8 @@ class BigtableTableAdminGrpcTransport(object):
                 are specified, the client will attempt to ascertain the
                 credentials from the environment.
             address (str): The address where the service is hosted.
+            grpc_interceptors (Optional[Sequence[grpc.*ClientInterceptor])]:
+                Interceptors to be applied when creating a GRPC channel.
         """
         # If both `channel` and `credentials` are specified, raise an
         # exception (channels come with credentials baked in already).
@@ -72,6 +76,8 @@ class BigtableTableAdminGrpcTransport(object):
                 address=address,
                 credentials=credentials,
             )
+            for interceptor in grpc_interceptors:
+                channel = grpc.intercept_channel(channel, interceptor)
 
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.

--- a/bigtable/google/cloud/bigtable_v2/gapic/bigtable_client.py
+++ b/bigtable/google/cloud/bigtable_v2/gapic/bigtable_client.py
@@ -82,6 +82,7 @@ class BigtableClient(object):
                  transport=None,
                  channel=None,
                  credentials=None,
+                 grpc_interceptors=(),
                  client_config=bigtable_client_config.config,
                  client_info=None):
         """Constructor.
@@ -106,6 +107,9 @@ class BigtableClient(object):
                 This argument is mutually exclusive with providing a
                 transport instance to ``transport``; doing so will raise
                 an exception.
+            grpc_interceptors (Optional[Sequence[grpc.*ClientInterceptor])]:
+                Interceptors to be applied to the GRPC channel.
+            List(derived from grpc.*ClientInterceptor)
             client_config (dict): DEPRECATED. A dictionary of call options for
                 each method. If not specified, the default configuration is used.
             client_info (google.api_core.gapic_v1.client_info.ClientInfo):
@@ -144,6 +148,7 @@ class BigtableClient(object):
                 address=self.SERVICE_ADDRESS,
                 channel=channel,
                 credentials=credentials,
+                grpc_interceptors=grpc_interceptors,
             )
 
         if client_info is None:

--- a/bigtable/google/cloud/bigtable_v2/gapic/transports/bigtable_grpc_transport.py
+++ b/bigtable/google/cloud/bigtable_v2/gapic/transports/bigtable_grpc_transport.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import grpc
 import google.api_core.grpc_helpers
 
 from google.cloud.bigtable_v2.proto import bigtable_pb2_grpc
@@ -41,7 +42,8 @@ class BigtableGrpcTransport(object):
     def __init__(self,
                  channel=None,
                  credentials=None,
-                 address='bigtable.googleapis.com:443'):
+                 address='bigtable.googleapis.com:443',
+                 grpc_interceptors=()):
         """Instantiate the transport class.
 
         Args:
@@ -54,6 +56,8 @@ class BigtableGrpcTransport(object):
                 are specified, the client will attempt to ascertain the
                 credentials from the environment.
             address (str): The address where the service is hosted.
+            grpc_interceptors (Optional[Sequence[grpc.*ClientInterceptor])]:
+                Interceptors to be applied when creating a GRPC channel.
         """
         # If both `channel` and `credentials` are specified, raise an
         # exception (channels come with credentials baked in already).
@@ -68,6 +72,8 @@ class BigtableGrpcTransport(object):
                 address=address,
                 credentials=credentials,
             )
+            for interceptor in grpc_interceptors:
+                channel = grpc.intercept_channel(channel, interceptor)
 
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.

--- a/bigtable/noxfile.py
+++ b/bigtable/noxfile.py
@@ -83,6 +83,7 @@ def system(session):
     for local_dep in LOCAL_DEPS:
         session.install('-e', local_dep)
     session.install('-e', '../test_utils/')
+    session.install('-e', '../trace/')
     session.install('-e', '.[opencensus]')
 
     # Run py.test against the system tests.

--- a/bigtable/noxfile.py
+++ b/bigtable/noxfile.py
@@ -60,6 +60,13 @@ def unit(session):
 
 
 @nox.session(python=['2.7', '3.7'])
+def unit_opencensus(session):
+    """Run the unit test suite with the 'opencensus' extra installed."""
+    session.install('-e', '.[opencensus]')
+    default(session)
+
+
+@nox.session(python=['2.7', '3.7'])
 def system(session):
     """Run the system test suite."""
 
@@ -76,7 +83,7 @@ def system(session):
     for local_dep in LOCAL_DEPS:
         session.install('-e', local_dep)
     session.install('-e', '../test_utils/')
-    session.install('-e', '.')
+    session.install('-e', '.[opencensus]')
 
     # Run py.test against the system tests.
     session.run('py.test', '--quiet', 'tests/system.py', *session.posargs)

--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -34,6 +34,7 @@ dependencies = [
     'grpc-google-iam-v1<0.12dev,>=0.11.4'
 ]
 extras = {
+    'opencensus': 'opencensus>=0.1.8,<0.2',
 }
 
 

--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -34,7 +34,9 @@ dependencies = [
     'grpc-google-iam-v1<0.12dev,>=0.11.4'
 ]
 extras = {
-    'opencensus': 'opencensus>=0.1.8,<0.2',
+    'opencensus': [
+        'opencensus>=0.1.8,<0.2[stackdriver]',
+    ],
 }
 
 

--- a/bigtable/tests/unit/test_client.py
+++ b/bigtable/tests/unit/test_client.py
@@ -134,6 +134,36 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(table_data_client, BigtableClient)
         self.assertIs(client._table_data_client, table_data_client)
 
+    def test_table_data_client_not_initialized_w_interceptors(self):
+        from grpc import UnaryUnaryClientInterceptor
+        from grpc._interceptor import _UnaryUnaryMultiCallable
+        from google.cloud.bigtable_v2 import BigtableClient
+
+        class _Interceptor(UnaryUnaryClientInterceptor):
+            def intercept_unary_unary(
+                self, continuation, client_call_details, request,
+            ):
+                pass
+
+        credentials = _make_credentials()
+        interceptor = _Interceptor()
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=credentials,
+            grpc_interceptors=[interceptor],
+        )
+
+        table_data_client = client.table_data_client
+        self.assertIsInstance(table_data_client, BigtableClient)
+        self.assertIs(client._table_data_client, table_data_client)
+
+        # Check that interceptors were propagated
+        transport = table_data_client.transport
+        stub = transport._stubs['bigtable_stub']
+        mutate_row = stub.MutateRow
+        self.assertIsInstance(mutate_row, _UnaryUnaryMultiCallable)
+        self.assertIs(mutate_row._interceptor, interceptor)
+
     def test_table_data_client_initialized(self):
         credentials = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=credentials,
@@ -158,6 +188,38 @@ class TestClient(unittest.TestCase):
 
         table_admin_client = client.table_admin_client
         self.assertIsInstance(table_admin_client, BigtableTableAdminClient)
+
+    def test_table_admin_client_not_initialized_w_interceptors(self):
+        from grpc import UnaryUnaryClientInterceptor
+        from grpc._interceptor import _UnaryUnaryMultiCallable
+        from google.cloud.bigtable_admin_v2 import BigtableTableAdminClient
+
+        class _Interceptor(UnaryUnaryClientInterceptor):
+            def intercept_unary_unary(
+                self, continuation, client_call_details, request,
+            ):
+                pass
+
+        credentials = _make_credentials()
+        interceptor = _Interceptor()
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=credentials,
+            admin=True,
+            grpc_interceptors=[interceptor],
+        )
+
+        table_admin_client = client.table_admin_client
+        self.assertIsInstance(
+            table_admin_client, BigtableTableAdminClient)
+        self.assertIs(client._table_admin_client, table_admin_client)
+
+        # Check that interceptors were propagated
+        transport = table_admin_client.transport
+        stub = transport._stubs['bigtable_table_admin_stub']
+        create_table = stub.CreateTable
+        self.assertIsInstance(create_table, _UnaryUnaryMultiCallable)
+        self.assertIs(create_table._interceptor, interceptor)
 
     def test_table_admin_client_initialized(self):
         credentials = _make_credentials()
@@ -184,6 +246,38 @@ class TestClient(unittest.TestCase):
         instance_admin_client = client.instance_admin_client
         self.assertIsInstance(
             instance_admin_client, BigtableInstanceAdminClient)
+
+    def test_instance_admin_client_not_initialized_w_interceptors(self):
+        from grpc import UnaryUnaryClientInterceptor
+        from grpc._interceptor import _UnaryUnaryMultiCallable
+        from google.cloud.bigtable_admin_v2 import BigtableInstanceAdminClient
+
+        class _Interceptor(UnaryUnaryClientInterceptor):
+            def intercept_unary_unary(
+                self, continuation, client_call_details, request,
+            ):
+                pass
+
+        credentials = _make_credentials()
+        interceptor = _Interceptor()
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=credentials,
+            admin=True,
+            grpc_interceptors=[interceptor],
+        )
+
+        instance_admin_client = client.instance_admin_client
+        self.assertIsInstance(
+            instance_admin_client, BigtableInstanceAdminClient)
+        self.assertIs(client._instance_admin_client, instance_admin_client)
+
+        # Check that interceptors were propagated
+        transport = instance_admin_client.transport
+        stub = transport._stubs['bigtable_instance_admin_stub']
+        create_instance = stub.CreateInstance
+        self.assertIsInstance(create_instance, _UnaryUnaryMultiCallable)
+        self.assertIs(create_instance._interceptor, interceptor)
 
     def test_instance_admin_client_initialized(self):
         credentials = _make_credentials()

--- a/bigtable/tests/unit/test_client.py
+++ b/bigtable/tests/unit/test_client.py
@@ -52,6 +52,7 @@ class TestClient(unittest.TestCase):
         self.assertFalse(client._admin)
         self.assertIsNone(client._channel)
         self.assertEqual(client.SCOPE, (DATA_SCOPE,))
+        self.assertEqual(len(client.grpc_interceptors), 0)
 
     def test_constructor_explicit(self):
         import warnings
@@ -59,6 +60,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigtable.client import DATA_SCOPE
 
         credentials = _make_credentials()
+        grpc_interceptors = [mock.Mock(spec=())]
 
         with warnings.catch_warnings(record=True) as warned:
             client = self._make_one(
@@ -67,6 +69,7 @@ class TestClient(unittest.TestCase):
                 read_only=False,
                 admin=True,
                 channel=mock.sentinel.channel,
+                grpc_interceptors=grpc_interceptors,
             )
 
         self.assertEqual(len(warned), 1)
@@ -78,6 +81,8 @@ class TestClient(unittest.TestCase):
         self.assertTrue(client._admin)
         self.assertIs(client._channel, mock.sentinel.channel)
         self.assertEqual(client.SCOPE, (DATA_SCOPE, ADMIN_SCOPE))
+        self.assertEqual(
+            len(client.grpc_interceptors), len(grpc_interceptors))
 
     def test_constructor_both_admin_and_read_only(self):
         credentials = _make_credentials()


### PR DESCRIPTION
Spiky bits:

- Getting the 'opencensus' extra installed when running the system tests required that I also install `../trace` into the Bigtable system test noxenv.
- Scribbling on the GAPIC-generated code to show the maintainers the kinds of changes we will need.
- Maybe configuring the tracer for *all* system tests isn't the Right Thing(TM), but it does work.
- I can probably ditch the `unit_opencensus` nox session:  we don't actually import from `opencensus` anywhere except the system tests.