### PR TITLE
Bigtable: Fix ConditionalRow interaction with check_and_mutate_row

### DIFF
--- a/bigtable/google/cloud/bigtable/row.py
+++ b/bigtable/google/cloud/bigtable/row.py
@@ -520,9 +520,13 @@ class ConditionalRow(_SetDeleteRow):
 
         data_client = self._table._instance._client.table_data_client
         resp = data_client.check_and_mutate_row(
-            table_name=self._table.name, row_key=self._row_key,)
+            table_name=self._table.name,
+            row_key=self._row_key,
+            predicate_filter=self._filter.to_pb(),
+            true_mutations=true_mutations,
+            false_mutations=false_mutations)
         self.clear()
-        return resp[0].predicate_matched
+        return resp.predicate_matched
 
     # pylint: disable=arguments-differ
     def set_cell(self, column_family_id, column, value, timestamp=None,

--- a/bigtable/tests/unit/test_row.py
+++ b/bigtable/tests/unit/test_row.py
@@ -445,7 +445,7 @@ class TestConditionalRow(unittest.TestCase):
             predicate_matched=predicate_matched)
 
         # Patch the stub used by the API method.
-        api.transport.check_and_mutate_row.side_effect = [[response_pb]]
+        api.transport.check_and_mutate_row.side_effect = [response_pb]
         client._table_data_client = api
 
         # Create expected_result.


### PR DESCRIPTION
Fixes #6292 

- `predicate_filter` and `*_mutation` parameters are getting passed again to `check_and_mutate_row`
- Remove erroneous index from `resp`, since it already is a single `google.cloud.bigtable_v2.types.CheckAndMutateRowResponse`

Unsure how to make the tests more sensible to this kind of error.