### PR TITLE
NDB: No longer excluding `__repr__` and abstract methods in coverage.

### DIFF
--- a/ndb/.coveragerc
+++ b/ndb/.coveragerc
@@ -7,10 +7,6 @@ show_missing = True
 exclude_lines =
     # Re-enable the standard pragma
     pragma: NO COVER
-    # Ignore debug-only repr
-    def __repr__
-    # Ignore abstract methods
-    raise NotImplementedError
 omit =
   */gapic/*.py
   */proto/*.py


### PR DESCRIPTION
These were added in #6642 but I think they should be there:

- We actually need to have a faithful reproduction of `__repr__` for the original source
- The original `__repr__` implementations are verbose
- Right now, there are lots of virtual methods and test they are virtual, hence the coverage for `raise NotImplementedError`

I also think that `fail_under = 100` should be removed from `[report]`. It causes the `pytest ...` invocation to fail, and so `session.notify("cover")` never gets triggered and the actual coverage report of missing lines is no longer printed.