### PR TITLE
Bigtable: fix instance IAM methods

### DIFF
--- a/bigtable/docs/snippets.py
+++ b/bigtable/docs/snippets.py
@@ -382,8 +382,7 @@ def test_bigtable_set_iam_policy_then_get_iam_policy():
 
     # [END bigtable_set_iam_policy]
 
-    service_account_email = '{}@appspot.gserviceaccount.com'.format(
-        Config.CLIENT.project)
+    service_account_email = Config.CLIENT._credentials.service_account_email
 
     # [START bigtable_set_iam_policy]
     client = Client(admin=True)

--- a/bigtable/google/cloud/bigtable/instance.py
+++ b/bigtable/google/cloud/bigtable/instance.py
@@ -106,6 +106,17 @@ class Instance(object):
         self.labels = labels
         self._state = _state
 
+    def _update_from_pb(self, instance_pb):
+        """Refresh self from the server-provided protobuf.
+        Helper for :meth:`from_pb` and :meth:`reload`.
+        """
+        if not instance_pb.display_name:  # Simple field (string)
+            raise ValueError('Instance protobuf does not contain display_name')
+        self.display_name = instance_pb.display_name
+        self.type_ = instance_pb.type
+        self.labels = dict(instance_pb.labels)
+        self._state = instance_pb.state
+
     @classmethod
     def from_pb(cls, instance_pb, client):
         """Creates an instance instance from a protobuf.
@@ -136,17 +147,6 @@ class Instance(object):
         result = cls(instance_id, client)
         result._update_from_pb(instance_pb)
         return result
-
-    def _update_from_pb(self, instance_pb):
-        """Refresh self from the server-provided protobuf.
-        Helper for :meth:`from_pb` and :meth:`reload`.
-        """
-        if not instance_pb.display_name:  # Simple field (string)
-            raise ValueError('Instance protobuf does not contain display_name')
-        self.display_name = instance_pb.display_name
-        self.type_ = instance_pb.type
-        self.labels = dict(instance_pb.labels)
-        self._state = instance_pb.state
 
     @property
     def name(self):
@@ -185,41 +185,6 @@ class Instance(object):
 
     def __ne__(self, other):
         return not self == other
-
-    def reload(self):
-        """Reload the metadata for this instance.
-
-        For example:
-
-        .. literalinclude:: snippets.py
-            :start-after: [START bigtable_reload_instance]
-            :end-before: [END bigtable_reload_instance]
-        """
-        instance_pb = self._client.instance_admin_client.get_instance(
-            self.name)
-
-        # NOTE: _update_from_pb does not check that the project and
-        #       instance ID on the response match the request.
-        self._update_from_pb(instance_pb)
-
-    def exists(self):
-        """Check whether the instance already exists.
-
-        For example:
-
-        .. literalinclude:: snippets.py
-            :start-after: [START bigtable_check_instance_exists]
-            :end-before: [END bigtable_check_instance_exists]
-
-        :rtype: bool
-        :returns: True if the table exists, else False.
-        """
-        try:
-            self._client.instance_admin_client.get_instance(name=self.name)
-            return True
-        # NOTE: There could be other exceptions that are returned to the user.
-        except NotFound:
-            return False
 
     def create(self, location_id=None,
                serve_nodes=None,
@@ -303,6 +268,41 @@ class Instance(object):
             parent=parent, instance_id=self.instance_id, instance=instance_pb,
             clusters={c.cluster_id: c._to_pb() for c in clusters})
 
+    def exists(self):
+        """Check whether the instance already exists.
+
+        For example:
+
+        .. literalinclude:: snippets.py
+            :start-after: [START bigtable_check_instance_exists]
+            :end-before: [END bigtable_check_instance_exists]
+
+        :rtype: bool
+        :returns: True if the table exists, else False.
+        """
+        try:
+            self._client.instance_admin_client.get_instance(name=self.name)
+            return True
+        # NOTE: There could be other exceptions that are returned to the user.
+        except NotFound:
+            return False
+
+    def reload(self):
+        """Reload the metadata for this instance.
+
+        For example:
+
+        .. literalinclude:: snippets.py
+            :start-after: [START bigtable_reload_instance]
+            :end-before: [END bigtable_reload_instance]
+        """
+        instance_pb = self._client.instance_admin_client.get_instance(
+            self.name)
+
+        # NOTE: _update_from_pb does not check that the project and
+        #       instance ID on the response match the request.
+        self._update_from_pb(instance_pb)
+
     def update(self):
         """Updates an instance within a project.
 
