### PR TITLE
Spanner: pick up fixes to GAPIC generator.

### DIFF
--- a/spanner/google/cloud/spanner_admin_database_v1/gapic/database_admin_client.py
+++ b/spanner/google/cloud/spanner_admin_database_v1/gapic/database_admin_client.py
@@ -104,7 +104,7 @@ class DatabaseAdminClient(object):
                  transport=None,
                  channel=None,
                  credentials=None,
-                 client_config=database_admin_client_config.config,
+                 client_config=None,
                  client_info=None):
         """Constructor.
 
@@ -137,13 +137,20 @@ class DatabaseAdminClient(object):
                 your own client library.
         """
         # Raise deprecation warnings for things we want to go away.
-        if client_config:
-            warnings.warn('The `client_config` argument is deprecated.',
-                          PendingDeprecationWarning)
+        if client_config is not None:
+            warnings.warn(
+                'The `client_config` argument is deprecated.',
+                PendingDeprecationWarning,
+                stacklevel=2)
+        else:
+            client_config = database_admin_client_config.config
+
         if channel:
             warnings.warn(
                 'The `channel` argument is deprecated; use '
-                '`transport` instead.', PendingDeprecationWarning)
+                '`transport` instead.',
+                PendingDeprecationWarning,
+                stacklevel=2)
 
         # Instantiate the transport.
         # The transport is responsible for handling serialization and

--- a/spanner/google/cloud/spanner_admin_database_v1/gapic/transports/database_admin_grpc_transport.py
+++ b/spanner/google/cloud/spanner_admin_database_v1/gapic/transports/database_admin_grpc_transport.py
@@ -66,6 +66,8 @@ class DatabaseAdminGrpcTransport(object):
                 credentials=credentials,
             )
 
+        self._channel = channel
+
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
@@ -101,6 +103,15 @@ class DatabaseAdminGrpcTransport(object):
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
         )
+
+    @property
+    def channel(self):
+        """The gRPC channel used by the transport.
+
+        Returns:
+            grpc.Channel: A gRPC channel object.
+        """
+        return self._channel
 
     @property
     def list_databases(self):

--- a/spanner/google/cloud/spanner_admin_instance_v1/gapic/instance_admin_client.py
+++ b/spanner/google/cloud/spanner_admin_instance_v1/gapic/instance_admin_client.py
@@ -128,7 +128,7 @@ class InstanceAdminClient(object):
                  transport=None,
                  channel=None,
                  credentials=None,
-                 client_config=instance_admin_client_config.config,
+                 client_config=None,
                  client_info=None):
         """Constructor.
 
@@ -161,13 +161,20 @@ class InstanceAdminClient(object):
                 your own client library.
         """
         # Raise deprecation warnings for things we want to go away.
-        if client_config:
-            warnings.warn('The `client_config` argument is deprecated.',
-                          PendingDeprecationWarning)
+        if client_config is not None:
+            warnings.warn(
+                'The `client_config` argument is deprecated.',
+                PendingDeprecationWarning,
+                stacklevel=2)
+        else:
+            client_config = instance_admin_client_config.config
+
         if channel:
             warnings.warn(
                 'The `channel` argument is deprecated; use '
-                '`transport` instead.', PendingDeprecationWarning)
+                '`transport` instead.',
+                PendingDeprecationWarning,
+                stacklevel=2)
 
         # Instantiate the transport.
         # The transport is responsible for handling serialization and

--- a/spanner/google/cloud/spanner_admin_instance_v1/gapic/transports/instance_admin_grpc_transport.py
+++ b/spanner/google/cloud/spanner_admin_instance_v1/gapic/transports/instance_admin_grpc_transport.py
@@ -66,6 +66,8 @@ class InstanceAdminGrpcTransport(object):
                 credentials=credentials,
             )
 
+        self._channel = channel
+
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
@@ -101,6 +103,15 @@ class InstanceAdminGrpcTransport(object):
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
         )
+
+    @property
+    def channel(self):
+        """The gRPC channel used by the transport.
+
+        Returns:
+            grpc.Channel: A gRPC channel object.
+        """
+        return self._channel
 
     @property
     def list_instance_configs(self):

--- a/spanner/google/cloud/spanner_v1/gapic/spanner_client.py
+++ b/spanner/google/cloud/spanner_v1/gapic/spanner_client.py
@@ -106,7 +106,7 @@ class SpannerClient(object):
                  transport=None,
                  channel=None,
                  credentials=None,
