### PR TITLE
Translate: Update README, correcting installation package

### DIFF
--- a/translate/README.rst
+++ b/translate/README.rst
@@ -61,7 +61,7 @@ Mac/Linux
     pip install virtualenv
     virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install google-cloud-datastore
+    <your-env>/bin/pip install google-cloud-translate
 
 
 Windows
@@ -72,7 +72,7 @@ Windows
     pip install virtualenv
     virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install google-cloud-datastore
+    <your-env>\Scripts\pip.exe install google-cloud-translate
 
 
 Example Usage


### PR DESCRIPTION
Correcting installation package from `google-cloud-datastore` to `google-cloud-translate`