### PR TITLE
Fix trace client memory leak

### DIFF
--- a/trace/google/cloud/trace/client.py
+++ b/trace/google/cloud/trace/client.py
@@ -51,7 +51,8 @@ class Client(ClientWithProject):
         https://cloud.google.com/trace/docs/reference/v2/rpc/google.devtools.
         cloudtrace.v2
         """
-        self._trace_api = make_trace_api(self)
+        if self._trace_api is None:
+            self._trace_api = make_trace_api(self)
         return self._trace_api
 
     def batch_write_spans(self, name, spans, retry=None, timeout=None):

--- a/trace/google/cloud/trace/v1/client.py
+++ b/trace/google/cloud/trace/v1/client.py
@@ -53,7 +53,8 @@ class Client(ClientWithProject):
         https://cloud.google.com/trace/docs/reference/v1/rpc/google.devtools.
         cloudtrace.v1
         """
-        self._trace_api = make_trace_api(self)
+        if self._trace_api is None:
+            self._trace_api = make_trace_api(self)
         return self._trace_api
 
     def patch_traces(self, traces, project_id=None):

--- a/trace/tests/unit/v1/test_client_v1.py
+++ b/trace/tests/unit/v1/test_client_v1.py
@@ -60,6 +60,15 @@ class TestClient(unittest.TestCase):
         self.assertIs(api, api_obj)
         self.assertEqual(clients, [client])
 
+    def test_trace_api_existing(self):
+        """Check that the client caches _trace_api."""
+        client = self._make_one(project=self.project,
+                                credentials=_make_credentials())
+        self.assertIsNone(client._trace_api)
+        trace_api = client.trace_api
+        self.assertIsNotNone(client._trace_api)
+        self.assertIs(client.trace_api, trace_api)
+
     def test_patch_traces_default(self):
         from google.cloud.trace.v1._gapic import _TraceAPI
 

--- a/trace/tests/unit/v1/test_client_v1.py
+++ b/trace/tests/unit/v1/test_client_v1.py
@@ -62,8 +62,7 @@ class TestClient(unittest.TestCase):
 
     def test_trace_api_existing(self):
         """Check that the client caches _trace_api."""
-        client = self._make_one(project=self.project,
-                                credentials=_make_credentials())
+        client = self._make_one(project=self.project, credentials=_make_credentials())
         client._trace_api = mock.sentinel.trace_api
         self.assertIs(client.trace_api, mock.sentinel.trace_api)
 

--- a/trace/tests/unit/v1/test_client_v1.py
+++ b/trace/tests/unit/v1/test_client_v1.py
@@ -64,10 +64,8 @@ class TestClient(unittest.TestCase):
         """Check that the client caches _trace_api."""
         client = self._make_one(project=self.project,
                                 credentials=_make_credentials())
-        self.assertIsNone(client._trace_api)
-        trace_api = client.trace_api
-        self.assertIsNotNone(client._trace_api)
-        self.assertIs(client.trace_api, trace_api)
+        client._trace_api = mock.sentinel.trace_api
+        self.assertIs(client.trace_api, mock.sentinel.trace_api)
 
     def test_patch_traces_default(self):
         from google.cloud.trace.v1._gapic import _TraceAPI

--- a/trace/tests/unit/v2/test_client_v2.py
+++ b/trace/tests/unit/v2/test_client_v2.py
@@ -62,8 +62,7 @@ class TestClient(unittest.TestCase):
 
     def test_trace_api_existing(self):
         """Check that the client caches _trace_api."""
-        client = self._make_one(project=self.project,
-                                credentials=_make_credentials())
+        client = self._make_one(project=self.project, credentials=_make_credentials())
         client._trace_api = mock.sentinel.trace_api
         self.assertIs(client.trace_api, mock.sentinel.trace_api)
 

--- a/trace/tests/unit/v2/test_client_v2.py
+++ b/trace/tests/unit/v2/test_client_v2.py
@@ -60,6 +60,15 @@ class TestClient(unittest.TestCase):
         self.assertIs(api, api_obj)
         self.assertEqual(clients, [client])
 
+    def test_trace_api_existing(self):
+        """Check that the client caches _trace_api."""
+        client = self._make_one(project=self.project,
+                                credentials=_make_credentials())
+        self.assertIsNone(client._trace_api)
+        trace_api = client.trace_api
+        self.assertIsNotNone(client._trace_api)
+        self.assertIs(client.trace_api, trace_api)
+
     def test_batch_write_spans(self):
         from google.cloud.trace._gapic import _TraceAPI
 

--- a/trace/tests/unit/v2/test_client_v2.py
+++ b/trace/tests/unit/v2/test_client_v2.py
@@ -64,10 +64,8 @@ class TestClient(unittest.TestCase):
         """Check that the client caches _trace_api."""
         client = self._make_one(project=self.project,
                                 credentials=_make_credentials())
-        self.assertIsNone(client._trace_api)
-        trace_api = client.trace_api
-        self.assertIsNotNone(client._trace_api)
-        self.assertIs(client.trace_api, trace_api)
+        client._trace_api = mock.sentinel.trace_api
+        self.assertIs(client.trace_api, mock.sentinel.trace_api)
 
     def test_batch_write_spans(self):
         from google.cloud.trace._gapic import _TraceAPI


### PR DESCRIPTION
cc @liyanhui1228 

@bogdandrutu and I are seeing a persistent [memory leak](https://github.com/census-instrumentation/opencensus-python/issues/334) in projects using the [opencensus stackdriver exporter](https://github.com/census-instrumentation/opencensus-python/blob/master/opencensus/stats/exporters/stackdriver_exporter.py), which uses `google.cloud.trace.client.Client` and repeatedly calls [`batch_write_spans`](https://github.com/googleapis/google-cloud-python/blob/92465cbc4d9c0ba251838e9cd17f61d14b470e04/trace/google/cloud/trace/client.py#L57-L100).

Reusing the trace client's API object fixes the leak.