### PR TITLE
Implementing `KeyProperty` constructor in `ndb`.

### DIFF
--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -103,6 +103,12 @@ The primary differences come from:
 - `model.GeoPt` is an alias for `google.cloud.datastore.helpers.GeoPoint`
   rather than an alias for `google.appengine.api.datastore_types.GeoPt`. These
   classes have slightly different characteristics.
+- The `Property()` constructor (and subclasses) originally accepted both
+  `unicode` and `str` (the Python 2 versions) for `name` (and `kind`) but we
+  only accept `str`.
+- The `Parameter()` constructor (and subclasses) originally accepted `int`,
+  `unicode` and `str` (the Python 2 versions) for `key` but we only accept
+  `int` and `str`.
 
 ## Comments
 

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -547,25 +547,19 @@ class Property(ModelAttribute):
         """Verify the name of the property.
 
         Args:
-            name (Union[bytes, str]): The name of the property.
+            name (str): The name of the property.
 
         Returns:
-            bytes: The UTF-8 encoded version of the ``name``, if not already
-            passed in as bytes.
+            str: The ``name`` passed in.
 
         Raises:
-            TypeError: If the ``name`` is not a string or bytes.
+            TypeError: If the ``name`` is not a string.
             ValueError: If the name contains a ``.``.
         """
-        if isinstance(name, str):
-            name = name.encode("utf-8")
+        if not isinstance(name, str):
+            raise TypeError("Name {!r} is not a string".format(name))
 
-        if not isinstance(name, bytes):
-            raise TypeError(
-                "Name {!r} is not a string or byte string".format(name)
-            )
-
-        if b"." in name:
+        if "." in name:
             raise ValueError(
                 "Name {!r} cannot contain period characters".format(name)
             )
@@ -1975,8 +1969,8 @@ class TextProperty(BlobProperty):
 
         if self._indexed and encoded_length > _MAX_STRING_LENGTH:
             raise exceptions.BadValueError(
-                "Indexed value %s must be at most %d bytes"
-                % (self._name, _MAX_STRING_LENGTH)
+                "Indexed value {} must be at most {:d} "
+                "bytes".format(self._name, _MAX_STRING_LENGTH)
             )
 
     def _to_base_type(self, value):
@@ -2270,13 +2264,13 @@ class KeyProperty(Property):
 
         >>> name = "my_value"
         >>> ndb.KeyProperty(name)
-        KeyProperty(b'my_value')
+        KeyProperty('my_value')
         >>> ndb.KeyProperty(SimpleModel)
-        KeyProperty(kind=b'SimpleModel')
+        KeyProperty(kind='SimpleModel')
         >>> ndb.KeyProperty(name, SimpleModel)
-        KeyProperty(b'my_value', kind=b'SimpleModel')
+        KeyProperty('my_value', kind='SimpleModel')
         >>> ndb.KeyProperty(SimpleModel, name)
-        KeyProperty(b'my_value', kind=b'SimpleModel')
+        KeyProperty('my_value', kind='SimpleModel')
 
     The type of the positional arguments will be used to determine their
     purpose: a string argument is assumed to be the ``name`` and a
@@ -2361,15 +2355,14 @@ class KeyProperty(Property):
                 twice in ``args``.
             TypeError: If a valid ``kind`` type (i.e. a subclass of
                 :class:`Model`) is specified twice in ``args``.
-            TypeError: If an element in ``args`` is not a :class:`bytes`,
-                :class:`str` or a subclass of :class:`Model`.
+            TypeError: If an element in ``args`` is not a :class:`str` or a
+                subclass of :class:`Model`.
             TypeError: If a ``name`` is specified both in ``args`` and via
                 the ``name`` keyword.
             TypeError: If a ``kind`` is specified both in ``args`` and via
                 the ``kind`` keyword.
             TypeError: If a ``kind`` was provided via ``keyword`` and is
