### PR TITLE
Continuation of `ndb` Property implementation (part 5)

### DIFF
--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -1190,6 +1190,31 @@ class Property(ModelAttribute):
 
         return value
 
+    def _get_value(self, entity):
+        """Get the value for this property from an entity.
+
+        For a repeated property this initializes the value to an empty
+        list if it is not set.
+
+        Args:
+            entity (Model): An entity to get a value from.
+
+        Returns:
+            Any: The user value stored for the current property.
+
+        Raises:
+            UnprojectedPropertyError: If the ``entity`` is the result of a
+                projection query and the current property is not one of the
+                projected properties.
+        """
+        if entity._projection:
+            if self._name not in entity._projection:
+                raise UnprojectedPropertyError(
+                    "Property {} is not in the projection".format(self._name)
+                )
+
+        return self._get_user_value(entity)
+
 
 class ModelKey(Property):
     __slots__ = ()

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -1230,6 +1230,20 @@ class Property(ModelAttribute):
         if self._name in entity._values:
             del entity._values[self._name]
 
+    def _is_initialized(self, entity):
+        """Ask if the entity has a value for this property.
+
+        This returns :data:`False` if a value is stored but the stored value
+        is :data:`None`.
+
+        Args:
+            entity (Model): An entity to get a value from.
+        """
+        return not self._required or (
+            (self._has_value(entity) or self._default is not None)
+            and self._get_value(entity) is not None
+        )
+
 
 class ModelKey(Property):
     __slots__ = ()

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -1244,6 +1244,22 @@ class Property(ModelAttribute):
             and self._get_value(entity) is not None
         )
 
+    def __get__(self, entity, unused_cls=None):
+        """Descriptor protocol: get the value from the entity."""
+        if entity is None:
+            # Handle the case where ``__get__`` is called on the class
+            # rather than an instance.
+            return self
+        return self._get_value(entity)
+
+    def __set__(self, entity, value):
+        """Descriptor protocol: set the value on the entity."""
+        self._set_value(entity, value)
+
+    def __delete__(self, entity):
+        """Descriptor protocol: delete the value from the entity."""
+        self._delete_value(entity)
+
 
 class ModelKey(Property):
     __slots__ = ()

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -1314,6 +1314,33 @@ class Property(ModelAttribute):
                 "property".format(self._name, rest, self._name)
             )
 
+    def _get_for_dict(self, entity):
+        """Retrieve the value like ``_get_value()``.
+
+        This is intended to be processed for ``_to_dict()``.
+
+        Property subclasses can override this if they want the dictionary
+        returned by ``entity._to_dict()`` to contain a different value. The
+        main use case is allowing :class:`StructuredProperty` and
+        :class:`LocalStructuredProperty` to allow the default ``_get_value()``
+        behavior.
+
+        * If you override ``_get_for_dict()`` to return a different type, you
+          must override ``_validate()`` to accept values of that type and
+          convert them back to the original type.
+
+        * If you override ``_get_for_dict()``, you must handle repeated values
+          and :data:`None` correctly. However, ``_validate()`` does not need to
+          handle these.
+
+        Args:
+            entity (Model): An entity to get a value from.
+
+        Returns:
+            Any: The user value stored for the current property.
+        """
+        return self._get_value(entity)
+
 
 class ModelKey(Property):
     __slots__ = ()

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -1260,6 +1260,9 @@ class Property(ModelAttribute):
         """Descriptor protocol: delete the value from the entity."""
         self._delete_value(entity)
 
+    def _prepare_for_put(self, entity):
+        pass
+
 
 class ModelKey(Property):
     __slots__ = ()

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -1215,6 +1215,21 @@ class Property(ModelAttribute):
 
         return self._get_user_value(entity)
 
