### PR TITLE
Prep 'api_core-1.5.1' release.

### DIFF
--- a/api_core/CHANGELOG.md
+++ b/api_core/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 [1]: https://pypi.org/project/google-api-core/#history
 
+## 1.5.1
+
+10-15-2018 09:04 PDT
+
+### Internal / Testing Changes
+- Don't URL-encode slashes in gRPC request headers ([#6310](https://github.com/GoogleCloudPlatform/google-cloud-python/pull/6310))
+- Fix branch coverage ([#6242](https://github.com/GoogleCloudPlatform/google-cloud-python/pull/6242))
+- Fix import order lint error.  ([#6240](https://github.com/GoogleCloudPlatform/google-cloud-python/pull/6240))
+
+### Documentation
+- Fix badges for PyPI / versions.  ([#6158](https://github.com/GoogleCloudPlatform/google-cloud-python/pull/6158))
+
 ## 1.5.0
 
 ### New Features

--- a/api_core/CHANGELOG.md
+++ b/api_core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## 1.5.1
 
-10-15-2018 09:04 PDT
+10-29-2018 13:15 PDT
 
 ### Internal / Testing Changes
 - Don't URL-encode slashes in gRPC request headers ([#6310](https://github.com/GoogleCloudPlatform/google-cloud-python/pull/6310))

--- a/api_core/google/api_core/gapic_v1/routing_header.py
+++ b/api_core/google/api_core/gapic_v1/routing_header.py
@@ -20,6 +20,8 @@ requests, especially for services that are regional.
 Generally, these headers are specified as gRPC metadata.
 """
 
+import sys
+
 from six.moves.urllib.parse import urlencode
 
 ROUTING_METADATA_KEY = 'x-goog-request-params'
@@ -35,7 +37,13 @@ def to_routing_header(params):
     Returns:
         str: The routing header string.
     """
-    return urlencode(params)
+    if sys.version_info[0] < 3:
+        # Python 2 does not have the "safe" parameter for urlencode.
+        return urlencode(params).replace('%2F', '/')
+    return urlencode(
+        params,
+        # Per Google API policy (go/api-url-encoding), / is not encoded.
+        safe='/')
 
 
 def to_grpc_metadata(params):

--- a/api_core/setup.py
+++ b/api_core/setup.py
@@ -22,7 +22,7 @@ import setuptools
 
 name = 'google-api-core'
 description = 'Google API client core library'
-version = '1.5.0'
+version = '1.5.1'
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'

--- a/api_core/tests/unit/gapic/test_routing_header.py
+++ b/api_core/tests/unit/gapic/test_routing_header.py
@@ -22,6 +22,12 @@ def test_to_routing_header():
     assert value == "name=meep&book.read=1"
 
 
+def test_to_routing_header_with_slashes():
+    params = [('name', 'me/ep'), ('book.read', '1&2')]
+    value = routing_header.to_routing_header(params)
+    assert value == "name=me/ep&book.read=1%262"
+
+
 def test_to_grpc_metadata():
     params = [('name', 'meep'), ('book.read', '1')]
     metadata = routing_header.to_grpc_metadata(params)


### PR DESCRIPTION
Release to be made from `api_core-1.5.x-maint` branch, if that strategy is chosen (see #6328 for the alternate strategy of repairing the `master` branch).

Closes #6326.