-                not a :class:`bytes`, :class:`str` or a subclass of
-                :class:`Model`.
+                not a :class:`str` or a subclass of :class:`Model`.
         """
         # Limit positional arguments.
         if len(args) > 2:
@@ -2385,7 +2378,7 @@ class KeyProperty(Property):
         name_via_positional = None
         kind_via_positional = None
         for value in args:
-            if isinstance(value, (bytes, str)):
+            if isinstance(value, str):
                 if name_via_positional is None:
                     name_via_positional = value
                 else:
@@ -2417,10 +2410,8 @@ class KeyProperty(Property):
             else:
                 raise TypeError("You can only specify kind once")
 
-        # Make sure the ``kind`` is converted to ``bytes``.
-        if isinstance(kind, str):
-            kind = kind.encode("utf-8")
-        elif kind is not None and not isinstance(kind, bytes):
+        # Make sure the ``kind`` is a ``str``.
+        if kind is not None and not isinstance(kind, str):
             raise TypeError("kind must be a Model class or a string")
 
         return name, kind
@@ -2530,9 +2521,9 @@ class DateTimeProperty(Property):
             multiple values.
         required (bool): Indicates if this property is required on the given
             model type.
-        default (bytes): The default value for this property.
-        choices (Iterable[bytes]): A container of allowed values for this
-            property.
+        default (~datetime.datetime): The default value for this property.
+        choices (Iterable[~datetime.datetime]): A container of allowed values
+            for this property.
         validator (Callable[[~google.cloud.ndb.model.Property, Any], bool]): A
             validator to be used to check values.
         verbose_name (str): A longer, user-friendly name for this property.

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -96,7 +96,7 @@ class Parameter(ParameterizedThing):
     __slots__ = ("_key",)
 
     def __init__(self, key):
-        if not isinstance(key, (int, str, bytes)):
+        if not isinstance(key, (int, bytes, str)):
             raise TypeError(
                 "Parameter key must be an integer or string, not {}".format(
                     key

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -96,7 +96,7 @@ class Parameter(ParameterizedThing):
     __slots__ = ("_key",)
 
     def __init__(self, key):
-        if not isinstance(key, (int, bytes, str)):
+        if not isinstance(key, (int, str)):
             raise TypeError(
                 "Parameter key must be an integer or string, not {}".format(
                     key

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -1784,9 +1784,96 @@ class TestUserProperty:
 
 class TestKeyProperty:
     @staticmethod
-    def test_constructor():
-        with pytest.raises(NotImplementedError):
-            model.KeyProperty()
+    def test_constructor_defaults():
+        prop = model.KeyProperty()
+        # Check that none of the constructor defaults were used.
+        assert prop.__dict__ == {}
+
+    @staticmethod
+    def test_constructor_too_many_positional():
+        with pytest.raises(TypeError):
+            model.KeyProperty("a", None, None)
+
+    @staticmethod
+    def test_constructor_positional_name_twice():
+        with pytest.raises(TypeError):
+            model.KeyProperty("a", "b")
+
+    @staticmethod
+    def test_constructor_positional_kind_twice():
+        class Simple(model.Model):
+            pass
+
+        with pytest.raises(TypeError):
+            model.KeyProperty(Simple, Simple)
+
+    @staticmethod
+    def test_constructor_positional_bad_type():
+        with pytest.raises(TypeError):
+            model.KeyProperty("a", unittest.mock.sentinel.bad)
+
+    @staticmethod
+    def test_constructor_name_both_ways():
+        with pytest.raises(TypeError):
+            model.KeyProperty("a", name="b")
+
+    @staticmethod
+    def test_constructor_kind_both_ways():
+        class Simple(model.Model):
+            pass
+
+        with pytest.raises(TypeError):
+            model.KeyProperty(Simple, kind="Simple")
+
+    @staticmethod
+    def test_constructor_bad_kind():
+        with pytest.raises(TypeError):
+            model.KeyProperty(kind=unittest.mock.sentinel.bad)
+
+    @staticmethod
+    def test_constructor_positional():
+        class Simple(model.Model):
+            pass
+
+        prop = model.KeyProperty(None, None)
+        assert prop._name is None
+        assert prop._kind is None
+
+        name_only_args = [("keyp",), (None, "keyp"), (b"keyp", None)]
+        for args in name_only_args:
+            prop = model.KeyProperty(*args)
+            assert prop._name == b"keyp"
+            assert prop._kind is None
+
+        kind_only_args = [(Simple,), (None, Simple), (Simple, None)]
+        for args in kind_only_args:
+            prop = model.KeyProperty(*args)
+            assert prop._name is None
+            assert prop._kind == b"Simple"
+
+        both_args = [("keyp", Simple), (Simple, "keyp")]
+        for args in both_args:
+            prop = model.KeyProperty(*args)
+            assert prop._name == b"keyp"
+            assert prop._kind == b"Simple"
+
+    @staticmethod
+    def test_constructor_hybrid():
+        class Simple(model.Model):
+            pass
+
+        prop1 = model.KeyProperty(Simple, name="keyp")
+        prop2 = model.KeyProperty("keyp", kind=Simple)
+        prop3 = model.KeyProperty("keyp", kind="Simple")
+        for prop in (prop1, prop2, prop3):
+            assert prop._name == b"keyp"
+            assert prop._kind == b"Simple"
+
+    @staticmethod
+    def test_repr():
+        prop = model.KeyProperty("keyp", kind="Simple", repeated=True)
+        expected = "KeyProperty(b'keyp', kind=b'Simple', repeated=True)"
+        assert repr(prop) == expected
 
 
 class TestBlobKeyProperty:

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -1875,6 +1875,52 @@ class TestKeyProperty:
         expected = "KeyProperty(b'keyp', kind=b'Simple', repeated=True)"
         assert repr(prop) == expected
 
+    @staticmethod
+    def test__validate():
+        kind = "Simple"
+        prop = model.KeyProperty("keyp", kind=kind)
+        value = key.Key(kind, 182983)
+        prop._kind = kind  # Ick
+        assert prop._validate(value) is None
+
+    @staticmethod
+    def test__validate_without_kind():
+        prop = model.KeyProperty("keyp")
+        value = key.Key("Foo", "Bar")
+        assert prop._validate(value) is None
+
+    @staticmethod
+    def test__validate_non_key():
+        prop = model.KeyProperty("keyp")
+        with pytest.raises(exceptions.BadValueError):
+            prop._validate(None)
+
+    @staticmethod
+    def test__validate_partial_key():
+        prop = model.KeyProperty("keyp")
+        value = key.Key("Kynd", None)
+        with pytest.raises(exceptions.BadValueError):
+            prop._validate(value)
+
+    @staticmethod
+    def test__validate_wrong_kind():
+        prop = model.KeyProperty("keyp", kind="Simple")
+        value = key.Key("Kynd", 184939)
+        with pytest.raises(exceptions.BadValueError):
+            prop._validate(value)
+
+    @staticmethod
+    def test__db_set_value():
+        prop = model.KeyProperty("keyp", kind="Simple")
+        with pytest.raises(NotImplementedError):
+            prop._db_set_value(None, None, None)
+
+    @staticmethod
+    def test__db_get_value():
+        prop = model.KeyProperty("keyp", kind="Simple")
+        with pytest.raises(NotImplementedError):
+            prop._db_get_value(None, None)
+
 
 class TestBlobKeyProperty:
     @staticmethod

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -363,7 +363,7 @@ class TestProperty:
             verbose_name="VALUE FOR READING",
             write_empty_list=False,
         )
-        assert prop._name == b"val" and prop._name != "val"
+        assert prop._name == "val"
         assert not prop._indexed
         assert not prop._repeated
         assert prop._required
@@ -412,7 +412,7 @@ class TestProperty:
             write_empty_list=False,
         )
         expected = (
-            "Property(b'val', indexed=False, required=True, "
+            "Property('val', indexed=False, required=True, "
             "default='zorp', choices={}, validator={}, "
             "verbose_name='VALUE FOR READING')".format(
                 prop._choices, prop._validator
@@ -449,13 +449,13 @@ class TestProperty:
     def test__comparison(property_clean_cache):
         prop = model.Property("sentiment", indexed=True)
         filter_node = prop._comparison(">=", 0.0)
-        assert filter_node == query.FilterNode(b"sentiment", ">=", 0.0)
+        assert filter_node == query.FilterNode("sentiment", ">=", 0.0)
 
     @staticmethod
     def test__comparison_empty_value():
         prop = model.Property("height", indexed=True)
         filter_node = prop._comparison("=", None)
-        assert filter_node == query.FilterNode(b"height", "=", None)
+        assert filter_node == query.FilterNode("height", "=", None)
         # Cache is untouched.
         assert model.Property._FIND_METHODS_CACHE == {}
 
@@ -463,7 +463,7 @@ class TestProperty:
     def test___eq__(property_clean_cache):
         prop = model.Property("name", indexed=True)
         value = 1337
-        expected = query.FilterNode(b"name", "=", value)
+        expected = query.FilterNode("name", "=", value)
 
         filter_node_left = prop == value
         assert filter_node_left == expected
@@ -475,8 +475,8 @@ class TestProperty:
         prop = model.Property("name", indexed=True)
         value = 7.0
         expected = query.DisjunctionNode(
-            query.FilterNode(b"name", "<", value),
-            query.FilterNode(b"name", ">", value),
+            query.FilterNode("name", "<", value),
+            query.FilterNode("name", ">", value),
         )
 
         or_node_left = prop != value
@@ -488,7 +488,7 @@ class TestProperty:
     def test___lt__(property_clean_cache):
         prop = model.Property("name", indexed=True)
         value = 2.0
-        expected = query.FilterNode(b"name", "<", value)
+        expected = query.FilterNode("name", "<", value)
 
         filter_node_left = prop < value
         assert filter_node_left == expected
@@ -499,7 +499,7 @@ class TestProperty:
     def test___le__(property_clean_cache):
         prop = model.Property("name", indexed=True)
         value = 20.0
-        expected = query.FilterNode(b"name", "<=", value)
+        expected = query.FilterNode("name", "<=", value)
 
         filter_node_left = prop <= value
         assert filter_node_left == expected
@@ -510,7 +510,7 @@ class TestProperty:
     def test___gt__(property_clean_cache):
         prop = model.Property("name", indexed=True)
         value = "new"
-        expected = query.FilterNode(b"name", ">", value)
+        expected = query.FilterNode("name", ">", value)
 
         filter_node_left = prop > value
         assert filter_node_left == expected
@@ -521,7 +521,7 @@ class TestProperty:
     def test___ge__(property_clean_cache):
         prop = model.Property("name", indexed=True)
         value = "old"
-        expected = query.FilterNode(b"name", ">=", value)
+        expected = query.FilterNode("name", ">=", value)
 
         filter_node_left = prop >= value
         assert filter_node_left == expected
@@ -551,9 +551,9 @@ class TestProperty:
         prop = model.Property("name", indexed=True)
         or_node = prop._IN(["a", None, "xy"])
         expected = query.DisjunctionNode(
-            query.FilterNode(b"name", "=", "a"),
-            query.FilterNode(b"name", "=", None),
-            query.FilterNode(b"name", "=", "xy"),
+            query.FilterNode("name", "=", "a"),
+            query.FilterNode("name", "=", None),
+            query.FilterNode("name", "=", "xy"),
         )
         assert or_node == expected
         # Also verify the alias
@@ -949,7 +949,7 @@ class TestProperty:
                 return len(self._name) < 20
 
         prop = SomeProperty(name="hi")
-        assert prop.find_me() == b"hi"
+        assert prop.find_me() == "hi"
         assert prop.IN()
 
         return SomeProperty
@@ -1230,7 +1230,7 @@ class TestProperty:
         value = 1234.5
         # __set__
         m.prop = value
-        assert m._values == {b"prop": value}
+        assert m._values == {"prop": value}
         # __get__
         assert m.prop == value
         # __delete__
@@ -1463,7 +1463,7 @@ class TestBlobProperty:
             verbose_name="VALUE FOR READING",
             write_empty_list=False,
         )
-        assert prop._name == b"blob_val" and prop._name != "blob_val"
+        assert prop._name == "blob_val"
         assert prop._compressed
         assert not prop._indexed
         assert not prop._repeated
@@ -1579,7 +1579,7 @@ class TestTextProperty:
     @staticmethod
     def test_constructor_explicit():
         prop = model.TextProperty(name="text", indexed=False)
-        assert prop._name == b"text"
+        assert prop._name == "text"
         assert not prop._indexed
 
     @staticmethod
@@ -1649,7 +1649,7 @@ class TestStringProperty:
     @staticmethod
     def test_constructor_explicit():
         prop = model.StringProperty(name="limited-text", indexed=True)
-        assert prop._name == b"limited-text"
+        assert prop._name == "limited-text"
         assert prop._indexed
 
     @staticmethod
@@ -1726,7 +1726,7 @@ class TestJsonProperty:
             verbose_name="VALUE FOR READING",
             write_empty_list=False,
         )
-        assert prop._name == b"json-val" and prop._name != "json-val"
+        assert prop._name == "json-val"
         assert prop._compressed
         assert prop._json_type is tuple
         assert not prop._indexed
@@ -1839,23 +1839,23 @@ class TestKeyProperty:
         assert prop._name is None
         assert prop._kind is None
 
-        name_only_args = [("keyp",), (None, "keyp"), (b"keyp", None)]
+        name_only_args = [("keyp",), (None, "keyp"), ("keyp", None)]
         for args in name_only_args:
             prop = model.KeyProperty(*args)
-            assert prop._name == b"keyp"
+            assert prop._name == "keyp"
             assert prop._kind is None
 
         kind_only_args = [(Simple,), (None, Simple), (Simple, None)]
         for args in kind_only_args:
             prop = model.KeyProperty(*args)
             assert prop._name is None
-            assert prop._kind == b"Simple"
+            assert prop._kind == "Simple"
 
         both_args = [("keyp", Simple), (Simple, "keyp")]
         for args in both_args:
             prop = model.KeyProperty(*args)
-            assert prop._name == b"keyp"
-            assert prop._kind == b"Simple"
+            assert prop._name == "keyp"
+            assert prop._kind == "Simple"
 
     @staticmethod
     def test_constructor_hybrid():
@@ -1866,13 +1866,13 @@ class TestKeyProperty:
         prop2 = model.KeyProperty("keyp", kind=Simple)
         prop3 = model.KeyProperty("keyp", kind="Simple")
         for prop in (prop1, prop2, prop3):
-            assert prop._name == b"keyp"
-            assert prop._kind == b"Simple"
+            assert prop._name == "keyp"
+            assert prop._kind == "Simple"
 
     @staticmethod
     def test_repr():
         prop = model.KeyProperty("keyp", kind="Simple", repeated=True)
-        expected = "KeyProperty(b'keyp', kind=b'Simple', repeated=True)"
+        expected = "KeyProperty('keyp', kind='Simple', repeated=True)"
         assert repr(prop) == expected
 
     @staticmethod
@@ -1880,7 +1880,6 @@ class TestKeyProperty:
         kind = "Simple"
         prop = model.KeyProperty("keyp", kind=kind)
         value = key.Key(kind, 182983)
-        prop._kind = kind  # Ick
         assert prop._validate(value) is None
 
     @staticmethod
@@ -1951,7 +1950,7 @@ class TestDateTimeProperty:
             verbose_name="VALUE FOR READING",
             write_empty_list=False,
         )
-        assert prop._name == b"dt_val" and prop._name != "dt_val"
+        assert prop._name == "dt_val"
         assert prop._auto_now
         assert not prop._auto_now_add
         assert not prop._indexed

--- a/ndb/tests/unit/test_query.py
+++ b/ndb/tests/unit/test_query.py
@@ -63,7 +63,7 @@ class TestParameterizedThing:
 class TestParameter:
     @staticmethod
     def test_constructor():
-        for key in (88, b"abc", "def"):
+        for key in (88, "def"):
             parameter = query.Parameter(key)
             assert parameter._key == key
 
@@ -301,7 +301,7 @@ class TestParameterNode:
         used = {}
         resolved_node = parameter_node.resolve(bindings, used)
 
-        assert resolved_node == query.FilterNode(b"val", "=", value)
+        assert resolved_node == query.FilterNode("val", "=", value)
         assert used == {"abc": True}
 
     @staticmethod
@@ -316,9 +316,9 @@ class TestParameterNode:
         resolved_node = parameter_node.resolve(bindings, used)
 
         assert resolved_node == query.DisjunctionNode(
-            query.FilterNode(b"val", "=", 19),
-            query.FilterNode(b"val", "=", 20),
-            query.FilterNode(b"val", "=", 28),
+            query.FilterNode("val", "=", 19),
+            query.FilterNode("val", "=", 20),
+            query.FilterNode("val", "=", 28),
         )
         assert used == {"replace": True}
 


### PR DESCRIPTION
This also required adding a small modification to `Property.__repr__` to change how it behaves for `KeyProperty`.