### PR TITLE
Implement `get_event_loop`.

### DIFF
--- a/ndb/src/google/cloud/ndb/_eventloop.py
+++ b/ndb/src/google/cloud/ndb/_eventloop.py
@@ -336,7 +336,7 @@ def get_event_loop(*args, **kwargs):
 
     Raises:
         exceptions.AsyncContextError: If called outside of a context
-        established by :func:`google.cloud.ndb.async_context`.
+            established by :func:`google.cloud.ndb.async_context`.
     """
     loop = contexts.current()
     if loop:

--- a/ndb/src/google/cloud/ndb/_eventloop.py
+++ b/ndb/src/google/cloud/ndb/_eventloop.py
@@ -21,6 +21,8 @@ import contextlib
 import threading
 import time
 
+from google.cloud.ndb import exceptions
+
 __all__ = [
     "add_idle",
     "async_context",
@@ -304,8 +306,9 @@ def async_context():
     context. Upon exiting the context, execution will block until all
     asynchronous calls loaded onto the event loop have finished execution.
 
-    Code within an asynchronous context should be single threaded. Internally, a
-    :class:`threading.local` instance is used to track the current event loop.
+    Code within an asynchronous context should be single threaded. Internally,
+    a :class:`threading.local` instance is used to track the current event
+    loop.
 
     In the context of a web application, it is recommended that a single
     asynchronous context be used per HTTP request. This can typically be
@@ -321,11 +324,28 @@ def async_context():
     contexts.pop()
 
 
-def add_idle(*args, **kwargs):
-    raise NotImplementedError
-
-
 def get_event_loop(*args, **kwargs):
+    """Get the current event loop.
+
+    This function should be called within a context established by
+    :func:`google.cloud.ndb.async_context`.
+
+    Returns:
+        EventLoop: The event loop for the current
+            context.
+
+    Raises:
+        exceptions.AsyncContextError: If called outside of a context
+        established by :func:`google.cloud.ndb.async_context`.
+    """
+    loop = contexts.current()
+    if loop:
+        return loop
+
+    raise exceptions.AsyncContextError()
+
+
+def add_idle(*args, **kwargs):
     raise NotImplementedError
 
 

--- a/ndb/src/google/cloud/ndb/_eventloop.py
+++ b/ndb/src/google/cloud/ndb/_eventloop.py
@@ -324,7 +324,7 @@ def async_context():
     contexts.pop()
 
 
-def get_event_loop(*args, **kwargs):
+def get_event_loop():
     """Get the current event loop.
 
     This function should be called within a context established by

--- a/ndb/src/google/cloud/ndb/exceptions.py
+++ b/ndb/src/google/cloud/ndb/exceptions.py
@@ -22,6 +22,7 @@ legacy Google App Engine runtime.
 
 __all__ = [
     "Error",
+    "AsyncContextError",
     "BadValueError",
     "BadArgumentError",
     "Rollback",
@@ -31,6 +32,20 @@ __all__ = [
 
 class Error(Exception):
     """Base datastore error type."""
+
+
+class AsyncContextError(Error):
+    """Indicates an async call being made without a context.
+
+    Raised whenever an asynchronous call is made outside of a context
+    established by :func:`google.cloud.ndb.async_context`.
+    """
+
+    def __init__(self):
+        super(AsyncContextError, self).__init__(
+            "No currently running event loop. Asynchronous calls must be made "
+            "in context established by google.cloud.ndb.async_context."
+        )
 
 
 class BadValueError(Error):

--- a/ndb/tests/unit/test__eventloop.py
+++ b/ndb/tests/unit/test__eventloop.py
@@ -17,8 +17,10 @@ import unittest.mock
 
 import pytest
 
-from google.cloud.ndb import _eventloop as eventloop
 import tests.unit.utils
+
+from google.cloud.ndb import exceptions
+from google.cloud.ndb import _eventloop as eventloop
 
 
 def test___all__():
@@ -317,14 +319,16 @@ def test_async_context(EventLoop):
     one.run.assert_called_once_with()
 
 
+def test_get_event_loop():
+    with pytest.raises(exceptions.AsyncContextError):
+        eventloop.get_event_loop()
+    with eventloop.async_context():
+        assert isinstance(eventloop.get_event_loop(), eventloop.EventLoop)
+
+
 def test_add_idle():
     with pytest.raises(NotImplementedError):
         eventloop.add_idle()
-
-
-def test_get_event_loop():
-    with pytest.raises(NotImplementedError):
-        eventloop.get_event_loop()
 
 
 def test_queue_call():


### PR DESCRIPTION
This has little to do with the function of the same name from the original
NDB, since the way of managing the current event loop has changed.