### PR TITLE
Firestore: pin 'google-api_core >= 1.7.0'.

### DIFF
--- a/firestore/setup.py
+++ b/firestore/setup.py
@@ -29,7 +29,7 @@ version = '0.30.0'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 4 - Beta'
 dependencies = [
-    'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
+    'google-api-core[grpc] >= 1.7.0, < 2.0.0dev',
     'google-cloud-core >= 0.29.0, < 0.30dev',
     'pytz',
 ]


### PR DESCRIPTION
That release added the `from_timestamp_pb` / `to_timestamp_pb` methods to `DatetimeWithNanos`.