### PR TITLE
Add to_bqstorage to convert from Table[Reference] google-cloud-bigquery-storage reference

### DIFF
--- a/bigquery/docs/snippets.py
+++ b/bigquery/docs/snippets.py
@@ -1314,7 +1314,7 @@ def test_load_table_from_file(client, to_delete):
 
 
 def test_load_table_from_uri_avro(client, to_delete, capsys):
-    dataset_id = 'load_table_from_uri_avro_{}'.format(_millis())
+    dataset_id = "load_table_from_uri_avro_{}".format(_millis())
     dataset = bigquery.Dataset(client.dataset(dataset_id))
     client.create_dataset(dataset)
     to_delete.append(dataset)
@@ -1327,23 +1327,22 @@ def test_load_table_from_uri_avro(client, to_delete, capsys):
     dataset_ref = client.dataset(dataset_id)
     job_config = bigquery.LoadJobConfig()
     job_config.source_format = bigquery.SourceFormat.AVRO
-    uri = 'gs://cloud-samples-data/bigquery/us-states/us-states.avro'
+    uri = "gs://cloud-samples-data/bigquery/us-states/us-states.avro"
 
     load_job = client.load_table_from_uri(
-        uri,
-        dataset_ref.table('us_states'),
-        job_config=job_config)  # API request
-    print('Starting job {}'.format(load_job.job_id))
+        uri, dataset_ref.table("us_states"), job_config=job_config
+    )  # API request
+    print("Starting job {}".format(load_job.job_id))
 
     load_job.result()  # Waits for table load to complete.
-    print('Job finished.')
+    print("Job finished.")
 
-    destination_table = client.get_table(dataset_ref.table('us_states'))
-    print('Loaded {} rows.'.format(destination_table.num_rows))
+    destination_table = client.get_table(dataset_ref.table("us_states"))
+    print("Loaded {} rows.".format(destination_table.num_rows))
     # [END bigquery_load_table_gcs_avro]
 
     out, _ = capsys.readouterr()
-    assert 'Loaded 50 rows.' in out
+    assert "Loaded 50 rows." in out
 
 
 def test_load_table_from_uri_csv(client, to_delete, capsys):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -279,7 +279,7 @@ class TableReference(object):
             "tableId": self._table_id,
         }
 
-    def to_bqstorage(self, selected_fields=None):
+    def to_bqstorage(self):
         """Construct a BigQuery Storage API representation of this table.
 
         If the ``table_id`` contains a partition identifier (e.g.
@@ -852,21 +852,11 @@ class Table(object):
         """
         return copy.deepcopy(self._properties)
 
-    def to_bqstorage(self, selected_fields=None):
+    def to_bqstorage(self):
         """Construct a BigQuery Storage API representation of this table.
 
-        Args:
-            selected_fields (Sequence[ \
-                google.cloud.bigquery.schema.SchemaField, \
-            ]):
-                Optional. A subset of columns to select from this table.
-
         Returns:
-            Tuple[ \
-                google.cloud.bigquery_storage_v1beta1.types.TableReference, \
-                google.cloud.bigquery_storage_v1beta1.types.TableModifiers, \
-                google.cloud.bigquery_storage_v1beta1.types.TableReadOptions, \
-            ]:
+            google.cloud.bigquery_storage_v1beta1.types.TableReference:
                 A reference to this table in the BigQuery Storage API.
         """
         return self.reference.to_bqstorage(selected_fields=selected_fields)
@@ -1048,21 +1038,11 @@ class TableListItem(object):
             {"tableReference": TableReference.from_string(full_table_id).to_api_repr()}
         )
 
-    def to_bqstorage(self, selected_fields=None):
+    def to_bqstorage(self):
         """Construct a BigQuery Storage API representation of this table.
 
-        Args:
-            selected_fields (Sequence[ \
-                google.cloud.bigquery.schema.SchemaField, \
-            ]):
-                Optional. A subset of columns to select from this table.
-
         Returns:
-            Tuple[ \
-                google.cloud.bigquery_storage_v1beta1.types.TableReference, \
-                google.cloud.bigquery_storage_v1beta1.types.TableModifiers, \
-                google.cloud.bigquery_storage_v1beta1.types.TableReadOptions, \
-            ]:
+            google.cloud.bigquery_storage_v1beta1.types.TableReference:
                 A reference to this table in the BigQuery Storage API.
         """
         return self.reference.to_bqstorage(selected_fields=selected_fields)

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -859,7 +859,7 @@ class Table(object):
             google.cloud.bigquery_storage_v1beta1.types.TableReference:
                 A reference to this table in the BigQuery Storage API.
         """
-        return self.reference.to_bqstorage(selected_fields=selected_fields)
+        return self.reference.to_bqstorage()
 
     def _build_resource(self, filter_fields):
         """Generate a resource for ``update``."""
@@ -1045,7 +1045,7 @@ class TableListItem(object):
             google.cloud.bigquery_storage_v1beta1.types.TableReference:
                 A reference to this table in the BigQuery Storage API.
         """
-        return self.reference.to_bqstorage(selected_fields=selected_fields)
+        return self.reference.to_bqstorage()
 
 
 def _row_from_mapping(mapping, schema):

--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -20,7 +20,7 @@ import nox
 
 
 LOCAL_DEPS = (
-    os.path.join('..', 'api_core'),
+    os.path.join('..', 'api_core[grpc]'),
     os.path.join('..', 'core'),
 )
 
