### PR TITLE
Error Reporting: fix client_info bug, update docstrings via synth.

### DIFF
--- a/error_reporting/google/cloud/errorreporting_v1beta1/gapic/enums.py
+++ b/error_reporting/google/cloud/errorreporting_v1beta1/gapic/enums.py
@@ -24,14 +24,12 @@ class TimedCountAlignment(enum.IntEnum):
 
     Attributes:
       ERROR_COUNT_ALIGNMENT_UNSPECIFIED (int): No alignment specified.
-      ALIGNMENT_EQUAL_ROUNDED (int): The time periods shall be consecutive, have width equal to the
-      requested duration, and be aligned at the ``alignment_time`` provided in
-      the request.
-      The ``alignment_time`` does not have to be inside the query period but
-      even if it is outside, only time periods are returned which overlap
-      with the query period.
-      A rounded alignment will typically result in a
-      different size of the first or the last time period.
+      ALIGNMENT_EQUAL_ROUNDED (int): The time periods shall be consecutive, have width equal to the requested
+      duration, and be aligned at the ``alignment_time`` provided in the
+      request. The ``alignment_time`` does not have to be inside the query
+      period but even if it is outside, only time periods are returned which
+      overlap with the query period. A rounded alignment will typically result
+      in a different size of the first or the last time period.
       ALIGNMENT_EQUAL_AT_END (int): The time periods shall be consecutive, have width equal to the
       requested duration, and be aligned at the end of the requested time
       period. This can result in a different size of the

--- a/error_reporting/google/cloud/errorreporting_v1beta1/gapic/error_group_service_client.py
+++ b/error_reporting/google/cloud/errorreporting_v1beta1/gapic/error_group_service_client.py
@@ -146,9 +146,10 @@ class ErrorGroupServiceClient(object):
             )
 
         if client_info is None:
-            client_info = (
-                google.api_core.gapic_v1.client_info.DEFAULT_CLIENT_INFO)
-        client_info.gapic_version = _GAPIC_LIBRARY_VERSION
+            client_info = google.api_core.gapic_v1.client_info.ClientInfo(
+                gapic_version=_GAPIC_LIBRARY_VERSION, )
+        else:
+            client_info.gapic_version = _GAPIC_LIBRARY_VERSION
         self._client_info = client_info
 
         # Parse out the default settings for retry and timeout for each RPC
@@ -184,13 +185,10 @@ class ErrorGroupServiceClient(object):
 
         Args:
             group_name (str): [Required] The group resource name. Written as
-                <code>projects/<var>projectID</var>/groups/<var>group_name</var></code>.
-                Call
-                <a href=\"/error-reporting/reference/rest/v1beta1/projects.groupStats/list\">
-                <code>groupStats.list</code></a> to return a list of groups belonging to
-                this project.
+                projects/projectID/groups/group\_name. Call groupStats.list to return a
+                list of groups belonging to this project.
 
-                Example: <code>projects/my-project-123/groups/my-group</code>
+                Example: projects/my-project-123/groups/my-group
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will not
                 be retried.
@@ -239,13 +237,14 @@ class ErrorGroupServiceClient(object):
             >>>
             >>> client = errorreporting_v1beta1.ErrorGroupServiceClient()
             >>>
