### PR TITLE
Continuation of `ndb` Property implementation (part 4)

### DIFF
--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -852,6 +852,42 @@ class Property(ModelAttribute):
         """
         return entity._values.get(self._name, default)
 
+    def _get_user_value(self, entity):
+        """Return the user value for this property of the given entity.
+
+        This implies removing the :class:`_BaseValue` wrapper if present, and
+        if it is, calling all ``_from_base_type()`` methods, in the reverse
+        method resolution order of the property's class. It also handles
+        default values and repeated properties.
+
+        Args:
+            entity (Model): An entity to get a value from.
+
+        Returns:
+            Any: The original value (if not :class:`_BaseValue`) or the wrapped
+            value converted from the base type.
+        """
+        return self._apply_to_values(entity, self._opt_call_from_base_type)
+
+    def _get_base_value(self, entity):
+        """Return the base value for this property of the given entity.
+
+        This implies calling all ``_to_base_type()`` methods, in the method
+        resolution order of the property's class, and adding a
+        :class:`_BaseValue` wrapper, if one is not already present. (If one
+        is present, no work is done.)  It also handles default values and
+        repeated properties.
+
+        Args:
+            entity (Model): An entity to get a value from.
+
+        Returns:
+            Union[_BaseValue, List[_BaseValue]]: The original value
+            (if :class:`_BaseValue`) or the value converted to the base type
+            and wrapped.
+        """
+        return self._apply_to_values(entity, self._opt_call_to_base_type)
+
     def _opt_call_from_base_type(self, value):
         """Call :meth:`_from_base_type` if necessary.
 

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -852,6 +852,25 @@ class Property(ModelAttribute):
         """
         return entity._values.get(self._name, default)
 
+    def _opt_call_to_base_type(self, value):
+        """Call :meth:`_to_base_type` if necessary.
+
+        If ``value`` is a :class:`_BaseValue`, return it unchanged.
+        Otherwise, call all :meth:`_validate` and :meth:`_to_base_type` methods
+        and wrap it in a :class:`_BaseValue`.
+
+        Args:
+            value (Any): The value to invoke :meth:`_call_to_base_type`
+               for.
+
+        Returns:
+            _BaseValue: The original value (if :class:`_BaseValue`) or the
+            value converted to the base type and wrapped.
+        """
+        if not isinstance(value, _BaseValue):
+            value = _BaseValue(self._call_to_base_type(value))
+        return value
+
     def _call_to_base_type(self, value):
         """Call all ``_validate()`` and ``_to_base_type()`` methods on value.
 

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -871,6 +871,24 @@ class Property(ModelAttribute):
             value = self._call_from_base_type(value.b_val)
         return value
 
+    def _value_to_repr(self, value):
+        """Turn a value (base or not) into its repr().
+
+        This exists so that property classes can override it separately.
+
+        This manually applies ``_from_base_type()`` so as not to have a side
+        effect on what's contained in the entity. Printing a value should not
+        change it.
+
+        Args:
+            value (Any): The value to convert to a pretty-print ``repr``.
+
+        Returns:
+            str: The ``repr`` of the "true" value.
+        """
+        val = self._opt_call_from_base_type(value)
+        return repr(val)
+
     def _opt_call_to_base_type(self, value):
         """Call :meth:`_to_base_type` if necessary.
 

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -871,6 +871,22 @@ class Property(ModelAttribute):
             value = _BaseValue(self._call_to_base_type(value))
         return value
 
+    def _call_from_base_type(self, value):
+        """Call all ``_from_base_type()`` methods on the value.
+
+        This calls the methods in the reverse method resolution order of
+        the property's class.
+
+        Args:
+            value (Any): The value to be converted.
+
+        Returns:
+            Any: The transformed ``value``.
+        """
+        methods = self._find_methods("_from_base_type", reverse=True)
+        call = self._apply_list(methods)
+        return call(value)
+
     def _call_to_base_type(self, value):
         """Call all ``_validate()`` and ``_to_base_type()`` methods on value.
 

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -888,6 +888,38 @@ class Property(ModelAttribute):
         """
         return self._apply_to_values(entity, self._opt_call_to_base_type)
 
+    def _get_base_value_unwrapped_as_list(self, entity):
+        """Like _get_base_value(), but always returns a list.
+
+        Args:
+            entity (Model): An entity to get a value from.
+
+        Returns:
+            List[Any]: The unwrapped base values. For an unrepeated
+            property, if the value is missing or :data:`None`, returns
+            ``[None]``; for a repeated property, if the original value is
+            missing or :data:`None` or empty, returns ``[]``.
+
+        Raises:
+            ValueError: If the property is repeated but the base value is not
+                a :class:`list` or :data:`None`.
+            ValueError: If the property is not repeated but the base value is
+                not a :class:`_BaseValue`.
+        """
+        wrapped = self._get_base_value(entity)
+        if self._repeated:
+            if not isinstance(wrapped, list):
+                raise ValueError("Expected the wrapped quantity to be a list.")
+            return [w.b_val for w in wrapped]
+        else:
+            if wrapped is None:
+                return [None]
+            if not isinstance(wrapped, _BaseValue):
+                raise ValueError(
+                    "Expected the wrapped quantity to be a _BaseValue."
+                )
+            return [wrapped.b_val]
+
     def _opt_call_from_base_type(self, value):
         """Call :meth:`_from_base_type` if necessary.
 

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -899,25 +899,13 @@ class Property(ModelAttribute):
             property, if the value is missing or :data:`None`, returns
             ``[None]``; for a repeated property, if the original value is
             missing or :data:`None` or empty, returns ``[]``.
