### PR TITLE
Firestore: for queries ordered on '__name__', expand field values to full paths.

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/query.py
+++ b/firestore/google/cloud/firestore_v1beta1/query.py
@@ -592,20 +592,17 @@ class Query(object):
             raise ValueError(msg)
 
         _transform_bases = (transforms.Sentinel, transforms._ValueList)
-        for field in document_fields:
+
+        for index, key_field in enumerate(zip(order_keys, document_fields)):
+            key, field = key_field
+
             if isinstance(field, _transform_bases):
                 msg = _INVALID_CURSOR_TRANSFORM
                 raise ValueError(msg)
 
-        try:
-            name_index = order_keys.index("__name__")
-        except ValueError:
-            pass
-        else:
-            name = document_fields[name_index]
-            if "/" not in name:
-                document_fields[name_index] = "{}/{}/{}".format(
-                    self._client._database_string, "/".join(self._parent._path), name
+            if key == "__name__" and "/" not in field:
+                document_fields[index] = "{}/{}/{}".format(
+                    self._client._database_string, "/".join(self._parent._path), field
                 )
 
         return document_fields, before

--- a/firestore/google/cloud/firestore_v1beta1/query.py
+++ b/firestore/google/cloud/firestore_v1beta1/query.py
@@ -563,8 +563,7 @@ class Query(object):
 
         return projection
 
-    @staticmethod
-    def _normalize_cursor(cursor, orders):
+    def _normalize_cursor(self, cursor, orders):
         """Helper: convert cursor to a list of values based on orders."""
         if cursor is None:
             return
@@ -597,6 +596,17 @@ class Query(object):
             if isinstance(field, _transform_bases):
                 msg = _INVALID_CURSOR_TRANSFORM
                 raise ValueError(msg)
+
+        try:
+            name_index = order_keys.index("__name__")
+        except ValueError:
+            pass
+        else:
+            name = document_fields[name_index]
+            if "/" not in name:
+                document_fields[name_index] = "{}/{}/{}".format(
+                    self._client._database_string, "/".join(self._parent._path), name
+                )
 
         return document_fields, before
 

--- a/firestore/tests/unit/test_query.py
+++ b/firestore/tests/unit/test_query.py
@@ -603,6 +603,36 @@ class TestQuery(unittest.TestCase):
 
         self.assertEqual(query._normalize_cursor(cursor, query._orders), ([1], True))
 
+    def test__normalize_cursor_w___name___w_slash(self):
+        db_string = "projects/my-project/database/(default)"
+        client = mock.Mock(spec=["_database_string"])
+        client._database_string = db_string
+        parent = mock.Mock(spec=["_path", "_client"])
+        parent._client = client
+        parent._path = ["C"]
+        query = self._make_one(parent).order_by("__name__", "ASCENDING")
+        expected = "{}/C/b".format(db_string)
+        cursor = ([expected], True)
+
+        self.assertEqual(
+            query._normalize_cursor(cursor, query._orders), ([expected], True)
+        )
+
+    def test__normalize_cursor_w___name___wo_slash(self):
+        db_string = "projects/my-project/database/(default)"
+        client = mock.Mock(spec=["_database_string"])
+        client._database_string = db_string
+        parent = mock.Mock(spec=["_path", "_client"])
+        parent._client = client
+        parent._path = ["C"]
+        query = self._make_one(parent).order_by("__name__", "ASCENDING")
+        cursor = (["b"], True)
+        expected = "{}/C/b".format(db_string)
+
+        self.assertEqual(
+            query._normalize_cursor(cursor, query._orders), ([expected], True)
+        )
+
     def test__to_protobuf_all_fields(self):
         from google.protobuf import wrappers_pb2
         from google.cloud.firestore_v1beta1.gapic import enums


### PR DESCRIPTION
Closes #6793.