### PR TITLE
Firestore: document timeouts for 'Query.get' / 'Collection.get'.

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/collection.py
+++ b/firestore/google/cloud/firestore_v1beta1/collection.py
@@ -354,8 +354,16 @@ class CollectionReference(object):
     def get(self, transaction=None):
         """Read the documents in this collection.
 
-        This sends a ``RunQuery`` RPC and then consumes each document
-        returned in the stream of ``RunQueryResponse`` messages.
+        This sends a ``RunQuery`` RPC and then returns an iterator which
+        consumes each document returned in the stream of ``RunQueryResponse``
+        messages.
+
+        .. note::
+
+           The underlying stream of responses will time out after
+           the ``max_rpc_timeout_millis`` value set in the GAPIC
+           client configuration for the ``RunQuery`` API.  Snapshots
+           not consumed from the iterator before that point will be lost.
 
         If a ``transaction`` is used and it already has write operations
         added, this method cannot be used (i.e. read-after-write is not

--- a/firestore/google/cloud/firestore_v1beta1/query.py
+++ b/firestore/google/cloud/firestore_v1beta1/query.py
@@ -640,8 +640,16 @@ class Query(object):
     def get(self, transaction=None):
         """Read the documents in the collection that match this query.
 
-        This sends a ``RunQuery`` RPC and then consumes each document
-        returned in the stream of ``RunQueryResponse`` messages.
+        This sends a ``RunQuery`` RPC and then returns an iterator which
+        consumes each document returned in the stream of ``RunQueryResponse``
+        messages.
+
+        .. note::
+
+           The underlying stream of responses will time out after
+           the ``max_rpc_timeout_millis`` value set in the GAPIC
+           client configuration for the ``RunQuery`` API.  Snapshots
+           not consumed from the iterator before that point will be lost.
 
         If a ``transaction`` is used and it already has write operations
         added, this method cannot be used (i.e. read-after-write is not


### PR DESCRIPTION
Closes #6043.