@@ -375,6 +375,87 @@ class Instance(object):
           permanently deleted.
         """
         self._client.instance_admin_client.delete_instance(name=self.name)
+
+    def get_iam_policy(self):
+        """Gets the access control policy for an instance resource.
+
+        For example:
+
+        .. literalinclude:: snippets.py
+            :start-after: [START bigtable_get_iam_policy]
+            :end-before: [END bigtable_get_iam_policy]
+
+        :rtype: :class:`google.cloud.bigtable.policy.Policy`
+        :returns: The current IAM policy of this instance
+        """
+        instance_admin_client = self._client._instance_admin_client
+        resp = instance_admin_client.get_iam_policy(resource=self.name)
+        return Policy.from_api_repr(self._to_dict_from_policy_pb(resp))
+
+    def set_iam_policy(self, policy):
+        """Sets the access control policy on an instance resource. Replaces any
+        existing policy.
+
+        For more information about policy, please see documentation of
+        class `google.cloud.bigtable.policy.Policy`
+
+        For example:
+
+        .. literalinclude:: snippets.py
+            :start-after: [START bigtable_set_iam_policy]
+            :end-before: [END bigtable_set_iam_policy]
+
+        :type policy: :class:`google.cloud.bigtable.policy.Policy`
+        :param policy: A new IAM policy to replace the current IAM policy
+                       of this instance
+
+        :rtype: :class:`google.cloud.bigtable.policy.Policy`
+        :returns: The current IAM policy of this instance.
+        """
+        instance_admin_client = self._client._instance_admin_client
+        resp = instance_admin_client.set_iam_policy(
+            resource=self.name, policy=policy.to_api_repr())
+        return Policy.from_api_repr(self._to_dict_from_policy_pb(resp))
+
+    def test_iam_permissions(self, permissions):
+        """Returns permissions that the caller has on the specified instance
+        resource.
+
+        For example:
+
+        .. literalinclude:: snippets.py
+            :start-after: [START bigtable_test_iam_permissions]
+            :end-before: [END bigtable_test_iam_permissions]
+
+        :type permissions: list
+        :param permissions: The set of permissions to check for
+               the ``resource``. Permissions with wildcards (such as '*'
+               or 'storage.*') are not allowed. For more information see
+               `IAM Overview
+               <https://cloud.google.com/iam/docs/overview#permissions>`_.
+               `Bigtable Permissions
+               <https://cloud.google.com/bigtable/docs/access-control>`_.
+
+        :rtype: list
+        :returns: A List(string) of permissions allowed on the instance
+        """
+        instance_admin_client = self._client._instance_admin_client
+        resp = instance_admin_client.test_iam_permissions(
+            resource=self.name, permissions=permissions)
+        return list(resp.permissions)
+
+    def _to_dict_from_policy_pb(self, policy):
+        """Returns a dictionary representation of resource returned from
+        the getIamPolicy API to use as parameter for
+        :meth: google.cloud.iam.Policy.from_api_repr
+        """
+        pb_dict = {}
+        bindings = [{'role': binding.role, 'members': binding.members}
+                    for binding in policy.bindings]
+        pb_dict['etag'] = policy.etag
+        pb_dict['version'] = policy.version
+        pb_dict['bindings'] = bindings
+        return pb_dict
 
     def cluster(self, cluster_id, location_id=None,
                 serve_nodes=None, default_storage_type=None):
@@ -550,84 +631,3 @@ class Instance(object):
         """
         resp = self._client._instance_admin_client.list_app_profiles(self.name)
         return [AppProfile.from_pb(app_profile, self) for app_profile in resp]
