### PR TITLE
Import stdlib ABCs from 'collections.abc' rather than 'collections'.

### DIFF
--- a/api_core/google/api_core/protobuf_helpers.py
+++ b/api_core/google/api_core/protobuf_helpers.py
@@ -15,6 +15,10 @@
 """Helpers for :mod:`protobuf`."""
 
 import collections
+try:
+    from collections import abc as collections_abc
+except ImportError:  # Python 2.7
+    import collections as collections_abc
 import copy
 import inspect
 
@@ -161,7 +165,7 @@ def get(msg_or_dict, key, default=_SENTINEL):
     # If we get something else, complain.
     if isinstance(msg_or_dict, message.Message):
         answer = getattr(msg_or_dict, key, default)
-    elif isinstance(msg_or_dict, collections.Mapping):
+    elif isinstance(msg_or_dict, collections_abc.Mapping):
         answer = msg_or_dict.get(key, default)
     else:
         raise TypeError(
@@ -184,7 +188,7 @@ def _set_field_on_message(msg, key, value):
     """Set helper for protobuf Messages."""
     # Attempt to set the value on the types of objects we know how to deal
     # with.
-    if isinstance(value, (collections.MutableSequence, tuple)):
+    if isinstance(value, (collections_abc.MutableSequence, tuple)):
         # Clear the existing repeated protobuf message of any elements
         # currently inside it.
         while getattr(msg, key):
@@ -192,13 +196,13 @@ def _set_field_on_message(msg, key, value):
 
         # Write our new elements to the repeated field.
         for item in value:
-            if isinstance(item, collections.Mapping):
+            if isinstance(item, collections_abc.Mapping):
                 getattr(msg, key).add(**item)
             else:
                 # protobuf's RepeatedCompositeContainer doesn't support
                 # append.
                 getattr(msg, key).extend([item])
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         # Assign the dictionary values to the protobuf message.
         for item_key, item_value in value.items():
             set(getattr(msg, key), item_key, item_value)
@@ -222,7 +226,7 @@ def set(msg_or_dict, key, value):
     """
     # Sanity check: Is our target object valid?
     if (not isinstance(msg_or_dict,
-                       (collections.MutableMapping, message.Message))):
+                       (collections_abc.MutableMapping, message.Message))):
         raise TypeError(
             'set() expected a dict or protobuf message, got {!r}.'.format(
                 type(msg_or_dict)))
@@ -233,12 +237,12 @@ def set(msg_or_dict, key, value):
     # If a subkey exists, then get that object and call this method
     # recursively against it using the subkey.
     if subkey is not None:
-        if isinstance(msg_or_dict, collections.MutableMapping):
+        if isinstance(msg_or_dict, collections_abc.MutableMapping):
             msg_or_dict.setdefault(basekey, {})
         set(get(msg_or_dict, basekey), subkey, value)
         return
 
-    if isinstance(msg_or_dict, collections.MutableMapping):
+    if isinstance(msg_or_dict, collections_abc.MutableMapping):
         msg_or_dict[key] = value
     else:
         _set_field_on_message(msg_or_dict, key, value)

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -16,7 +16,11 @@
 
 from __future__ import absolute_import
 
-import collections
+try:
+    from collections import abc as collections_abc
+except ImportError:  # Python 2.7
+    import collections as collections_abc
+
 import functools
 import gzip
 import os
@@ -1232,7 +1236,7 @@ class Client(ClientWithProject):
             destination = TableReference.from_string(
                 destination, default_project=self.project)
 
-        if not isinstance(sources, collections.Sequence):
+        if not isinstance(sources, collections_abc.Sequence):
             sources = [sources]
 
         copy_job = job.CopyJob(

--- a/bigquery/google/cloud/bigquery/dbapi/_helpers.py
+++ b/bigquery/google/cloud/bigquery/dbapi/_helpers.py
@@ -12,7 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import collections
+try:
+    from collections import abc as collections_abc
+except ImportError:  # Python 2.7
+    import collections as collections_abc
+
 import datetime
 import decimal
 import numbers
@@ -105,7 +109,7 @@ def to_query_parameters(parameters):
     if parameters is None:
         return []
 
-    if isinstance(parameters, collections.Mapping):
+    if isinstance(parameters, collections_abc.Mapping):
         return to_query_parameters_dict(parameters)
 
     return to_query_parameters_list(parameters)

--- a/bigquery/google/cloud/bigquery/dbapi/cursor.py
+++ b/bigquery/google/cloud/bigquery/dbapi/cursor.py
@@ -16,6 +16,11 @@
 
 import collections
 
+try:
+    from collections import abc as collections_abc
+except ImportError:  # Python 2.7
+    import collections as collections_abc
+
 import six
 
 from google.cloud.bigquery import job
@@ -335,7 +340,7 @@ def _format_operation(operation, parameters=None):
     if parameters is None:
         return operation
 
-    if isinstance(parameters, collections.Mapping):
+    if isinstance(parameters, collections_abc.Mapping):
         return _format_operation_dict(operation, parameters)
 
     return _format_operation_list(operation, parameters)

--- a/core/google/cloud/iam.py
+++ b/core/google/cloud/iam.py
@@ -18,6 +18,10 @@ https://cloud.google.com/iam/docs/understanding-roles
 """
 
 import collections
+try:
+    from collections import abc as collections_abc
+except ImportError:  # Python 2.7
+    import collections as collections_abc
 import warnings
 
 # Generic IAM roles
@@ -35,7 +39,7 @@ _ASSIGNMENT_DEPRECATED_MSG = """\
 Assigning to '{}' is deprecated.  Replace with 'policy[{}] = members."""
 
 
-class Policy(collections.MutableMapping):
+class Policy(collections_abc.MutableMapping):
     """IAM Policy
 
     See
@@ -239,4 +243,4 @@ class Policy(collections.MutableMapping):
         return resource
 
 
-collections.MutableMapping.register(Policy)
+collections_abc.MutableMapping.register(Policy)

--- a/firestore/google/cloud/firestore_v1beta1/_helpers.py
+++ b/firestore/google/cloud/firestore_v1beta1/_helpers.py
@@ -14,11 +14,10 @@
 
 """Common helpers shared across Google Cloud Firestore modules."""
 
-
 try:
-    from collections import abc
-except ImportError:  # python 2.7
-    import collections as abc
+    from collections import abc as collections_abc
+except ImportError:  # Python 2.7
+    import collections as collections_abc
 
 import datetime
 import re
@@ -749,7 +748,7 @@ def get_nested_value(field_path, data):
 
     nested_data = data
     for index, field_name in enumerate(field_names):
-        if isinstance(nested_data, abc.Mapping):
+        if isinstance(nested_data, collections_abc.Mapping):
             if field_name in nested_data:
                 nested_data = nested_data[field_name]
             else:


### PR DESCRIPTION
On Python 2.7, fall back to 'collections'.

Closes #6450.