### PR TITLE
Generalize `_eventloop.async_context` into `_runstate.ndb_context`.

### DIFF
--- a/ndb/docs/async.rst
+++ b/ndb/docs/async.rst
@@ -1,5 +1,0 @@
-#############
-Async Context
-#############
-
-.. autofunction:: google.cloud.ndb.async_context

--- a/ndb/docs/context.rst
+++ b/ndb/docs/context.rst
@@ -1,0 +1,5 @@
+###############
+Runtime Context
+###############
+
+.. autofunction:: google.cloud.ndb.ndb_context

--- a/ndb/docs/index.rst
+++ b/ndb/docs/index.rst
@@ -16,7 +16,7 @@
    blobstore
    metadata
    stats
-   async
+   context
 
 .. automodule:: google.cloud.ndb
     :no-members:

--- a/ndb/src/google/cloud/ndb/__init__.py
+++ b/ndb/src/google/cloud/ndb/__init__.py
@@ -24,7 +24,6 @@ version of the ``db`` API (hence ``ndb``).
 __version__ = "0.0.1.dev1"
 """Current ``ndb`` version."""
 __all__ = [
-    "async_context",
     "AutoBatcher",
     "Context",
     "ContextOptions",
@@ -67,6 +66,7 @@ __all__ = [
     "ModelAdapter",
     "ModelAttribute",
     "ModelKey",
+    "ndb_context",
     "non_transactional",
     "PickleProperty",
     "Property",
@@ -127,7 +127,6 @@ from google.cloud.ndb.context import Context
 from google.cloud.ndb.context import ContextOptions
 from google.cloud.ndb.context import EVENTUAL_CONSISTENCY
 from google.cloud.ndb.context import TransactionOptions
-from google.cloud.ndb._eventloop import async_context
 from google.cloud.ndb.key import Key
 from google.cloud.ndb.model import BlobKey
 from google.cloud.ndb.model import BlobKeyProperty
@@ -202,6 +201,7 @@ from google.cloud.ndb.query import Query
 from google.cloud.ndb.query import QueryIterator
 from google.cloud.ndb.query import QueryOptions
 from google.cloud.ndb.query import RepeatedStructuredPropertyPredicate
+from google.cloud.ndb._runstate import ndb_context
 from google.cloud.ndb.tasklets import add_flow_exception
 from google.cloud.ndb.tasklets import Future
 from google.cloud.ndb.tasklets import get_context

--- a/ndb/src/google/cloud/ndb/_eventloop.py
+++ b/ndb/src/google/cloud/ndb/_eventloop.py
@@ -19,7 +19,7 @@ This should handle both asynchronous ``ndb`` objects and arbitrary callbacks.
 import collections
 import time
 
-from google.cloud.ndb import _runstate as runstate
+from google.cloud.ndb import _runstate
 
 __all__ = [
     "add_idle",
@@ -270,7 +270,7 @@ def get_event_loop():
     Returns:
         EventLoop: The event loop for the current context.
     """
-    state = runstate.current()
+    state = _runstate.current()
 
     # Be lazy and avoid circular dependency with _runstate
     if state.eventloop is None:

--- a/ndb/src/google/cloud/ndb/_eventloop.py
+++ b/ndb/src/google/cloud/ndb/_eventloop.py
@@ -17,16 +17,12 @@
 This should handle both asynchronous ``ndb`` objects and arbitrary callbacks.
 """
 import collections
-import contextlib
-import threading
 import time
 
-from google.cloud.ndb import exceptions
+from google.cloud.ndb import _runstate as runstate
 
 __all__ = [
     "add_idle",
-    "async_context",
-    "contexts",
     "EventLoop",
     "get_event_loop",
     "queue_call",
@@ -265,104 +261,32 @@ class EventLoop:
                 break
 
 
-class _LocalContexts(threading.local):
-    """Maintain a thread local stack of event loops."""
-
-    def __init__(self):
-        self.stack = []
-
-    def push(self, loop):
-        self.stack.append(loop)
-
-    def pop(self):
-        return self.stack.pop(-1)
-
-    def current(self):
-        if self.stack:
-            return self.stack[-1]
-
-
-contexts = _LocalContexts()
-
-
-@contextlib.contextmanager
-def async_context():
-    """Establish an asynchronous context for a set of asynchronous API calls.
-
-    This function provides a context manager which establishes the event loop
-    that will be used for any asynchronous NDB calls that occur in the context.
-    For example:
-
-    .. code-block:: python
-
-        from google.cloud.ndb import async_context
-
-        with async_context():
-            # Make some asynchronous calls
-            pass
-
-    Within the context, any calls to a ``*_async`` function or to an
-    ``ndb.tasklet``, will be added to the event loop established by the
-    context. Upon exiting the context, execution will block until all
-    asynchronous calls loaded onto the event loop have finished execution.
-
-    Code within an asynchronous context should be single threaded. Internally,
-    a :class:`threading.local` instance is used to track the current event
-    loop.
-
-    In the context of a web application, it is recommended that a single
-    asynchronous context be used per HTTP request. This can typically be
-    accomplished in a middleware layer.
-    """
-    loop = EventLoop()
-    contexts.push(loop)
-    yield
-    loop.run()
-
-    # This will pop the same loop pushed above unless someone is severely
-    # abusing our private data structure.
-    contexts.pop()
-
-
 def get_event_loop():
     """Get the current event loop.
 
     This function should be called within a context established by
-    :func:`~google.cloud.ndb.async_context`.
+    :func:`~google.cloud.ndb.ndb_context`.
 
     Returns:
-        EventLoop: The event loop for the current
-            context.
-
-    Raises:
-        .AsyncContextError: If called outside of a context
-            established by :func:`~google.cloud.ndb.async_context`.
+        EventLoop: The event loop for the current context.
     """
-    loop = contexts.current()
-    if loop:
-        return loop
+    state = runstate.current()
 
-    raise exceptions.AsyncContextError()
+    # Be lazy and avoid circular dependency with _runstate
+    if state.eventloop is None:
+        state.eventloop = EventLoop()
+
+    return state.eventloop
 
 
 def add_idle(callback, *args, **kwargs):
-    """Calls :method:`EventLoop.add_idle` on current event loop.
-
-    Raises:
-        .AsyncContextError: If called outside of a context
-            established by :func:`~google.cloud.ndb.async_context`.
-    """
+    """Calls :method:`EventLoop.add_idle` on current event loop."""
     loop = get_event_loop()
     loop.add_idle(callback, *args, **kwargs)
 
 
 def queue_call(delay, callback, *args, **kwargs):
-    """Calls :method:`EventLoop.queue_call` on current event loop.
-
-    Raises:
-        .AsyncContextError: If called outside of a context
-            established by :func:`~google.cloud.ndb.async_context`.
-    """
+    """Calls :method:`EventLoop.queue_call` on current event loop. """
     loop = get_event_loop()
     loop.queue_call(delay, callback, *args, **kwargs)
 
@@ -372,33 +296,18 @@ def queue_rpc(*args, **kwargs):
 
 
 def run():
-    """Calls :method:`EventLoop.run` on current event loop.
-
-    Raises:
-        .AsyncContextError: If called outside of a context
-            established by :func:`~google.cloud.ndb.async_context`.
-    """
+    """Calls :method:`EventLoop.run` on current event loop."""
     loop = get_event_loop()
     loop.run()
 
 
 def run0():
-    """Calls :method:`EventLoop.run0` on current event loop.
-
-    Raises:
-        .AsyncContextError: If called outside of a context
-            established by :func:`~google.cloud.ndb.async_context`.
-    """
+    """Calls :method:`EventLoop.run0` on current event loop."""
     loop = get_event_loop()
     loop.run0()
 
 
 def run1():
-    """Calls :method:`EventLoop.run1` on current event loop.
-
-    Raises:
-        .AsyncContextError: If called outside of a context
-            established by :func:`~google.cloud.ndb.async_context`.
-    """
+    """Calls :method:`EventLoop.run1` on current event loop."""
     loop = get_event_loop()
     loop.run1()

--- a/ndb/src/google/cloud/ndb/_runstate.py
+++ b/ndb/src/google/cloud/ndb/_runstate.py
@@ -64,7 +64,7 @@ def ndb_context():
             pass
 
     Use of a context is required--NDB can only be used inside a running
-    context.  The context is used to coordinate an event loop for asynchronous
+    context. The context is used to coordinate an event loop for asynchronous
     API calls, runtime caching policy, and other essential runtime state.
 
     Code within an asynchronous context should be single threaded. Internally,

--- a/ndb/src/google/cloud/ndb/_runstate.py
+++ b/ndb/src/google/cloud/ndb/_runstate.py
@@ -1,0 +1,107 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Management of current running state."""
+
+import contextlib
+import threading
+
+from google.cloud.ndb import exceptions
+
+
+class State:
+    eventloop = None
+
+
+class LocalStates(threading.local):
+    """Maintain a thread local stack of contextual state."""
+
+    __slots__ = ("stack",)
+
+    def __init__(self):
+        self.stack = []
+
+    def push(self, state):
+        self.stack.append(state)
+
+    def pop(self):
+        return self.stack.pop(-1)
+
+    def current(self):
+        if self.stack:
+            return self.stack[-1]
+
+
+states = LocalStates()
+
+
+@contextlib.contextmanager
+def ndb_context():
+    """Establish a context for a set of NDB calls.
+
+    This function provides a context manager which establishes the runtime
+    state for using NDB.
+
+    For example:
+
+    .. code-block:: python
+
+        from google.cloud.ndb import ndb_context
+
+        with ndb_context():
+            # Use NDB for some stuff
+            pass
+
+    Use of a context is required--NDB can only be used inside a running
+    context.  The context is used to coordinate an event loop for asynchronous
+    API calls, runtime caching policy, and other essential runtime state.
+
+    Code within an asynchronous context should be single threaded. Internally,
+    a :class:`threading.local` instance is used to track the current event
+    loop.
+
+    In a web application, it is recommended that a single context be used per
+    HTTP request. This can typically be accomplished in a middleware layer.
+    """
+    state = State()
+    states.push(state)
+    yield
+
+    # Finish up any work left to do on the event loop
+    if state.eventloop is not None:
+        state.eventloop.run()
+
+    # This will pop the same state pushed above unless someone is severely
+    # abusing our private data structure.
+    states.pop()
+
+
+def current():
+    """Get the current context state.
+
+    This function should be called within a context established by
+    :func:`~google.cloud.ndb.ndb_context`.
+
+    Returns:
+        State: The state for the current context.
+
+    Raises:
+        .ContextError: If called outside of a context
+            established by :func:`~google.cloud.ndb.ndb_context`.
+    """
+    state = states.current()
+    if state:
+        return state
+
+    raise exceptions.ContextError()

--- a/ndb/src/google/cloud/ndb/exceptions.py
+++ b/ndb/src/google/cloud/ndb/exceptions.py
@@ -22,7 +22,7 @@ legacy Google App Engine runtime.
 
 __all__ = [
     "Error",
-    "AsyncContextError",
+    "ContextError",
     "BadValueError",
     "BadArgumentError",
     "Rollback",
@@ -34,17 +34,17 @@ class Error(Exception):
     """Base datastore error type."""
 
 
-class AsyncContextError(Error):
-    """Indicates an async call being made without a context.
+class ContextError(Error):
+    """Indicates an NDB call being made without a context.
 
-    Raised whenever an asynchronous call is made outside of a context
-    established by :func:`~google.cloud.ndb.async_context`.
+    Raised whenever an NDB call is made outside of a context
+    established by :func:`~google.cloud.ndb.ndb_context`.
     """
 
     def __init__(self):
-        super(AsyncContextError, self).__init__(
+        super(ContextError, self).__init__(
             "No currently running event loop. Asynchronous calls must be made "
-            "in context established by google.cloud.ndb.async_context."
+            "in context established by google.cloud.ndb.ndb_context."
         )
 
 

--- a/ndb/tests/unit/test__eventloop.py
+++ b/ndb/tests/unit/test__eventloop.py
@@ -20,22 +20,22 @@ import pytest
 import tests.unit.utils
 
 from google.cloud.ndb import exceptions
-from google.cloud.ndb import ndb_context
-from google.cloud.ndb import _eventloop as eventloop
+from google.cloud.ndb import _runstate
+from google.cloud.ndb import _eventloop
 
 
 def test___all__():
-    tests.unit.utils.verify___all__(eventloop)
+    tests.unit.utils.verify___all__(_eventloop)
 
 
 def _Event(when=0, what="foo", args=(), kw={}):
-    return eventloop._Event(when, what, args, kw)
+    return _eventloop._Event(when, what, args, kw)
 
 
 class TestEventLoop:
     @staticmethod
     def _make_one(**attrs):
-        loop = eventloop.EventLoop()
+        loop = _eventloop.EventLoop()
         for name, value in attrs.items():
             setattr(loop, name, value)
         return loop
@@ -299,11 +299,11 @@ class TestEventLoop:
 
 def test_get_event_loop():
     with pytest.raises(exceptions.ContextError):
-        eventloop.get_event_loop()
-    with ndb_context():
-        loop = eventloop.get_event_loop()
-        assert isinstance(loop, eventloop.EventLoop)
-        assert eventloop.get_event_loop() is loop
+        _eventloop.get_event_loop()
+    with _runstate.ndb_context():
+        loop = _eventloop.get_event_loop()
+        assert isinstance(loop, _eventloop.EventLoop)
+        assert _eventloop.get_event_loop() is loop
 
 
 @unittest.mock.patch("google.cloud.ndb._eventloop.EventLoop")
@@ -311,8 +311,8 @@ def test_add_idle(EventLoop):
     EventLoop.return_value = loop = unittest.mock.Mock(
         spec=("run", "add_idle")
     )
-    with ndb_context():
-        eventloop.add_idle("foo", "bar", baz="qux")
+    with _runstate.ndb_context():
+        _eventloop.add_idle("foo", "bar", baz="qux")
         loop.add_idle.assert_called_once_with("foo", "bar", baz="qux")
 
 
@@ -321,35 +321,35 @@ def test_queue_call(EventLoop):
     EventLoop.return_value = loop = unittest.mock.Mock(
         spec=("run", "queue_call")
     )
-    with ndb_context():
-        eventloop.queue_call(42, "foo", "bar", baz="qux")
+    with _runstate.ndb_context():
+        _eventloop.queue_call(42, "foo", "bar", baz="qux")
         loop.queue_call.assert_called_once_with(42, "foo", "bar", baz="qux")
 
 
 def test_queue_rpc():
     with pytest.raises(NotImplementedError):
-        eventloop.queue_rpc()
+        _eventloop.queue_rpc()
 
 
 @unittest.mock.patch("google.cloud.ndb._eventloop.EventLoop")
 def test_run(EventLoop):
     EventLoop.return_value = loop = unittest.mock.Mock(spec=("run",))
-    with ndb_context():
-        eventloop.run()
+    with _runstate.ndb_context():
+        _eventloop.run()
         loop.run.assert_called_once_with()
 
 
 @unittest.mock.patch("google.cloud.ndb._eventloop.EventLoop")
 def test_run0(EventLoop):
     EventLoop.return_value = loop = unittest.mock.Mock(spec=("run", "run0"))
-    with ndb_context():
-        eventloop.run0()
+    with _runstate.ndb_context():
+        _eventloop.run0()
         loop.run0.assert_called_once_with()
 
 
 @unittest.mock.patch("google.cloud.ndb._eventloop.EventLoop")
 def test_run1(EventLoop):
     EventLoop.return_value = loop = unittest.mock.Mock(spec=("run", "run1"))
-    with ndb_context():
-        eventloop.run1()
+    with _runstate.ndb_context():
+        _eventloop.run1()
         loop.run1.assert_called_once_with()

--- a/ndb/tests/unit/test__runstate.py
+++ b/ndb/tests/unit/test__runstate.py
@@ -1,0 +1,34 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from google.cloud.ndb import _runstate as runstate
+
+
+def test_ndb_context():
+    assert runstate.states.current() is None
+
+    with runstate.ndb_context():
+        one = runstate.current()
+
+        with runstate.ndb_context():
+            two = runstate.current()
+            assert one is not two
+            two.eventloop = unittest.mock.Mock(spec=("run",))
+            two.eventloop.run.assert_not_called()
+
+        assert runstate.current() is one
+        two.eventloop.run.assert_called_once_with()
+
+    assert runstate.states.current() is None

--- a/ndb/tests/unit/test__runstate.py
+++ b/ndb/tests/unit/test__runstate.py
@@ -11,24 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import unittest
 
-from google.cloud.ndb import _runstate as runstate
+from google.cloud.ndb import _runstate
 
 
 def test_ndb_context():
-    assert runstate.states.current() is None
+    assert _runstate.states.current() is None
 
-    with runstate.ndb_context():
-        one = runstate.current()
+    with _runstate.ndb_context():
+        one = _runstate.current()
 
-        with runstate.ndb_context():
-            two = runstate.current()
+        with _runstate.ndb_context():
+            two = _runstate.current()
             assert one is not two
             two.eventloop = unittest.mock.Mock(spec=("run",))
             two.eventloop.run.assert_not_called()
 
-        assert runstate.current() is one
+        assert _runstate.current() is one
         two.eventloop.run.assert_called_once_with()
 
-    assert runstate.states.current() is None
+    assert _runstate.states.current() is None


### PR DESCRIPTION
The state managed by `_runstate` will eventually manage all of the runtime
state that falls under the aegis of `context.Context` and `tasklets._State`
in the legacy code.