### PR TITLE
Bigtable: remove 'deepcopy' from 'PartialRowData.cells' property.

### DIFF
--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -181,7 +181,7 @@ class PartialRowData(object):
                   and second for column names/qualifiers within a family). For
                   a given column, a list of :class:`Cell` objects is stored.
         """
-        return copy.deepcopy(self._cells)
+        return self._cells
 
     @property
     def row_key(self):

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -305,8 +305,6 @@ class TestPartialRowData(unittest.TestCase):
         partial_row_data = self._make_one(None)
         cells = {1: 2}
         partial_row_data._cells = cells
-        # Make sure we get a copy, not the original.
-        self.assertIsNot(partial_row_data.cells, cells)
         self.assertEqual(partial_row_data.cells, cells)
 
     def test_row_key_getter(self):


### PR DESCRIPTION
Closes #6643.