### PR TITLE
Ndb eventloop helpers

### DIFF
--- a/ndb/src/google/cloud/ndb/_eventloop.py
+++ b/ndb/src/google/cloud/ndb/_eventloop.py
@@ -328,7 +328,7 @@ def get_event_loop():
     """Get the current event loop.
 
     This function should be called within a context established by
-    :func:`google.cloud.ndb.async_context`.
+    :func:`~google.cloud.ndb.async_context`.
 
     Returns:
         EventLoop: The event loop for the current
@@ -336,7 +336,7 @@ def get_event_loop():
 
     Raises:
         exceptions.AsyncContextError: If called outside of a context
-            established by :func:`google.cloud.ndb.async_context`.
+            established by :func:`~google.cloud.ndb.async_context`.
     """
     loop = contexts.current()
     if loop:
@@ -345,25 +345,70 @@ def get_event_loop():
     raise exceptions.AsyncContextError()
 
 
-def add_idle(*args, **kwargs):
-    raise NotImplementedError
+def add_idle(callback, *args, **kwargs):
+    """Helper function.
+
+    Calls :method:`EventLoop.add_idle` on current event loop.
+
+    Raises:
+        exceptions.AsyncContextError: If called outside of a context
+            established by :func:`~google.cloud.ndb.async_context`.
+    """
+    loop = get_event_loop()
+    loop.add_idle(callback, *args, **kwargs)
 
 
-def queue_call(*args, **kwargs):
-    raise NotImplementedError
+def queue_call(delay, callback, *args, **kwargs):
+    """Helper function.
+
+    Calls :method:`EventLoop.queue_call` on current event loop.
+
+    Raises:
+        exceptions.AsyncContextError: If called outside of a context
+            established by :func:`~google.cloud.ndb.async_context`.
+    """
+    loop = get_event_loop()
+    loop.queue_call(delay, callback, *args, **kwargs)
 
 
 def queue_rpc(*args, **kwargs):
     raise NotImplementedError
 
 
-def run(*args, **kwargs):
-    raise NotImplementedError
+def run():
+    """Helper function.
+
+    Calls :method:`EventLoop.run` on current event loop.
+
+    Raises:
+        exceptions.AsyncContextError: If called outside of a context
+            established by :func:`~google.cloud.ndb.async_context`.
+    """
+    loop = get_event_loop()
+    loop.run()
 
 
-def run0(*args, **kwargs):
-    raise NotImplementedError
+def run0():
+    """Helper function.
+
+    Calls :method:`EventLoop.run0` on current event loop.
+
+    Raises:
+        exceptions.AsyncContextError: If called outside of a context
+            established by :func:`~google.cloud.ndb.async_context`.
+    """
+    loop = get_event_loop()
+    loop.run0()
 
 
-def run1(*args, **kwargs):
-    raise NotImplementedError
+def run1():
+    """Helper function.
+
+    Calls :method:`EventLoop.run1` on current event loop.
+
+    Raises:
+        exceptions.AsyncContextError: If called outside of a context
+            established by :func:`~google.cloud.ndb.async_context`.
+    """
+    loop = get_event_loop()
+    loop.run1()

--- a/ndb/src/google/cloud/ndb/_eventloop.py
+++ b/ndb/src/google/cloud/ndb/_eventloop.py
@@ -335,7 +335,7 @@ def get_event_loop():
             context.
 
     Raises:
-        exceptions.AsyncContextError: If called outside of a context
+        .AsyncContextError: If called outside of a context
             established by :func:`~google.cloud.ndb.async_context`.
     """
     loop = contexts.current()
@@ -346,12 +346,10 @@ def get_event_loop():
 
 
 def add_idle(callback, *args, **kwargs):
-    """Helper function.
-
-    Calls :method:`EventLoop.add_idle` on current event loop.
+    """Calls :method:`EventLoop.add_idle` on current event loop.
 
     Raises:
-        exceptions.AsyncContextError: If called outside of a context
+        .AsyncContextError: If called outside of a context
             established by :func:`~google.cloud.ndb.async_context`.
     """
     loop = get_event_loop()
@@ -359,12 +357,10 @@ def add_idle(callback, *args, **kwargs):
 
 
 def queue_call(delay, callback, *args, **kwargs):