-
-    def get_iam_policy(self):
-        """Gets the access control policy for an instance resource.
-
-        For example:
-
-        .. literalinclude:: snippets.py
-            :start-after: [START bigtable_get_iam_policy]
-            :end-before: [END bigtable_get_iam_policy]
-
-        :rtype: :class:`google.cloud.bigtable.policy.Policy`
-        :returns: The current IAM policy of this instance
-        """
-        instance_admin_client = self._client._instance_admin_client
-        resp = instance_admin_client.get_iam_policy(resource=self.name)
-        return Policy.from_api_repr(self._to_dict_from_policy_pb(resp))
-
-    def set_iam_policy(self, policy):
-        """Sets the access control policy on an instance resource. Replaces any
-        existing policy.
-
-        For more information about policy, please see documentation of
-        class `google.cloud.bigtable.policy.Policy`
-
-        For example:
-
-        .. literalinclude:: snippets.py
-            :start-after: [START bigtable_set_iam_policy]
-            :end-before: [END bigtable_set_iam_policy]
-
-        :type policy: :class:`google.cloud.bigtable.policy.Policy`
-        :param policy: A new IAM policy to replace the current IAM policy
-                       of this instance
-
-        :rtype: :class:`google.cloud.bigtable.policy.Policy`
-        :returns: The current IAM policy of this instance.
-        """
-        instance_admin_client = self._client._instance_admin_client
-        resp = instance_admin_client.set_iam_policy(
-            resource=self.name, policy=policy.to_api_repr())
-        return Policy.from_api_repr(self._to_dict_from_policy_pb(resp))
-
-    def test_iam_permissions(self, permissions):
-        """Returns permissions that the caller has on the specified instance
-        resource.
-
-        For example:
-
-        .. literalinclude:: snippets.py
-            :start-after: [START bigtable_test_iam_permissions]
-            :end-before: [END bigtable_test_iam_permissions]
-
-        :type permissions: list
-        :param permissions: The set of permissions to check for
-               the ``resource``. Permissions with wildcards (such as '*'
-               or 'storage.*') are not allowed. For more information see
-               `IAM Overview
-               <https://cloud.google.com/iam/docs/overview#permissions>`_.
-               `Bigtable Permissions
-               <https://cloud.google.com/bigtable/docs/access-control>`_.
-
-        :rtype: list
-        :returns: A List(string) of permissions allowed on the instance
-        """
-        instance_admin_client = self._client._instance_admin_client
-        resp = instance_admin_client.test_iam_permissions(
-            resource=self.name, permissions=permissions)
-        return list(resp.permissions)
-
-    def _to_dict_from_policy_pb(self, policy):
-        """Returns a dictionary representation of resource returned from
-        the getIamPolicy API to use as parameter for
-        :meth: google.cloud.iam.Policy.from_api_repr
-        """
-        pb_dict = {}
-        bindings = [{'role': binding.role, 'members': binding.members}
-                    for binding in policy.bindings]
-        pb_dict['etag'] = policy.etag
-        pb_dict['version'] = policy.version
-        pb_dict['bindings'] = bindings
-        return pb_dict

--- a/bigtable/google/cloud/bigtable/instance.py
+++ b/bigtable/google/cloud/bigtable/instance.py
@@ -388,7 +388,7 @@ class Instance(object):
         :rtype: :class:`google.cloud.bigtable.policy.Policy`
         :returns: The current IAM policy of this instance
         """
-        instance_admin_client = self._client._instance_admin_client
+        instance_admin_client = self._client.instance_admin_client
         resp = instance_admin_client.get_iam_policy(resource=self.name)
         return Policy.from_api_repr(self._to_dict_from_policy_pb(resp))
 
@@ -412,7 +412,7 @@ class Instance(object):
         :rtype: :class:`google.cloud.bigtable.policy.Policy`
         :returns: The current IAM policy of this instance.
         """
-        instance_admin_client = self._client._instance_admin_client
+        instance_admin_client = self._client.instance_admin_client
         resp = instance_admin_client.set_iam_policy(
             resource=self.name, policy=policy.to_api_repr())
         return Policy.from_api_repr(self._to_dict_from_policy_pb(resp))
@@ -439,7 +439,7 @@ class Instance(object):
         :rtype: list
         :returns: A List(string) of permissions allowed on the instance
         """
-        instance_admin_client = self._client._instance_admin_client
+        instance_admin_client = self._client.instance_admin_client
         resp = instance_admin_client.test_iam_permissions(
             resource=self.name, permissions=permissions)
         return list(resp.permissions)
@@ -629,5 +629,5 @@ class Instance(object):
                   :class:`~google.cloud.bigtable.app_profile.AppProfile`
                   instances.
         """
