### PR TITLE
Implementing `IntegerProperty` in `ndb`.

### DIFF
--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -1431,7 +1431,7 @@ class IntegerProperty(Property):
 
     .. note::
 
-        If a value is a :class:`bool`, it will be treated as ``0`` (for
+        If a value is a :class:`bool`, it will be coerced to ``0`` (for
         :data:`False`) or ``1`` (for :data:`True`).
 
     .. automethod:: _validate

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -1427,17 +1427,20 @@ class BooleanProperty(Property):
 
 
 class IntegerProperty(Property):
-    """A property that contains values of type integer."""
+    """A property that contains values of type integer.
+
+    .. note::
+
+        If a value is a :class:`bool`, it will be treated as ``0`` (for
+        :data:`False`) or ``1`` (for :data:`True`).
+
+    .. automethod:: _validate
+    """
 
     __slots__ = ()
 
     def _validate(self, value):
         """Validate a ``value`` before setting it.
-
-        .. note::
-
-            If ``value`` is a :class:`bool`, it will be treated as ``0`` (for
-            :data:`False`) or ``1`` (for :data:`True`).
 
         Args:
             value (Union[int, bool]): The value to check.

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -1427,9 +1427,47 @@ class BooleanProperty(Property):
 
 
 class IntegerProperty(Property):
+    """A property that contains values of type integer."""
+
     __slots__ = ()
 
-    def __init__(self, *args, **kwargs):
+    def _validate(self, value):
+        """Validate a ``value`` before setting it.
+
+        .. note::
+
+            If ``value`` is a :class:`bool`, it will be treated as ``0`` (for
+            :data:`False`) or ``1`` (for :data:`True`).
+
+        Args:
+            value (int): The value to check.
+
+        Returns:
+            int: The passed-in ``value``.
+
+        Raises:
+            .BadValueError: If ``value`` is not a :class:`bool`.
+        """
+        if not isinstance(value, int):
+            raise exceptions.BadValueError(
+                "Expected integer, got {!r}".format(value)
+            )
+        return int(value)
+
+    def _db_set_value(self, v, unused_p, value):
+        """Helper for :meth:`_serialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is virtual.
+        """
+        raise NotImplementedError
+
+    def _db_get_value(self, v, unused_p):
+        """Helper for :meth:`_deserialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is virtual.
+        """
         raise NotImplementedError
 
 

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -1440,13 +1440,14 @@ class IntegerProperty(Property):
             :data:`False`) or ``1`` (for :data:`True`).
 
         Args:
-            value (int): The value to check.
+            value (Union[int, bool]): The value to check.
 
         Returns:
             int: The passed-in ``value``.
 
         Raises:
-            .BadValueError: If ``value`` is not a :class:`bool`.
+            .BadValueError: If ``value`` is not an :class:`int` or convertible
+                to one.
         """
         if not isinstance(value, int):
             raise exceptions.BadValueError(

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -1324,9 +1324,34 @@ class TestBooleanProperty:
 
 class TestIntegerProperty:
     @staticmethod
-    def test_constructor():
+    def test__validate():
+        prop = model.IntegerProperty(name="count")
+        value = 829038402384
+        assert prop._validate(value) is value
+
+    @staticmethod
+    def test__validate_bool():
+        prop = model.IntegerProperty(name="count")
+        value = True
+        assert prop._validate(value) == 1
+
+    @staticmethod
+    def test__validate_bad_value():
+        prop = model.IntegerProperty(name="count")
+        with pytest.raises(exceptions.BadValueError):
+            prop._validate(None)
+
+    @staticmethod
+    def test__db_set_value():
+        prop = model.IntegerProperty(name="count")
         with pytest.raises(NotImplementedError):
-            model.IntegerProperty()
+            prop._db_set_value(None, None, None)
+
+    @staticmethod
+    def test__db_get_value():
+        prop = model.IntegerProperty(name="count")
+        with pytest.raises(NotImplementedError):
+            prop._db_get_value(None, None)
 
 
 class TestFloatProperty:


### PR DESCRIPTION
The `_db_set_value()` and `_db_get_value()` methods are just helpers for `Property._serialize()` and `Property._deserialize()`. As in #6389, I'm fairly certain that this won't be needed so for now I'm not implementing. (The previous implementation relies on the old protobuf definition, which is "stuck" inside Google App Engine standard.)