### PR TITLE
Storage: Update Blob.update_storage_class to support rewrite tokens

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -1536,11 +1536,9 @@ class Blob(_PropertyMixin):
         self._patch_property('storageClass', new_class)
 
         # Execute consecutive rewrite operations until operation is done
-        token = None
-        while True:
+        token, _, _ = self.rewrite(self)
+        while token is not None:
             token, _, _ = self.rewrite(self, token=token)
-            if token is None:
-                break
 
     cache_control = _scalar_property("cacheControl")
     """HTTP 'Cache-Control' header for this object.

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -963,6 +963,39 @@ class TestStorageRewrite(TestStorageFiles):
             retry_429(created.delete)(force=True)
 
 
+class TestStorageUpdateStorageClass(TestStorageFiles):
+
+    def test_update_storage_class_small_file(self):
+        blob = self.bucket.blob("SmallFile")
+
+        file_data = self.FILES["simple"]
+        blob.upload_from_filename(file_data["path"])
+        self.case_blobs_to_delete.append(blob)
+
+        blob.update_storage_class("NEARLINE")
+        blob.reload()
+        self.assertEqual(blob.storage_class, "NEARLINE")
+
+        blob.update_storage_class("COLDLINE")
+        blob.reload()
+        self.assertEqual(blob.storage_class, "COLDLINE")
+
+    def test_update_storage_class_large_file(self):
+        blob = self.bucket.blob("BigFile")
+
+        file_data = self.FILES["big"]
+        blob.upload_from_filename(file_data["path"])
+        self.case_blobs_to_delete.append(blob)
+
+        blob.update_storage_class("NEARLINE")
+        blob.reload()
+        self.assertEqual(blob.storage_class, "NEARLINE")
+
+        blob.update_storage_class("COLDLINE")
+        blob.reload()
+        self.assertEqual(blob.storage_class, "COLDLINE")
+
+
 class TestStorageNotificationCRUD(unittest.TestCase):
 
     topic = None

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -2499,10 +2499,43 @@ class Test_Blob(unittest.TestCase):
         with self.assertRaises(ValueError):
             blob.update_storage_class(u"BOGUS")
 
+    def test_update_storage_class_large_file(self):
+        BLOB_NAME = "blob-name"
+        STORAGE_CLASS = u"NEARLINE"
+        TOKEN = "TOKEN"
+        INCOMPLETE_RESPONSE = {
+            "totalBytesRewritten": 42,
+            "objectSize": 84,
+            "done": False,
+            "rewriteToken": TOKEN,
+            "resource": {"storageClass": STORAGE_CLASS}
+        }
+        COMPLETE_RESPONSE = {
+            "totalBytesRewritten": 84,
+            "objectSize": 84,
+            "done": True,
+            "resource": {"storageClass": STORAGE_CLASS}
+        }
+        response_1 = ({"status": http_client.OK}, INCOMPLETE_RESPONSE)
+        response_2 = ({"status": http_client.OK}, COMPLETE_RESPONSE)
+        connection = _Connection(response_1, response_2)
+        client = _Client(connection)
+        bucket = _Bucket(client=client)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
+
+        blob.update_storage_class("NEARLINE")
+
+        self.assertEqual(blob.storage_class, "NEARLINE")
+
     def test_update_storage_class_wo_encryption_key(self):
         BLOB_NAME = "blob-name"
         STORAGE_CLASS = u"NEARLINE"
-        RESPONSE = {"resource": {"storageClass": STORAGE_CLASS}}
+        RESPONSE = {
+            "totalBytesRewritten": 42,
+            "objectSize": 42,
+            "done": True,
+            "resource": {"storageClass": STORAGE_CLASS}
+        }
         response = ({"status": http_client.OK}, RESPONSE)
         connection = _Connection(response)
         client = _Client(connection)
@@ -2542,7 +2575,12 @@ class Test_Blob(unittest.TestCase):
         BLOB_KEY_HASH_B64 = base64.b64encode(BLOB_KEY_HASH).rstrip().decode("ascii")
         STORAGE_CLASS = u"NEARLINE"
         USER_PROJECT = "user-project-123"
-        RESPONSE = {"resource": {"storageClass": STORAGE_CLASS}}
+        RESPONSE = {
+            "totalBytesRewritten": 42,
+            "objectSize": 42,
+            "done": True,
+            "resource": {"storageClass": STORAGE_CLASS}
+        }
         response = ({"status": http_client.OK}, RESPONSE)
         connection = _Connection(response)
         client = _Client(connection)


### PR DESCRIPTION
Fixes #6524

#### Test Plan

Test code (`test_6524.py`) -
```
from google.cloud import storage

client = storage.Client()

# https://console.cloud.google.com/storage/browser/[bucket-id]/
bucket = client.get_bucket('test_cloud-python_6524')

# Then do other things...
blob = bucket.get_blob('big_file.bin')

# Test with multiple-sized files
blob.update_storage_class('NEARLINE')
```

Create a 5GB file `big_file.bin` in the `test_pr6524` bucket -
```
dd if=/dev/urandom of=big_file.bin bs=1k count=5000000
gsutil cp big_file.bin gs://test_cloud-python_6524/big_file.bin
```

Test using `google-cloud-storage==1.13.0` -
```
$ virtualenv 6524-old
...
$ ./6524-old/bin/pip install -r requirements.txt
$ gsutil ls -L gs://test_cloud-python_6524/big_file.bin | grep 'Storage class:'
    Storage class:          MULTI_REGIONAL
$ ./6524-old/bin/python test_6524.py
Traceback (most recent call last):
  File "test_6524.py", line 10, in <module>
    blob.update_storage_class('NEARLINE')
  File "/usr/local/google/home/erikwebb/.local/lib/python2.7/site-packages/google/cloud/storage/blob.py", line 1497, in update_storage_class
    self._set_properties(api_response['resource'])
KeyError: 'resource'
$ gsutil ls -L gs://test_cloud-python_6524/big_file.bin | grep 'Storage class:'
    Storage class:          MULTI_REGIONAL
```

Reset object storage class to be safe -
```
gsutil rewrite -s MULTI_REGIONAL gs://test_cloud-python_6524/big_file.bin
```

Test using PR #6527 -
```
$ virtualenv 6524-new
...
$ ./6524-new/bin/pip install google-cloud-python/storage/
...
$ gsutil ls -L gs://test_cloud-python_6524/big_file.bin | grep 'Storage class:'
    Storage class:          MULTI_REGIONAL
$ time ./6524-new/bin/python test_6524.py

real    1m32.537s
user    0m0.750s
sys     0m0.194s
$ gsutil ls -L gs://test_cloud-python_6524/big_file.bin | grep 'Storage class:'
    Storage class:          NEARLINE
```