### PR TITLE
Remove mentions / links of 'google-cloud' from Github landing page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,10 +81,9 @@
     <div class="container clearfix">
       <div class="col col-left">
         <h1>google-cloud</h1>
-        <p>Google Cloud Client Library for Python
-        - an idiomatic, intuitive, and natural way for Python developers to
-        integrate with Google Cloud Platform services, like Cloud Datastore
-        and Cloud Storage.</p>
+        <p>Google Cloud client libraries for Python - idiomatic, intuitive,
+        and natural way for Python developers to integrate with Google Cloud
+        Platform services, such as Cloud Datastore and Cloud Storage.</p>
       </div><!-- end of .col.col-left -->
     </div><!-- end of .container -->
   </section><!-- end of .hero-banner -->
@@ -116,12 +115,6 @@
             StackOverflow
           </a>
         </li>
-        <li>
-          <a href="https://pypi.python.org/pypi/google-cloud" title="google-cloud-python on PyPI" class="ext-link">
-            <img src="_landing-page-static/images/icon-link-package-manager.svg" alt="PyPI icon" />
-            PyPI
-          </a>
-        </li>
       </ul>
     </div><!-- end of .container -->
   </section><!-- end of .featuring -->
@@ -131,20 +124,19 @@
       <div class="col col-left">
         <h3 class="block-title">What is it?</h3>
 
-        <p><code>google-cloud</code> is a client library for accessing Google
-        Cloud Platform services that significantly reduces the boilerplate
-        code you have to write. The library provides high-level API
-        abstractions so they're easier to understand. It embraces
-        idioms of Python, works well with the standard library, and
-        integrates better with your codebase.
-        All this means you spend more time creating code that matters
-        to you.</p>
+        <p>The <code>google-cloud-*</code> libraries provide clients for
+        accessing Google Cloud Platform services, significantly reducing
+        the boilerplate code you have to write. The libraries provide
+        high-level API abstractions so they're easier to understand.
+        They embrace idioms of Python, work well with the standard library,
+        and integrate better with your codebase.  All this means you spend
+        more time creating code that matters to you.</p>
 
-        <p><code>google-cloud</code> is configured to access Google Cloud Platform
-        services and authorize (OAuth 2.0) automatically on your behalf.
-        With a one-line install and a private key, you are up and ready
-        to go. Better yet, if you are running on a Google Compute Engine
-        instance, the one-line install is enough!</p>
+        <p>The <code>google-cloud-*</code> clients are configured to access
+        Google Cloud Platform services and authorize (OAuth 2.0) automatically
+        on your behalf.  With a one-line install and a private key, you are up
+        and ready to go. Better yet, if you are running on a Google Compute
+        Engine instance, the one-line install is enough!</p>
 
       </div><!-- end of .col.col-left -->
 
@@ -179,25 +171,28 @@
       <div class="container clearfix">
       <h3 class="block-title">FAQ</h3>
 
-      <h4>What is the relationship between the <code>google-cloud</code> package
-      and the <code>gcloud</code> command-line tool?</h4>
-      <p>Both the <code>gcloud</code> command-line tool and
-      <code>google-cloud</code> package are a part of the Google Cloud SDK: a collection
-      of tools and libraries that enable you to easily create and manage
-      resources on the Google Cloud Platform. The <code>gcloud</code> command-line
-      tool can be used to manage both your development workflow and your
-      Google Cloud Platform resources while the <code>google-cloud</code> package is the
-      Google Cloud Client Library for Python.</p>
+      <h4>What is the relationship between the <code>google-cloud-*<ecode>
+      libraries and the <code>gcloud</code> command-line tool?</h4>
+      <p>Both the <code>gcloud</code> command-line tool and the
+      <code>google-cloud-*</code> libraries are a part of the Google Cloud
+      SDK: a collection of tools and libraries that enable you to easily
+      create and manage resources on the Google Cloud Platform.
+      The <code>gcloud</code> command-line tool can be used to manage both
+      your development workflow and your Google Cloud Platform resources while
+      the <code>google-cloud-*</code> libraries provide the
+      libraries for creating and interacting with those reesources
+      from Python.</p>
 
-      <h4>What is the relationship between <code>google-cloud</code>
-      and the Google APIs Python Client?</h4>
+      <h4>What is the relationship between the <code>google-cloud-*</code>
+      libraries and the Google APIs Python Client?</h4>
       <p>The <a href="https://github.com/google/google-api-python-client">
-      Google APIs Python Client</a> is a client library for
-      using the broad set of Google APIs.
-      <code>google-cloud</code> is built specifically for the Google Cloud Platform
-      and is the recommended way to integrate Google Cloud APIs into your
-      Python applications. If your application requires both Google Cloud Platform and
-      other Google APIs, the 2 libraries may be used by your application.</p>
+      Google APIs Python Client</a> is a client library for using the broad
+      set of Google APIs.
+      The <code>google-cloud-*</code> libraries are built specifically for the
+      Google Cloud Platform and provide the recommended way to integrate
+      Google Cloud APIs into your Python applications. If your application
+      requires both Google Cloud Platform and other Google APIs, both may be
+      used by your application.</p>
       </div>
   </section> <!-- end of FAQ -->
 


### PR DESCRIPTION
Closes #5984.