### PR TITLE
Firestore: enable use of 'WriteBatch' as a context manager.

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/batch.py
+++ b/firestore/google/cloud/firestore_v1beta1/batch.py
@@ -33,6 +33,8 @@ class WriteBatch(object):
     def __init__(self, client):
         self._client = client
         self._write_pbs = []
+        self.write_results = None
+        self.commit_time = None
 
     def _add_write_pbs(self, write_pbs):
         """Add `Write`` protobufs to this transaction.
@@ -147,4 +149,14 @@ class WriteBatch(object):
         )
 
         self._write_pbs = []
-        return list(commit_response.write_results)
+        self.write_results = results = list(commit_response.write_results)
+        self.commit_time = commit_response.commit_time
+        return results
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type is None:
+            self.commit()

--- a/firestore/google/cloud/firestore_v1beta1/batch.py
+++ b/firestore/google/cloud/firestore_v1beta1/batch.py
@@ -156,7 +156,6 @@ class WriteBatch(object):
     def __enter__(self):
         return self
 
-
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type is None:
             self.commit()

--- a/firestore/tests/unit/test_collection.py
+++ b/firestore/tests/unit/test_collection.py
@@ -233,7 +233,8 @@ class TestCollectionReference(unittest.TestCase):
             update_time=mock.sentinel.update_time, spec=["update_time"]
         )
         commit_response = mock.Mock(
-            write_results=[write_result], spec=["write_results", "commit_time"],
+            write_results=[write_result],
+            spec=["write_results", "commit_time"],
             commit_time=mock.sentinel.commit_time,
         )
         firestore_api.commit.return_value = commit_response

--- a/firestore/tests/unit/test_collection.py
+++ b/firestore/tests/unit/test_collection.py
@@ -233,7 +233,8 @@ class TestCollectionReference(unittest.TestCase):
             update_time=mock.sentinel.update_time, spec=["update_time"]
         )
         commit_response = mock.Mock(
-            write_results=[write_result], spec=["write_results"]
+            write_results=[write_result], spec=["write_results", "commit_time"],
+            commit_time=mock.sentinel.commit_time,
         )
         firestore_api.commit.return_value = commit_response
 

--- a/firestore/tests/unit/test_document.py
+++ b/firestore/tests/unit/test_document.py
@@ -198,13 +198,19 @@ class TestDocumentReference(unittest.TestCase):
             current_document=common_pb2.Precondition(exists=False),
         )
 
+    @staticmethod
+    def _make_commit_repsonse(write_results=None):
+        from google.cloud.firestore_v1beta1.proto import firestore_pb2
+
+        response = mock.create_autospec(firestore_pb2.CommitResponse)
+        response.write_results = write_results or [mock.sentinel.write_result]
+        response.commit_time = mock.sentinel.commit_time
+        return response
+
     def test_create(self):
         # Create a minimal fake GAPIC with a dummy response.
         firestore_api = mock.Mock(spec=["commit"])
-        commit_response = mock.Mock(
-            write_results=[mock.sentinel.write_result], spec=["write_results"]
-        )
-        firestore_api.commit.return_value = commit_response
+        firestore_api.commit.return_value = self._make_commit_repsonse()
 
         # Attach the fake GAPIC to a real client.
         client = _make_client("dignity")
@@ -235,10 +241,8 @@ class TestDocumentReference(unittest.TestCase):
         snapshot = mock.create_autospec(DocumentSnapshot)
         snapshot.exists = True
         document_reference.get.return_value = snapshot
-        commit_response = mock.Mock(
-            write_results=[document_reference], get=[snapshot], spec=["write_results"]
-        )
-        firestore_api.commit.return_value = commit_response
+        firestore_api.commit.return_value = self._make_commit_repsonse(
+            write_results=[document_reference])
 
         # Attach the fake GAPIC to a real client.
         client = _make_client("dignity")
@@ -281,10 +285,7 @@ class TestDocumentReference(unittest.TestCase):
     def _set_helper(self, merge=False, **option_kwargs):
         # Create a minimal fake GAPIC with a dummy response.
         firestore_api = mock.Mock(spec=["commit"])
-        commit_response = mock.Mock(
-            write_results=[mock.sentinel.write_result], spec=["write_results"]
-        )
-        firestore_api.commit.return_value = commit_response
+        firestore_api.commit.return_value = self._make_commit_repsonse()
 
         # Attach the fake GAPIC to a real client.
         client = _make_client("db-dee-bee")
@@ -332,10 +333,7 @@ class TestDocumentReference(unittest.TestCase):
 
         # Create a minimal fake GAPIC with a dummy response.
         firestore_api = mock.Mock(spec=["commit"])
-        commit_response = mock.Mock(
-            write_results=[mock.sentinel.write_result], spec=["write_results"]
-        )
-        firestore_api.commit.return_value = commit_response
+        firestore_api.commit.return_value = self._make_commit_repsonse()
 
         # Attach the fake GAPIC to a real client.
         client = _make_client("potato-chip")
@@ -389,10 +387,7 @@ class TestDocumentReference(unittest.TestCase):
     def test_empty_update(self):
         # Create a minimal fake GAPIC with a dummy response.
         firestore_api = mock.Mock(spec=["commit"])
-        commit_response = mock.Mock(
-            write_results=[mock.sentinel.write_result], spec=["write_results"]
-        )
-        firestore_api.commit.return_value = commit_response
+        firestore_api.commit.return_value = self._make_commit_repsonse()
 
         # Attach the fake GAPIC to a real client.
         client = _make_client("potato-chip")
@@ -410,10 +405,7 @@ class TestDocumentReference(unittest.TestCase):
 
         # Create a minimal fake GAPIC with a dummy response.
         firestore_api = mock.Mock(spec=["commit"])
-        commit_response = mock.Mock(
-            commit_time=mock.sentinel.commit_time, spec=["commit_time"]
-        )
-        firestore_api.commit.return_value = commit_response
+        firestore_api.commit.return_value = self._make_commit_repsonse()
 
         # Attach the fake GAPIC to a real client.
         client = _make_client("donut-base")

--- a/firestore/tests/unit/test_document.py
+++ b/firestore/tests/unit/test_document.py
@@ -242,7 +242,8 @@ class TestDocumentReference(unittest.TestCase):
         snapshot.exists = True
         document_reference.get.return_value = snapshot
         firestore_api.commit.return_value = self._make_commit_repsonse(
-            write_results=[document_reference])
+            write_results=[document_reference]
+        )
 
         # Attach the fake GAPIC to a real client.
         client = _make_client("dignity")


### PR DESCRIPTION
Closes #6548.