### PR TITLE
Added 'array_contains' to the _COMPARISON_OPERATORS dict, to enable using array_contains in firestore queries.

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/query.py
+++ b/firestore/google/cloud/firestore_v1beta1/query.py
@@ -39,6 +39,7 @@ _COMPARISON_OPERATORS = {
     _EQ_OP: enums.StructuredQuery.FieldFilter.Operator.EQUAL,
     '>=': enums.StructuredQuery.FieldFilter.Operator.GREATER_THAN_OR_EQUAL,
     '>': enums.StructuredQuery.FieldFilter.Operator.GREATER_THAN,
+    'array_contains': enums.StructuredQuery.FieldFilter.Operator.ARRAY_CONTAINS,
 }
 _BAD_OP_STRING = 'Operator string {!r} is invalid. Valid choices are: {}.'
 _BAD_OP_NAN_NULL = (

--- a/firestore/tests/unit/test_query.py
+++ b/firestore/tests/unit/test_query.py
@@ -965,6 +965,7 @@ class Test__enum_from_op_string(unittest.TestCase):
         self.assertEqual(self._call_fut('=='), op_class.EQUAL)
         self.assertEqual(self._call_fut('>='), op_class.GREATER_THAN_OR_EQUAL)
         self.assertEqual(self._call_fut('>'), op_class.GREATER_THAN)
+        self.assertEqual(self._call_fut('array_contains'), op_class.ARRAY_CONTAINS)
 
     def test_failure(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This appears to fix #6479.