-            >>> # TODO: Initialize ``group``:
+            >>> # TODO: Initialize `group`:
             >>> group = {}
             >>>
             >>> response = client.update_group(group)
 
         Args:
             group (Union[dict, ~google.cloud.errorreporting_v1beta1.types.ErrorGroup]): [Required] The group which replaces the resource on the server.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.errorreporting_v1beta1.types.ErrorGroup`
             retry (Optional[google.api_core.retry.Retry]):  A retry object used

--- a/error_reporting/google/cloud/errorreporting_v1beta1/gapic/error_stats_service_client.py
+++ b/error_reporting/google/cloud/errorreporting_v1beta1/gapic/error_stats_service_client.py
@@ -154,9 +154,10 @@ class ErrorStatsServiceClient(object):
             )
 
         if client_info is None:
-            client_info = (
-                google.api_core.gapic_v1.client_info.DEFAULT_CLIENT_INFO)
-        client_info.gapic_version = _GAPIC_LIBRARY_VERSION
+            client_info = google.api_core.gapic_v1.client_info.ClientInfo(
+                gapic_version=_GAPIC_LIBRARY_VERSION, )
+        else:
+            client_info.gapic_version = _GAPIC_LIBRARY_VERSION
         self._client_info = client_info
 
         # Parse out the default settings for retry and timeout for each RPC
@@ -196,7 +197,7 @@ class ErrorStatsServiceClient(object):
             >>>
             >>> project_name = client.project_path('[PROJECT]')
             >>>
-            >>> # TODO: Initialize ``time_range``:
+            >>> # TODO: Initialize `time_range`:
             >>> time_range = {}
             >>>
             >>> # Iterate over all results
@@ -208,45 +209,46 @@ class ErrorStatsServiceClient(object):
             >>> # Alternatively:
             >>>
             >>> # Iterate over results one page at a time
-            >>> for page in client.list_group_stats(project_name, time_range, options=CallOptions(page_token=INITIAL_PAGE)):
+            >>> for page in client.list_group_stats(project_name, time_range).pages:
             ...     for element in page:
             ...         # process element
             ...         pass
 
         Args:
-            project_name (str): [Required] The resource name of the Google Cloud Platform project. Written
-                as <code>projects/</code> plus the
-                <a href=\"https://support.google.com/cloud/answer/6158840\">Google Cloud
-                Platform project ID</a>.
+            project_name (str): [Required] The resource name of the Google Cloud Platform project.
+                Written as projects/ plus the Google Cloud Platform project ID.
 
-                Example: <code>projects/my-project-123</code>.
-            time_range (Union[dict, ~google.cloud.errorreporting_v1beta1.types.QueryTimeRange]): [Optional] List data for the given time range.
-                If not set a default time range is used. The field time_range_begin
-                in the response will specify the beginning of this time range.
-                Only <code>ErrorGroupStats</code> with a non-zero count in the given time
-                range are returned, unless the request contains an explicit group_id list.
-                If a group_id list is given, also <code>ErrorGroupStats</code> with zero
-                occurrences are returned.
+                Example: projects/my-project-123.
+            time_range (Union[dict, ~google.cloud.errorreporting_v1beta1.types.QueryTimeRange]): [Optional] List data for the given time range. If not set a default time
+                range is used. The field time\_range\_begin in the response will specify
+                the beginning of this time range. Only ErrorGroupStats with a non-zero
+                count in the given time range are returned, unless the request contains
+                an explicit group\_id list. If a group\_id list is given, also
+                ErrorGroupStats with zero occurrences are returned.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.errorreporting_v1beta1.types.QueryTimeRange`
-            group_id (list[str]): [Optional] List all <code>ErrorGroupStats</code> with these IDs.
-            service_filter (Union[dict, ~google.cloud.errorreporting_v1beta1.types.ServiceContextFilter]): [Optional] List only <code>ErrorGroupStats</code> which belong to a service
-                context that matches the filter.
-                Data for all service contexts is returned if this field is not specified.
+            group_id (list[str]): [Optional] List all ErrorGroupStats with these IDs.
+            service_filter (Union[dict, ~google.cloud.errorreporting_v1beta1.types.ServiceContextFilter]): [Optional] List only ErrorGroupStats which belong to a service context
+                that matches the filter. Data for all service contexts is returned if
+                this field is not specified.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.errorreporting_v1beta1.types.ServiceContextFilter`
             timed_count_duration (Union[dict, ~google.cloud.errorreporting_v1beta1.types.Duration]): [Optional] The preferred duration for a single returned ``TimedCount``.
                 If not set, no timed counts are returned.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.errorreporting_v1beta1.types.Duration`
