### PR TITLE
Pubsub: override client classmethod factories inherited from GAPIC.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/client.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/client.py
@@ -20,6 +20,7 @@ import os
 import grpc
 
 from google.api_core import grpc_helpers
+from google.oauth2 import service_account
 
 from google.cloud.pubsub_v1 import _gapic
 from google.cloud.pubsub_v1 import types
@@ -30,9 +31,15 @@ from google.cloud.pubsub_v1.subscriber._protocol import streaming_pull_manager
 
 __version__ = pkg_resources.get_distribution('google-cloud-pubsub').version
 
+_BLACKLISTED_METHODS = (
+    'publish',
+    'from_service_account_file',
+    'from_service_account_json',
+)
 
-@_gapic.add_methods(subscriber_client.SubscriberClient,
-                    blacklist=('streaming_pull',))
+
+@_gapic.add_methods(
+    subscriber_client.SubscriberClient, blacklist=_BLACKLISTED_METHODS)
 class Client(object):
     """A subscriber client for Google Cloud Pub/Sub.
 
@@ -74,6 +81,26 @@ class Client(object):
         # Add the metrics headers, and instantiate the underlying GAPIC
         # client.
         self._api = subscriber_client.SubscriberClient(**kwargs)
+
+    @classmethod
+    def from_service_account_file(cls, filename, **kwargs):
+        """Creates an instance of this client using the provided credentials
+        file.
+
+        Args:
+            filename (str): The path to the service account private key json
+                file.
+            kwargs: Additional arguments to pass to the constructor.
+
+        Returns:
+            PublisherClient: The constructed client.
+        """
+        credentials = service_account.Credentials.from_service_account_file(
+            filename)
+        kwargs['credentials'] = credentials
+        return cls(**kwargs)
+
+    from_service_account_json = from_service_account_file
 
     @property
     def target(self):

--- a/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -221,6 +221,16 @@ def test_gapic_class_method_on_class():
     assert answer == 'projects/foo/topics/bar'
 
 
+def test_class_method_factory():
+    patch = mock.patch(
+        'google.oauth2.service_account.Credentials.from_service_account_file')
+
+    with patch:
+        client = publisher.Client.from_service_account_file('filename.json')
+
+    assert isinstance(client, publisher.Client)
+
+
 def test_gapic_class_method_on_instance():
     creds = mock.Mock(spec=credentials.Credentials)
     client = publisher.Client(credentials=creds)

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -40,6 +40,16 @@ def test_init_emulator(monkeypatch):
     assert channel.target().decode('utf8') == '/baz/bacon/'
 
 
+def test_class_method_factory():
+    patch = mock.patch(
+        'google.oauth2.service_account.Credentials.from_service_account_file')
+
+    with patch:
+        client = subscriber.Client.from_service_account_file('filename.json')
+
+    assert isinstance(client, subscriber.Client)
+
+
 @mock.patch(
     'google.cloud.pubsub_v1.subscriber._protocol.streaming_pull_manager.'
     'StreamingPullManager.open', autospec=True)


### PR DESCRIPTION
The `_gapic.add_methods` decorator doesn't quite get them right, so blacklist them from it and create them locally.

Closes #5903.