-    """Helper function.
-
-    Calls :method:`EventLoop.queue_call` on current event loop.
+    """Calls :method:`EventLoop.queue_call` on current event loop.
 
     Raises:
-        exceptions.AsyncContextError: If called outside of a context
+        .AsyncContextError: If called outside of a context
             established by :func:`~google.cloud.ndb.async_context`.
     """
     loop = get_event_loop()
@@ -376,12 +372,10 @@ def queue_rpc(*args, **kwargs):
 
 
 def run():
-    """Helper function.
-
-    Calls :method:`EventLoop.run` on current event loop.
+    """Calls :method:`EventLoop.run` on current event loop.
 
     Raises:
-        exceptions.AsyncContextError: If called outside of a context
+        .AsyncContextError: If called outside of a context
             established by :func:`~google.cloud.ndb.async_context`.
     """
     loop = get_event_loop()
@@ -389,12 +383,10 @@ def run():
 
 
 def run0():
-    """Helper function.
-
-    Calls :method:`EventLoop.run0` on current event loop.
+    """Calls :method:`EventLoop.run0` on current event loop.
 
     Raises:
-        exceptions.AsyncContextError: If called outside of a context
+        .AsyncContextError: If called outside of a context
             established by :func:`~google.cloud.ndb.async_context`.
     """
     loop = get_event_loop()
@@ -402,12 +394,10 @@ def run0():
 
 
 def run1():
-    """Helper function.
-
-    Calls :method:`EventLoop.run1` on current event loop.
+    """Calls :method:`EventLoop.run1` on current event loop.
 
     Raises:
-        exceptions.AsyncContextError: If called outside of a context
+        .AsyncContextError: If called outside of a context
             established by :func:`~google.cloud.ndb.async_context`.
     """
     loop = get_event_loop()

--- a/ndb/src/google/cloud/ndb/exceptions.py
+++ b/ndb/src/google/cloud/ndb/exceptions.py
@@ -38,7 +38,7 @@ class AsyncContextError(Error):
     """Indicates an async call being made without a context.
 
     Raised whenever an asynchronous call is made outside of a context
-    established by :func:`google.cloud.ndb.async_context`.
+    established by :func:`~google.cloud.ndb.async_context`.
     """
 
     def __init__(self):

--- a/ndb/tests/unit/test__eventloop.py
+++ b/ndb/tests/unit/test__eventloop.py
@@ -326,14 +326,22 @@ def test_get_event_loop():
         assert isinstance(eventloop.get_event_loop(), eventloop.EventLoop)
 
 
-def test_add_idle():
-    with pytest.raises(NotImplementedError):
-        eventloop.add_idle()
+@unittest.mock.patch('google.cloud.ndb._eventloop.EventLoop')
+def test_add_idle(EventLoop):
+    EventLoop.return_value = loop = unittest.mock.Mock(
+        spec=("run", "add_idle"))
+    with eventloop.async_context():
+        eventloop.add_idle('foo', 'bar', baz='qux')
+        loop.add_idle.assert_called_once_with('foo', 'bar', baz='qux')
 
 
-def test_queue_call():
-    with pytest.raises(NotImplementedError):
-        eventloop.queue_call()
+@unittest.mock.patch('google.cloud.ndb._eventloop.EventLoop')
+def test_queue_call(EventLoop):
+    EventLoop.return_value = loop = unittest.mock.Mock(
+        spec=("run", "queue_call"))
+    with eventloop.async_context():
+        eventloop.queue_call(42, 'foo', 'bar', baz='qux')
+        loop.queue_call.assert_called_once_with(42, 'foo', 'bar', baz='qux')
 
 
 def test_queue_rpc():
@@ -341,16 +349,28 @@ def test_queue_rpc():
         eventloop.queue_rpc()
 
 
-def test_run():
-    with pytest.raises(NotImplementedError):
+@unittest.mock.patch('google.cloud.ndb._eventloop.EventLoop')
+def test_run(EventLoop):
+    EventLoop.return_value = loop = unittest.mock.Mock(
+        spec=("run",))
+    with eventloop.async_context():
         eventloop.run()
