### PR TITLE
Implement comparison helpers for `ndb.Model`

### DIFF
--- a/ndb/src/google/cloud/ndb/key.py
+++ b/ndb/src/google/cloud/ndb/key.py
@@ -357,10 +357,6 @@ class Key:
 
         return self._tuple() == other._tuple()
 
-    def __ne__(self, other):
-        """Inequality comparison operation."""
-        return not self == other
-
     def __lt__(self, other):
         """Less than ordering."""
         if not isinstance(other, Key):

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -3685,16 +3685,7 @@ class Model(metaclass=MetaModel):
         Returns:
             bool: Indicating if the current entity and ``other`` are
             equivalent.
-
-        Raises:
-            NotImplementedError: If the type's don't match.
         """
-        if type(other) is not type(self):
-            raise NotImplementedError(
-                "Cannot compare different model classes. {} is "
-                "not {}".format(type(self).__name__, type(other).__name__)
-            )
-
         if set(self._projection) != set(other._projection):
             return False
 

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -3682,7 +3682,7 @@ class Model(metaclass=MetaModel):
         Raises:
             TypeError: Always, to emphasize that entities are mutable.
         """
-        raise TypeError("Model is not immutable")
+        raise TypeError("Model is mutable, so cannot be hashed.")
 
     def __eq__(self, other):
         """Compare two entities of the same class for equality."""

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -3718,23 +3718,12 @@ class Model(metaclass=MetaModel):
         if set(self._projection) != set(other._projection):
             return False
 
-        # Short-circuit equality check, can only happen for ``Expando``.
-        if len(self._properties) != len(other._properties):
-            return False
-
         prop_names = set(self._properties.keys())
-        other_prop_names = set(other._properties.keys())
-        if prop_names != other_prop_names:
-            return False  # Can only happen for ``Expando``.
-
         # Restrict properties to the projection if set.
         if self._projection:
             prop_names = set(self._projection)
 
         for name in prop_names:
-            if "." in name:
-                # Only use / compare on base name.
-                name, _ = name.split(".", 1)
             value = self._properties[name]._get_value(self)
             if value != other._properties[name]._get_value(other):
                 return False

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -172,10 +172,6 @@ class IndexProperty:
             return NotImplemented
         return self.name == other.name and self.direction == other.direction
 
-    def __ne__(self, other):
-        """Inequality comparison operation."""
-        return not self == other
-
     def __hash__(self):
         return hash((self.name, self.direction))
 
@@ -223,10 +219,6 @@ class Index:
             and self.properties == other.properties
             and self.ancestor == other.ancestor
         )
-
-    def __ne__(self, other):
-        """Inequality comparison operation."""
-        return not self == other
 
     def __hash__(self):
         return hash((self.kind, self.properties, self.ancestor))
@@ -279,10 +271,6 @@ class IndexState:
             and self.state == other.state
             and self.id == other.id
         )
-
-    def __ne__(self, other):
-        """Inequality comparison operation."""
-        return not self == other
 
     def __hash__(self):
         return hash((self.definition, self.state, self.id))
@@ -348,10 +336,6 @@ class _BaseValue:
             return NotImplemented
 
         return self.b_val == other.b_val
-
-    def __ne__(self, other):
-        """Inequality comparison operation."""
-        return not self == other
 
     def __hash__(self):
         raise TypeError("_BaseValue is not immutable")
@@ -1839,10 +1823,6 @@ class _CompressedValue:
             return NotImplemented
 
         return self.z_val == other.z_val
-
-    def __ne__(self, other):
-        """Inequality comparison operation."""
-        return not self == other
 
     def __hash__(self):
         raise TypeError("_CompressedValue is not immutable")
@@ -3729,10 +3709,6 @@ class Model(metaclass=MetaModel):
                 return False
 
         return True
-
-    def __ne__(self, other):
-        """Inequality comparison operation."""
-        return not self == other
 
     def __lt__(self, value):
         """The ``<`` comparison is not well-defined."""

--- a/ndb/src/google/cloud/ndb/query.py
+++ b/ndb/src/google/cloud/ndb/query.py
@@ -74,9 +74,6 @@ class ParameterizedThing:
     def __eq__(self, other):
         raise NotImplementedError
 
