### PR TITLE
NDB: Get Datastore gRPC API stub

### DIFF
--- a/ndb/src/google/cloud/ndb/_api.py
+++ b/ndb/src/google/cloud/ndb/_api.py
@@ -1,0 +1,41 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Functions that interact with Datastore backend."""
+
+import grpc
+
+from google.cloud import _helpers
+from google.cloud import _http
+from google.cloud.datastore_v1.proto import datastore_pb2_grpc
+
+
+def stub(client):
+    """Get a stub for the `Google Datastore` API.
+
+    Arguments:
+        client (:class:`~client.Client`): An NDB client instance.
+
+    Returns:
+        :class:`~google.cloud.datastore_v1.proto.datastore_pb2_grpc.DatastoreStub`:
+            The stub instance.
+    """
+    if client.secure:
+        channel = _helpers.make_secure_channel(
+            client._credentials, _http.DEFAULT_USER_AGENT, client.host
+        )
+    else:
+        channel = grpc.insecure_channel(client.host)
+    stub = datastore_pb2_grpc.DatastoreStub(channel)
+    return stub

--- a/ndb/src/google/cloud/ndb/client.py
+++ b/ndb/src/google/cloud/ndb/client.py
@@ -73,6 +73,9 @@ class Client(google_client.ClientWithProject):
     SCOPE = ("https://www.googleapis.com/auth/datastore",)
     """The scopes required for authenticating as a Cloud Datastore consumer."""
 
+    secure = True
+    """Whether to use a secure connection for API calls."""
+
     def __init__(self, project=None, namespace=None, credentials=None):
         super(Client, self).__init__(project=project, credentials=credentials)
         self.namespace = namespace

--- a/ndb/tests/unit/test__api.py
+++ b/ndb/tests/unit/test__api.py
@@ -1,0 +1,51 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from google.cloud import _http
+from google.cloud.ndb import _api
+
+
+class TestStub:
+    @staticmethod
+    @mock.patch("google.cloud.ndb._api._helpers")
+    @mock.patch("google.cloud.ndb._api.datastore_pb2_grpc")
+    def test_secure_channel(datastore_pb2_grpc, _helpers):
+        channel = _helpers.make_secure_channel.return_value
+        client = mock.Mock(
+            _credentials="creds",
+            secure=True,
+            host="thehost",
+            spec=("_credentials", "secure", "host"),
+        )
+        stub = _api.stub(client)
+        assert stub is datastore_pb2_grpc.DatastoreStub.return_value
+        datastore_pb2_grpc.DatastoreStub.assert_called_once_with(channel)
+        _helpers.make_secure_channel.assert_called_once_with(
+            "creds", _http.DEFAULT_USER_AGENT, "thehost"
+        )
+
+    @staticmethod
+    @mock.patch("google.cloud.ndb._api.grpc")
+    @mock.patch("google.cloud.ndb._api.datastore_pb2_grpc")
+    def test_insecure_channel(datastore_pb2_grpc, grpc):
+        channel = grpc.insecure_channel.return_value
+        client = mock.Mock(
+            secure=False, host="thehost", spec=("secure", "host")
+        )
+        stub = _api.stub(client)
+        assert stub is datastore_pb2_grpc.DatastoreStub.return_value
+        datastore_pb2_grpc.DatastoreStub.assert_called_once_with(channel)
+        grpc.insecure_channel.assert_called_once_with("thehost")


### PR DESCRIPTION
A helper function which takes a `client.Client` instance and returns an instance of the gRPC "stub" for the Google Datastore API. Based off of #6876 