### PR TITLE
Adding class docstring for `ndb` `Property`.

### DIFF
--- a/ndb/docs/conf.py
+++ b/ndb/docs/conf.py
@@ -36,7 +36,18 @@ version = ".".join(release.split(".")[:2])
 # needs_sphinx = '1.0'
 nitpicky = True
 nitpick_ignore = [
-    ("py:obj", "google.cloud.datastore._app_engine_key_pb2.Reference")
+    ("py:obj", "google.cloud.datastore._app_engine_key_pb2.Reference"),
+    ("py:class", "google.cloud.datastore._app_engine_key_pb2.Reference"),
+    ("py:class", "google.cloud.datastore_v1.proto.entity_pb2.Entity"),
+    ("py:class", ".."),
+    ("py:class", "Any"),
+    ("py:class", "Callable"),
+    ("py:class", "Dict"),
+    ("py:class", "Iterable"),
+    ("py:class", "List"),
+    ("py:class", "Optional"),
+    ("py:class", "Tuple"),
+    ("py:class", "Union"),
 ]
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -50,7 +61,6 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
-    "sphinx_docstring_typing",
 ]
 
 # autodoc/autosummary flags

--- a/ndb/noxfile.py
+++ b/ndb/noxfile.py
@@ -86,7 +86,7 @@ def blacken(session):
 @nox.session(py=DEFAULT_INTERPRETER)
 def docs(session):
     # Install all dependencies.
-    session.install("Sphinx", "sphinx-docstring-typing")
+    session.install("Sphinx")
     session.install(".")
     # Building the docs.
     run_args = [
@@ -105,7 +105,7 @@ def docs(session):
 @nox.session(py=DEFAULT_INTERPRETER)
 def doctest(session):
     # Install all dependencies.
-    session.install("Sphinx", "sphinx-docstring-typing")
+    session.install("Sphinx")
     session.install(".")
     # Run the script for building docs and running doctests.
     run_args = [

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -455,6 +455,22 @@ class Property(ModelAttribute):
     .. automethod:: _serialize
     .. automethod:: _call_to_base_type
     .. automethod:: _call_from_base_type
+
+    Args:
+        name (str): The name of the property.
+        indexed (bool): Indicates if the value should be indexed.
+        repeated (bool): Indicates if this property is repeated, i.e. contains
+            multiple values.
+        required (bool): Indicates if this property is required on the given
+            model type.
+        default (Any): The default value for this property.
+        choices (Iterable[Any]): A container of allowed values for this
+            property.
+        validator (Callable[[Property, Any], bool]): A validator to be used
+            to check values.
+        verbose_name (str): A longer, user-friendly name for this property.
+        write_empty_list (bool): Indicates if an empty list should be written
+            to the datastore.
     """
 
     # Instance default fallbacks provided by class.

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -382,7 +382,7 @@ class Property(ModelAttribute):
     call :meth:`_store_value`.
 
     A :class:`Property` subclass that wants to implement a specific
-    transformation between user values and serialiazble values should
+    transformation between user values and serializable values should
     implement two methods, ``_to_base_type()`` and ``_from_base_type()``.
     These should **not** call their ``super()`` method; super calls are taken
     care of by :meth:`_call_to_base_type` and :meth:`_call_from_base_type`.
@@ -404,18 +404,18 @@ class Property(ModelAttribute):
     a strict value. This means that when setting the property value, lax values
     are accepted, while when getting the property value, only strict values
     will be returned. If no conversion is needed, ``_validate()`` may return
-    :data`None`. If the argument is outside the set of accepted lax values,
+    :data:`None`. If the argument is outside the set of accepted lax values,
     ``_validate()`` should raise an exception, preferably :exc:`TypeError` or
     :exc:`.BadValueError`.
 
-    Example/boilerplate:
+    Example / boilerplate:
 
     .. code-block:: python
 
         def _validate(self, value):
             # Lax user value to strict user value.
-            if not isinstance(value, <top type>):
-                raise TypeError(...)  # Or datastore_errors.BadValueError(...).
+            if not isinstance(value, TopType):
+                raise TypeError(value)  # Or BadValueError(...).
 
         def _to_base_type(self, value):
             # (Strict) user value to base value.

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -466,8 +466,8 @@ class Property(ModelAttribute):
         default (Any): The default value for this property.
         choices (Iterable[Any]): A container of allowed values for this
             property.
-        validator (Callable[[Property, Any], bool]): A validator to be used
-            to check values.
+        validator (Callable[[~google.cloud.ndb.model.Property, Any], bool]): A
+            validator to be used to check values.
         verbose_name (str): A longer, user-friendly name for this property.
         write_empty_list (bool): Indicates if an empty list should be written
             to the datastore.

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -390,7 +390,7 @@ class Property(ModelAttribute):
 
         class SingleDigit(Positive):
             def _validate(self, value):
-                if value > 10:
+                if value > 9:
                     raise ndb.exceptions.BadValueError("Multi-digit", value)
 
     neither ``_validate()`` method calls ``super()``. Instead, when a
@@ -402,11 +402,15 @@ class Property(ModelAttribute):
     * ``IntegerProperty._validate``
 
     The API supports "stacking" classes with ever more sophisticated
-    user <-> base conversions: the user -> base conversion goes from more
-    sophisticated to less sophisticated, while the base -> user conversion goes
-    from less sophisticated to more sophisticated. For example, see the
-    relationship between :class:`BlobProperty`, :class:`TextProperty` and
-    :class:`StringProperty`.
+    user / base conversions:
+
+    * the user to base conversion goes from more sophisticated to less
+      sophisticated
+    * the base to user conversion goes from less sophisticated to more
+      sophisticated
+
+    For example, see the relationship between :class:`BlobProperty`,
+    :class:`TextProperty` and :class:`StringProperty`.
 
     The validation API distinguishes between "lax" and "strict" user values.
     The set of lax values is a superset of the set of strict values. The
@@ -433,7 +437,7 @@ class Property(ModelAttribute):
             def _to_base_type(self, value):
                 # (Strict) user value to base value.
                 if isinstance(value, Widget):
-                    return _WidgetInternal.to_value()
+                    return value.to_internal()
 
             def _from_base_type(self, value):
                 # Base value to (strict) user value.'


### PR DESCRIPTION
In the process:

- Removing `sphinx-docstring-typing` from the `ndb` docs process (the extension made it impossible to refer to `TextProperty`)
- Adding the Python `typing` helpers to `nitpick_ignore`
- Adding `autoclass` and `automethod` for some public members that have non-public names

----

I've marked this "do not merge" because there are several things that need discussion:

-   Is there a better way to handle the "`Text` gets replaced by `~typing.Text`" issue caused by `sphinx-docstring-typing`? (cc @theacodes) **UPDATE**: Sphinx does have support for type annotations, so maybe we should just do that?
-   @chrisrossi This would be a good time for us to decide which non-public methods should be documented as public. The [docs][1] you previously pointed to just repeat what's in the `Property` docstring:

    > All special `Property` attributes, even those considered 'public', have names starting with an underscore. This is because `StructuredProperty` uses the non-underscore attribute namespace to refer to nested `Property` names; this is essential for specifying queries on subproperties.

-   The `_BaseValue` class likely shouldn't be documented, but there are quite a few references to it.

[1]: https://cloud.google.com/appengine/docs/standard/python/ndb/subclassprop