### PR TITLE
Firestore: implement equality semantics for public types

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/_helpers.py
+++ b/firestore/google/cloud/firestore_v1beta1/_helpers.py
@@ -941,6 +941,11 @@ class LastUpdateOption(WriteOption):
     def __init__(self, last_update_time):
         self._last_update_time = last_update_time
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self._last_update_time == other._last_update_time
+
     def modify_write(self, write_pb, **unused_kwargs):
         """Modify a ``Write`` protobuf based on the state of this write option.
 
@@ -972,6 +977,11 @@ class ExistsOption(WriteOption):
 
     def __init__(self, exists):
         self._exists = exists
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self._exists == other._exists
 
     def modify_write(self, write_pb, **unused_kwargs):
         """Modify a ``Write`` protobuf based on the state of this write option.

--- a/firestore/google/cloud/firestore_v1beta1/collection.py
+++ b/firestore/google/cloud/firestore_v1beta1/collection.py
@@ -63,6 +63,11 @@ class CollectionReference(object):
                 "Received unexpected arguments", kwargs, "Only `client` is supported"
             )
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self._path == other._path and self._client == other._client
+
     @property
     def id(self):
         """The collection identifier.

--- a/firestore/google/cloud/firestore_v1beta1/document.py
+++ b/firestore/google/cloud/firestore_v1beta1/document.py
@@ -560,7 +560,12 @@ class DocumentSnapshot(object):
     def __hash__(self):
         seconds = self.read_time.seconds
         nanos = self.read_time.nanos
-        return hash(self._reference) + hash(seconds) + hash(nanos)
+        return (
+            hash(self._reference)
+            + hash(seconds)
+            + hash(nanos)
+            + hash(tuple(sorted(self._data.items())))
+        )
 
     @property
     def _client(self):

--- a/firestore/google/cloud/firestore_v1beta1/document.py
+++ b/firestore/google/cloud/firestore_v1beta1/document.py
@@ -99,6 +99,9 @@ class DocumentReference(object):
         else:
             return NotImplemented
 
+    def __hash__(self):
+        return hash(self._path) + hash(self._client)
+
     def __ne__(self, other):
         """Inequality check against another instance.
 
@@ -553,6 +556,11 @@ class DocumentSnapshot(object):
         if not isinstance(other, self.__class__):
             return NotImplemented
         return self._reference == other._reference and self._data == other._data
+
+    def __hash__(self):
+        seconds = self.read_time.seconds
+        nanos = self.read_time.nanos
+        return hash(self._reference) + hash(seconds) + hash(nanos)
 
     @property
     def _client(self):

--- a/firestore/google/cloud/firestore_v1beta1/document.py
+++ b/firestore/google/cloud/firestore_v1beta1/document.py
@@ -558,14 +558,9 @@ class DocumentSnapshot(object):
         return self._reference == other._reference and self._data == other._data
 
     def __hash__(self):
-        seconds = self.read_time.seconds
-        nanos = self.read_time.nanos
-        return (
-            hash(self._reference)
-            + hash(seconds)
-            + hash(nanos)
-            + hash(tuple(sorted(self._data.items())))
-        )
+        seconds = self.update_time.seconds
+        nanos = self.update_time.nanos
+        return hash(self._reference) + hash(seconds) + hash(nanos)
 
     @property
     def _client(self):

--- a/firestore/google/cloud/firestore_v1beta1/document.py
+++ b/firestore/google/cloud/firestore_v1beta1/document.py
@@ -549,6 +549,11 @@ class DocumentSnapshot(object):
         self.update_time = update_time
         """google.protobuf.timestamp_pb2.Timestamp: Document's last update."""
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self._reference == other._reference and self._data == other._data
+
     @property
     def _client(self):
         """The client that owns the document reference for this snapshot.

--- a/firestore/google/cloud/firestore_v1beta1/query.py
+++ b/firestore/google/cloud/firestore_v1beta1/query.py
@@ -143,6 +143,20 @@ class Query(object):
         self._start_at = start_at
         self._end_at = end_at
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return (
+            self._parent == other._parent
+            and self._projection == other._projection
+            and self._field_filters == other._field_filters
+            and self._orders == other._orders
+            and self._limit == other._limit
+            and self._offset == other._offset
+            and self._start_at == other._start_at
+            and self._end_at == other._end_at
+        )
+
     @property
     def _client(self):
         """The client of the parent collection.