-                 client_config=spanner_client_config.config,
+                 client_config=None,
                  client_info=None):
         """Constructor.
 
@@ -139,13 +139,20 @@ class SpannerClient(object):
                 your own client library.
         """
         # Raise deprecation warnings for things we want to go away.
-        if client_config:
-            warnings.warn('The `client_config` argument is deprecated.',
-                          PendingDeprecationWarning)
+        if client_config is not None:
+            warnings.warn(
+                'The `client_config` argument is deprecated.',
+                PendingDeprecationWarning,
+                stacklevel=2)
+        else:
+            client_config = spanner_client_config.config
+
         if channel:
             warnings.warn(
                 'The `channel` argument is deprecated; use '
-                '`transport` instead.', PendingDeprecationWarning)
+                '`transport` instead.',
+                PendingDeprecationWarning,
+                stacklevel=2)
 
         # Instantiate the transport.
         # The transport is responsible for handling serialization and

--- a/spanner/google/cloud/spanner_v1/gapic/transports/spanner_grpc_transport.py
+++ b/spanner/google/cloud/spanner_v1/gapic/transports/spanner_grpc_transport.py
@@ -71,6 +71,8 @@ class SpannerGrpcTransport(object):
                 credentials=credentials,
             )
 
+        self._channel = channel
+
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
@@ -102,6 +104,15 @@ class SpannerGrpcTransport(object):
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
         )
+
+    @property
+    def channel(self):
+        """The gRPC channel used by the transport.
+
+        Returns:
+            grpc.Channel: A gRPC channel object.
+        """
+        return self._channel
 
     @property
     def create_session(self):

