### PR TITLE
Container: WIP: try to accomodate multiple API versions.

### DIFF
--- a/container/synth.py
+++ b/container/synth.py
@@ -18,17 +18,16 @@ from synthtool import gcp
 
 gapic = gcp.GAPICGenerator()
 
+versions = ['v1alpha1', 'v1beta1', 'v1']
 
-#----------------------------------------------------------------------------
-# Generate container client
-#----------------------------------------------------------------------------
-library = gapic.py_library(
-    'container',
-    'v1',
-    config_path='/google/container/artman_container.yaml',
-    artman_output_name='container-v1')
+for version in versions:
+    library = gapic.py_library(
+        'container',
+        version,
+        config_path='/google/container/artman_container.yaml',
+        artman_output_name=f'container-{version}')
 
-s.move(library / 'google/cloud/container_v1')
+    s.move(library / f'google/cloud/container_{version}')
 
 # Issues exist where python files should define the source encoding
 # https://github.com/googleapis/gapic-generator/issues/2097


### PR DESCRIPTION
See: #6314.

@crwilcox the `synthtool` run here fails:

```bash
$ /path/to/gcp-tools/bin/synthtool 
synthtool > Executing /path/to/gcp/container/synth.py.
synthtool > Cloning googleapis.
synthtool > Running generator for google/container/artman_container.yaml.
synthtool > Ensuring dependencies.
synthtool > Pulling artman image.
Traceback (most recent call last):
  File "/path/to/gcp-tools/bin/synthtool", line 11, in <module>
    sys.exit(main())
  File "/path/to/gcp-tools/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/path/to/gcp-tools/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/path/to/gcp-tools/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/path/to/gcp-tools/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/path/to/gcp-tools/lib/python3.6/site-packages/synthtool/__main__.py", line 33, in main
    spec.loader.exec_module(synth_module)
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/path/to/gcp/container/synth.py", line 28, in <module>
    artman_output_name=f'container-{version}')
  File "/path/to/gcp-tools/lib/python3.6/site-packages/synthtool/gcp/gapic_generator.py", line 38, in py_library
    return self._generate_code(service, version, "python", **kwargs)
  File "/path/to/gcp-tools/lib/python3.6/site-packages/synthtool/gcp/gapic_generator.py", line 122, in _generate_code
    f"Unable to find generated output of artman: {genfiles}."
FileNotFoundError: Unable to find generated output of artman: /home/tseaver/.cache/synthtool/googleapis/artman-genfiles/python/container-v1alpha1.
synthtool > Cleaned up 0 temporary directories.
```

Any suggestions?