### PR TITLE
Firestore: prevent use of transforms as values passed to 'Query.where'.

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/query.py
+++ b/firestore/google/cloud/firestore_v1beta1/query.py
@@ -46,6 +46,7 @@ _COMPARISON_OPERATORS = {
 _BAD_OP_STRING = 'Operator string {!r} is invalid. Valid choices are: {}.'
 _BAD_OP_NAN_NULL = (
     'Only an equality filter ("==") can be used with None or NaN values')
+_INVALID_WHERE_TRANSFORM = 'Transforms cannot be used as where values.'
 _BAD_DIR_STRING = 'Invalid direction {!r}. Must be one of {!r} or {!r}.'
 _INVALID_CURSOR_TRANSFORM = 'Transforms cannot be used as cursor values.'
 _MISSING_ORDER_BY = (
@@ -225,6 +226,8 @@ class Query(object):
                 ),
                 op=enums.StructuredQuery.UnaryFilter.Operator.IS_NAN,
             )
+        elif isinstance(value, (transforms.Sentinel, transforms._ValueList)):
+            raise ValueError(_INVALID_WHERE_TRANSFORM)
         else:
             filter_pb = query_pb2.StructuredQuery.FieldFilter(
                 field=query_pb2.StructuredQuery.FieldReference(

--- a/firestore/tests/unit/test_query.py
+++ b/firestore/tests/unit/test_query.py
@@ -187,6 +187,30 @@ class TestQuery(unittest.TestCase):
         with self.assertRaises(ValueError):
             self._where_unary_helper(float('nan'), 0, op_string='<=')
 
+    def test_where_w_delete(self):
+        from google.cloud.firestore_v1beta1 import DELETE_FIELD
+
+        with self.assertRaises(ValueError):
+            self._where_unary_helper(DELETE_FIELD, 0)
+
+    def test_where_w_server_timestamp(self):
+        from google.cloud.firestore_v1beta1 import SERVER_TIMESTAMP
+
+        with self.assertRaises(ValueError):
+            self._where_unary_helper(SERVER_TIMESTAMP, 0)
+
+    def test_where_w_array_remove(self):
+        from google.cloud.firestore_v1beta1 import ArrayRemove
+
+        with self.assertRaises(ValueError):
+            self._where_unary_helper(ArrayRemove([1, 3, 5]), 0)
+
+    def test_where_w_array_union(self):
+        from google.cloud.firestore_v1beta1 import ArrayUnion
+
+        with self.assertRaises(ValueError):
+            self._where_unary_helper(ArrayUnion([2, 4, 8]), 0)
+
     def test_order_by(self):
         from google.cloud.firestore_v1beta1.gapic import enums
 


### PR DESCRIPTION
Closes #6699.