### PR TITLE
Configure Kokoro for releases for bigquery_storage.

### DIFF
--- a/.kokoro/release/bigquery_storage.cfg
+++ b/.kokoro/release/bigquery_storage.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Tell the trampoline which build file to use.
+env_vars: {
+    key: "PACKAGE"
+    value: "bigquery_storage"
+}


### PR DESCRIPTION
CL 223438946 pending internally to enable Kokoro.

@busunkim96 Since I already tagged the release, does this mean we'll have to submit the package manually?