-    def __ne__(self, other):
-        return not self == other
-
 
 class Parameter(ParameterizedThing):
     """Represents a bound variable in a GQL query.
@@ -171,9 +168,6 @@ class Node:
 
     def __eq__(self, other):
         raise NotImplementedError
-
-    def __ne__(self, other):
-        return not self == other
 
     def __le__(self, unused_other):
         raise TypeError("Nodes cannot be ordered")

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2712,6 +2712,99 @@ class TestModel:
         assert Simple._get_kind() == "Simple"
 
     @staticmethod
+    def test___hash__():
+        entity = ManyFields(self=909, id="hi", value=None, _id=78)
+        with pytest.raises(TypeError):
+            hash(entity)
+
+    @staticmethod
+    def test___eq__wrong_type():
+        class Simple(model.Model):
+            pass
+
+        entity1 = ManyFields(self=909, id="hi", value=None, _id=78)
+        entity2 = Simple()
+        assert not entity1 == entity2
+
+    @staticmethod
+    def test___eq__wrong_key():
+        entity1 = ManyFields(_id=78)
+        entity2 = ManyFields(_id="seventy-eight")
+        assert not entity1 == entity2
+
+    @staticmethod
+    def test___eq__wrong_projection():
+        entity1 = ManyFields(self=90, projection=("self",))
+        entity2 = ManyFields(
+            value="a", unused=0.0, projection=("value", "unused")
+        )
+        assert not entity1 == entity2
+
+    @staticmethod
+    def test___eq__same_type_same_key():
+        entity1 = ManyFields(self=909, id="hi", _id=78)
+        entity2 = ManyFields(self=909, id="bye", _id=78)
+        assert entity1 == entity1
+        assert not entity1 == entity2
+
+    @staticmethod
+    def test___eq__same_type_same_key_same_projection():
+        entity1 = ManyFields(self=-9, id="hi", projection=("self", "id"))
+        entity2 = ManyFields(self=-9, id="bye", projection=("self", "id"))
+        assert entity1 == entity1
+        assert not entity1 == entity2
+
+    @staticmethod
+    def test__equivalent_wrong_type():
+        class Simple(model.Model):
+            pass
+
+        entity1 = ManyFields(self=909, id="hi", value=None, _id=78)
+        entity2 = Simple()
+        with pytest.raises(NotImplementedError):
+            entity1._equivalent(entity2)
+
+    @staticmethod
+    def test___ne__():
+        class Simple(model.Model):
+            pass
+
+        entity1 = ManyFields(self=-9, id="hi")
+        entity2 = Simple()
+        entity3 = ManyFields(self=-9, id="bye")
+        entity4 = ManyFields(self=-9, id="bye", projection=("self", "id"))
+        entity5 = None
+        assert not entity1 != entity1
+        assert entity1 != entity2
+        assert entity1 != entity3
+        assert entity1 != entity4
+        assert entity1 != entity5
+
+    @staticmethod
+    def test___lt__():
+        entity = ManyFields(self=-9, id="hi")
+        with pytest.raises(TypeError):
+            entity < entity
+
+    @staticmethod
+    def test___le__():
+        entity = ManyFields(self=-9, id="hi")
+        with pytest.raises(TypeError):
+            entity <= entity
+
+    @staticmethod
+    def test___gt__():
+        entity = ManyFields(self=-9, id="hi")
+        with pytest.raises(TypeError):
+            entity > entity
+
+    @staticmethod
+    def test___ge__():
+        entity = ManyFields(self=-9, id="hi")
+        with pytest.raises(TypeError):
+            entity >= entity
+
+    @staticmethod
     def test__validate_key():
         value = unittest.mock.sentinel.value
         assert model.Model._validate_key(value) is value

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2755,16 +2755,6 @@ class TestModel:
         assert not entity1 == entity2
 
     @staticmethod
-    def test__equivalent_wrong_type():
-        class Simple(model.Model):
-            pass
-
-        entity1 = ManyFields(self=909, id="hi", value=None, _id=78)
-        entity2 = Simple()
-        with pytest.raises(NotImplementedError):
-            entity1._equivalent(entity2)
-
-    @staticmethod
     def test___ne__():
         class Simple(model.Model):
             pass


### PR DESCRIPTION
~~**NOTE**: This has #6694 as diffbase.~~

I have removed some features of comparison that depend on `StructuredProperty` or `Expando` being implemented. I added a note to #6251 to go back and add the behavior when relevant.