### PR TITLE
BigQuery: allow setting None as partition expiration

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1335,7 +1335,10 @@ class TimePartitioning(object):
 
     @expiration_ms.setter
     def expiration_ms(self, value):
-        self._properties["expirationMs"] = str(value)
+        if value is not None:
+            # Allow explicitly setting the expiration to None.
+            value = str(value)
+        self._properties["expirationMs"] = value
 
     @property
     def require_partition_filter(self):

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -1683,3 +1683,8 @@ class TestTimePartitioning(unittest.TestCase):
             "type=DAY)"
         )
         self.assertEqual(repr(time_partitioning), expected)
+
+    def test_set_expiration_w_none(self):
+        time_partitioning = self._make_one()
+        time_partitioning.expiration_ms = None
+        assert time_partitioning._properties["expirationMs"] is None


### PR DESCRIPTION
Per internal bug report 120204617.