@@ -40,9 +40,9 @@ def default(session):
 
     # Pyarrow does not support Python 3.7
     if session.python == '3.7':
-        dev_install = '.[pandas]'
+        dev_install = '.[bqstorage, pandas]'
     else:
-        dev_install = '.[pandas, pyarrow]'
+        dev_install = '.[bqstorage, pandas, pyarrow]'
     session.install('-e', dev_install)
 
     # IPython does not support Python 2 after version 5.x

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -34,6 +34,7 @@ dependencies = [
     'google-resumable-media >= 0.3.1',
 ]
 extras = {
+    'bqstorage': 'google-cloud-bigquery-storage<=2.0.0dev',
     'pandas': 'pandas>=0.17.1',
     # Exclude PyArrow dependency from Windows Python 2.7.
     'pyarrow: platform_system != "Windows" or python_version >= "3.4"':

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -800,7 +800,7 @@ class Test_AsyncJob(unittest.TestCase):
         begin.assert_called_once_with(retry=DEFAULT_RETRY)
         result.assert_called_once_with(timeout=None)
 
-    @mock.patch('google.api_core.future.polling.PollingFuture.result')
+    @mock.patch("google.api_core.future.polling.PollingFuture.result")
     def test_result_w_retry_wo_state(self, result):
         client = _make_client(project=self.PROJECT)
         job = self._make_one(self.JOB_ID, client)

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -1700,96 +1700,22 @@ class TestTimePartitioning(unittest.TestCase):
     bigquery_storage_v1beta1 is None, reason="Requires `google-cloud-bigquery-storage`"
 )
 def test_table_reference_to_bqstorage():
-    from google.protobuf import timestamp_pb2
     from google.cloud.bigquery import table as mut
 
     # Can't use parametrized pytest because bigquery_storage_v1beta1 may not be
     # available.
-    ts1234567890 = timestamp_pb2.Timestamp()
-    ts1234567890.FromMilliseconds(1234567890)
+    expected = bigquery_storage_v1beta1.types.TableReference(
+        project_id="my-project", dataset_id="my_dataset", table_id="my_table"
+    )
     cases = (
-        (
-            "my-project.my_dataset.my_table",
-            None,
-            (
-                bigquery_storage_v1beta1.types.TableReference(
-                    project_id="my-project",
-                    dataset_id="my_dataset",
-                    table_id="my_table",
-                ),
-                bigquery_storage_v1beta1.types.TableModifiers(),
-                bigquery_storage_v1beta1.types.TableReadOptions(),
-            ),
-        ),
-        (
-            "my-project.my_dataset.my_table",
-            (mut.SchemaField("col_name", "IGNORED"),),
-            (
-                bigquery_storage_v1beta1.types.TableReference(
-                    project_id="my-project",
-                    dataset_id="my_dataset",
-                    table_id="my_table",
-                ),
-                bigquery_storage_v1beta1.types.TableModifiers(),
-                bigquery_storage_v1beta1.types.TableReadOptions(
-                    selected_fields=["col_name"]
-                ),
-            ),
-        ),
-        (
-            "my-project.my_dataset.my_table$20181225",
-            None,
-            (
-                bigquery_storage_v1beta1.types.TableReference(
-                    project_id="my-project",
-                    dataset_id="my_dataset",
-                    table_id="my_table",
-                ),
-                bigquery_storage_v1beta1.types.TableModifiers(),
-                bigquery_storage_v1beta1.types.TableReadOptions(
-                    row_restriction="_PARTITIONTIME = TIMESTAMP('2018-12-25')"
-                ),
-            ),
-        ),
-        (
-            "my-project.my_dataset.my_table@1234567890",
-            None,
-            (
-                bigquery_storage_v1beta1.types.TableReference(
-                    project_id="my-project",
-                    dataset_id="my_dataset",
-                    table_id="my_table",
-                ),
-                bigquery_storage_v1beta1.types.TableModifiers(
-                    snapshot_time=ts1234567890
-                ),
-                bigquery_storage_v1beta1.types.TableReadOptions(),
-            ),
-        ),
-        (
-            "my-project.my_dataset.my_table$20181225@1234567890",
-            None,
-            (
-                bigquery_storage_v1beta1.types.TableReference(
-                    project_id="my-project",
-                    dataset_id="my_dataset",
-                    table_id="my_table",
-                ),
-                bigquery_storage_v1beta1.types.TableModifiers(
-                    snapshot_time=ts1234567890
-                ),
-                bigquery_storage_v1beta1.types.TableReadOptions(
-                    row_restriction="_PARTITIONTIME = TIMESTAMP('2018-12-25')"
-                ),
-            ),
-        ),
+        "my-project.my_dataset.my_table",
+        "my-project.my_dataset.my_table$20181225",
+        "my-project.my_dataset.my_table@1234567890",
+        "my-project.my_dataset.my_table$20181225@1234567890",
     )
 
     classes = (mut.TableReference, mut.Table, mut.TableListItem)
 
     for case, cls in itertools.product(cases, classes):
-        table_string, selected_fields, expected = case
-        got = cls.from_string(table_string).to_bqstorage(
-            selected_fields=selected_fields
-        )
+        got = cls.from_string(case).to_bqstorage()
         assert got == expected


### PR DESCRIPTION
This makes it easier to use the new BigQuery Storage API (currently in
Alpha) in combination with the BigQuery API.