### PR TITLE
Trace: pick up fixes to GAPIC generator.

### DIFF
--- a/trace/google/cloud/trace_v1/gapic/trace_service_client.py
+++ b/trace/google/cloud/trace_v1/gapic/trace_service_client.py
@@ -80,7 +80,7 @@ class TraceServiceClient(object):
                  transport=None,
                  channel=None,
                  credentials=None,
-                 client_config=trace_service_client_config.config,
+                 client_config=None,
                  client_info=None):
         """Constructor.
 
@@ -113,13 +113,20 @@ class TraceServiceClient(object):
                 your own client library.
         """
         # Raise deprecation warnings for things we want to go away.
-        if client_config:
-            warnings.warn('The `client_config` argument is deprecated.',
-                          PendingDeprecationWarning)
+        if client_config is not None:
+            warnings.warn(
+                'The `client_config` argument is deprecated.',
+                PendingDeprecationWarning,
+                stacklevel=2)
+        else:
+            client_config = trace_service_client_config.config
+
         if channel:
             warnings.warn(
                 'The `channel` argument is deprecated; use '
-                '`transport` instead.', PendingDeprecationWarning)
+                '`transport` instead.',
+                PendingDeprecationWarning,
+                stacklevel=2)
 
         # Instantiate the transport.
         # The transport is responsible for handling serialization and

--- a/trace/google/cloud/trace_v1/gapic/transports/trace_service_grpc_transport.py
+++ b/trace/google/cloud/trace_v1/gapic/transports/trace_service_grpc_transport.py
@@ -66,6 +66,8 @@ class TraceServiceGrpcTransport(object):
                 credentials=credentials,
             )
 
+        self._channel = channel
+
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
@@ -94,6 +96,15 @@ class TraceServiceGrpcTransport(object):
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
         )
+
+    @property
+    def channel(self):
+        """The gRPC channel used by the transport.
+
+        Returns:
+            grpc.Channel: A gRPC channel object.
+        """
+        return self._channel
 
     @property
     def patch_traces(self):

--- a/trace/google/cloud/trace_v2/gapic/trace_service_client.py
+++ b/trace/google/cloud/trace_v2/gapic/trace_service_client.py
@@ -100,7 +100,7 @@ class TraceServiceClient(object):
                  transport=None,
                  channel=None,
                  credentials=None,
-                 client_config=trace_service_client_config.config,
+                 client_config=None,
                  client_info=None):
         """Constructor.
 
@@ -133,13 +133,20 @@ class TraceServiceClient(object):
                 your own client library.
         """
         # Raise deprecation warnings for things we want to go away.
-        if client_config:
-            warnings.warn('The `client_config` argument is deprecated.',
-                          PendingDeprecationWarning)
+        if client_config is not None:
+            warnings.warn(
+                'The `client_config` argument is deprecated.',
+                PendingDeprecationWarning,
+                stacklevel=2)
+        else:
+            client_config = trace_service_client_config.config
+
         if channel:
             warnings.warn(
                 'The `channel` argument is deprecated; use '
-                '`transport` instead.', PendingDeprecationWarning)
+                '`transport` instead.',
+                PendingDeprecationWarning,
+                stacklevel=2)
 
         # Instantiate the transport.
         # The transport is responsible for handling serialization and

--- a/trace/google/cloud/trace_v2/gapic/transports/trace_service_grpc_transport.py
+++ b/trace/google/cloud/trace_v2/gapic/transports/trace_service_grpc_transport.py
@@ -65,6 +65,8 @@ class TraceServiceGrpcTransport(object):
                 credentials=credentials,
             )
 
+        self._channel = channel
+
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
@@ -93,6 +95,15 @@ class TraceServiceGrpcTransport(object):
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
         )
+
+    @property
+    def channel(self):
+        """The gRPC channel used by the transport.
+
+        Returns:
+            grpc.Channel: A gRPC channel object.
+        """
+        return self._channel
 
     @property
     def batch_write_spans(self):

--- a/trace/synth.py
+++ b/trace/synth.py
@@ -28,6 +28,7 @@ for version in ['v1', 'v2']:
     )
 
     s.move(library / f'google/cloud/trace_{version}')