-        resp = self._client._instance_admin_client.list_app_profiles(self.name)
+        resp = self._client.instance_admin_client.list_app_profiles(self.name)
         return [AppProfile.from_pb(app_profile, self) for app_profile in resp]

--- a/bigtable/noxfile.py
+++ b/bigtable/noxfile.py
@@ -115,7 +115,7 @@ def cover(session):
     session.run('coverage', 'erase')
 
 
-@nox.session(python='3.7')
+@nox.session(python=['2.7', '3.7'])
 def snippets(session):
     """Run the system test suite."""
     # Sanity check: Only run system tests if the environment variable is set.
@@ -126,9 +126,11 @@ def snippets(session):
     session.install('mock', 'pytest')
     for local_dep in LOCAL_DEPS:
         session.install('-e', local_dep)
-    session.install('-e', os.path.join('..', 'bigtable'))
     session.install('-e', '../test_utils/')
     session.install('-e', '.')
-    session.run('py.test', '--quiet', \
-                os.path.join('docs', 'snippets.py'), \
-                *session.posargs)
+    session.run(
+        'py.test',
+        '--quiet',
+        os.path.join('docs', 'snippets.py'),
+        *session.posargs,
+    )

--- a/bigtable/tests/unit/test_instance.py
+++ b/bigtable/tests/unit/test_instance.py
@@ -1004,21 +1004,19 @@ class TestInstance(unittest.TestCase):
 
         permissions = ["bigtable.tables.create", "bigtable.clusters.create"]
 
-        expected_request = iam_policy_pb2.TestIamPermissionsRequest(
-            resource=instance.name,
+        response = iam_policy_pb2.TestIamPermissionsResponse(
             permissions=permissions)
 
-        # Patch the stub used by the API method.
-        channel = ChannelStub(responses=[expected_request])
-        instance_api = (
-            bigtable_instance_admin_client.BigtableInstanceAdminClient(
-                channel=channel))
+        instance_api = mock.create_autospec(
+            bigtable_instance_admin_client.BigtableInstanceAdminClient)
+        instance_api.test_iam_permissions.return_value = response
         client._instance_admin_client = instance_api
 
         result = instance.test_iam_permissions(permissions)
-        actual_request = channel.requests[0][1]
-        self.assertEqual(actual_request, expected_request)
+
         self.assertEqual(result, permissions)
+        instance_api.test_iam_permissions.assert_called_once_with(
+            resource=instance.name, permissions=permissions)
 
 
 class _Client(object):

--- a/bigtable/tests/unit/test_instance.py
+++ b/bigtable/tests/unit/test_instance.py
@@ -704,23 +704,21 @@ class TestInstance(unittest.TestCase):
         from google.cloud.bigtable_admin_v2.gapic import (
             bigtable_instance_admin_client)
 
-        api = bigtable_instance_admin_client.BigtableInstanceAdminClient(
-            mock.Mock())
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
         instance = self._make_one(self.INSTANCE_ID, client)
+        instance_api = mock.create_autospec(
+            bigtable_instance_admin_client.BigtableInstanceAdminClient)
+        instance_api.delete_instance.return_value = None
+        client._instance_admin_client = instance_api
 
-        # Mock api calls
-        client._instance_admin_client = api
-
-        # Create expected_result.
-        expected_result = None  # delete() has no return value.
-
-        # Perform the method and check the result.
         result = instance.delete()
 
-        self.assertEqual(result, expected_result)
+        instance_api.delete_instance.assert_called_once_with(
+            instance.name)
+
+        self.assertIsNone(result)
 
     def _list_tables_helper(self, table_name=None):
         from google.cloud.bigtable_admin_v2.proto import (


### PR DESCRIPTION
Closes #6337.

Refactor instance tests to mock 'instance_admin_client' directly, rather than underlying channel.

Normalize instance method order, and make testcase order match.  For the testcase changes, it might be easier to review commit-by-commit, at least up through fa5602c.