### PR TITLE
Implementing `BooleanProperty` in `ndb`.

### DIFF
--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -1387,9 +1387,42 @@ class ModelKey(Property):
 
 
 class BooleanProperty(Property):
+    """A property that contains values of type bool."""
+
     __slots__ = ()
 
-    def __init__(self, *args, **kwargs):
+    def _validate(self, value):
+        """Validate a ``value`` before setting it.
+
+        Args:
+            value (bool): The value to check.
+
+        Returns:
+            bool: The passed-in ``value``.
+
+        Raises:
+            .BadValueError: If ``value`` is not a :class:`bool`.
+        """
+        if not isinstance(value, bool):
+            raise exceptions.BadValueError(
+                "Expected bool, got {!r}".format(value)
+            )
+        return value
+
+    def _db_set_value(self, v, unused_p, value):
+        """Helper for :meth:`_serialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is virtual.
+        """
+        raise NotImplementedError
+
+    def _db_get_value(self, v, unused_p):
+        """Helper for :meth:`_deserialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is virtual.
+        """
         raise NotImplementedError
 
 

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -1298,9 +1298,28 @@ class TestModelKey:
 
 class TestBooleanProperty:
     @staticmethod
-    def test_constructor():
+    def test__validate():
+        prop = model.BooleanProperty(name="certify")
+        value = True
+        assert prop._validate(value) is value
+
+    @staticmethod
+    def test__validate_bad_value():
+        prop = model.BooleanProperty(name="certify")
+        with pytest.raises(exceptions.BadValueError):
+            prop._validate(None)
+
+    @staticmethod
+    def test__db_set_value():
+        prop = model.BooleanProperty(name="certify")
         with pytest.raises(NotImplementedError):
-            model.BooleanProperty()
+            prop._db_set_value(None, None, None)
+
+    @staticmethod
+    def test__db_get_value():
+        prop = model.BooleanProperty(name="certify")
+        with pytest.raises(NotImplementedError):
+            prop._db_get_value(None, None)
 
 
 class TestIntegerProperty:


### PR DESCRIPTION
The `_db_set_value()` and `_db_get_value()` methods are just helpers for `Property._serialize()` and `Property._deserialize()`. As in #6389, I'm fairly certain that this won't be needed so for now I'm not implementing. (The previous implementation relies on the old protobuf definition, which is "stuck" inside Google App Engine standard.)