### PR TITLE
remove hyphen from named extra in api_core

### DIFF
--- a/api_core/setup.py
+++ b/api_core/setup.py
@@ -40,7 +40,7 @@ dependencies = [
 ]
 extras = {
     'grpc': 'grpcio >= 1.8.2',
-    'grpcio-gcp': 'grpcio-gcp >= 0.2.2'
+    'grpcgcp': 'grpcio-gcp >= 0.2.2'
 }
 
 

--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -29,7 +29,7 @@ version = '1.6.0'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
-    'google-api-core[grpc, grpcio-gcp] >= 1.4.1, < 2.0.0dev',
+    'google-api-core[grpc, grpcgcp] >= 1.4.1, < 2.0.0dev',
     'google-cloud-core >= 0.28.0, < 0.29dev',
     'grpc-google-iam-v1 >= 0.11.4, < 0.12dev',
 ]


### PR DESCRIPTION
In pip 8, which is currently used on ubuntu 16.04 LTS, extras with hyphens are ignored and not installed.