### PR TITLE
Require grpcio-gcp >= 0.2.2 directly

### DIFF
--- a/api_core/setup.py
+++ b/api_core/setup.py
@@ -36,11 +36,11 @@ dependencies = [
     'setuptools >= 34.0.0',
     'six >= 1.10.0',
     'pytz',
-    'futures >= 3.2.0; python_version < "3.2"'
+    'futures >= 3.2.0; python_version < "3.2"',
+    'grpcio-gcp': 'grpcio-gcp >= 0.2.2'
 ]
 extras = {
-    'grpc': 'grpcio >= 1.8.2',
-    'grpcio-gcp': 'grpcio-gcp >= 0.2.2'
+    'grpc': 'grpcio >= 1.8.2'
 }
 
 


### PR DESCRIPTION
Older versions of pip don't process the extras correctly when passed to another dependency. Require grpcio-gcp explicitly instead.

See https://github.com/pypa/pip/issues/4957, GCP case #17453259, etc.

I don't seem to be having a problem with grpc itself, but could move that one too (and / or adjust version requirements) if you all want.

```
root@b3e5163e877e:/# pip install "google-api-core[grpcio-gcp]"
Collecting google-api-core[grpcio-gcp]
  Using cached https://files.pythonhosted.org/packages/48/53/2ec314fe5c167d150b6980f23765a8a8aa56861eb59e7e0fc45f499c62e3/google_api_core-1.5.1-py2.py3-none-any.whl
  google-api-core 1.5.1 does not provide the extra 'grpcio-gcp'
```