### PR TITLE
Ignore generated file types.py when linting

### DIFF
--- a/automl/.flake8
+++ b/automl/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/bigquery/.flake8
+++ b/bigquery/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/bigtable/.flake8
+++ b/bigtable/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/datastore/.flake8
+++ b/datastore/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/dns/.flake8
+++ b/dns/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/error_reporting/.flake8
+++ b/error_reporting/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/firestore/.flake8
+++ b/firestore/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/language/.flake8
+++ b/language/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/logging/.flake8
+++ b/logging/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/monitoring/.flake8
+++ b/monitoring/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/pubsub/.flake8
+++ b/pubsub/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/redis/.flake8
+++ b/redis/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/resource_manager/.flake8
+++ b/resource_manager/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/runtimeconfig/.flake8
+++ b/runtimeconfig/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/spanner/.flake8
+++ b/spanner/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/speech/.flake8
+++ b/speech/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/storage/.flake8
+++ b/storage/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/trace/.flake8
+++ b/trace/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/translate/.flake8
+++ b/translate/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/vision/.flake8
+++ b/vision/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.

--- a/websecurityscanner/.flake8
+++ b/websecurityscanner/.flake8
@@ -3,6 +3,7 @@ exclude =
   # Exclude generated code.
   **/proto/**
   **/gapic/**
+  **/types.py
   *_pb2.py
 
   # Standard linting exemptions.


### PR DESCRIPTION
Making the flake8 files, excepting core and api_core, consistent.