### PR TITLE
Correct release_status for bigquery_storage

### DIFF
--- a/bigquery_storage/setup.py
+++ b/bigquery_storage/setup.py
@@ -22,7 +22,7 @@ import setuptools
 name = 'google-cloud-bigquery-storage'
 description = 'BigQuery Storage API API client library'
 version = '0.1.0'
-release_status = '3 - Alpha'
+release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     'google-api-core[grpc] >= 1.5.1, < 2.0.0dev',
     'enum34; python_version < "3.4"',


### PR DESCRIPTION
The bigquery_storage release job failed with 
```HTTPError: 400 Client Error: Invalid value for classifiers. Error: '3 - Alpha' is not a valid choice for this field for url: https://upload.pypi.org/legacy/```