+    def _delete_value(self, entity):
+        """Delete the value for this property from an entity.
+
+        .. note::
+
+            If no value exists this is a no-op; deleted values will not be
+            serialized but requesting their value will return :data:`None` (or
+            an empty list in the case of a repeated property).
+
+        Args:
+            entity (Model): An entity to get a value from.
+        """
+        if self._name in entity._values:
+            del entity._values[self._name]
+
 
 class ModelKey(Property):
     __slots__ = ()

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -1188,6 +1188,23 @@ class TestProperty:
         # Cache is untouched.
         assert model.Property._FIND_METHODS_CACHE == {}
 
+    @staticmethod
+    def test__delete_value():
+        prop = model.Property(name="prop")
+        value = b"\x00\x01"
+        values = {prop._name: value}
+        entity = unittest.mock.Mock(_values=values, spec=("_values",))
+        prop._delete_value(entity)
+        assert values == {}
+
+    @staticmethod
+    def test__delete_value_no_op():
+        prop = model.Property(name="prop")
+        values = {}
+        entity = unittest.mock.Mock(_values=values, spec=("_values",))
+        prop._delete_value(entity)
+        assert values == {}
+
 
 class TestModelKey:
     @staticmethod

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -1235,6 +1235,35 @@ class TestProperty:
         # Cache is untouched.
         assert model.Property._FIND_METHODS_CACHE == {}
 
+    @staticmethod
+    def test_instance_descriptors():
+        class Model:
+            prop = model.Property(name="prop", required=True)
+
+            def __init__(self):
+                self._projection = None
+                self._values = {}
+
+        m = Model()
+        value = 1234.5
+        # __set__
+        m.prop = value
+        assert m._values == {b"prop": value}
+        # __get__
+        assert m.prop == value
+        # __delete__
+        del m.prop
+        assert m._values == {}
+
+    @staticmethod
+    def test_class_descriptors():
+        prop = model.Property(name="prop", required=True)
+
+        class Model:
+            prop2 = prop
+
+        assert Model.prop2 is prop
+
 
 class TestModelKey:
     @staticmethod

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -1264,6 +1264,11 @@ class TestProperty:
 
         assert Model.prop2 is prop
 
+    @staticmethod
+    def test__prepare_for_put():
+        prop = model.Property(name="prop")
+        assert prop._prepare_for_put(None) is None
+
 
 class TestModelKey:
     @staticmethod

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -1157,7 +1157,7 @@ class TestProperty:
         value = b"\x00\x01"
         values = {prop._name: value}
         entity = unittest.mock.Mock(
-            _projection=(), _values=values, spec=("_projection", "_values")
+            _projection=None, _values=values, spec=("_projection", "_values")
         )
         assert value is prop._get_value(entity)
         # Cache is untouched.
@@ -1204,6 +1204,36 @@ class TestProperty:
         entity = unittest.mock.Mock(_values=values, spec=("_values",))
         prop._delete_value(entity)
         assert values == {}
+
+    @staticmethod
+    def test__is_initialized_not_required():
+        prop = model.Property(name="prop", required=False)
+        entity = unittest.mock.sentinel.entity
+        assert prop._is_initialized(entity)
+        # Cache is untouched.
+        assert model.Property._FIND_METHODS_CACHE == {}
+
+    @staticmethod
+    def test__is_initialized_default_fallback():
+        prop = model.Property(name="prop", required=True, default=11111)
+        values = {}
+        entity = unittest.mock.Mock(
+            _projection=None, _values=values, spec=("_projection", "_values")
+        )
+        assert prop._is_initialized(entity)
+        # Cache is untouched.
+        assert model.Property._FIND_METHODS_CACHE == {}
+
+    @staticmethod
+    def test__is_initialized_set_to_none():
+        prop = model.Property(name="prop", required=True)
+        values = {prop._name: None}
+        entity = unittest.mock.Mock(
+            _projection=None, _values=values, spec=("_projection", "_values")
+        )
+        assert not prop._is_initialized(entity)
+        # Cache is untouched.
+        assert model.Property._FIND_METHODS_CACHE == {}
 
 
 class TestModelKey:

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -1151,6 +1151,43 @@ class TestProperty:
         # Check mocks.
         function.assert_not_called()
 
