### PR TITLE
Pubsub: fix error from new flake8 version.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -264,7 +264,7 @@ class StreamingPullManager(object):
         if self._UNARY_REQUESTS:
             try:
                 self._send_unary_request(request)
-            except exceptions.GoogleAPICallError as exc:
+            except exceptions.GoogleAPICallError:
                 _LOGGER.debug(
                     'Exception while sending unary RPC. This is typically '
                     'non-fatal as stream requests are best-effort.',


### PR DESCRIPTION
Trivial lint fix.  I will merge when green to get `master` green again for pubsub.