### PR TITLE
NDB: Sketch high level strategy

### DIFF
--- a/ndb/noxfile.py
+++ b/ndb/noxfile.py
@@ -45,7 +45,7 @@ def unit(session):
         run_args.extend(
             [
                 "--cov=google.cloud.ndb",
-                "--cov=tests",
+                "--cov=tests.unit",
                 "--cov-config",
                 get_path(".coveragerc"),
                 "--cov-report=",
@@ -87,6 +87,14 @@ def run_black(session, use_check=False):
 
 
 @nox.session(py=DEFAULT_INTERPRETER)
+def blacken(session):
+    # Install all dependencies.
+    session.install("black")
+    # Run ``black``.
+    run_black(session)
+
+
+@nox.session(py=DEFAULT_INTERPRETER)
 def lint(session):
     """Run linters.
     Returns a failure if the linters find linting errors or sufficiently
@@ -95,14 +103,6 @@ def lint(session):
     session.install("flake8", "black")
     run_black(session, use_check=True)
     session.run("flake8", "google", "tests")
-
-
-@nox.session(py=DEFAULT_INTERPRETER)
-def blacken(session):
-    # Install all dependencies.
-    session.install("black")
-    # Run ``black``.
-    run_black(session)
 
 
 @nox.session(py=DEFAULT_INTERPRETER)

--- a/ndb/noxfile.py
+++ b/ndb/noxfile.py
@@ -45,7 +45,7 @@ def unit(session):
         run_args.extend(
             [
                 "--cov=google.cloud.ndb",
-                "--cov=tests.unit",
+                "--cov=tests",
                 "--cov-config",
                 get_path(".coveragerc"),
                 "--cov-report=",
@@ -87,14 +87,6 @@ def run_black(session, use_check=False):
 
 
 @nox.session(py=DEFAULT_INTERPRETER)
-def blacken(session):
-    # Install all dependencies.
-    session.install("black")
-    # Run ``black``.
-    run_black(session)
-
-
-@nox.session(py=DEFAULT_INTERPRETER)
 def lint(session):
     """Run linters.
     Returns a failure if the linters find linting errors or sufficiently
@@ -103,6 +95,14 @@ def lint(session):
     session.install("flake8", "black")
     run_black(session, use_check=True)
     session.run("flake8", "google", "tests")
+
+
+@nox.session(py=DEFAULT_INTERPRETER)
+def blacken(session):
+    # Install all dependencies.
+    session.install("black")
+    # Run ``black``.
+    run_black(session)
 
 
 @nox.session(py=DEFAULT_INTERPRETER)

--- a/ndb/src/google/cloud/ndb/__init__.py
+++ b/ndb/src/google/cloud/ndb/__init__.py
@@ -25,6 +25,7 @@ __version__ = "0.0.1.dev1"
 """Current ``ndb`` version."""
 __all__ = [
     "AutoBatcher",
+    "Client",
     "Context",
     "ContextOptions",
     "EVENTUAL_CONSISTENCY",
@@ -122,6 +123,7 @@ __all__ = [
 ]
 """All top-level exported names."""
 
+from google.cloud.ndb.client import Client
 from google.cloud.ndb.context import AutoBatcher
 from google.cloud.ndb.context import Context
 from google.cloud.ndb.context import ContextOptions

--- a/ndb/src/google/cloud/ndb/_api.py
+++ b/ndb/src/google/cloud/ndb/_api.py
@@ -1,0 +1,41 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Functions that interact with Datastore backend."""
+
+import grpc
+
+from google.cloud import _helpers
+from google.cloud.datastore_v1.proto import datastore_pb2_grpc
+
+
+def stub(client):
+    """Get a stub for the `Google Datastore` API.
+
+    Arguments:
+        client (:class:`~client.Client`): An NDB client instance.
+
+    Returns:
+        :class:`~google.cloud.datastore_v1.proto.datastore_pb2_grpc.DatastoreStub`:
+            The stub instance.
+    """
+    user_agent = "gcloud-python/ndb"
+    if client.secure:
+        channel = _helpers.make_secure_channel(
+            client.credentials, user_agent, client.host
+        )
+    else:
+        channel = grpc.insecure_channel(client.host)
+    stub = datastore_pb2_grpc.DatastoreStub(channel)
+    return stub

--- a/ndb/src/google/cloud/ndb/_api.py
+++ b/ndb/src/google/cloud/ndb/_api.py
@@ -33,7 +33,7 @@ def stub(client):
     user_agent = "gcloud-python/ndb"
     if client.secure:
         channel = _helpers.make_secure_channel(
-            client.credentials, user_agent, client.host
+            client._credentials, user_agent, client.host
         )
     else:
         channel = grpc.insecure_channel(client.host)

--- a/ndb/src/google/cloud/ndb/_api.py
+++ b/ndb/src/google/cloud/ndb/_api.py
@@ -47,9 +47,9 @@ def stub():
 def lookup(key):
     """Lookup one NDB entity by key."""
     state = _runstate.current()
-    request = datastore_pb2.LookupRequest(project_id=state.project)
-    key_pb = request.keys.add()
-    key_pb.CopyFrom(key._key.to_protobuf())
+    request = datastore_pb2.LookupRequest(
+        project_id=state.project,
+        keys=[key._key.to_protobuf()])
 
     api = stub()
     return api.Lookup.future(request)

--- a/ndb/src/google/cloud/ndb/_future.py
+++ b/ndb/src/google/cloud/ndb/_future.py
@@ -1,0 +1,43 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A Future class."""
+
+_NOT_COMPUTED = object()
+
+
+class Future:
+    """A future that waits on one or more gRPC futures.
+
+    This class is meant to be subclassed with code to compute a result from the
+    results of the wrapped gRPC futures. :method:`_compute_result` should be
+    overriden to compute a result from the completed gRPC calls.
+    """
+    _result = _NOT_COMPUTED
+    _complete = False
+
+    def __init__(self, *grpc_futures):
+        self._grpc_futures = grpc_futures
+
+    def get_result(self):
+        """Get the computed result for this future."""
+        if self._result is _NOT_COMPUTED:
+            self._result = self._compute_result(
+                *[future.result() for future in self._grpc_futures])
+        return self._result
+
+    def _compute_result(self, *gprc_results):
+        """Compute the result, given results from gRPC calls."""
+        raise NotImplementedError(
+            "Future._compute_result must be overridden by a subclass")

--- a/ndb/src/google/cloud/ndb/_future.py
+++ b/ndb/src/google/cloud/ndb/_future.py
@@ -14,7 +14,6 @@
 
 """A Future class."""
 
-_NOT_COMPUTED = object()
 
 
 class Future:
@@ -24,6 +23,7 @@ class Future:
     results of the wrapped gRPC futures. :method:`_compute_result` should be
     overriden to compute a result from the completed gRPC calls.
     """
+    _NOT_COMPUTED = object()
     _result = _NOT_COMPUTED
     _complete = False
 
@@ -32,7 +32,7 @@ class Future:
 
     def get_result(self):
         """Get the computed result for this future."""
-        if self._result is _NOT_COMPUTED:
+        if self._result is Future._NOT_COMPUTED:
             self._result = self._compute_result(
                 *[future.result() for future in self._grpc_futures])
         return self._result

--- a/ndb/src/google/cloud/ndb/_future.py
+++ b/ndb/src/google/cloud/ndb/_future.py
@@ -15,7 +15,6 @@
 """A Future class."""
 
 
-
 class Future:
     """A future that waits on one or more gRPC futures.
 

--- a/ndb/src/google/cloud/ndb/_runstate.py
+++ b/ndb/src/google/cloud/ndb/_runstate.py
@@ -22,6 +22,12 @@ from google.cloud.ndb import exceptions
 
 class State:
     eventloop = None
+    credentials = None
+    host = None
+    namespace = None
+    stub = None
+    secure = False
+    project = None
 
 
 class LocalStates(threading.local):
@@ -47,7 +53,7 @@ states = LocalStates()
 
 
 @contextlib.contextmanager
-def ndb_context():
+def ndb_context(client=None):
     """Establish a context for a set of NDB calls.
 
     This function provides a context manager which establishes the runtime
@@ -75,6 +81,13 @@ def ndb_context():
     HTTP request. This can typically be accomplished in a middleware layer.
     """
     state = State()
+    if client:
+        state.credentials = client._credentials
+        state.host = client.host
+        state.namespace = client.namespace
+        state.secure = client.secure
+        state.project = client.project
+
     states.push(state)
     yield
 

--- a/ndb/src/google/cloud/ndb/client.py
+++ b/ndb/src/google/cloud/ndb/client.py
@@ -38,12 +38,12 @@ def _determine_default_project(project=None):
     * GOOGLE_CLOUD_PROJECT environment variable
     * Google App Engine application ID
     * Google Compute Engine project ID (from metadata server)
+_
+    Arguments:
+        project (Optional[str]): The project to use as default.
 
-    :type project: str
-    :param project: Optional. The project to use as default.
-
-    :rtype: str or ``NoneType``
-    :returns: Default project if it can be determined.
+    Returns:
+        Union([str, None]): Default project if it can be determined.
     """
     if project is None:
         project = _get_gcd_project()

--- a/ndb/src/google/cloud/ndb/client.py
+++ b/ndb/src/google/cloud/ndb/client.py
@@ -73,7 +73,7 @@ class Client(ClientWithProject):
     def __init__(self, project=None, namespace=None, credentials=None):
         super(Client, self).__init__(project=project, credentials=credentials)
         self.namespace = namespace
-        self._host = os.environ.get(environment_vars.GCD_HOST, _DATASTORE_HOST)
+        self.host = os.environ.get(environment_vars.GCD_HOST, _DATASTORE_HOST)
 
     @property
     def _http(self):

--- a/ndb/src/google/cloud/ndb/client.py
+++ b/ndb/src/google/cloud/ndb/client.py
@@ -1,0 +1,90 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A client for NDB which manages credentials, project, namespace."""
+
+import os
+
+from google.cloud import environment_vars
+from google.cloud.client import ClientWithProject
+from google.cloud import _helpers
+
+_DATASTORE_HOST = "datastore.googleapis.com"
+
+
+def _get_gcd_project():
+    """Gets the GCD application ID if it can be inferred."""
+    return os.getenv(environment_vars.GCD_DATASET)
+
+
+def _determine_default_project(project=None):
+    """Determine default project explicitly or implicitly as fall-back.
+
+    In implicit case, supports four environments. In order of precedence, the
+    implicit environments are:
+
+    * DATASTORE_DATASET environment variable (for ``gcd`` / emulator testing)
+    * GOOGLE_CLOUD_PROJECT environment variable
+    * Google App Engine application ID
+    * Google Compute Engine project ID (from metadata server)
+
+    :type project: str
+    :param project: Optional. The project to use as default.
+
+    :rtype: str or ``NoneType``
+    :returns: Default project if it can be determined.
+    """
+    if project is None:
+        project = _get_gcd_project()
+
+    if project is None:
+        project = _helpers._determine_default_project(project=project)
+
+    return project
+
+
+class Client(ClientWithProject):
+    """An NDB client.
+
+    Arguments:
+        project (Optional[str]): The project to pass to proxied API methods. If
+            not passed, falls back to the default inferred from the
+            environment.
+        namespace (Optional[str]): Namespace to pass to proxied API methods.
+        credentials (Optional[:class:`~google.auth.credentials.Credentials`]):
+            The OAuth2 Credentials to use for this client. If not passed, falls
+            back to the default inferred from the environment.
+    """
+
+    SCOPE = ("https://www.googleapis.com/auth/datastore",)
+    """The scopes required for authenticating as a Cloud Datastore consumer."""
+
+    def __init__(self, project=None, namespace=None, credentials=None):
+        super(Client, self).__init__(project=project, credentials=credentials)
+        self.namespace = namespace
+        self._host = os.environ.get(environment_vars.GCD_HOST, _DATASTORE_HOST)
+
+    @property
+    def _http(self):
+        """Getter for object used for HTTP transport.
+
+        Raises:
+            NotImplementedError: Always, HTTP transport is not supported.
+        """
+        raise NotImplementedError("HTTP transport is not supported.")
+
+    @staticmethod
+    def _determine_default(project):
+        """Helper:  override default project detection."""
+        return _determine_default_project(project)

--- a/ndb/src/google/cloud/ndb/client.py
+++ b/ndb/src/google/cloud/ndb/client.py
@@ -70,6 +70,9 @@ class Client(ClientWithProject):
     SCOPE = ("https://www.googleapis.com/auth/datastore",)
     """The scopes required for authenticating as a Cloud Datastore consumer."""
 
+    secure = True
+    """Whether to use a secure connection for API calls."""
+
     def __init__(self, project=None, namespace=None, credentials=None):
         super(Client, self).__init__(project=project, credentials=credentials)
         self.namespace = namespace

--- a/ndb/src/google/cloud/ndb/client.py
+++ b/ndb/src/google/cloud/ndb/client.py
@@ -20,6 +20,8 @@ from google.cloud import environment_vars
 from google.cloud.client import ClientWithProject
 from google.cloud import _helpers
 
+from google.cloud.ndb import _runstate
+
 _DATASTORE_HOST = "datastore.googleapis.com"
 
 
@@ -91,3 +93,7 @@ class Client(ClientWithProject):
     def _determine_default(project):
         """Helper:  override default project detection."""
         return _determine_default_project(project)
+
+    def context(self):
+        """Returns a context manager that sets the client."""
+        return _runstate.ndb_context(client=self)

--- a/ndb/tests/conftest.py
+++ b/ndb/tests/conftest.py
@@ -48,7 +48,7 @@ def reset_state(environ):
 @pytest.fixture
 def environ():
     """Copy of ``os.environ``"""
-    original = os.environ.copy()
+    original = os.environ
     environ = original.copy()
     os.environ = environ
     yield environ

--- a/ndb/tests/system/test_system.py
+++ b/ndb/tests/system/test_system.py
@@ -1,0 +1,36 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from google.cloud import datastore
+from google.cloud import ndb
+
+
+def test_retrieve_entity():
+    ds_client = datastore.Client()
+    ds_key = ds_client.key("SomeKind", 1234)
+    ds_entity = datastore.Entity(key=ds_key)
+    ds_entity.update({"foo": 42, "bar": "none"})
+    ds_client.put(ds_entity)
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+        bar = ndb.StringProperty()
+
+    client = ndb.Client()
+
+    with client.context():
+        key = ndb.Key("SomeKind", 1234)
+        entity = key.get()
+        assert isinstance(entity, SomeKind)
+        assert entity.foo == 42
+        assert entity.bar == "none"

--- a/ndb/tests/unit/test__api.py
+++ b/ndb/tests/unit/test__api.py
@@ -1,0 +1,50 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from google.cloud.ndb import _api
+
+
+class TestStub:
+    @staticmethod
+    @mock.patch("google.cloud.ndb._api._helpers")
+    @mock.patch("google.cloud.ndb._api.datastore_pb2_grpc")
+    def test_secure_channel(datastore_pb2_grpc, _helpers):
+        channel = _helpers.make_secure_channel.return_value
+        client = mock.Mock(
+            credentials="creds",
+            secure=True,
+            host="thehost",
+            spec=("credentials", "secure", "host"),
+        )
+        stub = _api.stub(client)
+        assert stub is datastore_pb2_grpc.DatastoreStub.return_value
+        datastore_pb2_grpc.DatastoreStub.assert_called_once_with(channel)
+        _helpers.make_secure_channel.assert_called_once_with(
+            "creds", "gcloud-python/ndb", "thehost"
+        )
+
+    @staticmethod
+    @mock.patch("google.cloud.ndb._api.grpc")
+    @mock.patch("google.cloud.ndb._api.datastore_pb2_grpc")
+    def test_insecure_channel(datastore_pb2_grpc, grpc):
+        channel = grpc.insecure_channel.return_value
+        client = mock.Mock(
+            secure=False, host="thehost", spec=("secure", "host")
+        )
+        stub = _api.stub(client)
+        assert stub is datastore_pb2_grpc.DatastoreStub.return_value
+        datastore_pb2_grpc.DatastoreStub.assert_called_once_with(channel)
+        grpc.insecure_channel.assert_called_once_with("thehost")

--- a/ndb/tests/unit/test__api.py
+++ b/ndb/tests/unit/test__api.py
@@ -24,10 +24,10 @@ class TestStub:
     def test_secure_channel(datastore_pb2_grpc, _helpers):
         channel = _helpers.make_secure_channel.return_value
         client = mock.Mock(
-            credentials="creds",
+            _credentials="creds",
             secure=True,
             host="thehost",
-            spec=("credentials", "secure", "host"),
+            spec=("_credentials", "secure", "host"),
         )
         stub = _api.stub(client)
         assert stub is datastore_pb2_grpc.DatastoreStub.return_value

--- a/ndb/tests/unit/test_client.py
+++ b/ndb/tests/unit/test_client.py
@@ -1,0 +1,72 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import pytest
+
+from unittest import mock
+
+from google.auth import credentials
+from google.cloud import environment_vars
+from google.cloud.ndb import client as client_module
+
+
+@contextlib.contextmanager
+def patch_credentials(project):
+    creds = mock.Mock(spec=credentials.Credentials)
+    patch = mock.patch("google.auth.default", return_value=(creds, project))
+    with patch:
+        yield creds
+
+
+class TestClient:
+    @staticmethod
+    def test_constructor_no_args():
+        with patch_credentials("testing"):
+            client = client_module.Client()
+        assert client.SCOPE == ("https://www.googleapis.com/auth/datastore",)
+        assert client.namespace is None
+        assert client._host == client_module._DATASTORE_HOST
+        assert client.project == "testing"
+
+    @staticmethod
+    def test_constructor_get_project_from_environ(environ):
+        environ[environment_vars.GCD_DATASET] = "gcd-project"
+        with patch_credentials(None):
+            client = client_module.Client()
+        assert client.project == "gcd-project"
+
+    @staticmethod
+    def test_constructor_all_args():
+        with patch_credentials("testing") as creds:
+            client = client_module.Client(
+                project="test-project",
+                namespace="test-namespace",
+                credentials=creds,
+            )
+        assert client.namespace == "test-namespace"
+        assert client.project == "test-project"
+
+    @staticmethod
+    def test__determine_default():
+        with patch_credentials("testing"):
+            client = client_module.Client()
+        assert client._determine_default("this") == "this"
+
+    @staticmethod
+    def test__http():
+        with patch_credentials("testing"):
+            client = client_module.Client()
+        with pytest.raises(NotImplementedError):
+            client._http

--- a/ndb/tests/unit/test_client.py
+++ b/ndb/tests/unit/test_client.py
@@ -37,7 +37,7 @@ class TestClient:
             client = client_module.Client()
         assert client.SCOPE == ("https://www.googleapis.com/auth/datastore",)
         assert client.namespace is None
-        assert client._host == client_module._DATASTORE_HOST
+        assert client.host == client_module._DATASTORE_HOST
         assert client.project == "testing"
 
     @staticmethod


### PR DESCRIPTION
Diff base is #6888 

This code is intentionally sketchy. It contains very partial implementations, non-conformant docstrings, and less than 100% test coverage. This code is not being proposed for merge but is offered as a sketch for discussion of general strategy and/or a guide for me to follow to produce a more complete, real implementation.

The main point of this was to provide the bare minimum to make the single system test pass. This test uses `google.cloud.datastore` to write an entity to Datastore and uses `google.cloud.ndb` to read it back out of Datastore as an instance of an NDB model class.  I suggest looking at the test and thinking about if that is the correct user experience.

The salient points are:

* `google.cloud.ndb.Client` as a parallel to `google.cloud.datastore.Client`, as a means of bootstrapping NDB and its connection to Datastore in a way familiar to GCP users. This is the entry point for establishing credentials, the working project/app, and the namespace, exactly like `google.cloud.datastore`.

* `Client.context()` as a context manager for encapsulating code that uses NDB. Under the hood there is a thread local state which legacy NDB previously managed in GAE by attaching it to the running HTTP request, an fixture which is no longer available in GCP.  Use of the context manager means most existing projects which use NDB can simply wrap their code in a context and their existing business code continues to work, as it can access any needed state from the running context.

* `_future.Future` as a thin wrapper around Futures returned by gRPC. This class is meant to be subclassed and can wrap any number of gRPC Futures and compute an arbitrary result based on the results of those wrapped futures. As an example, there is `key.GetByKeyFuture` which wraps the return value of a call to `Lookup.future()` in Datastore's gRPC API and marsahall's an NDB entity from the returned Datastore protocol buffer. It's not doing any async on its own, here, just wrapping the raw gRPC async calls to provide Futures that yield arbitrarily computed results.

I think pretty much everything except the `tasklets` surface can be implemented in this way. I haven't fully worked out, yet, how this will integrate with the `tasklets` mini-framework but I think having a lot of the rest fleshed out will give us a good starting point.