+        loop.run.assert_called_once_with()
 
 
-def test_run0():
-    with pytest.raises(NotImplementedError):
+@unittest.mock.patch('google.cloud.ndb._eventloop.EventLoop')
+def test_run0(EventLoop):
+    EventLoop.return_value = loop = unittest.mock.Mock(
+        spec=("run", "run0"))
+    with eventloop.async_context():
         eventloop.run0()
+        loop.run0.assert_called_once_with()
 
 
-def test_run1():
-    with pytest.raises(NotImplementedError):
+@unittest.mock.patch('google.cloud.ndb._eventloop.EventLoop')
+def test_run1(EventLoop):
+    EventLoop.return_value = loop = unittest.mock.Mock(
+        spec=("run", "run1"))
+    with eventloop.async_context():
         eventloop.run1()
+        loop.run1.assert_called_once_with()

--- a/ndb/tests/unit/test__eventloop.py
+++ b/ndb/tests/unit/test__eventloop.py
@@ -326,22 +326,24 @@ def test_get_event_loop():
         assert isinstance(eventloop.get_event_loop(), eventloop.EventLoop)
 
 
-@unittest.mock.patch('google.cloud.ndb._eventloop.EventLoop')
+@unittest.mock.patch("google.cloud.ndb._eventloop.EventLoop")
 def test_add_idle(EventLoop):
     EventLoop.return_value = loop = unittest.mock.Mock(
-        spec=("run", "add_idle"))
+        spec=("run", "add_idle")
+    )
     with eventloop.async_context():
-        eventloop.add_idle('foo', 'bar', baz='qux')
-        loop.add_idle.assert_called_once_with('foo', 'bar', baz='qux')
+        eventloop.add_idle("foo", "bar", baz="qux")
+        loop.add_idle.assert_called_once_with("foo", "bar", baz="qux")
 
 
-@unittest.mock.patch('google.cloud.ndb._eventloop.EventLoop')
+@unittest.mock.patch("google.cloud.ndb._eventloop.EventLoop")
 def test_queue_call(EventLoop):
     EventLoop.return_value = loop = unittest.mock.Mock(
-        spec=("run", "queue_call"))
+        spec=("run", "queue_call")
+    )
     with eventloop.async_context():
-        eventloop.queue_call(42, 'foo', 'bar', baz='qux')
-        loop.queue_call.assert_called_once_with(42, 'foo', 'bar', baz='qux')
+        eventloop.queue_call(42, "foo", "bar", baz="qux")
+        loop.queue_call.assert_called_once_with(42, "foo", "bar", baz="qux")
 
 
 def test_queue_rpc():
@@ -349,28 +351,25 @@ def test_queue_rpc():
         eventloop.queue_rpc()
 
 
-@unittest.mock.patch('google.cloud.ndb._eventloop.EventLoop')
+@unittest.mock.patch("google.cloud.ndb._eventloop.EventLoop")
 def test_run(EventLoop):
-    EventLoop.return_value = loop = unittest.mock.Mock(
-        spec=("run",))
+    EventLoop.return_value = loop = unittest.mock.Mock(spec=("run",))
     with eventloop.async_context():
         eventloop.run()
         loop.run.assert_called_once_with()
 
 
-@unittest.mock.patch('google.cloud.ndb._eventloop.EventLoop')
+@unittest.mock.patch("google.cloud.ndb._eventloop.EventLoop")
 def test_run0(EventLoop):
-    EventLoop.return_value = loop = unittest.mock.Mock(
-        spec=("run", "run0"))
+    EventLoop.return_value = loop = unittest.mock.Mock(spec=("run", "run0"))
     with eventloop.async_context():
         eventloop.run0()
         loop.run0.assert_called_once_with()
 
 
-@unittest.mock.patch('google.cloud.ndb._eventloop.EventLoop')
+@unittest.mock.patch("google.cloud.ndb._eventloop.EventLoop")
 def test_run1(EventLoop):
-    EventLoop.return_value = loop = unittest.mock.Mock(
-        spec=("run", "run1"))
+    EventLoop.return_value = loop = unittest.mock.Mock(spec=("run", "run1"))
     with eventloop.async_context():
         eventloop.run1()
         loop.run1.assert_called_once_with()


### PR DESCRIPTION
Implementations for the relatively trivial helper/wrapper functions that merely get the current event loop and then call the corresponding method on the loop.