-            alignment (~google.cloud.errorreporting_v1beta1.types.TimedCountAlignment): [Optional] The alignment of the timed counts to be returned.
-                Default is ``ALIGNMENT_EQUAL_AT_END``.
+            alignment (~google.cloud.errorreporting_v1beta1.types.TimedCountAlignment): [Optional] The alignment of the timed counts to be returned. Default is
+                ``ALIGNMENT_EQUAL_AT_END``.
             alignment_time (Union[dict, ~google.cloud.errorreporting_v1beta1.types.Timestamp]): [Optional] Time where the timed counts shall be aligned if rounded
                 alignment is chosen. Default is 00:00 UTC.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.errorreporting_v1beta1.types.Timestamp`
-            order (~google.cloud.errorreporting_v1beta1.types.ErrorGroupOrder): [Optional] The sort order in which the results are returned.
-                Default is ``COUNT_DESC``.
+            order (~google.cloud.errorreporting_v1beta1.types.ErrorGroupOrder): [Optional] The sort order in which the results are returned. Default is
+                ``COUNT_DESC``.
             page_size (int): The maximum number of resources contained in the
                 underlying API response. If page streaming is performed per-
                 resource, this parameter does not affect the return value. If page
@@ -329,7 +331,7 @@ class ErrorStatsServiceClient(object):
             >>>
             >>> project_name = client.project_path('[PROJECT]')
             >>>
-            >>> # TODO: Initialize ``group_id``:
+            >>> # TODO: Initialize `group_id`:
             >>> group_id = ''
             >>>
             >>> # Iterate over all results
@@ -341,26 +343,27 @@ class ErrorStatsServiceClient(object):
             >>> # Alternatively:
             >>>
             >>> # Iterate over results one page at a time
-            >>> for page in client.list_events(project_name, group_id, options=CallOptions(page_token=INITIAL_PAGE)):
+            >>> for page in client.list_events(project_name, group_id).pages:
             ...     for element in page:
             ...         # process element
             ...         pass
 
         Args:
-            project_name (str): [Required] The resource name of the Google Cloud Platform project. Written
-                as ``projects/`` plus the
-                [Google Cloud Platform project
-                ID](https://support.google.com/cloud/answer/6158840).
-                Example: ``projects/my-project-123``.
+            project_name (str): [Required] The resource name of the Google Cloud Platform project.
+                Written as ``projects/`` plus the `Google Cloud Platform project
+                ID <https://support.google.com/cloud/answer/6158840>`__. Example:
+                ``projects/my-project-123``.
             group_id (str): [Required] The group for which events shall be returned.
             service_filter (Union[dict, ~google.cloud.errorreporting_v1beta1.types.ServiceContextFilter]): [Optional] List only ErrorGroups which belong to a service context that
-                matches the filter.
-                Data for all service contexts is returned if this field is not specified.
+                matches the filter. Data for all service contexts is returned if this
+                field is not specified.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.errorreporting_v1beta1.types.ServiceContextFilter`
-            time_range (Union[dict, ~google.cloud.errorreporting_v1beta1.types.QueryTimeRange]): [Optional] List only data for the given time range.
-                If not set a default time range is used. The field time_range_begin
-                in the response will specify the beginning of this time range.
+            time_range (Union[dict, ~google.cloud.errorreporting_v1beta1.types.QueryTimeRange]): [Optional] List only data for the given time range. If not set a default
+                time range is used. The field time\_range\_begin in the response will
+                specify the beginning of this time range.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.errorreporting_v1beta1.types.QueryTimeRange`
             page_size (int): The maximum number of resources contained in the
@@ -439,11 +442,10 @@ class ErrorStatsServiceClient(object):
             >>> response = client.delete_events(project_name)
 
         Args:
-            project_name (str): [Required] The resource name of the Google Cloud Platform project. Written
-                as ``projects/`` plus the
-                [Google Cloud Platform project
-                ID](https://support.google.com/cloud/answer/6158840).
-                Example: ``projects/my-project-123``.
+            project_name (str): [Required] The resource name of the Google Cloud Platform project.
+                Written as ``projects/`` plus the `Google Cloud Platform project
+                ID <https://support.google.com/cloud/answer/6158840>`__. Example:
+                ``projects/my-project-123``.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will not
                 be retried.

--- a/error_reporting/google/cloud/errorreporting_v1beta1/gapic/report_errors_service_client.py
+++ b/error_reporting/google/cloud/errorreporting_v1beta1/gapic/report_errors_service_client.py
@@ -151,9 +151,10 @@ class ReportErrorsServiceClient(object):
             )
 
         if client_info is None:
