### PR TITLE
[DNS] Ensure that `ManagedZone:exists()` does not misreport `True` result.

### DIFF
--- a/dns/google/cloud/dns/zone.py
+++ b/dns/google/cloud/dns/zone.py
@@ -280,9 +280,7 @@ class ManagedZone(object):
         client = self._require_client(client)
 
         try:
-            client._connection.api_request(
-                method="GET", path=self.path, query_params={"fields": "id"}
-            )
+            client._connection.api_request(method="GET", path=self.path)
         except NotFound:
             return False
         else:

--- a/dns/tests/unit/test_zone.py
+++ b/dns/tests/unit/test_zone.py
@@ -330,7 +330,6 @@ class TestManagedZone(unittest.TestCase):
         req = conn._requested[0]
         self.assertEqual(req["method"], "GET")
         self.assertEqual(req["path"], "/%s" % PATH)
-        self.assertEqual(req["query_params"], {"fields": "id"})
 
     def test_exists_hit_w_alternate_client(self):
         PATH = "projects/%s/managedZones/%s" % (self.PROJECT, self.ZONE_NAME)
@@ -347,7 +346,6 @@ class TestManagedZone(unittest.TestCase):
         req = conn2._requested[0]
         self.assertEqual(req["method"], "GET")
         self.assertEqual(req["path"], "/%s" % PATH)
-        self.assertEqual(req["query_params"], {"fields": "id"})
 
     def test_reload_w_bound_client(self):
         PATH = "projects/%s/managedZones/%s" % (self.PROJECT, self.ZONE_NAME)


### PR DESCRIPTION
The behaviour of the [`MangedZones: get`](https://cloud.google.com/dns/docs/reference/v1/managedZones/get) endpoint is such that when only the `id` field of a non-existent `ManagedZone` is requested, a 200 status code response with body `{}` is returned.

This is arguably undesirable behaviour, however this patch serves to ensure that the Python SDK behaves expectedly with the API in its current state.

Is anyone aware of where the best place to leave feedback on the API would be? Is the "Leave Feedback" section on the documentation page appropriate? Is it an open-source project?