### PR TITLE
API Core: add usage example for 'google.api_core.iam.Polcy'.

### DIFF
--- a/docs/core/iam.rst
+++ b/docs/core/iam.rst
@@ -4,3 +4,4 @@ Identity and Access Management
 .. automodule:: google.api_core.iam
   :members:
   :show-inheritance:
+  :member-order: bysource


### PR DESCRIPTION
Napoleon-ize docstrings in `google.api_core.iam`.

Order the `core/iam` docs page entries in source order.

Closes #6161.