### PR TITLE
Deserialize an entity from a protobuffer.

### DIFF
--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -130,11 +130,11 @@ Datastore API, rather than the legacy App Engine Datastore. In general, for
 users coding to the public interface, this won't be an issue, but users relying
 on pieces of the ostensibly private API that are exposed to the bare metal of
 the original datastore implementation will have to rewrite those pieces.
-Specifically, any function or method that dealt directly with protocol buffers will
-no longer work. Datastore, itself, has moved to gRPC and protobuffers
-themselves are significantly different from legacy Datastore.  Additionally,
-this version of NDB makes less direct use of protobuffers and relies more
-heavily on Datastore for parsing and generating protobuffers, which is a
+Specifically, any function or method that dealt directly with protocol buffers
+will no longer work. The Datastore `.protobuf` definitions have changed
+significantly from the barely public API used by App Engine to the current
+published API.  Additionally, this version of NDB mostly delegates to
+`google.cloud.datastore` for parsing data returned by RPCs, which is a
 significant internal refactoring.
 
 - `ModelAdapter` is no longer used. In legacy NDB, this was passed to Datastore
@@ -142,10 +142,11 @@ significant internal refactoring.
   Datastore RPC calls. AFAIK, Datastore no longer accepts an adapter for
   adpating entities. At any rate, we no longer do it that way.
 - `Property._db_get_value` is no longer used. It worked directly with Datastore
-  protobuffers, work which is now delegated to Datastore.
-- `Model._deserialize` is no longer used. It worked directly with protobuffers,
-  so wasn't really salvageable. Unfortunately, there were comments indicating
-  it was overridden by subclasses. Hopefully this isn't broadly the case.
+  protocol buffers, work which is now delegated to Datastore.
+- `Model._deserialize` is no longer used. It worked directly with protocol
+  buffers, so wasn't really salvageable. Unfortunately, there were comments
+  indicating it was overridden by subclasses. Hopefully this isn't broadly the
+  case.
 
 ## Comments
 

--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -128,9 +128,9 @@ The primary differences come from:
 One of the largest classes of differences comes from the use of the current
 Datastore API, rather than the legacy App Engine Datastore. In general, for
 users coding to the public interface, this won't be an issue, but users relying
-on pieces of the onstensibly private API that are exposed to the bare metal of
+on pieces of the ostensibly private API that are exposed to the bare metal of
 the original datastore implementation will have to rewrite those pieces.
-Specifically, any function or method that dealt directly with protobuffers will
+Specifically, any function or method that dealt directly with protocol buffers will
 no longer work. Datastore, itself, has moved to gRPC and protobuffers
 themselves are significantly different from legacy Datastore.  Additionally,
 this version of NDB makes less direct use of protobuffers and relies more
@@ -145,7 +145,7 @@ significant internal refactoring.
   protobuffers, work which is now delegated to Datastore.
 - `Model._deserialize` is no longer used. It worked directly with protobuffers,
   so wasn't really salvageable. Unfortunately, there were comments indicating
-  was overridden by subclasses. Hopefully this isn't broadly the case.
+  it was overridden by subclasses. Hopefully this isn't broadly the case.
 
 ## Comments
 

--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -123,6 +123,30 @@ The primary differences come from:
   is also a user-defined property named `key`. For an example, see the
   class docstring for `Model`.
 
+## Bare Metal
+
+One of the largest classes of differences comes from the use of the current
+Datastore API, rather than the legacy App Engine Datastore. In general, for
+users coding to the public interface, this won't be an issue, but users relying
+on pieces of the onstensibly private API that are exposed to the bare metal of
+the original datastore implementation will have to rewrite those pieces.
+Specifically, any function or method that dealt directly with protobuffers will
+no longer work. Datastore, itself, has moved to gRPC and protobuffers
+themselves are significantly different from legacy Datastore.  Additionally,
+this version of NDB makes less direct use of protobuffers and relies more
+heavily on Datastore for parsing and generating protobuffers, which is a
+significant internal refactoring.
+
+- `ModelAdapter` is no longer used. In legacy NDB, this was passed to Datastore
+  so that calls to Datastore RPCs could yield NDB entities directly from
+  Datastore RPC calls. AFAIK, Datastore no longer accepts an adapter for
+  adpating entities. At any rate, we no longer do it that way.
+- `Property._db_get_value` is no longer used. It worked directly with Datastore
+  protobuffers, work which is now delegated to Datastore.
+- `Model._deserialize` is no longer used. It worked directly with protobuffers,
+  so wasn't really salvageable. Unfortunately, there were comments indicating
+  was overridden by subclasses. Hopefully this isn't broadly the case.
+
 ## Comments
 
 - There is rampant use (and abuse) of `__new__` rather than `__init__` as

--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -133,16 +133,16 @@ the original datastore implementation will have to rewrite those pieces.
 Specifically, any function or method that dealt directly with protocol buffers
 will no longer work. The Datastore `.protobuf` definitions have changed
 significantly from the barely public API used by App Engine to the current
-published API.  Additionally, this version of NDB mostly delegates to
+published API. Additionally, this version of NDB mostly delegates to
 `google.cloud.datastore` for parsing data returned by RPCs, which is a
 significant internal refactoring.
 
-- `ModelAdapter` is no longer used. In legacy NDB, this was passed to Datastore
-  so that calls to Datastore RPCs could yield NDB entities directly from
-  Datastore RPC calls. AFAIK, Datastore no longer accepts an adapter for
-  adpating entities. At any rate, we no longer do it that way.
+- `ModelAdapter` is no longer used. In legacy NDB, this was passed to the 
+  Datastore RPC client so that calls to Datastore RPCs could yield NDB entities
+  directly from Datastore RPC calls. AFAIK, Datastore no longer accepts an
+  adapter for adpating entities. At any rate, we no longer do it that way.
 - `Property._db_get_value` is no longer used. It worked directly with Datastore
-  protocol buffers, work which is now delegated to Datastore.
+  protocol buffers, work which is now delegated to `google.cloud.datastore`.
 - `Model._deserialize` is no longer used. It worked directly with protocol
   buffers, so wasn't really salvageable. Unfortunately, there were comments
   indicating it was overridden by subclasses. Hopefully this isn't broadly the