--- a/spanner/synth.py
+++ b/spanner/synth.py
@@ -30,6 +30,7 @@ library = gapic.py_library(
 
 s.move(library / 'google/cloud/spanner_v1/proto')
 s.move(library / 'google/cloud/spanner_v1/gapic')
+s.move(library / 'tests')
 
 # Add grpcio-gcp options
 s.replace(
@@ -89,114 +90,6 @@ s.replace(
 
 # Fix docstrings
 s.replace(
-    'google/cloud/spanner_admin_instance_v1/gapic/instance_admin_client.py',
-    r"""
-        \* The instance is readable via the API, with all requested attributes
-        but no allocated resources. Its state is `CREATING`.""",
-    r"""
-        * The instance is readable via the API, with all requested attributes
-          but no allocated resources. Its state is `CREATING`.""",
-)
-s.replace(
-    'google/cloud/spanner_admin_instance_v1/gapic/instance_admin_client.py',
-    r"""
-        \* Cancelling the operation renders the instance immediately unreadable
-        via the API.""",
-    r"""
-        * Cancelling the operation renders the instance immediately unreadable
-          via the API.""",
-)
-s.replace(
-    'google/cloud/spanner_admin_instance_v1/gapic/instance_admin_client.py',
-    r"""
-        \* Billing for all successfully-allocated resources begins \(some types
-        may have lower than the requested levels\).""",
-    r"""
-        * Billing for all successfully-allocated resources begins (some types
-          may have lower than the requested levels).""",
-)
-s.replace(
-    'google/cloud/spanner_admin_instance_v1/gapic/instance_admin_client.py',
-    r"""
-        \* The instance and \*all of its databases\* immediately and
-        irrevocably disappear from the API. All data in the databases
-        is permanently deleted.""",
-    r"""
-        * The instance and *all of its databases* immediately and
-          irrevocably disappear from the API. All data in the databases
-          is permanently deleted.""",
-)
-s.replace(
-    'google/cloud/spanner_admin_instance_v1/gapic/instance_admin_client.py',
-    r"""
-                  \* ``labels.env:dev`` --> The instance has the label \\"env\\" and the value of
-                ::
-
-                                       the label contains the string \\"dev\\".""",
-    r"""
-                  * ``labels.env:dev`` --> The instance has the label \\"env\\"
-                    and the value of the label contains the string \\"dev\\".""",
-)
-s.replace(
-    'google/cloud/spanner_admin_instance_v1/gapic/instance_admin_client.py',
-    r"""
-                  \* ``name:howl labels.env:dev`` --> The instance's name contains \\"howl\\" and
-                ::
-
-                                                 it has the label \\"env\\" with its value
-                                                 containing \\"dev\\".""",
-    r"""
-                  * ``name:howl labels.env:dev`` --> The instance's name
-                    contains \\"howl\\" and it has the label \\"env\\" with
-                    its value containing \\"dev\\".""",
-)
-s.replace(
-    'google/cloud/spanner_admin_instance_v1/gapic/instance_admin_client.py',
-    r"""
-        \* For resource types for which a decrease in the instance's allocation
-        has been requested, billing is based on the newly-requested level.""",
-    r"""
-        * For resource types for which a decrease in the instance's allocation
-          has been requested, billing is based on the newly-requested level.""",
-)
-s.replace(
-    'google/cloud/spanner_admin_instance_v1/gapic/instance_admin_client.py',
-    r"""
-        \* Cancelling the operation sets its metadata's
-        \[cancel_time\]\[google.spanner.admin.instance.v1.UpdateInstanceMetadata.cancel_time\], and begins
-        restoring resources to their pre-request values. The operation
-        is guaranteed to succeed at undoing all resource changes,
-        after which point it terminates with a `CANCELLED` status.""",
-    r"""
-        * Cancelling the operation sets its metadata's
-          [cancel_time][google.spanner.admin.instance.v1.UpdateInstanceMetadata.cancel_time],
-          and begins restoring resources to their pre-request values.
-          The operation is guaranteed to succeed at undoing all resource
-          changes, after which point it terminates with a `CANCELLED` status.""",
-)
-s.replace(
-    'google/cloud/spanner_admin_instance_v1/gapic/instance_admin_client.py',
-    r"""
-        \* Reading the instance via the API continues to give the pre-request
-        resource levels.""",
-    r"""
-        * Reading the instance via the API continues to give the pre-request
-          resource levels.""",
-)
-s.replace(
-    'google/cloud/spanner_admin_instance_v1/gapic/instance_admin_client.py',
-    r"""
-        \* Billing begins for all successfully-allocated resources \(some types
-        may have lower than the requested levels\).
-        \* All newly-reserved resources are available for serving the instance's
-        tables.""",
-    r"""
-        * Billing begins for all successfully-allocated resources (some types
-          may have lower than the requested levels).
-        * All newly-reserved resources are available for serving the instance's
-          tables.""",
-)
-s.replace(
     'google/cloud/spanner_v1/proto/transaction_pb2.py',
     r"""====*""",
     r"",
@@ -238,11 +131,4 @@ s.replace(
     "google/**/*.py",
     'from google\.cloud\.spanner\.admin\.database_v1.proto',
     'from google.cloud.spanner_admin_database_v1.proto',
-)
-
-# Fix docstrings
-s.replace(
-    'google/cloud/spanner_admin_database_v1/gapic/database_admin_client.py',
-    r'database ID must be enclosed in backticks \(`` `` ``\).',
-    r'database ID must be enclosed in backticks.',
 )

--- a/spanner/synth.py
+++ b/spanner/synth.py
@@ -59,6 +59,11 @@ s.replace(
     '\g<1>options = [(grpc_gcp.API_CONFIG_CHANNEL_ARG, grpc_gcp_config)]'
     '\g<0>',
 )
+s.replace(
+    "tests/unit/gapic/v1/test_spanner_client_v1.py",
+    "from google.cloud import spanner_v1",
+    "from google.cloud.spanner_v1.gapic import spanner_client as spanner_v1",
+)
 
 #----------------------------------------------------------------------------
 # Generate instance admin client

--- a/spanner/tests/unit/gapic/v1/test_database_admin_client_v1.py
+++ b/spanner/tests/unit/gapic/v1/test_database_admin_client_v1.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """Unit tests."""
 
+import mock
 import pytest
 
 from google.rpc import status_pb2
@@ -81,7 +82,10 @@ class TestDatabaseAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup Request
         parent = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -100,7 +104,10 @@ class TestDatabaseAdminClient(object):
 
     def test_list_databases_exception(self):
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup request
         parent = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -121,7 +128,10 @@ class TestDatabaseAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup Request
         parent = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -146,7 +156,10 @@ class TestDatabaseAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup Request
         parent = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -165,7 +178,10 @@ class TestDatabaseAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup Request
         name = client.database_path('[PROJECT]', '[INSTANCE]', '[DATABASE]')
@@ -182,7 +198,10 @@ class TestDatabaseAdminClient(object):
     def test_get_database_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup request
         name = client.database_path('[PROJECT]', '[INSTANCE]', '[DATABASE]')
@@ -200,7 +219,10 @@ class TestDatabaseAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup Request
         database = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -226,7 +248,10 @@ class TestDatabaseAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup Request
         database = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -239,7 +264,10 @@ class TestDatabaseAdminClient(object):
 
     def test_drop_database(self):
         channel = ChannelStub()
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup Request
         database = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -256,7 +284,10 @@ class TestDatabaseAdminClient(object):
     def test_drop_database_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup request
         database = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -273,7 +304,10 @@ class TestDatabaseAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup Request
         database = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -291,7 +325,10 @@ class TestDatabaseAdminClient(object):
     def test_get_database_ddl_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup request
         database = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -309,7 +346,10 @@ class TestDatabaseAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup Request
         resource = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -328,7 +368,10 @@ class TestDatabaseAdminClient(object):
     def test_set_iam_policy_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup request
         resource = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -347,7 +390,10 @@ class TestDatabaseAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup Request
         resource = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -365,7 +411,10 @@ class TestDatabaseAdminClient(object):
     def test_get_iam_policy_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup request
         resource = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -382,7 +431,10 @@ class TestDatabaseAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup Request
         resource = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -401,7 +453,10 @@ class TestDatabaseAdminClient(object):
     def test_test_iam_permissions_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_database_v1.DatabaseAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_database_v1.DatabaseAdminClient()
 
         # Setup request
         resource = client.database_path('[PROJECT]', '[INSTANCE]',

--- a/spanner/tests/unit/gapic/v1/test_instance_admin_client_v1.py
+++ b/spanner/tests/unit/gapic/v1/test_instance_admin_client_v1.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """Unit tests."""
 
+import mock
 import pytest
 
 from google.rpc import status_pb2
@@ -82,7 +83,10 @@ class TestInstanceAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup Request
         parent = client.project_path('[PROJECT]')
@@ -101,7 +105,10 @@ class TestInstanceAdminClient(object):
 
     def test_list_instance_configs_exception(self):
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup request
         parent = client.project_path('[PROJECT]')
@@ -120,7 +127,10 @@ class TestInstanceAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup Request
         name = client.instance_config_path('[PROJECT]', '[INSTANCE_CONFIG]')
@@ -137,7 +147,10 @@ class TestInstanceAdminClient(object):
     def test_get_instance_config_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup request
         name = client.instance_config_path('[PROJECT]', '[INSTANCE_CONFIG]')
@@ -159,7 +172,10 @@ class TestInstanceAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup Request
         parent = client.project_path('[PROJECT]')
@@ -178,7 +194,10 @@ class TestInstanceAdminClient(object):
 
     def test_list_instances_exception(self):
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup request
         parent = client.project_path('[PROJECT]')
@@ -204,7 +223,10 @@ class TestInstanceAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup Request
         name = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -221,7 +243,10 @@ class TestInstanceAdminClient(object):
     def test_get_instance_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup request
         name = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -249,7 +274,10 @@ class TestInstanceAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup Request
         parent = client.project_path('[PROJECT]')
@@ -275,7 +303,10 @@ class TestInstanceAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup Request
         parent = client.project_path('[PROJECT]')
@@ -306,7 +337,10 @@ class TestInstanceAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup Request
         instance = {}
@@ -331,7 +365,10 @@ class TestInstanceAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[operation])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup Request
         instance = {}
@@ -343,7 +380,10 @@ class TestInstanceAdminClient(object):
 
     def test_delete_instance(self):
         channel = ChannelStub()
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup Request
         name = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -359,7 +399,10 @@ class TestInstanceAdminClient(object):
     def test_delete_instance_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup request
         name = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -376,7 +419,10 @@ class TestInstanceAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup Request
         resource = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -394,7 +440,10 @@ class TestInstanceAdminClient(object):
     def test_set_iam_policy_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup request
         resource = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -412,7 +461,10 @@ class TestInstanceAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup Request
         resource = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -429,7 +481,10 @@ class TestInstanceAdminClient(object):
     def test_get_iam_policy_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup request
         resource = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -445,7 +500,10 @@ class TestInstanceAdminClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup Request
         resource = client.instance_path('[PROJECT]', '[INSTANCE]')
@@ -463,7 +521,10 @@ class TestInstanceAdminClient(object):
     def test_test_iam_permissions_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_admin_instance_v1.InstanceAdminClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_admin_instance_v1.InstanceAdminClient()
 
         # Setup request
         resource = client.instance_path('[PROJECT]', '[INSTANCE]')

--- a/spanner/tests/unit/gapic/v1/test_spanner_client_v1.py
+++ b/spanner/tests/unit/gapic/v1/test_spanner_client_v1.py
@@ -18,10 +18,7 @@
 import mock
 import pytest
 
-# Manual edit to auto-generated import because we do not expose the
-# auto-generated client in the `g.c.spanner_v1` namespace (unlike most APIs).
-from google.cloud.spanner_v1.gapic import spanner_client as spanner_v1
-
+from google.cloud import spanner_v1
 from google.cloud.spanner_v1.proto import keys_pb2
 from google.cloud.spanner_v1.proto import result_set_pb2
 from google.cloud.spanner_v1.proto import spanner_pb2
@@ -83,7 +80,10 @@ class TestSpannerClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         database = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -100,7 +100,10 @@ class TestSpannerClient(object):
     def test_create_session_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         database = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -117,7 +120,10 @@ class TestSpannerClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         name = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -134,7 +140,10 @@ class TestSpannerClient(object):
     def test_get_session_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         name = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -157,7 +166,10 @@ class TestSpannerClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         database = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -176,7 +188,10 @@ class TestSpannerClient(object):
 
     def test_list_sessions_exception(self):
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         database = client.database_path('[PROJECT]', '[INSTANCE]',
@@ -188,7 +203,10 @@ class TestSpannerClient(object):
 
     def test_delete_session(self):
         channel = ChannelStub()
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         name = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -204,7 +222,10 @@ class TestSpannerClient(object):
     def test_delete_session_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         name = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -220,7 +241,10 @@ class TestSpannerClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -239,7 +263,10 @@ class TestSpannerClient(object):
     def test_execute_sql_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -262,7 +289,10 @@ class TestSpannerClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[iter([expected_response])])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -283,7 +313,10 @@ class TestSpannerClient(object):
     def test_execute_streaming_sql_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -300,7 +333,10 @@ class TestSpannerClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -321,7 +357,10 @@ class TestSpannerClient(object):
     def test_read_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -346,7 +385,10 @@ class TestSpannerClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[iter([expected_response])])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -369,7 +411,10 @@ class TestSpannerClient(object):
     def test_streaming_read_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -389,7 +434,10 @@ class TestSpannerClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -408,7 +456,10 @@ class TestSpannerClient(object):
     def test_begin_transaction_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -425,7 +476,10 @@ class TestSpannerClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -444,7 +498,10 @@ class TestSpannerClient(object):
     def test_commit_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -456,7 +513,10 @@ class TestSpannerClient(object):
 
     def test_rollback(self):
         channel = ChannelStub()
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -474,7 +534,10 @@ class TestSpannerClient(object):
     def test_rollback_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -491,7 +554,10 @@ class TestSpannerClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -510,7 +576,10 @@ class TestSpannerClient(object):
     def test_partition_query_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -527,7 +596,10 @@ class TestSpannerClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup Request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',
@@ -547,7 +619,10 @@ class TestSpannerClient(object):
     def test_partition_read_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = spanner_v1.SpannerClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = spanner_v1.SpannerClient()
 
         # Setup request
         session = client.session_path('[PROJECT]', '[INSTANCE]', '[DATABASE]',

--- a/spanner/tests/unit/gapic/v1/test_spanner_client_v1.py
+++ b/spanner/tests/unit/gapic/v1/test_spanner_client_v1.py
@@ -18,7 +18,7 @@
 import mock
 import pytest
 
-from google.cloud import spanner_v1
+from google.cloud.spanner_v1.gapic import spanner_client as spanner_v1
 from google.cloud.spanner_v1.proto import keys_pb2
 from google.cloud.spanner_v1.proto import result_set_pb2
 from google.cloud.spanner_v1.proto import spanner_pb2


### PR DESCRIPTION
Includes fixes from these PRs:

- googleapis/gapic-generator#2407 (closing googleapis/gapic-generator#2389)
- googleapis/gapic-generator#2396 (for #5523 and dupes).

Includes changes to *all* generated tests.

Removes now-spurious docstring fixups.

Closes #6507.