+    s.move(library / f'tests/unit/gapic/{version}')
         
     # Fix up imports
     s.replace(
@@ -43,10 +44,3 @@ s.replace(
     'google/**/proto/*_pb2.py',
     r"(^.*$\n)*",
     r"# -*- coding: utf-8 -*-\n\g<0>")
-
-# GAPIC-Generator is mangling some docstrings
-# Missing blank line after bulleted list
-s.replace(
-    "google/cloud/trace_v1/gapic/trace_service_client.py",
-    '                ::\n\n',
-    '')

--- a/trace/tests/unit/gapic/v1/test_trace_service_client_v1.py
+++ b/trace/tests/unit/gapic/v1/test_trace_service_client_v1.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +15,7 @@
 # limitations under the License.
 """Unit tests."""
 
+import mock
 import pytest
 
 from google.cloud import trace_v1
@@ -62,7 +65,10 @@ class CustomException(Exception):
 class TestTraceServiceClient(object):
     def test_patch_traces(self):
         channel = ChannelStub()
-        client = trace_v1.TraceServiceClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = trace_v1.TraceServiceClient()
 
         # Setup Request
         project_id = 'projectId-1969970175'
@@ -79,7 +85,10 @@ class TestTraceServiceClient(object):
     def test_patch_traces_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = trace_v1.TraceServiceClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = trace_v1.TraceServiceClient()
 
         # Setup request
         project_id = 'projectId-1969970175'
@@ -100,7 +109,10 @@ class TestTraceServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = trace_v1.TraceServiceClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = trace_v1.TraceServiceClient()
 
         # Setup Request
         project_id = 'projectId-1969970175'
@@ -118,7 +130,10 @@ class TestTraceServiceClient(object):
     def test_get_trace_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = trace_v1.TraceServiceClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = trace_v1.TraceServiceClient()
 
         # Setup request
         project_id = 'projectId-1969970175'
@@ -140,7 +155,10 @@ class TestTraceServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = trace_v1.TraceServiceClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = trace_v1.TraceServiceClient()
 
         # Setup Request
         project_id = 'projectId-1969970175'
@@ -158,7 +176,10 @@ class TestTraceServiceClient(object):
 
     def test_list_traces_exception(self):
         channel = ChannelStub(responses=[CustomException()])
-        client = trace_v1.TraceServiceClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = trace_v1.TraceServiceClient()
 
         # Setup request
         project_id = 'projectId-1969970175'

--- a/trace/tests/unit/gapic/v2/test_trace_service_client_v2.py
+++ b/trace/tests/unit/gapic/v2/test_trace_service_client_v2.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +15,7 @@
 # limitations under the License.
 """Unit tests."""
 
+import mock
 import pytest
 
 from google.cloud import trace_v2
@@ -64,7 +67,10 @@ class CustomException(Exception):
 class TestTraceServiceClient(object):
     def test_batch_write_spans(self):
         channel = ChannelStub()
-        client = trace_v2.TraceServiceClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = trace_v2.TraceServiceClient()
 
         # Setup Request
         name = client.project_path('[PROJECT]')
@@ -81,7 +87,10 @@ class TestTraceServiceClient(object):
     def test_batch_write_spans_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = trace_v2.TraceServiceClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = trace_v2.TraceServiceClient()
 
         # Setup request
         name = client.project_path('[PROJECT]')
@@ -104,7 +113,10 @@ class TestTraceServiceClient(object):
 
         # Mock the API response
         channel = ChannelStub(responses=[expected_response])
-        client = trace_v2.TraceServiceClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = trace_v2.TraceServiceClient()
 
         # Setup Request
         name = client.span_path('[PROJECT]', '[TRACE]', '[SPAN]')
@@ -130,7 +142,10 @@ class TestTraceServiceClient(object):
     def test_create_span_exception(self):
         # Mock the API response
         channel = ChannelStub(responses=[CustomException()])
-        client = trace_v2.TraceServiceClient(channel=channel)
+        patch = mock.patch('google.api_core.grpc_helpers.create_channel')
+        with patch as create_channel:
+            create_channel.return_value = channel
+            client = trace_v2.TraceServiceClient()
 
         # Setup request
         name = client.span_path('[PROJECT]', '[TRACE]', '[SPAN]')


### PR DESCRIPTION
Includes fixes from these PRs:

- googleapis/gapic-generator#2407 (closing googleapis/gapic-generator#2389)
- googleapis/gapic-generator#2396 (for #5523 and dupes).

Includes changes to generated tests.

Removes now-spurious docstring fixups.

Closes #6511.