### PR TITLE
Firestore: 'Query.select([])' implies '__name__'.

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/query.py
+++ b/firestore/google/cloud/firestore_v1beta1/query.py
@@ -536,6 +536,23 @@ class Query(object):
                 composite_filter=composite_filter)
 
     @staticmethod
+    def _normalize_projection(projection):
+        """Helper:  convert field paths to message."""
+        if projection is not None:
+
+            fields = list(projection.fields)
+
+            if not fields:
+                field_ref = query_pb2.StructuredQuery.FieldReference(
+                    field_path='__name__',
+                )
+                return query_pb2.StructuredQuery.Projection(
+                    fields=[field_ref],
+                )
+
+        return projection
+
+    @staticmethod
     def _normalize_cursor(cursor, orders):
         """Helper: convert cursor to a list of values based on orders."""
         if cursor is None:
@@ -580,11 +597,12 @@ class Query(object):
             google.cloud.firestore_v1beta1.types.StructuredQuery: The
             query protobuf.
         """
+        projection = self._normalize_projection(self._projection)
         start_at = self._normalize_cursor(self._start_at, self._orders)
         end_at = self._normalize_cursor(self._end_at, self._orders)
 
         query_kwargs = {
-            'select': self._projection,
+            'select': projection,
             'from': [
                 query_pb2.StructuredQuery.CollectionSelector(
                     collection_id=self._parent.id,

--- a/firestore/tests/unit/test_query.py
+++ b/firestore/tests/unit/test_query.py
@@ -476,6 +476,23 @@ class TestQuery(unittest.TestCase):
         )
         self.assertEqual(filter_pb, expected_pb)
 
+    def test__normalize_projection_none(self):
+        query = self._make_one(mock.sentinel.parent)
+        self.assertIsNone(query._normalize_projection(None))
+
+    def test__normalize_projection_empty(self):
+        projection = self._make_projection_for_select([])
+        query = self._make_one(mock.sentinel.parent)
+        normalized = query._normalize_projection(projection)
+        field_paths = [
+            field_ref.field_path for field_ref in normalized.fields]
+        self.assertEqual(field_paths, ['__name__'])
+
+    def test__normalize_projection_non_empty(self):
+        projection = self._make_projection_for_select(['a', 'b'])
+        query = self._make_one(mock.sentinel.parent)
+        self.assertIs(query._normalize_projection(projection), projection)
+
     def test__normalize_cursor_none(self):
         query = self._make_one(mock.sentinel.parent)
         self.assertIsNone(query._normalize_cursor(None, query._orders))


### PR DESCRIPTION
Per the `query-select-empty.textproto` conformance test.

Closes #6734.