### PR TITLE
Avoid broken 'google-common-apis 1.5.4' release.

### DIFF
--- a/api_core/setup.py
+++ b/api_core/setup.py
@@ -29,7 +29,7 @@ version = '1.5.1'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
-    'googleapis-common-protos<2.0dev,>=1.5.3',
+    'googleapis-common-protos<2.0dev,>=1.5.3,!=1.5.4',
     'protobuf>=3.4.0',
     'google-auth<2.0.0dev,>=0.4.0',
     'requests<3.0.0dev,>=2.18.0',

--- a/asset/noxfile.py
+++ b/asset/noxfile.py
@@ -19,9 +19,16 @@ import os
 
 import nox
 
+
+LOCAL_DEPS = (
+    os.path.join('..', 'api_core'),
+)
+
 def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install('pytest')
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/automl/noxfile.py
+++ b/automl/noxfile.py
@@ -18,13 +18,20 @@ import os
 import nox
 
 
-def default(session):
-  # Install all test dependencies, then install this package in-place.
-  session.install('pytest')
-  session.install('-e', '.')
+LOCAL_DEPS = (
+    os.path.join('..', 'api_core'),
+)
 
-  # Run py.test against the unit tests.
-  session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
+
+def default(session):
+    # Install all test dependencies, then install this package in-place.
+    session.install('pytest')
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    session.install('-e', '.')
+
+    # Run py.test against the unit tests.
+    session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 
 @nox.session(python=['2.7', '3.5', '3.6', '3.7'])

--- a/iot/noxfile.py
+++ b/iot/noxfile.py
@@ -18,9 +18,16 @@ import os
 import nox
 
 
+LOCAL_DEPS = (
+    os.path.join('..', 'api_core'),
+)
+
+
 def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install('pytest')
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -43,6 +50,8 @@ def system(session):
 
     # Install all test dependencies, then install this package in-place.
     session.install('pytest')
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/kms/noxfile.py
+++ b/kms/noxfile.py
@@ -20,9 +20,16 @@ import os
 import nox
 
 
+LOCAL_DEPS = (
+    os.path.join('..', 'api_core'),
+)
+
+
 def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install('pytest')
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/oslogin/noxfile.py
+++ b/oslogin/noxfile.py
@@ -18,9 +18,16 @@ import os
 import nox
 
 
+LOCAL_DEPS = (
+    os.path.join('..', 'api_core'),
+)
+
+
 def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install('pytest')
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/tasks/noxfile.py
+++ b/tasks/noxfile.py
@@ -20,9 +20,16 @@ import os
 import nox
 
 
+LOCAL_DEPS = (
+    os.path.join('..', 'api_core'),
+)
+
+
 def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install('pytest')
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/texttospeech/noxfile.py
+++ b/texttospeech/noxfile.py
@@ -17,9 +17,16 @@ import os
 
 import nox
 
+
+LOCAL_DEPS = (
+    os.path.join('..', 'api_core'),
+)
+
 def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install('pytest')
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/videointelligence/noxfile.py
+++ b/videointelligence/noxfile.py
@@ -18,9 +18,16 @@ import os
 import nox
 
 
+LOCAL_DEPS = (
+    os.path.join('..', 'api_core'),
+)
+
+
 def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install('pytest')
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.


### PR DESCRIPTION
Install `api_core` dependency in-place in affected packages.