### PR TITLE
BigQuery: Do not return results of query magic when assigned to variable

### DIFF
--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -257,17 +257,13 @@ def _run_query(client, query, job_config=None):
 @magic_arguments.argument(
     "destination_var",
     nargs="?",
-    help=(
-        "If provided, save the output to this variable instead of displaying it."
-    ),
+    help=("If provided, save the output to this variable instead of displaying it."),
 )
 @magic_arguments.argument(
     "--project",
     type=str,
     default=None,
-    help=(
-        "Project to use for executing this query. Defaults to the context project."
-    ),
+    help=("Project to use for executing this query. Defaults to the context project."),
 )
 @magic_arguments.argument(
     "--use_legacy_sql",

--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -27,7 +27,8 @@
     Parameters:
 
     * ``<destination_var>`` (optional, line argument):
-        variable to store the query results.
+        variable to store the query results. The results are not displayed if
+        this parameter is used.
     * ``--project <project>`` (optional, line argument):
         Project to use for running the query. Defaults to the context
         :attr:`~google.cloud.bigquery.magics.Context.project`.
@@ -96,12 +97,6 @@
         Query executing: 2.61s
         Query complete after 2.92s
 
-        Out[3]:          name    count
-           ...: ----------------------
-           ...: 0        Mary  3736239
-           ...: 1    Patricia  1568495
-           ...: 2   Elizabeth  1519946
-
         In [4]: df
 
         Out[4]:          name    count
@@ -110,7 +105,7 @@
            ...: 1    Patricia  1568495
            ...: 2   Elizabeth  1519946
 
-        In [5]: %%bigquery df --params {"num": 17}
+        In [5]: %%bigquery --params {"num": 17}
            ...: SELECT @num AS num
 
         Out[5]:     num
@@ -263,7 +258,7 @@ def _run_query(client, query, job_config=None):
     "destination_var",
     nargs="?",
     help=(
-        "If provided, save the output to this variable in addition " "to displaying it."
+        "If provided, save the output to this variable instead of displaying it."
     ),
 )
 @magic_arguments.argument(
@@ -271,7 +266,7 @@ def _run_query(client, query, job_config=None):
     type=str,
     default=None,
     help=(
-        "Project to use for executing this query. Defaults to the context " "project."
+        "Project to use for executing this query. Defaults to the context project."
     ),
 )
 @magic_arguments.argument(
@@ -348,4 +343,5 @@ def _cell_magic(line, query):
     result = query_job.to_dataframe()
     if args.destination_var:
         IPython.get_ipython().push({args.destination_var: result})
-    return result
+    else:
+        return result

--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -114,7 +114,7 @@
 
         In [6]: params = {"num": 17}
 
-        In [7]: %%bigquery df --params $params
+        In [7]: %%bigquery --params $params
            ...: SELECT @num AS num
 
         Out[7]:     num

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -160,11 +160,11 @@ def test_bigquery_magic_without_optional_arguments():
     with run_query_patch as run_query_mock:
         run_query_mock.return_value = query_job_mock
 
-        result = ip.run_cell_magic("bigquery", "", sql)
+        return_value = ip.run_cell_magic("bigquery", "", sql)
 
-    assert isinstance(result, pandas.DataFrame)
-    assert len(result) == len(result)  # verify row count
-    assert list(result) == list(result)  # verify column names
+    assert isinstance(return_value, pandas.DataFrame)
+    assert len(return_value) == len(result)  # verify row count
+    assert list(return_value) == list(result)  # verify column names
 
 
 @pytest.mark.usefixtures("ipython_interactive")
@@ -208,8 +208,9 @@ def test_bigquery_magic_with_result_saved_to_variable():
     with run_query_patch as run_query_mock:
         run_query_mock.return_value = query_job_mock
 
-        ip.run_cell_magic("bigquery", "df", sql)
+        return_value = ip.run_cell_magic("bigquery", "df", sql)
 
+    assert return_value is None
     assert "df" in ip.user_ns  # verify that variable exists
     df = ip.user_ns["df"]
     assert len(df) == len(result)  # verify row count


### PR DESCRIPTION
This update will result in better consistency with other Jupyter magics and also allow the user to avoid displaying large results when using the BigQuery cell magic.

Resolves https://github.com/googleapis/google-cloud-python/issues/6907