--- a/firestore/google/cloud/firestore_v1beta1/transforms.py
+++ b/firestore/google/cloud/firestore_v1beta1/transforms.py
@@ -53,6 +53,11 @@ class _ValueList(object):
 
         self._values = list(values)
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self._values == other._values
+
     @property
     def values(self):
         """Values to append.

--- a/firestore/tests/unit/test__helpers.py
+++ b/firestore/tests/unit/test__helpers.py
@@ -1981,6 +1981,21 @@ class TestLastUpdateOption(unittest.TestCase):
         option = self._make_one(mock.sentinel.timestamp)
         self.assertIs(option._last_update_time, mock.sentinel.timestamp)
 
+    def test___eq___different_type(self):
+        option = self._make_one(mock.sentinel.timestamp)
+        other = object()
+        self.assertFalse(option == other)
+
+    def test___eq___different_timestamp(self):
+        option = self._make_one(mock.sentinel.timestamp)
+        other = self._make_one(mock.sentinel.other_timestamp)
+        self.assertFalse(option == other)
+
+    def test___eq___same_timestamp(self):
+        option = self._make_one(mock.sentinel.timestamp)
+        other = self._make_one(mock.sentinel.timestamp)
+        self.assertTrue(option == other)
+
     def test_modify_write_update_time(self):
         from google.protobuf import timestamp_pb2
         from google.cloud.firestore_v1beta1.proto import common_pb2
@@ -2010,6 +2025,21 @@ class TestExistsOption(unittest.TestCase):
     def test_constructor(self):
         option = self._make_one(mock.sentinel.totes_bool)
         self.assertIs(option._exists, mock.sentinel.totes_bool)
+
+    def test___eq___different_type(self):
+        option = self._make_one(mock.sentinel.timestamp)
+        other = object()
+        self.assertFalse(option == other)
+
+    def test___eq___different_exists(self):
+        option = self._make_one(True)
+        other = self._make_one(False)
+        self.assertFalse(option == other)
+
+    def test___eq___same_exists(self):
+        option = self._make_one(True)
+        other = self._make_one(True)
+        self.assertTrue(option == other)
 
     def test_modify_write(self):
         from google.cloud.firestore_v1beta1.proto import common_pb2

--- a/firestore/tests/unit/test_collection.py
+++ b/firestore/tests/unit/test_collection.py
@@ -76,6 +76,31 @@ class TestCollectionReference(unittest.TestCase):
         with self.assertRaises(TypeError):
             self._make_one("Coh-lek-shun", donut=True)
 
+    def test___eq___other_type(self):
+        client = mock.sentinel.client
+        collection = self._make_one("name", client=client)
+        other = object()
+        self.assertFalse(collection == other)
+
+    def test___eq___different_path_same_client(self):
+        client = mock.sentinel.client
+        collection = self._make_one("name", client=client)
+        other = self._make_one("other", client=client)
+        self.assertFalse(collection == other)
+
+    def test___eq___same_path_different_client(self):
+        client = mock.sentinel.client
+        other_client = mock.sentinel.other_client
+        collection = self._make_one("name", client=client)
+        other = self._make_one("name", client=other_client)
+        self.assertFalse(collection == other)
+
+    def test___eq___same_path_same_client(self):
+        client = mock.sentinel.client
+        collection = self._make_one("name", client=client)
+        other = self._make_one("name", client=client)
+        self.assertTrue(collection == other)
+
     def test_id_property(self):
         collection_id = "hi-bob"
         collection = self._make_one(collection_id)

--- a/firestore/tests/unit/test_document.py
+++ b/firestore/tests/unit/test_document.py
@@ -673,9 +673,13 @@ class TestDocumentSnapshot(unittest.TestCase):
             mock.sentinel.create_time,
             mock.sentinel.update_time,
         )
-        self.assertEqual(
-            hash(snapshot), hash(reference) + hash(123456) + hash(123456789)
+        expected_hash = (
+            hash(reference)
+            + hash(123456)
+            + hash(123456789)
+            + hash(tuple(sorted(data.items())))
         )
+        self.assertEqual(hash(snapshot), expected_hash)
 
     def test__client_property(self):
         reference = self._make_reference(

--- a/firestore/tests/unit/test_document.py
+++ b/firestore/tests/unit/test_document.py
@@ -107,7 +107,8 @@ class TestDocumentReference(unittest.TestCase):
         self.assertIs(document.__eq__(other), NotImplemented)
 
     def test___hash__(self):
-        client = mock.sentinel.client
+        client = mock.MagicMock()
+        client.__hash__.return_value = 234566789
         document = self._make_one("X", "YY", client=client)
         self.assertEqual(hash(document), hash(("X", "YY")) + hash(client))
 
@@ -661,25 +662,17 @@ class TestDocumentSnapshot(unittest.TestCase):
     def test___hash__(self):
         from google.protobuf import timestamp_pb2
 
-        client = mock.sentinel.client
+        client = mock.MagicMock()
+        client.__hash__.return_value = 234566789
         reference = self._make_reference("hi", "bye", client=client)
         data = {"zoop": 83}
-        read_time = timestamp_pb2.Timestamp(seconds=123456, nanos=123456789)
+        update_time = timestamp_pb2.Timestamp(seconds=123456, nanos=123456789)
         snapshot = self._make_one(
-            reference,
-            data,
-            True,
-            read_time,
-            mock.sentinel.create_time,
-            mock.sentinel.update_time,
+            reference, data, True, None, mock.sentinel.create_time, update_time
         )
-        expected_hash = (
-            hash(reference)
-            + hash(123456)
-            + hash(123456789)
-            + hash(tuple(sorted(data.items())))
+        self.assertEqual(
+            hash(snapshot), hash(reference) + hash(123456) + hash(123456789)
         )
-        self.assertEqual(hash(snapshot), expected_hash)
 
     def test__client_property(self):
         reference = self._make_reference(

--- a/firestore/tests/unit/test_document.py
+++ b/firestore/tests/unit/test_document.py
@@ -600,8 +600,21 @@ class TestDocumentSnapshot(unittest.TestCase):
 
         return DocumentReference(*args, **kwargs)
 
+    def _make_w_ref(self, ref_path=("a", "b"), data={}, exists=True):
+        client = mock.sentinel.client
+        reference = self._make_reference(*ref_path, client=client)
+        return self._make_one(
+            reference,
+            data,
+            exists,
+            mock.sentinel.read_time,
+            mock.sentinel.create_time,
+            mock.sentinel.update_time,
+        )
+
     def test_constructor(self):
-        reference = self._make_reference("hi", "bye", client=mock.sentinel.client)
+        client = mock.sentinel.client
+        reference = self._make_reference("hi", "bye", client=client)
         data = {"zoop": 83}
         snapshot = self._make_one(
             reference,
@@ -618,6 +631,26 @@ class TestDocumentSnapshot(unittest.TestCase):
         self.assertIs(snapshot.read_time, mock.sentinel.read_time)
         self.assertIs(snapshot.create_time, mock.sentinel.create_time)
         self.assertIs(snapshot.update_time, mock.sentinel.update_time)
+
+    def test___eq___other_type(self):
+        snapshot = self._make_w_ref()
+        other = object()
+        self.assertFalse(snapshot == other)
+
+    def test___eq___different_reference_same_data(self):
+        snapshot = self._make_w_ref(("a", "b"))
+        other = self._make_w_ref(("c", "d"))
+        self.assertFalse(snapshot == other)
+
+    def test___eq___same_reference_different_data(self):
+        snapshot = self._make_w_ref(("a", "b"))
+        other = self._make_w_ref(("a", "b"), {"foo": "bar"})
+        self.assertFalse(snapshot == other)
+
+    def test___eq___same_reference_same_data(self):
+        snapshot = self._make_w_ref(("a", "b"), {"foo": "bar"})
+        other = self._make_w_ref(("a", "b"), {"foo": "bar"})
+        self.assertTrue(snapshot == other)
 
     def test__client_property(self):
         reference = self._make_reference(

--- a/firestore/tests/unit/test_query.py
+++ b/firestore/tests/unit/test_query.py
@@ -80,6 +80,77 @@ class TestQuery(unittest.TestCase):
         query = self._make_one(parent)
         self.assertIs(query._client, mock.sentinel.client)
 
+    def test___eq___other_type(self):
+        client = self._make_one_all_fields()
+        other = object()
+        self.assertFalse(client == other)
+
+    def test___eq___different_parent(self):
+        parent = mock.sentinel.parent
+        other_parent = mock.sentinel.other_parent
+        client = self._make_one_all_fields(parent=parent)
+        other = self._make_one_all_fields(parent=other_parent)
+        self.assertFalse(client == other)
+
+    def test___eq___different_projection(self):
+        parent = mock.sentinel.parent
+        client = self._make_one_all_fields(parent=parent, skip_fields=("projection",))
+        client._projection = mock.sentinel.projection
+        other = self._make_one_all_fields(parent=parent, skip_fields=("projection",))
+        other._projection = mock.sentinel.other_projection
+        self.assertFalse(client == other)
+
+    def test___eq___different_field_filters(self):
+        parent = mock.sentinel.parent
+        client = self._make_one_all_fields(
+            parent=parent, skip_fields=("field_filters",)
+        )
+        client._field_filters = mock.sentinel.field_filters
+        other = self._make_one_all_fields(parent=parent, skip_fields=("field_filters",))
+        other._field_filters = mock.sentinel.other_field_filters
+        self.assertFalse(client == other)
+
+    def test___eq___different_orders(self):
+        parent = mock.sentinel.parent
+        client = self._make_one_all_fields(parent=parent, skip_fields=("orders",))
+        client._orders = mock.sentinel.orders
+        other = self._make_one_all_fields(parent=parent, skip_fields=("orders",))
+        other._orders = mock.sentinel.other_orders
+        self.assertFalse(client == other)
+
+    def test___eq___different_limit(self):
+        parent = mock.sentinel.parent
+        client = self._make_one_all_fields(parent=parent, limit=10)
+        other = self._make_one_all_fields(parent=parent, limit=20)
+        self.assertFalse(client == other)
+
+    def test___eq___different_offset(self):
+        parent = mock.sentinel.parent
+        client = self._make_one_all_fields(parent=parent, offset=10)
+        other = self._make_one_all_fields(parent=parent, offset=20)
+        self.assertFalse(client == other)
+
+    def test___eq___different_start_at(self):
+        parent = mock.sentinel.parent
+        client = self._make_one_all_fields(parent=parent, skip_fields=("start_at",))
+        client._start_at = mock.sentinel.start_at
+        other = self._make_one_all_fields(parent=parent, skip_fields=("start_at",))
+        other._start_at = mock.sentinel.other_start_at
+        self.assertFalse(client == other)
+
+    def test___eq___different_end_at(self):
+        parent = mock.sentinel.parent
+        client = self._make_one_all_fields(parent=parent, skip_fields=("end_at",))
+        client._end_at = mock.sentinel.end_at
+        other = self._make_one_all_fields(parent=parent, skip_fields=("end_at",))
+        other._end_at = mock.sentinel.other_end_at
+        self.assertFalse(client == other)
+
+    def test___eq___hit(self):
+        client = self._make_one_all_fields()
+        other = self._make_one_all_fields()
+        self.assertTrue(client == other)
+
     def _compare_queries(self, query1, query2, attr_name):
         attrs1 = query1.__dict__.copy()
         attrs2 = query2.__dict__.copy()

--- a/firestore/tests/unit/test_transforms.py
+++ b/firestore/tests/unit/test_transforms.py
@@ -37,10 +37,29 @@ class Test_ValueList(unittest.TestCase):
 
     def test_ctor_w_non_empty_list(self):
         values = ["phred", "bharney"]
-        union = self._make_one(values)
-        self.assertEqual(union.values, values)
+        inst = self._make_one(values)
+        self.assertEqual(inst.values, values)
 
     def test_ctor_w_non_empty_tuple(self):
         values = ("phred", "bharney")
-        union = self._make_one(values)
-        self.assertEqual(union.values, list(values))
+        inst = self._make_one(values)
+        self.assertEqual(inst.values, list(values))
+
+    def test___eq___other_type(self):
+        values = ("phred", "bharney")
+        inst = self._make_one(values)
+        other = object()
+        self.assertFalse(inst == other)
+
+    def test___eq___different_values(self):
+        values = ("phred", "bharney")
+        other_values = ("wylma", "bhetty")
+        inst = self._make_one(values)
+        other = self._make_one(other_values)
+        self.assertFalse(inst == other)
+
+    def test___eq___same_values(self):
+        values = ("phred", "bharney")
+        inst = self._make_one(values)
+        other = self._make_one(values)
+        self.assertTrue(inst == other)


### PR DESCRIPTION
Adds `__eq__` for the following types:

- `ArrayRemove`
- `ArrayUnion`
- `CollectionReference`
- `DocumentSnapshot`
- `ExistsOption`
- `LastUpdatedOption`
- `Query`

Closes #6552.