-            client_info = (
-                google.api_core.gapic_v1.client_info.DEFAULT_CLIENT_INFO)
-        client_info.gapic_version = _GAPIC_LIBRARY_VERSION
+            client_info = google.api_core.gapic_v1.client_info.ClientInfo(
+                gapic_version=_GAPIC_LIBRARY_VERSION, )
+        else:
+            client_info.gapic_version = _GAPIC_LIBRARY_VERSION
         self._client_info = client_info
 
         # Parse out the default settings for retry and timeout for each RPC
@@ -179,13 +180,6 @@ class ReportErrorsServiceClient(object):
         """
         Report an individual error event.
 
-        This endpoint accepts <strong>either</strong> an OAuth token,
-        <strong>or</strong> an
-        <a href=\"https://support.google.com/cloud/answer/6158862\">API key</a>
-        for authentication. To use an API key, append it to the URL as the value of
-        a ``key`` parameter. For example:
-        <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
-
         Example:
             >>> from google.cloud import errorreporting_v1beta1
             >>>
@@ -193,17 +187,18 @@ class ReportErrorsServiceClient(object):
             >>>
             >>> project_name = client.project_path('[PROJECT]')
             >>>
-            >>> # TODO: Initialize ``event``:
+            >>> # TODO: Initialize `event`:
             >>> event = {}
             >>>
             >>> response = client.report_error_event(project_name, event)
 
         Args:
-            project_name (str): [Required] The resource name of the Google Cloud Platform project. Written
-                as ``projects/`` plus the
-                `Google Cloud Platform project ID <https://support.google.com/cloud/answer/6158840>`_.
-                Example: ``projects/my-project-123``.
+            project_name (str): [Required] The resource name of the Google Cloud Platform project.
+                Written as ``projects/`` plus the `Google Cloud Platform project
+                ID <https://support.google.com/cloud/answer/6158840>`__. Example:
+                ``projects/my-project-123``.
             event (Union[dict, ~google.cloud.errorreporting_v1beta1.types.ReportedErrorEvent]): [Required] The error event to be reported.
+
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.errorreporting_v1beta1.types.ReportedErrorEvent`
             retry (Optional[google.api_core.retry.Retry]):  A retry object used

--- a/error_reporting/google/cloud/errorreporting_v1beta1/gapic/transports/report_errors_service_grpc_transport.py
+++ b/error_reporting/google/cloud/errorreporting_v1beta1/gapic/transports/report_errors_service_grpc_transport.py
@@ -98,13 +98,6 @@ class ReportErrorsServiceGrpcTransport(object):
 
         Report an individual error event.
 
-        This endpoint accepts <strong>either</strong> an OAuth token,
-        <strong>or</strong> an
-        <a href=\"https://support.google.com/cloud/answer/6158862\">API key</a>
-        for authentication. To use an API key, append it to the URL as the value of
-        a ``key`` parameter. For example:
-        <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
-
         Returns:
             Callable: A callable which accepts the appropriate
                 deserialized request object and returns a

--- a/error_reporting/synth.py
+++ b/error_reporting/synth.py
@@ -38,3 +38,24 @@ s.replace(
     r"from google.devtools.clouderrorreporting_v1beta1.proto import ",
     r"from google.cloud.errorreporting_v1beta1.proto import ",
 )
+
+# Fix up docstrings in GAPIC clients
+DISCARD_AUTH_BOILERPLATE = r"""
+        This endpoint accepts either an OAuth token, or an API key for
+        authentication. To use an API key, append it to the URL as the value of
+        a ``key`` parameter. For example:
+
+        \.\. raw:: html
+        <pre>POST .*
+"""
+
+targets = [
+    'google/cloud/errorreporting_v1beta1/gapic/*_client.py',
+    'google/cloud/errorreporting_v1beta1/gapic/transports/*_transport.py',
+]
+
+s.replace(
+    targets,
+    DISCARD_AUTH_BOILERPLATE,
+    r"",
+)


### PR DESCRIPTION
Remove now-spurious replacements from synth.

Fix newly-generated raw HTML junk in docstrings.

Closes #6411.