### PR TITLE
NDB: Start in on `ndb.client.Client`

### DIFF
--- a/ndb/noxfile.py
+++ b/ndb/noxfile.py
@@ -45,7 +45,7 @@ def unit(session):
         run_args.extend(
             [
                 "--cov=google.cloud.ndb",
-                "--cov=tests",
+                "--cov=tests.unit",
                 "--cov-config",
                 get_path(".coveragerc"),
                 "--cov-report=",
@@ -87,6 +87,14 @@ def run_black(session, use_check=False):
 
 
 @nox.session(py=DEFAULT_INTERPRETER)
+def blacken(session):
+    # Install all dependencies.
+    session.install("black")
+    # Run ``black``.
+    run_black(session)
+
+
+@nox.session(py=DEFAULT_INTERPRETER)
 def lint(session):
     """Run linters.
     Returns a failure if the linters find linting errors or sufficiently
@@ -95,14 +103,6 @@ def lint(session):
     session.install("flake8", "black")
     run_black(session, use_check=True)
     session.run("flake8", "google", "tests")
-
-
-@nox.session(py=DEFAULT_INTERPRETER)
-def blacken(session):
-    # Install all dependencies.
-    session.install("black")
-    # Run ``black``.
-    run_black(session)
 
 
 @nox.session(py=DEFAULT_INTERPRETER)

--- a/ndb/noxfile.py
+++ b/ndb/noxfile.py
@@ -45,7 +45,7 @@ def unit(session):
         run_args.extend(
             [
                 "--cov=google.cloud.ndb",
-                "--cov=tests.unit",
+                "--cov=tests",
                 "--cov-config",
                 get_path(".coveragerc"),
                 "--cov-report=",
@@ -87,14 +87,6 @@ def run_black(session, use_check=False):
 
 
 @nox.session(py=DEFAULT_INTERPRETER)
-def blacken(session):
-    # Install all dependencies.
-    session.install("black")
-    # Run ``black``.
-    run_black(session)
-
-
-@nox.session(py=DEFAULT_INTERPRETER)
 def lint(session):
     """Run linters.
     Returns a failure if the linters find linting errors or sufficiently
@@ -103,6 +95,14 @@ def lint(session):
     session.install("flake8", "black")
     run_black(session, use_check=True)
     session.run("flake8", "google", "tests")
+
+
+@nox.session(py=DEFAULT_INTERPRETER)
+def blacken(session):
+    # Install all dependencies.
+    session.install("black")
+    # Run ``black``.
+    run_black(session)
 
 
 @nox.session(py=DEFAULT_INTERPRETER)

--- a/ndb/src/google/cloud/ndb/__init__.py
+++ b/ndb/src/google/cloud/ndb/__init__.py
@@ -25,6 +25,7 @@ __version__ = "0.0.1.dev1"
 """Current ``ndb`` version."""
 __all__ = [
     "AutoBatcher",
+    "Client",
     "Context",
     "ContextOptions",
     "EVENTUAL_CONSISTENCY",
@@ -122,6 +123,7 @@ __all__ = [
 ]
 """All top-level exported names."""
 
+from google.cloud.ndb.client import Client
 from google.cloud.ndb.context import AutoBatcher
 from google.cloud.ndb.context import Context
 from google.cloud.ndb.context import ContextOptions

--- a/ndb/src/google/cloud/ndb/client.py
+++ b/ndb/src/google/cloud/ndb/client.py
@@ -38,12 +38,12 @@ def _determine_default_project(project=None):
     * GOOGLE_CLOUD_PROJECT environment variable
     * Google App Engine application ID
     * Google Compute Engine project ID (from metadata server)
+_
+    Arguments:
+        project (Optional[str]): The project to use as default.
 
-    :type project: str
-    :param project: Optional. The project to use as default.
-
-    :rtype: str or ``NoneType``
-    :returns: Default project if it can be determined.
+    Returns:
+        Union([str, None]): Default project if it can be determined.
     """
     if project is None:
         project = _get_gcd_project()

--- a/ndb/src/google/cloud/ndb/client.py
+++ b/ndb/src/google/cloud/ndb/client.py
@@ -73,7 +73,7 @@ class Client(ClientWithProject):
     def __init__(self, project=None, namespace=None, credentials=None):
         super(Client, self).__init__(project=project, credentials=credentials)
         self.namespace = namespace
-        self._host = os.environ.get(environment_vars.GCD_HOST, _DATASTORE_HOST)
+        self.host = os.environ.get(environment_vars.GCD_HOST, _DATASTORE_HOST)
 
     @property
     def _http(self):

--- a/ndb/src/google/cloud/ndb/client.py
+++ b/ndb/src/google/cloud/ndb/client.py
@@ -1,0 +1,90 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A client for NDB which manages credentials, project, namespace."""
+
+import os
+
+from google.cloud import environment_vars
+from google.cloud.client import ClientWithProject
+from google.cloud import _helpers
+
+_DATASTORE_HOST = "datastore.googleapis.com"
+
+
+def _get_gcd_project():
+    """Gets the GCD application ID if it can be inferred."""
+    return os.getenv(environment_vars.GCD_DATASET)
+
+
+def _determine_default_project(project=None):
+    """Determine default project explicitly or implicitly as fall-back.
+
+    In implicit case, supports four environments. In order of precedence, the
+    implicit environments are:
+
+    * DATASTORE_DATASET environment variable (for ``gcd`` / emulator testing)
+    * GOOGLE_CLOUD_PROJECT environment variable
+    * Google App Engine application ID
+    * Google Compute Engine project ID (from metadata server)
+
+    :type project: str
+    :param project: Optional. The project to use as default.
+
+    :rtype: str or ``NoneType``
+    :returns: Default project if it can be determined.
+    """
+    if project is None:
+        project = _get_gcd_project()
+
+    if project is None:
+        project = _helpers._determine_default_project(project=project)
+
+    return project
+
+
+class Client(ClientWithProject):
+    """An NDB client.
+
+    Arguments:
+        project (Optional[str]): The project to pass to proxied API methods. If
+            not passed, falls back to the default inferred from the
+            environment.
+        namespace (Optional[str]): Namespace to pass to proxied API methods.
+        credentials (Optional[:class:`~google.auth.credentials.Credentials`]):
+            The OAuth2 Credentials to use for this client. If not passed, falls
+            back to the default inferred from the environment.
+    """
+
+    SCOPE = ("https://www.googleapis.com/auth/datastore",)
+    """The scopes required for authenticating as a Cloud Datastore consumer."""
+
+    def __init__(self, project=None, namespace=None, credentials=None):
+        super(Client, self).__init__(project=project, credentials=credentials)
+        self.namespace = namespace
+        self._host = os.environ.get(environment_vars.GCD_HOST, _DATASTORE_HOST)
+
+    @property
+    def _http(self):
+        """Getter for object used for HTTP transport.
+
+        Raises:
+            NotImplementedError: Always, HTTP transport is not supported.
+        """
+        raise NotImplementedError("HTTP transport is not supported.")
+
+    @staticmethod
+    def _determine_default(project):
+        """Helper:  override default project detection."""
+        return _determine_default_project(project)

--- a/ndb/src/google/cloud/ndb/client.py
+++ b/ndb/src/google/cloud/ndb/client.py
@@ -73,7 +73,8 @@ class Client(ClientWithProject):
         super(Client, self).__init__(project=project, credentials=credentials)
         self.namespace = namespace
         self.host = os.environ.get(
-            environment_vars.GCD_HOST, _http.DATASTORE_API_HOST)
+            environment_vars.GCD_HOST, _http.DATASTORE_API_HOST
+        )
 
     @property
     def _http(self):

--- a/ndb/src/google/cloud/ndb/client.py
+++ b/ndb/src/google/cloud/ndb/client.py
@@ -17,10 +17,9 @@
 import os
 
 from google.cloud import environment_vars
-from google.cloud.client import ClientWithProject
 from google.cloud import _helpers
-
-_DATASTORE_HOST = "datastore.googleapis.com"
+from google.cloud.client import ClientWithProject
+from google.cloud.datastore import _http
 
 
 def _get_gcd_project():
@@ -73,7 +72,8 @@ class Client(ClientWithProject):
     def __init__(self, project=None, namespace=None, credentials=None):
         super(Client, self).__init__(project=project, credentials=credentials)
         self.namespace = namespace
-        self.host = os.environ.get(environment_vars.GCD_HOST, _DATASTORE_HOST)
+        self.host = os.environ.get(
+            environment_vars.GCD_HOST, _http.DATASTORE_API_HOST)
 
     @property
     def _http(self):

--- a/ndb/src/google/cloud/ndb/client.py
+++ b/ndb/src/google/cloud/ndb/client.py
@@ -18,8 +18,12 @@ import os
 
 from google.cloud import environment_vars
 from google.cloud import _helpers
-from google.cloud.client import ClientWithProject
-from google.cloud.datastore import _http
+from google.cloud import client as google_client
+from google.cloud.datastore_v1.gapic import datastore_client
+
+DATASTORE_API_HOST = datastore_client.DatastoreClient.SERVICE_ADDRESS.rstrip(
+    ":443"
+)
 
 
 def _get_gcd_project():
@@ -53,7 +57,7 @@ _
     return project
 
 
-class Client(ClientWithProject):
+class Client(google_client.ClientWithProject):
     """An NDB client.
 
     Arguments:
@@ -73,7 +77,7 @@ class Client(ClientWithProject):
         super(Client, self).__init__(project=project, credentials=credentials)
         self.namespace = namespace
         self.host = os.environ.get(
-            environment_vars.GCD_HOST, _http.DATASTORE_API_HOST
+            environment_vars.GCD_HOST, DATASTORE_API_HOST
         )
 
     @property

--- a/ndb/tests/conftest.py
+++ b/ndb/tests/conftest.py
@@ -48,7 +48,7 @@ def reset_state(environ):
 @pytest.fixture
 def environ():
     """Copy of ``os.environ``"""
-    original = os.environ.copy()
+    original = os.environ
     environ = original.copy()
     os.environ = environ
     yield environ

--- a/ndb/tests/conftest.py
+++ b/ndb/tests/conftest.py
@@ -64,7 +64,7 @@ def initialize_environment(request, environ):
     the current request, determines whether it's in a unit test, or not, and
     does the right thing.
     """
-    if request.module.__name__.startswith("tests.unit"):
+    if request.module.__name__.startswith("tests.unit"):  # pragma: NO COVER
         environ.pop(environment_vars.GCD_DATASET, None)
         environ.pop(environment_vars.GCD_HOST, None)
         environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)

--- a/ndb/tests/conftest.py
+++ b/ndb/tests/conftest.py
@@ -49,9 +49,9 @@ def reset_state(environ):
 def environ():
     """Copy of ``os.environ``"""
     original = os.environ
-    environ = original.copy()
-    os.environ = environ
-    yield environ
+    environ_copy = original.copy()
+    os.environ = environ_copy
+    yield environ_copy
     os.environ = original
 
 

--- a/ndb/tests/unit/test_client.py
+++ b/ndb/tests/unit/test_client.py
@@ -1,0 +1,72 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import pytest
+
+from unittest import mock
+
+from google.auth import credentials
+from google.cloud import environment_vars
+from google.cloud.ndb import client as client_module
+
+
+@contextlib.contextmanager
+def patch_credentials(project):
+    creds = mock.Mock(spec=credentials.Credentials)
+    patch = mock.patch("google.auth.default", return_value=(creds, project))
+    with patch:
+        yield creds
+
+
+class TestClient:
+    @staticmethod
+    def test_constructor_no_args():
+        with patch_credentials("testing"):
+            client = client_module.Client()
+        assert client.SCOPE == ("https://www.googleapis.com/auth/datastore",)
+        assert client.namespace is None
+        assert client._host == client_module._DATASTORE_HOST
+        assert client.project == "testing"
+
+    @staticmethod
+    def test_constructor_get_project_from_environ(environ):
+        environ[environment_vars.GCD_DATASET] = "gcd-project"
+        with patch_credentials(None):
+            client = client_module.Client()
+        assert client.project == "gcd-project"
+
+    @staticmethod
+    def test_constructor_all_args():
+        with patch_credentials("testing") as creds:
+            client = client_module.Client(
+                project="test-project",
+                namespace="test-namespace",
+                credentials=creds,
+            )
+        assert client.namespace == "test-namespace"
+        assert client.project == "test-project"
+
+    @staticmethod
+    def test__determine_default():
+        with patch_credentials("testing"):
+            client = client_module.Client()
+        assert client._determine_default("this") == "this"
+
+    @staticmethod
+    def test__http():
+        with patch_credentials("testing"):
+            client = client_module.Client()
+        with pytest.raises(NotImplementedError):
+            client._http

--- a/ndb/tests/unit/test_client.py
+++ b/ndb/tests/unit/test_client.py
@@ -37,7 +37,7 @@ class TestClient:
             client = client_module.Client()
         assert client.SCOPE == ("https://www.googleapis.com/auth/datastore",)
         assert client.namespace is None
-        assert client._host == client_module._DATASTORE_HOST
+        assert client.host == client_module._DATASTORE_HOST
         assert client.project == "testing"
 
     @staticmethod

--- a/ndb/tests/unit/test_client.py
+++ b/ndb/tests/unit/test_client.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 from google.auth import credentials
 from google.cloud import environment_vars
+from google.cloud.datastore import _http
 from google.cloud.ndb import client as client_module
 
 
@@ -37,7 +38,7 @@ class TestClient:
             client = client_module.Client()
         assert client.SCOPE == ("https://www.googleapis.com/auth/datastore",)
         assert client.namespace is None
-        assert client.host == client_module._DATASTORE_HOST
+        assert client.host == _http.DATASTORE_API_HOST
         assert client.project == "testing"
 
     @staticmethod


### PR DESCRIPTION
This is patterned off of `datastore.client.Client` and depends heavily on `google.cloud.client`.