--- a/ndb/src/google/cloud/ndb/__init__.py
+++ b/ndb/src/google/cloud/ndb/__init__.py
@@ -63,6 +63,7 @@ __all__ = [
     "make_connection",
     "MetaModel",
     "Model",
+    "ModelAdapter",
     "ModelAttribute",
     "ModelKey",
     "ndb_context",
@@ -161,6 +162,7 @@ from google.cloud.ndb.model import LocalStructuredProperty
 from google.cloud.ndb.model import make_connection
 from google.cloud.ndb.model import MetaModel
 from google.cloud.ndb.model import Model
+from google.cloud.ndb.model import ModelAdapter
 from google.cloud.ndb.model import ModelAttribute
 from google.cloud.ndb.model import ModelKey
 from google.cloud.ndb.model import non_transactional

--- a/ndb/src/google/cloud/ndb/__init__.py
+++ b/ndb/src/google/cloud/ndb/__init__.py
@@ -63,7 +63,6 @@ __all__ = [
     "make_connection",
     "MetaModel",
     "Model",
-    "ModelAdapter",
     "ModelAttribute",
     "ModelKey",
     "ndb_context",
@@ -162,7 +161,6 @@ from google.cloud.ndb.model import LocalStructuredProperty
 from google.cloud.ndb.model import make_connection
 from google.cloud.ndb.model import MetaModel
 from google.cloud.ndb.model import Model
-from google.cloud.ndb.model import ModelAdapter
 from google.cloud.ndb.model import ModelAttribute
 from google.cloud.ndb.model import ModelKey
 from google.cloud.ndb.model import non_transactional

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -304,7 +304,7 @@ def _entity_from_protobuf(protobuf):
             continue
         if value is not None:
             if prop._repeated:
-                value = [_BaseValue(x) for x in value]
+                value = [_BaseValue(sub_value) for sub_value in value]
             else:
                 value = _BaseValue(value)
         prop._store_value(entity, value)

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -295,7 +295,7 @@ def _entity_from_protobuf(protobuf):
             continue
         if value is not None:
             if prop._repeated:
-                value = list(map(_BaseValue, value))
+                value = [_BaseValue(x) for x in value]
             else:
                 value = _BaseValue(value)
         prop._store_value(entity, value)

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -50,6 +50,7 @@ __all__ = [
     "IndexProperty",
     "Index",
     "IndexState",
+    "ModelAdapter",
     "make_connection",
     "ModelAttribute",
     "Property",
@@ -97,6 +98,7 @@ __all__ = [
 
 _MEANING_PREDEFINED_ENTITY_USER = 20
 _MAX_STRING_LENGTH = 1500
+_NO_LONGER_IMPLEMENTED = "No longer used"
 Key = key_module.Key
 BlobKey = _datastore_types.BlobKey
 GeoPt = helpers.GeoPoint
@@ -273,6 +275,13 @@ class IndexState:
 
     def __hash__(self):
         return hash((self.definition, self.state, self.id))
+
+
+class ModelAdapter:
+    __slots__ = ()
+
+    def __new__(self, *args, **kwargs):
+        raise NotImplementedError(_NO_LONGER_IMPLEMENTED)
 
 
 def _entity_from_protobuf(protobuf):
@@ -1476,6 +1485,14 @@ class Property(ModelAttribute):
         """
         raise NotImplementedError
 
+    def _deserialize(self, entity, p, unused_depth=1):
+        """Deserialize this property from a protocol buffer.
+
+        Raises:
+            NotImplementedError: Always. This method is deprecated.
+        """
+        raise NotImplementedError(_NO_LONGER_IMPLEMENTED)
+
     def _prepare_for_put(self, entity):
         """Allow this property to define a pre-put hook.
 
@@ -1697,6 +1714,14 @@ class BooleanProperty(Property):
         """
         raise NotImplementedError
 
+    def _db_get_value(self, v, unused_p):
+        """Helper for :meth:`_deserialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is deprecated.
+        """
+        raise NotImplementedError(_NO_LONGER_IMPLEMENTED)
+
 
 class IntegerProperty(Property):
     """A property that contains values of type integer.
@@ -1737,6 +1762,14 @@ class IntegerProperty(Property):
             NotImplementedError: Always. This method is virtual.
         """
         raise NotImplementedError
+
+    def _db_get_value(self, v, unused_p):
+        """Helper for :meth:`_deserialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is deprecated.
+        """
+        raise NotImplementedError(_NO_LONGER_IMPLEMENTED)
 
 
 class FloatProperty(Property):
@@ -1779,6 +1812,14 @@ class FloatProperty(Property):
             NotImplementedError: Always. This method is virtual.
         """
         raise NotImplementedError
+
+    def _db_get_value(self, v, unused_p):
+        """Helper for :meth:`_deserialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is deprecated.
+        """
+        raise NotImplementedError(_NO_LONGER_IMPLEMENTED)
 
 
 class _CompressedValue:
@@ -1974,6 +2015,14 @@ class BlobProperty(Property):
             NotImplementedError: Always. This method is virtual.
         """
         raise NotImplementedError
+
+    def _db_get_value(self, v, unused_p):
+        """Helper for :meth:`_deserialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is deprecated.
+        """
+        raise NotImplementedError(_NO_LONGER_IMPLEMENTED)
 
 
 class TextProperty(BlobProperty):
@@ -2175,6 +2224,14 @@ class GeoPtProperty(Property):
             NotImplementedError: Always. This method is virtual.
         """
         raise NotImplementedError
+
+    def _db_get_value(self, v, unused_p):
+        """Helper for :meth:`_deserialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is deprecated.
+        """
+        raise NotImplementedError(_NO_LONGER_IMPLEMENTED)
 
 
 class PickleProperty(BlobProperty):
@@ -2666,6 +2723,14 @@ class UserProperty(Property):
         """
         raise NotImplementedError
 
+    def _db_get_value(self, v, unused_p):
+        """Helper for :meth:`_deserialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is deprecated.
+        """
+        raise NotImplementedError(_NO_LONGER_IMPLEMENTED)
+
 
 class KeyProperty(Property):
     """A property that contains :class:`.Key` values.
@@ -2893,6 +2958,14 @@ class KeyProperty(Property):
         """
         raise NotImplementedError
 
+    def _db_get_value(self, v, unused_p):
+        """Helper for :meth:`_deserialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is deprecated.
+        """
+        raise NotImplementedError(_NO_LONGER_IMPLEMENTED)
+
 
 class BlobKeyProperty(Property):
     """A property containing :class:`~google.cloud.ndb.model.BlobKey` values.
@@ -2924,6 +2997,14 @@ class BlobKeyProperty(Property):
             NotImplementedError: Always. This method is virtual.
         """
         raise NotImplementedError
+
+    def _db_get_value(self, v, unused_p):
+        """Helper for :meth:`_deserialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is deprecated.
+        """
+        raise NotImplementedError(_NO_LONGER_IMPLEMENTED)
 
 
 class DateTimeProperty(Property):
@@ -3068,6 +3149,14 @@ class DateTimeProperty(Property):
             NotImplementedError: Always. This method is virtual.
         """
         raise NotImplementedError
+
+    def _db_get_value(self, v, unused_p):
+        """Helper for :meth:`_deserialize`.
+
+        Raises:
+            NotImplementedError: Always. This method is deprecated.
+        """
+        raise NotImplementedError(_NO_LONGER_IMPLEMENTED)
 
 
 class DateProperty(DateTimeProperty):

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -288,7 +288,7 @@ def _entity_from_protobuf(protobuf):
     ds_entity = helpers.entity_from_protobuf(protobuf)
     model_class = Model._lookup_model(ds_entity.kind)
     entity = model_class()
-    entity.key = key_module.Key._from_ds_key(ds_entity.key)
+    entity._key = key_module.Key._from_ds_key(ds_entity.key)
     for name, value in ds_entity.items():
         prop = getattr(model_class, name, None)
         if not (prop and isinstance(prop, Property)):

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -3654,8 +3654,8 @@ class Model(metaclass=MetaModel):
 
         Args:
             kind (str): The name of the kind to look up.
-            default_model: The model class to return if the kind can't be
-                found.
+            default_model (Optional[type]): The model class to return if the
+                kind can't be found.
 
         Returns:
             type: The model class for the requested kind or the default model.

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -3650,7 +3650,7 @@ class Model(metaclass=MetaModel):
 
     @classmethod
     def _lookup_model(cls, kind, default_model=None):
-        """Get the model class for  the given kind.
+        """Get the model class for the given kind.
 
         Args:
             kind (str): The name of the kind to look up.
@@ -3658,10 +3658,10 @@ class Model(metaclass=MetaModel):
                 found.
 
         Returns:
-            class: The model class for the requested kind or the default model.
+            type: The model class for the requested kind or the default model.
 
         Raises:
-            .KindError: If the kind was not found and no default_model was
+            .KindError: If the kind was not found and no ``default_model`` was
                 provided.
         """
         model_class = cls._kind_map.get(kind, default_model)

--- a/ndb/tests/conftest.py
+++ b/ndb/tests/conftest.py
@@ -36,3 +36,19 @@ def property_clean_cache():
     finally:
         assert model.Property._FIND_METHODS_CACHE != {}
         model.Property._FIND_METHODS_CACHE.clear()
+
+
+@pytest.fixture
+def reset_kind_map():
+    """Reset ``Model._kind_map``.
+
+    This mapping of "kind" to class is set whenever a new subclass of ``Model``
+    is created. We create ``Model`` subclasses in tests and don't want those
+    definitions to leak to other tests, so this fixture resets the mapping to
+    its value before the text. (Since some classes might be declared at module
+    scope, we can't just clear the mapping altogether.)
+    """
+    previous = model.Model._kind_map
+    model.Model._kind_map = previous.copy()
+    yield
+    model.Model._kind_map = previous

--- a/ndb/tests/conftest.py
+++ b/ndb/tests/conftest.py
@@ -23,32 +23,17 @@ from google.cloud.ndb import model
 import pytest
 
 
-@pytest.fixture
-def property_clean_cache():
-    """Reset the ``_FIND_METHODS_CACHE`` class attribute on ``Property``
+@pytest.fixture(autouse=True)
+def reset_state():
+    """Reset module and class level runtime state.
 
-    This property is set at runtime (with calls to ``_find_methods()``), so
-    this fixture allows resetting the class to its original state.
+    To make sure that each test has the same starting conditions, we reset
+    module or class level datastructures that maintain runtime state.
+
+    This resets:
+
+    - ``model.Property._FIND_METHODS_CACHE``
+    - ``model.Model._kind_map``
     """
-    assert model.Property._FIND_METHODS_CACHE == {}
-    try:
-        yield
-    finally:
-        assert model.Property._FIND_METHODS_CACHE != {}
-        model.Property._FIND_METHODS_CACHE.clear()
-
-
-@pytest.fixture
-def reset_kind_map():
-    """Reset ``Model._kind_map``.
-
-    This mapping of "kind" to class is set whenever a new subclass of ``Model``
-    is created. We create ``Model`` subclasses in tests and don't want those
-    definitions to leak to other tests, so this fixture resets the mapping to
-    its value before the text. (Since some classes might be declared at module
-    scope, we can't just clear the mapping altogether.)
-    """
-    previous = model.Model._kind_map
-    model.Model._kind_map = previous.copy()
-    yield
-    model.Model._kind_map = previous
+    model.Property._FIND_METHODS_CACHE.clear()
+    model.Model._kind_map.clear()

--- a/ndb/tests/conftest.py
+++ b/ndb/tests/conftest.py
@@ -35,5 +35,8 @@ def reset_state():
     - ``model.Property._FIND_METHODS_CACHE``
     - ``model.Model._kind_map``
     """
+    assert model.Property._FIND_METHODS_CACHE == {}
+    assert model.Model._kind_map == {}
+    yield
     model.Property._FIND_METHODS_CACHE.clear()
     model.Model._kind_map.clear()

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2832,58 +2832,62 @@ class TestModel:
             model.Model._lookup_model("NoKind")
 
 
-def test__entity_from_protobuf():
-    class ThisKind(model.Model):
-        a = model.IntegerProperty()
-        b = model.BooleanProperty()
-        c = model.PickleProperty()
-        d = model.StringProperty(repeated=True)
-        e = model.PickleProperty(repeated=True)
-        notaproperty = True
+class Test_entity_from_protobuf:
 
-    dill = {"sandwiches": ["turkey", "reuben"], "not_sandwiches": "tacos"}
-    gherkin = [{"a": {"b": "c"}, "d": 0}, [1, 2, 3], "himom"]
-    key = datastore.Key("ThisKind", 123, project="testing")
-    datastore_entity = datastore.Entity(key=key)
-    datastore_entity.update(
-        {
-            "a": 42,
-            "b": None,
-            "c": pickle.dumps(gherkin, pickle.HIGHEST_PROTOCOL),
-            "d": ["foo", "bar", "baz"],
-            "e": [
-                pickle.dumps(gherkin, pickle.HIGHEST_PROTOCOL),
-                pickle.dumps(dill, pickle.HIGHEST_PROTOCOL),
-            ],
-            "notused": 32,
-            "notaproperty": None,
-        }
-    )
-    protobuf = helpers.entity_to_protobuf(datastore_entity)
-    entity = model._entity_from_protobuf(protobuf)
-    assert isinstance(entity, ThisKind)
-    assert entity.a == 42
-    assert entity.b is None
-    assert entity.c == gherkin
-    assert entity.d == ["foo", "bar", "baz"]
-    assert entity.e == [gherkin, dill]
-    assert entity._key == key_module.Key("ThisKind", 123, app="testing")
-    assert entity.notaproperty is True
+    @staticmethod
+    def test_standard_case():
+        class ThisKind(model.Model):
+            a = model.IntegerProperty()
+            b = model.BooleanProperty()
+            c = model.PickleProperty()
+            d = model.StringProperty(repeated=True)
+            e = model.PickleProperty(repeated=True)
+            notaproperty = True
+
+        dill = {"sandwiches": ["turkey", "reuben"], "not_sandwiches": "tacos"}
+        gherkin = [{"a": {"b": "c"}, "d": 0}, [1, 2, 3], "himom"]
+        key = datastore.Key("ThisKind", 123, project="testing")
+        datastore_entity = datastore.Entity(key=key)
+        datastore_entity.update(
+            {
+                "a": 42,
+                "b": None,
+                "c": pickle.dumps(gherkin, pickle.HIGHEST_PROTOCOL),
+                "d": ["foo", "bar", "baz"],
+                "e": [
+                    pickle.dumps(gherkin, pickle.HIGHEST_PROTOCOL),
+                    pickle.dumps(dill, pickle.HIGHEST_PROTOCOL),
+                ],
+                "notused": 32,
+                "notaproperty": None,
+            }
+        )
+        protobuf = helpers.entity_to_protobuf(datastore_entity)
+        entity = model._entity_from_protobuf(protobuf)
+        assert isinstance(entity, ThisKind)
+        assert entity.a == 42
+        assert entity.b is None
+        assert entity.c == gherkin
+        assert entity.d == ["foo", "bar", "baz"]
+        assert entity.e == [gherkin, dill]
+        assert entity._key == key_module.Key("ThisKind", 123, app="testing")
+        assert entity.notaproperty is True
 
 
-def test__entity_from_protobuf_w_property_named_key():
-    class ThisKind(model.Model):
-        key = model.StringProperty()
+    @staticmethod
+    def test_property_named_key():
+        class ThisKind(model.Model):
+            key = model.StringProperty()
 
-    key = datastore.Key("ThisKind", 123, project="testing")
-    datastore_entity = datastore.Entity(key=key)
-    datastore_entity.update({"key": "luck"})
-    protobuf = helpers.entity_to_protobuf(datastore_entity)
-    entity = model._entity_from_protobuf(protobuf)
-    assert isinstance(entity, ThisKind)
-    assert entity.key == "luck"
-    assert entity._key.kind() == "ThisKind"
-    assert entity._key.id() == 123
+        key = datastore.Key("ThisKind", 123, project="testing")
+        datastore_entity = datastore.Entity(key=key)
+        datastore_entity.update({"key": "luck"})
+        protobuf = helpers.entity_to_protobuf(datastore_entity)
+        entity = model._entity_from_protobuf(protobuf)
+        assert isinstance(entity, ThisKind)
+        assert entity.key == "luck"
+        assert entity._key.kind() == "ThisKind"
+        assert entity._key.id() == 123
 
 
 class TestExpando:

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2867,8 +2867,7 @@ def test__entity_from_protobuf():
     assert entity.c == gherkin
     assert entity.d == ["foo", "bar", "baz"]
     assert entity.e == [gherkin, dill]
-    assert entity._key.kind() == "ThisKind"
-    assert entity._key.id() == 123
+    assert entity._key == key_module.Key("ThisKind", 123, app="testing")
     assert entity.notaproperty is True
 
 

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2787,6 +2787,8 @@ def test__entity_from_protobuf():
     assert entity.c == gherkin
     assert entity.d == ["foo", "bar", "baz"]
     assert entity.e == [gherkin, dill]
+    assert entity._key.kind() == "ThisKind"
+    assert entity._key.id() == 123
 
 
 def test__entity_from_protobuf_model_has_constructor():
@@ -2803,6 +2805,21 @@ def test__entity_from_protobuf_model_has_constructor():
     entity = model._entity_from_protobuf(protobuf)
     assert isinstance(entity, ThisKind)
     assert entity.a == 43
+
+
+def test__entity_from_protobuf_w_property_named_key():
+    class ThisKind(model.Model):
+        key = model.StringProperty()
+
+    key = datastore.Key("ThisKind", 123, project="testing")
+    datastore_entity = datastore.Entity(key=key)
+    datastore_entity.update({"key": "luck"})
+    protobuf = helpers.entity_to_protobuf(datastore_entity)
+    entity = model._entity_from_protobuf(protobuf)
+    assert isinstance(entity, ThisKind)
+    assert entity.key == "luck"
+    assert entity._key.kind() == "ThisKind"
+    assert entity._key.id() == 123
 
 
 class TestExpando:

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2739,6 +2739,7 @@ class TestModel:
         with pytest.raises(NotImplementedError):
             entity._put()
 
+    @pytest.mark.usefixtures("property_clean_cache")
     @staticmethod
     def test__lookup_model():
         class ThisKind(model.Model):

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2626,6 +2626,7 @@ class TestModel:
         assert entity.__dict__ == {"_values": {"key": 1001}}
 
     @staticmethod
+    @pytest.mark.usefixtures("reset_kind_map")
     def test_constructor_with_projection():
         class Book(model.Model):
             pages = model.IntegerProperty()
@@ -2654,12 +2655,14 @@ class TestModel:
             TimeTravelVehicle(speed=28)
 
     @staticmethod
+    @pytest.mark.usefixtures("reset_kind_map")
     def test_repr():
         entity = ManyFields(self=909, id="hi", key=[88.5, 0.0], value=None)
         expected = "ManyFields(id='hi', key=[88.5, 0.0], self=909, value=None)"
         assert repr(entity) == expected
 
     @staticmethod
+    @pytest.mark.usefixtures("reset_kind_map")
     def test_repr_with_projection():
         entity = ManyFields(
             self=909,
@@ -2675,6 +2678,7 @@ class TestModel:
         assert repr(entity) == expected
 
     @staticmethod
+    @pytest.mark.usefixtures("reset_kind_map")
     def test_repr_with_property_named_key():
         entity = ManyFields(
             self=909, id="hi", key=[88.5, 0.0], value=None, _id=78
@@ -2686,6 +2690,7 @@ class TestModel:
         assert repr(entity) == expected
 
     @staticmethod
+    @pytest.mark.usefixtures("reset_kind_map")
     def test_repr_with_property_named_key_not_set():
         entity = ManyFields(self=909, id="hi", value=None, _id=78)
         expected = (
@@ -2806,22 +2811,22 @@ class TestModel:
         with pytest.raises(NotImplementedError):
             entity._put()
 
-    @pytest.mark.usefixtures("property_clean_cache")
     @staticmethod
+    @pytest.mark.usefixtures("reset_kind_map")
     def test__lookup_model():
         class ThisKind(model.Model):
             pass
 
         assert model.Model._lookup_model("ThisKind") is ThisKind
 
-    @pytest.mark.usefixtures("property_clean_cache")
     @staticmethod
+    @pytest.mark.usefixtures("reset_kind_map")
     def test__lookup_model_use_default():
         sentinel = object()
         assert model.Model._lookup_model("NoKind", sentinel) is sentinel
 
-    @pytest.mark.usefixtures("property_clean_cache")
     @staticmethod
+    @pytest.mark.usefixtures("reset_kind_map")
     def test__lookup_model_not_found():
         with pytest.raises(model.KindError):
             model.Model._lookup_model("NoKind")

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2833,7 +2833,6 @@ class TestModel:
 
 
 class Test_entity_from_protobuf:
-
     @staticmethod
     def test_standard_case():
         class ThisKind(model.Model):
@@ -2872,7 +2871,6 @@ class Test_entity_from_protobuf:
         assert entity.e == [gherkin, dill]
         assert entity._key == key_module.Key("ThisKind", 123, app="testing")
         assert entity.notaproperty is True
-
 
     @staticmethod
     def test_property_named_key():

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2789,6 +2789,22 @@ def test__entity_from_protobuf():
     assert entity.e == [gherkin, dill]
 
 
+def test__entity_from_protobuf_model_has_constructor():
+    class ThisKind(model.Model):
+        a = model.IntegerProperty()
+
+        def __init__(self, somearg):
+            pass
+
+    key = datastore.Key("ThisKind", 123, project="testing")
+    datastore_entity = datastore.Entity(key=key)
+    datastore_entity.update({"a": 43})
+    protobuf = helpers.entity_to_protobuf(datastore_entity)
+    entity = model._entity_from_protobuf(protobuf)
+    assert isinstance(entity, ThisKind)
+    assert entity.a == 43
+
+
 class TestExpando:
     @staticmethod
     def test_constructor():

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2781,7 +2781,7 @@ def test__entity_from_protobuf():
     )
     protobuf = helpers.entity_to_protobuf(datastore_entity)
     entity = model._entity_from_protobuf(protobuf)
-    assert type(entity) is ThisKind
+    assert isinstance(entity, ThisKind)
     assert entity.a == 42
     assert entity.b is None
     assert entity.c == gherkin

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2869,6 +2869,7 @@ def test__entity_from_protobuf():
     assert entity.e == [gherkin, dill]
     assert entity._key.kind() == "ThisKind"
     assert entity._key.id() == 123
+    assert entity.notaproperty is True
 
 
 def test__entity_from_protobuf_w_property_named_key():

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2871,22 +2871,6 @@ def test__entity_from_protobuf():
     assert entity._key.id() == 123
 
 
-def test__entity_from_protobuf_model_has_constructor():
-    class ThisKind(model.Model):
-        a = model.IntegerProperty()
-
-        def __init__(self, somearg):
-            pass
-
-    key = datastore.Key("ThisKind", 123, project="testing")
-    datastore_entity = datastore.Entity(key=key)
-    datastore_entity.update({"a": 43})
-    protobuf = helpers.entity_to_protobuf(datastore_entity)
-    entity = model._entity_from_protobuf(protobuf)
-    assert isinstance(entity, ThisKind)
-    assert entity.a == 43
-
-
 def test__entity_from_protobuf_w_property_named_key():
     class ThisKind(model.Model):
         key = model.StringProperty()

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2655,12 +2655,14 @@ class TestModel:
 
     @staticmethod
     def test_repr():
+        ManyFields = ManyFieldsFactory()
         entity = ManyFields(self=909, id="hi", key=[88.5, 0.0], value=None)
         expected = "ManyFields(id='hi', key=[88.5, 0.0], self=909, value=None)"
         assert repr(entity) == expected
 
     @staticmethod
     def test_repr_with_projection():
+        ManyFields = ManyFieldsFactory()
         entity = ManyFields(
             self=909,
             id="hi",
@@ -2676,6 +2678,7 @@ class TestModel:
 
     @staticmethod
     def test_repr_with_property_named_key():
+        ManyFields = ManyFieldsFactory()
         entity = ManyFields(
             self=909, id="hi", key=[88.5, 0.0], value=None, _id=78
         )
@@ -2687,6 +2690,7 @@ class TestModel:
 
     @staticmethod
     def test_repr_with_property_named_key_not_set():
+        ManyFields = ManyFieldsFactory()
         entity = ManyFields(self=909, id="hi", value=None, _id=78)
         expected = (
             "ManyFields(_key=Key('ManyFields', 78), id='hi', "
@@ -2714,6 +2718,7 @@ class TestModel:
 
     @staticmethod
     def test___hash__():
+        ManyFields = ManyFieldsFactory()
         entity = ManyFields(self=909, id="hi", value=None, _id=78)
         with pytest.raises(TypeError):
             hash(entity)
@@ -2723,18 +2728,21 @@ class TestModel:
         class Simple(model.Model):
             pass
 
+        ManyFields = ManyFieldsFactory()
         entity1 = ManyFields(self=909, id="hi", value=None, _id=78)
         entity2 = Simple()
         assert not entity1 == entity2
 
     @staticmethod
     def test___eq__wrong_key():
+        ManyFields = ManyFieldsFactory()
         entity1 = ManyFields(_id=78)
         entity2 = ManyFields(_id="seventy-eight")
         assert not entity1 == entity2
 
     @staticmethod
     def test___eq__wrong_projection():
+        ManyFields = ManyFieldsFactory()
         entity1 = ManyFields(self=90, projection=("self",))
         entity2 = ManyFields(
             value="a", unused=0.0, projection=("value", "unused")
@@ -2743,6 +2751,7 @@ class TestModel:
 
     @staticmethod
     def test___eq__same_type_same_key():
+        ManyFields = ManyFieldsFactory()
         entity1 = ManyFields(self=909, id="hi", _id=78)
         entity2 = ManyFields(self=909, id="bye", _id=78)
         assert entity1 == entity1
@@ -2750,6 +2759,7 @@ class TestModel:
 
     @staticmethod
     def test___eq__same_type_same_key_same_projection():
+        ManyFields = ManyFieldsFactory()
         entity1 = ManyFields(self=-9, id="hi", projection=("self", "id"))
         entity2 = ManyFields(self=-9, id="bye", projection=("self", "id"))
         assert entity1 == entity1
@@ -2760,6 +2770,7 @@ class TestModel:
         class Simple(model.Model):
             pass
 
+        ManyFields = ManyFieldsFactory()
         entity1 = ManyFields(self=-9, id="hi")
         entity2 = Simple()
         entity3 = ManyFields(self=-9, id="bye")
@@ -2773,24 +2784,28 @@ class TestModel:
 
     @staticmethod
     def test___lt__():
+        ManyFields = ManyFieldsFactory()
         entity = ManyFields(self=-9, id="hi")
         with pytest.raises(TypeError):
             entity < entity
 
     @staticmethod
     def test___le__():
+        ManyFields = ManyFieldsFactory()
         entity = ManyFields(self=-9, id="hi")
         with pytest.raises(TypeError):
             entity <= entity
 
     @staticmethod
     def test___gt__():
+        ManyFields = ManyFieldsFactory()
         entity = ManyFields(self=-9, id="hi")
         with pytest.raises(TypeError):
             entity > entity
 
     @staticmethod
     def test___ge__():
+        ManyFields = ManyFieldsFactory()
         entity = ManyFields(self=-9, id="hi")
         with pytest.raises(TypeError):
             entity >= entity
@@ -2962,9 +2977,19 @@ def test_get_indexes():
         model.get_indexes()
 
 
-class ManyFields(model.Model):
-    self = model.IntegerProperty()
-    id = model.StringProperty()
-    key = model.FloatProperty(repeated=True)
-    value = model.StringProperty()
-    unused = model.FloatProperty()
+def ManyFieldsFactory():
+    """Model type class factory.
+
+    This indirection makes sure ``Model._kind_map`` isn't mutated at module
+    scope, since any mutations would be reset by the ``reset_state`` fixture
+    run for each test.
+    """
+
+    class ManyFields(model.Model):
+        self = model.IntegerProperty()
+        id = model.StringProperty()
+        key = model.FloatProperty(repeated=True)
+        value = model.StringProperty()
+        unused = model.FloatProperty()
+
+    return ManyFields

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -449,7 +449,7 @@ class TestProperty:
             prop._comparison("!=", "red")
 
     @staticmethod
-    def test__comparison(property_clean_cache):
+    def test__comparison():
         prop = model.Property("sentiment", indexed=True)
         filter_node = prop._comparison(">=", 0.0)
         assert filter_node == query.FilterNode("sentiment", ">=", 0.0)
@@ -463,7 +463,7 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
-    def test___eq__(property_clean_cache):
+    def test___eq__():
         prop = model.Property("name", indexed=True)
         value = 1337
         expected = query.FilterNode("name", "=", value)
@@ -474,7 +474,7 @@ class TestProperty:
         assert filter_node_right == expected
 
     @staticmethod
-    def test___ne__(property_clean_cache):
+    def test___ne__():
         prop = model.Property("name", indexed=True)
         value = 7.0
         expected = query.DisjunctionNode(
@@ -488,7 +488,7 @@ class TestProperty:
         assert or_node_right == expected
 
     @staticmethod
-    def test___lt__(property_clean_cache):
+    def test___lt__():
         prop = model.Property("name", indexed=True)
         value = 2.0
         expected = query.FilterNode("name", "<", value)
@@ -499,7 +499,7 @@ class TestProperty:
         assert filter_node_right == expected
 
     @staticmethod
-    def test___le__(property_clean_cache):
+    def test___le__():
         prop = model.Property("name", indexed=True)
         value = 20.0
         expected = query.FilterNode("name", "<=", value)
@@ -510,7 +510,7 @@ class TestProperty:
         assert filter_node_right == expected
 
     @staticmethod
-    def test___gt__(property_clean_cache):
+    def test___gt__():
         prop = model.Property("name", indexed=True)
         value = "new"
         expected = query.FilterNode("name", ">", value)
@@ -521,7 +521,7 @@ class TestProperty:
         assert filter_node_right == expected
 
     @staticmethod
-    def test___ge__(property_clean_cache):
+    def test___ge__():
         prop = model.Property("name", indexed=True)
         value = "old"
         expected = query.FilterNode("name", ">=", value)
@@ -550,7 +550,7 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
-    def test__IN(property_clean_cache):
+    def test__IN():
         prop = model.Property("name", indexed=True)
         or_node = prop._IN(["a", None, "xy"])
         expected = query.DisjunctionNode(
@@ -575,7 +575,7 @@ class TestProperty:
             +prop
 
     @staticmethod
-    def test__do_validate(property_clean_cache):
+    def test__do_validate():
         validator = unittest.mock.Mock(spec=())
         value = 18
         choices = (1, 2, validator.return_value)
@@ -597,7 +597,7 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
-    def test__do_validate_validator_none(property_clean_cache):
+    def test__do_validate_validator_none():
         validator = unittest.mock.Mock(spec=(), return_value=None)
         value = 18
 
@@ -608,7 +608,7 @@ class TestProperty:
         validator.assert_called_once_with(prop, value)
 
     @staticmethod
-    def test__do_validate_not_in_choices(property_clean_cache):
+    def test__do_validate_not_in_choices():
         value = 18
         prop = model.Property(name="foo", choices=(1, 2))
 
@@ -616,7 +616,7 @@ class TestProperty:
             prop._do_validate(value)
 
     @staticmethod
-    def test__do_validate_call_validation(property_clean_cache):
+    def test__do_validate_call_validation():
         class SimpleProperty(model.Property):
             def _validate(self, value):
                 value.append("SimpleProperty._validate")
@@ -653,7 +653,7 @@ class TestProperty:
         assert entity._values == {prop._name: unittest.mock.sentinel.value}
 
     @staticmethod
-    def test__set_value(property_clean_cache):
+    def test__set_value():
         entity = unittest.mock.Mock(
             _projection=None, _values={}, spec=("_projection", "_values")
         )
@@ -673,7 +673,7 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
-    def test__set_value_repeated(property_clean_cache):
+    def test__set_value_repeated():
         entity = unittest.mock.Mock(
             _projection=None, _values={}, spec=("_projection", "_values")
         )
@@ -735,7 +735,7 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
-    def test__get_user_value_wrapped(property_clean_cache):
+    def test__get_user_value_wrapped():
         class SimpleProperty(model.Property):
             def _from_base_type(self, value):
                 return value * 2.0
@@ -746,7 +746,7 @@ class TestProperty:
         assert prop._get_user_value(entity) == 19.0
 
     @staticmethod
-    def test__get_base_value(property_clean_cache):
+    def test__get_base_value():
         class SimpleProperty(model.Property):
             def _validate(self, value):
                 return value + 1
@@ -767,7 +767,7 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
-    def test__get_base_value_unwrapped_as_list(property_clean_cache):
+    def test__get_base_value_unwrapped_as_list():
         class SimpleProperty(model.Property):
             def _validate(self, value):
                 return value + 11
@@ -786,7 +786,7 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
-    def test__get_base_value_unwrapped_as_list_repeated(property_clean_cache):
+    def test__get_base_value_unwrapped_as_list_repeated():
         class SimpleProperty(model.Property):
             def _validate(self, value):
                 return value / 10.0
@@ -806,7 +806,7 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
-    def test__opt_call_from_base_type_wrapped(property_clean_cache):
+    def test__opt_call_from_base_type_wrapped():
         class SimpleProperty(model.Property):
             def _from_base_type(self, value):
                 return value * 2.0
@@ -816,7 +816,7 @@ class TestProperty:
         assert prop._opt_call_from_base_type(value) == 17.0
 
     @staticmethod
-    def test__value_to_repr(property_clean_cache):
+    def test__value_to_repr():
         class SimpleProperty(model.Property):
             def _from_base_type(self, value):
                 return value * 3.0
@@ -826,7 +826,7 @@ class TestProperty:
         assert prop._value_to_repr(value) == "27.75"
 
     @staticmethod
-    def test__opt_call_to_base_type(property_clean_cache):
+    def test__opt_call_to_base_type():
         class SimpleProperty(model.Property):
             def _validate(self, value):
                 return value + 1
@@ -845,7 +845,7 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
-    def test__call_from_base_type(property_clean_cache):
+    def test__call_from_base_type():
         class SimpleProperty(model.Property):
             def _from_base_type(self, value):
                 value.append("SimpleProperty._from_base_type")
@@ -910,7 +910,7 @@ class TestProperty:
 
         return A, B, C
 
-    def test__call_to_base_type(self, property_clean_cache):
+    def test__call_to_base_type(self):
         _, _, PropertySubclass = self._property_subtype_chain()
         prop = PropertySubclass(name="prop")
         value = []
@@ -923,7 +923,7 @@ class TestProperty:
             "A._to_base_type",
         ]
 
-    def test__call_shallow_validation(self, property_clean_cache):
+    def test__call_shallow_validation(self):
         _, _, PropertySubclass = self._property_subtype_chain()
         prop = PropertySubclass(name="prop")
         value = []
@@ -931,7 +931,7 @@ class TestProperty:
         assert value == ["C._validate", "B._validate"]
 
     @staticmethod
-    def test__call_shallow_validation_no_break(property_clean_cache):
+    def test__call_shallow_validation_no_break():
         class SimpleProperty(model.Property):
             def _validate(self, value):
                 value.append("SimpleProperty._validate")
@@ -957,7 +957,7 @@ class TestProperty:
 
         return SomeProperty
 
-    def test__find_methods(self, property_clean_cache):
+    def test__find_methods(self):
         SomeProperty = self._property_subtype()
         # Make sure cache is empty.
         assert model.Property._FIND_METHODS_CACHE == {}
@@ -976,7 +976,7 @@ class TestProperty:
             key: {("IN", "find_me"): methods}
         }
 
-    def test__find_methods_reverse(self, property_clean_cache):
+    def test__find_methods_reverse(self):
         SomeProperty = self._property_subtype()
         # Make sure cache is empty.
         assert model.Property._FIND_METHODS_CACHE == {}
@@ -995,7 +995,7 @@ class TestProperty:
             key: {("IN", "find_me"): list(reversed(methods))}
         }
 
-    def test__find_methods_cached(self, property_clean_cache):
+    def test__find_methods_cached(self):
         SomeProperty = self._property_subtype()
         # Set cache
         methods = unittest.mock.sentinel.methods
@@ -1007,7 +1007,7 @@ class TestProperty:
         }
         assert SomeProperty._find_methods("IN", "find_me") is methods
 
-    def test__find_methods_cached_reverse(self, property_clean_cache):
+    def test__find_methods_cached_reverse(self):
         SomeProperty = self._property_subtype()
         # Set cache
         methods = ["a", "b"]
@@ -1221,7 +1221,7 @@ class TestProperty:
         assert model.Property._FIND_METHODS_CACHE == {}
 
     @staticmethod
-    def test_instance_descriptors(property_clean_cache):
+    def test_instance_descriptors():
         class Model:
             prop = model.Property(name="prop", required=True)
 
@@ -2626,7 +2626,6 @@ class TestModel:
         assert entity.__dict__ == {"_values": {"key": 1001}}
 
     @staticmethod
-    @pytest.mark.usefixtures("reset_kind_map")
     def test_constructor_with_projection():
         class Book(model.Model):
             pages = model.IntegerProperty()
@@ -2655,14 +2654,12 @@ class TestModel:
             TimeTravelVehicle(speed=28)
 
     @staticmethod
-    @pytest.mark.usefixtures("reset_kind_map")
     def test_repr():
         entity = ManyFields(self=909, id="hi", key=[88.5, 0.0], value=None)
         expected = "ManyFields(id='hi', key=[88.5, 0.0], self=909, value=None)"
         assert repr(entity) == expected
 
     @staticmethod
-    @pytest.mark.usefixtures("reset_kind_map")
     def test_repr_with_projection():
         entity = ManyFields(
             self=909,
@@ -2678,7 +2675,6 @@ class TestModel:
         assert repr(entity) == expected
 
     @staticmethod
-    @pytest.mark.usefixtures("reset_kind_map")
     def test_repr_with_property_named_key():
         entity = ManyFields(
             self=909, id="hi", key=[88.5, 0.0], value=None, _id=78
@@ -2690,7 +2686,6 @@ class TestModel:
         assert repr(entity) == expected
 
     @staticmethod
-    @pytest.mark.usefixtures("reset_kind_map")
     def test_repr_with_property_named_key_not_set():
         entity = ManyFields(self=909, id="hi", value=None, _id=78)
         expected = (
@@ -2812,7 +2807,6 @@ class TestModel:
             entity._put()
 
     @staticmethod
-    @pytest.mark.usefixtures("reset_kind_map")
     def test__lookup_model():
         class ThisKind(model.Model):
             pass
@@ -2820,13 +2814,11 @@ class TestModel:
         assert model.Model._lookup_model("ThisKind") is ThisKind
 
     @staticmethod
-    @pytest.mark.usefixtures("reset_kind_map")
     def test__lookup_model_use_default():
         sentinel = object()
         assert model.Model._lookup_model("NoKind", sentinel) is sentinel
 
     @staticmethod
-    @pytest.mark.usefixtures("reset_kind_map")
     def test__lookup_model_not_found():
         with pytest.raises(model.KindError):
             model.Model._lookup_model("NoKind")

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -2745,10 +2745,17 @@ class TestModel:
         class ThisKind(model.Model):
             pass
 
+        assert model.Model._lookup_model("ThisKind") is ThisKind
+
+    @pytest.mark.usefixtures("property_clean_cache")
+    @staticmethod
+    def test__lookup_model_use_default():
         sentinel = object()
-        assert model.Model._lookup_model("ThisKind")
         assert model.Model._lookup_model("NoKind", sentinel) is sentinel
 
+    @pytest.mark.usefixtures("property_clean_cache")
+    @staticmethod
+    def test__lookup_model_not_found():
         with pytest.raises(model.KindError):
             model.Model._lookup_model("NoKind")
 

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -270,6 +270,13 @@ class TestIndexState:
         assert hash(index_state1) == hash((self.INDEX, "error", 88))
 
 
+class TestModelAdapter:
+    @staticmethod
+    def test_constructor():
+        with pytest.raises(NotImplementedError):
+            model.ModelAdapter()
+
+
 def test_make_connection():
     with pytest.raises(NotImplementedError):
         model.make_connection()
@@ -1249,6 +1256,12 @@ class TestProperty:
             prop._serialize(None, None)
 
     @staticmethod
+    def test__deserialize():
+        prop = model.Property(name="prop")
+        with pytest.raises(NotImplementedError):
+            prop._deserialize(None, None)
+
+    @staticmethod
     def test__prepare_for_put():
         prop = model.Property(name="prop")
         assert prop._prepare_for_put(None) is None
@@ -1423,6 +1436,12 @@ class TestBooleanProperty:
         with pytest.raises(NotImplementedError):
             prop._db_set_value(None, None, None)
 
+    @staticmethod
+    def test__db_get_value():
+        prop = model.BooleanProperty(name="certify")
+        with pytest.raises(NotImplementedError):
+            prop._db_get_value(None, None)
+
 
 class TestIntegerProperty:
     @staticmethod
@@ -1448,6 +1467,12 @@ class TestIntegerProperty:
         prop = model.IntegerProperty(name="count")
         with pytest.raises(NotImplementedError):
             prop._db_set_value(None, None, None)
+
+    @staticmethod
+    def test__db_get_value():
+        prop = model.IntegerProperty(name="count")
+        with pytest.raises(NotImplementedError):
+            prop._db_get_value(None, None)
 
 
 class TestFloatProperty:
@@ -1480,6 +1505,12 @@ class TestFloatProperty:
         prop = model.FloatProperty(name="continuous")
         with pytest.raises(NotImplementedError):
             prop._db_set_value(None, None, None)
+
+    @staticmethod
+    def test__db_get_value():
+        prop = model.FloatProperty(name="continuous")
+        with pytest.raises(NotImplementedError):
+            prop._db_get_value(None, None)
 
 
 class Test_CompressedValue:
@@ -1649,6 +1680,12 @@ class TestBlobProperty:
         with pytest.raises(NotImplementedError):
             prop._db_set_uncompressed_meaning(None)
 
+    @staticmethod
+    def test__db_get_value():
+        prop = model.BlobProperty(name="blob")
+        with pytest.raises(NotImplementedError):
+            prop._db_get_value(None, None)
+
 
 class TestTextProperty:
     @staticmethod
@@ -1775,6 +1812,12 @@ class TestGeoPtProperty:
         prop = model.GeoPtProperty(name="cartesian")
         with pytest.raises(NotImplementedError):
             prop._db_set_value(None, None, None)
+
+    @staticmethod
+    def test__db_get_value():
+        prop = model.GeoPtProperty(name="cartesian")
+        with pytest.raises(NotImplementedError):
+            prop._db_get_value(None, None)
 
 
 class TestPickleProperty:
@@ -2105,6 +2148,12 @@ class TestUserProperty:
         with pytest.raises(NotImplementedError):
             prop._db_set_value(None, None, None)
 
+    @staticmethod
+    def test__db_get_value():
+        prop = model.UserProperty(name="u")
+        with pytest.raises(NotImplementedError):
+            prop._db_get_value(None, None)
+
 
 class TestKeyProperty:
     @staticmethod
@@ -2238,6 +2287,12 @@ class TestKeyProperty:
         with pytest.raises(NotImplementedError):
             prop._db_set_value(None, None, None)
 
+    @staticmethod
+    def test__db_get_value():
+        prop = model.KeyProperty("keyp", kind="Simple")
+        with pytest.raises(NotImplementedError):
+            prop._db_get_value(None, None)
+
 
 class TestBlobKeyProperty:
     @staticmethod
@@ -2257,6 +2312,12 @@ class TestBlobKeyProperty:
         prop = model.BlobKeyProperty(name="object-gcs")
         with pytest.raises(NotImplementedError):
             prop._db_set_value(None, None, None)
+
+    @staticmethod
+    def test__db_get_value():
+        prop = model.BlobKeyProperty(name="object-gcs")
+        with pytest.raises(NotImplementedError):
+            prop._db_get_value(None, None)
 
 
 class TestDateTimeProperty:
@@ -2370,6 +2431,12 @@ class TestDateTimeProperty:
         prop = model.DateTimeProperty(name="dt_val")
         with pytest.raises(NotImplementedError):
             prop._db_set_value(None, None, None)
+
+    @staticmethod
+    def test__db_get_value():
+        prop = model.DateTimeProperty(name="dt_val")
+        with pytest.raises(NotImplementedError):
+            prop._db_get_value(None, None)
 
 
 class TestDateProperty:


### PR DESCRIPTION
Deserialization is largely delegated to Datastore, so it's really just a matter of adapting an NDB entity to a Datastore entity.