-
-        Raises:
-            ValueError: If the property is repeated but the base value is not
-                a :class:`list` or :data:`None`.
-            ValueError: If the property is not repeated but the base value is
-                not a :class:`_BaseValue`.
         """
         wrapped = self._get_base_value(entity)
         if self._repeated:
-            if not isinstance(wrapped, list):
-                raise ValueError("Expected the wrapped quantity to be a list.")
             return [w.b_val for w in wrapped]
         else:
             if wrapped is None:
                 return [None]
-            if not isinstance(wrapped, _BaseValue):
-                raise ValueError(
-                    "Expected the wrapped quantity to be a _BaseValue."
-                )
             return [wrapped.b_val]
 
     def _opt_call_from_base_type(self, value):

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -852,6 +852,25 @@ class Property(ModelAttribute):
         """
         return entity._values.get(self._name, default)
 
+    def _opt_call_from_base_type(self, value):
+        """Call :meth:`_from_base_type` if necessary.
+
+        If ``value`` is a :class:`_BaseValue`, unwrap it and call all
+        :math:`_from_base_type` methods. Otherwise, return the value
+        unchanged.
+
+        Args:
+            value (Any): The value to invoke :meth:`_call_from_base_type`
+               for.
+
+        Returns:
+            Any: The original value (if not :class:`_BaseValue`) or the value
+            converted from the base type.
+        """
+        if isinstance(value, _BaseValue):
+            value = self._call_from_base_type(value.b_val)
+        return value
+
     def _opt_call_to_base_type(self, value):
         """Call :meth:`_to_base_type` if necessary.
 

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -801,20 +801,6 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
-    def test__get_base_value_unwrapped_as_list_invalid(property_clean_cache):
-        class SimpleProperty(model.Property):
-            def _validate(self, value):
-                self._repeated = False  # Switch from repeated midflight.
-                return value + 6
-
-        prop = SimpleProperty(name="prop", repeated=True)
-        values = {prop._name: [20]}
-        entity = unittest.mock.Mock(_values=values, spec=("_values",))
-        with pytest.raises(ValueError):
-            prop._get_base_value_unwrapped_as_list(entity)
-        assert values == {prop._name: [model._BaseValue(26)]}
-
-    @staticmethod
     def test__get_base_value_unwrapped_as_list_repeated(property_clean_cache):
         class SimpleProperty(model.Property):
             def _validate(self, value):
@@ -825,21 +811,6 @@ class TestProperty:
         entity = unittest.mock.Mock(_values=values, spec=("_values",))
         expected = [2.0, 3.0, 4.0]
         assert prop._get_base_value_unwrapped_as_list(entity) == expected
-
-    @staticmethod
-    def test__get_base_value_unwrapped_as_list_repeated_invalid(
-        property_clean_cache
-    ):
-        class SimpleProperty(model.Property):
-            def _validate(self, value):
-                self._repeated = True  # Switch to repeated midflight.
-                return value + 6
-
-        prop = SimpleProperty(name="prop", repeated=False)
-        values = {prop._name: 11}
-        entity = unittest.mock.Mock(_values=values, spec=("_values",))
-        with pytest.raises(ValueError):
-            prop._get_base_value_unwrapped_as_list(entity)
 
     @staticmethod
     def test__opt_call_from_base_type():

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -782,6 +782,66 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
+    def test__get_base_value_unwrapped_as_list(property_clean_cache):
+        class SimpleProperty(model.Property):
+            def _validate(self, value):
+                return value + 11
+
+        prop = SimpleProperty(name="prop", repeated=False)
+        values = {prop._name: 20}
+        entity = unittest.mock.Mock(_values=values, spec=("_values",))
+        assert prop._get_base_value_unwrapped_as_list(entity) == [31]
+
+    @staticmethod
+    def test__get_base_value_unwrapped_as_list_empty():
+        prop = model.Property(name="prop", repeated=False)
+        entity = unittest.mock.Mock(_values={}, spec=("_values",))
+        assert prop._get_base_value_unwrapped_as_list(entity) == [None]
+        # Cache is untouched.
+        assert model.Property._FIND_METHODS_CACHE == {}
+
+    @staticmethod
+    def test__get_base_value_unwrapped_as_list_invalid(property_clean_cache):
+        class SimpleProperty(model.Property):
+            def _validate(self, value):
+                self._repeated = False  # Switch from repeated midflight.
+                return value + 6
+
+        prop = SimpleProperty(name="prop", repeated=True)
+        values = {prop._name: [20]}
+        entity = unittest.mock.Mock(_values=values, spec=("_values",))
+        with pytest.raises(ValueError):
+            prop._get_base_value_unwrapped_as_list(entity)
+        assert values == {prop._name: [model._BaseValue(26)]}
+
+    @staticmethod
+    def test__get_base_value_unwrapped_as_list_repeated(property_clean_cache):
+        class SimpleProperty(model.Property):
+            def _validate(self, value):
+                return value / 10.0
+
+        prop = SimpleProperty(name="prop", repeated=True)
+        values = {prop._name: [20, 30, 40]}
+        entity = unittest.mock.Mock(_values=values, spec=("_values",))
+        expected = [2.0, 3.0, 4.0]
+        assert prop._get_base_value_unwrapped_as_list(entity) == expected
+
+    @staticmethod
+    def test__get_base_value_unwrapped_as_list_repeated_invalid(
+        property_clean_cache
+    ):
+        class SimpleProperty(model.Property):
+            def _validate(self, value):
+                self._repeated = True  # Switch to repeated midflight.
+                return value + 6
+
+        prop = SimpleProperty(name="prop", repeated=False)
+        values = {prop._name: 11}
+        entity = unittest.mock.Mock(_values=values, spec=("_values",))
+        with pytest.raises(ValueError):
+            prop._get_base_value_unwrapped_as_list(entity)
+
+    @staticmethod
     def test__opt_call_from_base_type():
         prop = model.Property(name="prop")
         value = b"\x00\x01"

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -759,6 +759,18 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
+    def test__call_from_base_type(property_clean_cache):
+        class SimpleProperty(model.Property):
+            def _from_base_type(self, value):
+                value.append("SimpleProperty._from_base_type")
+                return value
+
+        prop = SimpleProperty(name="prop")
+        value = []
+        assert value is prop._call_from_base_type(value)
+        assert value == ["SimpleProperty._from_base_type"]
+
+    @staticmethod
     def _property_subtype_chain():
         class A(model.Property):
             def _validate(self, value):

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -740,6 +740,25 @@ class TestProperty:
         assert prop._retrieve_value(entity2, default=b"zip") == b"zip"
 
     @staticmethod
+    def test__opt_call_to_base_type(property_clean_cache):
+        class SimpleProperty(model.Property):
+            def _validate(self, value):
+                return value + 1
+
+        prop = SimpleProperty(name="prop")
+        value = 17
+        result = prop._opt_call_to_base_type(value)
+        assert result == model._BaseValue(value + 1)
+
+    @staticmethod
+    def test__opt_call_to_base_type_wrapped():
+        prop = model.Property(name="prop")
+        value = model._BaseValue(b"\x00\x01")
+        assert value is prop._opt_call_to_base_type(value)
+        # Cache is untouched.
+        assert model.Property._FIND_METHODS_CACHE == {}
+
+    @staticmethod
     def _property_subtype_chain():
         class A(model.Property):
             def _validate(self, value):

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -758,6 +758,16 @@ class TestProperty:
         assert prop._opt_call_from_base_type(value) == 17.0
 
     @staticmethod
+    def test__value_to_repr(property_clean_cache):
+        class SimpleProperty(model.Property):
+            def _from_base_type(self, value):
+                return value * 3.0
+
+        prop = SimpleProperty(name="prop")
+        value = model._BaseValue(9.25)
+        assert prop._value_to_repr(value) == "27.75"
+
+    @staticmethod
     def test__opt_call_to_base_type(property_clean_cache):
         class SimpleProperty(model.Property):
             def _validate(self, value):

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -740,6 +740,24 @@ class TestProperty:
         assert prop._retrieve_value(entity2, default=b"zip") == b"zip"
 
     @staticmethod
+    def test__opt_call_from_base_type():
+        prop = model.Property(name="prop")
+        value = b"\x00\x01"
+        assert value is prop._opt_call_from_base_type(value)
+        # Cache is untouched.
+        assert model.Property._FIND_METHODS_CACHE == {}
+
+    @staticmethod
+    def test__opt_call_from_base_type_wrapped(property_clean_cache):
+        class SimpleProperty(model.Property):
+            def _from_base_type(self, value):
+                return value * 2.0
+
+        prop = SimpleProperty(name="prop")
+        value = model._BaseValue(8.5)
+        assert prop._opt_call_from_base_type(value) == 17.0
+
+    @staticmethod
     def test__opt_call_to_base_type(property_clean_cache):
         class SimpleProperty(model.Property):
             def _validate(self, value):

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -740,6 +740,48 @@ class TestProperty:
         assert prop._retrieve_value(entity2, default=b"zip") == b"zip"
 
     @staticmethod
+    def test__get_user_value():
+        prop = model.Property(name="prop")
+        value = b"\x00\x01"
+        values = {prop._name: value}
+        entity = unittest.mock.Mock(_values=values, spec=("_values",))
+        assert value is prop._get_user_value(entity)
+        # Cache is untouched.
+        assert model.Property._FIND_METHODS_CACHE == {}
+
+    @staticmethod
+    def test__get_user_value_wrapped(property_clean_cache):
+        class SimpleProperty(model.Property):
+            def _from_base_type(self, value):
+                return value * 2.0
+
+        prop = SimpleProperty(name="prop")
+        values = {prop._name: model._BaseValue(9.5)}
+        entity = unittest.mock.Mock(_values=values, spec=("_values",))
+        assert prop._get_user_value(entity) == 19.0
+
+    @staticmethod
+    def test__get_base_value(property_clean_cache):
+        class SimpleProperty(model.Property):
+            def _validate(self, value):
+                return value + 1
+
+        prop = SimpleProperty(name="prop")
+        values = {prop._name: 20}
+        entity = unittest.mock.Mock(_values=values, spec=("_values",))
+        assert prop._get_base_value(entity) == model._BaseValue(21)
+
+    @staticmethod
+    def test__get_base_value_wrapped():
+        prop = model.Property(name="prop")
+        value = model._BaseValue(b"\x00\x01")
+        values = {prop._name: value}
+        entity = unittest.mock.Mock(_values=values, spec=("_values",))
+        assert value is prop._get_base_value(entity)
+        # Cache is untouched.
+        assert model.Property._FIND_METHODS_CACHE == {}
+
+    @staticmethod
     def test__opt_call_from_base_type():
         prop = model.Property(name="prop")
         value = b"\x00\x01"


### PR DESCRIPTION
This is still incomplete, it's a very large class.

In particular, this implements:

- `Property._apply_to_values`
- `Property._opt_call_to_base_type`
- `Property._call_from_base_type`
- `Property._opt_call_from_base_type`
- `Property._value_to_repr`
- `Property._get_user_value`
- `Property._get_base_value`
- `Property._get_base_value_unwrapped_as_list`