+    @staticmethod
+    def test__get_value():
+        prop = model.Property(name="prop")
+        value = b"\x00\x01"
+        values = {prop._name: value}
+        entity = unittest.mock.Mock(
+            _projection=(), _values=values, spec=("_projection", "_values")
+        )
+        assert value is prop._get_value(entity)
+        # Cache is untouched.
+        assert model.Property._FIND_METHODS_CACHE == {}
+
+    @staticmethod
+    def test__get_value_projected_present():
+        prop = model.Property(name="prop")
+        value = 92.5
+        values = {prop._name: value}
+        entity = unittest.mock.Mock(
+            _projection=(prop._name,),
+            _values=values,
+            spec=("_projection", "_values"),
+        )
+        assert value is prop._get_value(entity)
+        # Cache is untouched.
+        assert model.Property._FIND_METHODS_CACHE == {}
+
+    @staticmethod
+    def test__get_value_projected_absent():
+        prop = model.Property(name="prop")
+        entity = unittest.mock.Mock(
+            _projection=("nope",), spec=("_projection",)
+        )
+        with pytest.raises(model.UnprojectedPropertyError):
+            prop._get_value(entity)
+        # Cache is untouched.
+        assert model.Property._FIND_METHODS_CACHE == {}
+
 
 class TestModelKey:
     @staticmethod

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -1269,6 +1269,23 @@ class TestProperty:
         prop = model.Property(name="prop")
         assert prop._prepare_for_put(None) is None
 
+    @staticmethod
+    def test__check_property():
+        prop = model.Property(name="prop")
+        assert prop._check_property() is None
+
+    @staticmethod
+    def test__check_property_not_indexed():
+        prop = model.Property(name="prop", indexed=False)
+        with pytest.raises(model.InvalidPropertyError):
+            prop._check_property(require_indexed=True)
+
+    @staticmethod
+    def test__check_property_with_subproperty():
+        prop = model.Property(name="prop", indexed=True)
+        with pytest.raises(model.InvalidPropertyError):
+            prop._check_property(rest="a.b.c")
+
 
 class TestModelKey:
     @staticmethod

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -1236,7 +1236,7 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
-    def test_instance_descriptors():
+    def test_instance_descriptors(property_clean_cache):
         class Model:
             prop = model.Property(name="prop", required=True)
 
@@ -1285,6 +1285,18 @@ class TestProperty:
         prop = model.Property(name="prop", indexed=True)
         with pytest.raises(model.InvalidPropertyError):
             prop._check_property(rest="a.b.c")
+
+    @staticmethod
+    def test__get_for_dict():
+        prop = model.Property(name="prop")
+        value = b"\x00\x01"
+        values = {prop._name: value}
+        entity = unittest.mock.Mock(
+            _projection=None, _values=values, spec=("_projection", "_values")
+        )
+        assert value is prop._get_for_dict(entity)
+        # Cache is untouched.
+        assert model.Property._FIND_METHODS_CACHE == {}
 
 
 class TestModelKey:


### PR DESCRIPTION
This is still incomplete, it's a very large class.

In particular, this implements:

- `Property._get_value`
- `Property._delete_value`
- `Property._is_initialized`
- Descriptors for `Property` (i.e. `__get__`, `__set__` and `__delete__`)
- `Property._prepare_for_put`
- `Property._check_property`
- `Property._get_for_dict`

----

Luckily this class is almost finished, with `_serialize`, `_deserialize`, `_prepare_for_put` (a no-op), `_check_property` and `_get_for_dict` the last remaining methods. I **think** I'll be able to port `_serialize|_deserialize` to the new [protobuf definitions][1] but I haven't looked into it deeply.

~~I'll probably update this PR with the implementations for `_prepare_for_put`, `_check_property` and `_get_for_dict` as well.~~

[1]: https://github.com/googleapis/googleapis/tree/caa431d9ddb71a29b14ff6bfa6ccd7c044cf9697/google/datastore/v1