### PR TITLE
Implement ``Client.context()``

### DIFF
--- a/ndb/docs/client.rst
+++ b/ndb/docs/client.rst
@@ -1,0 +1,7 @@
+######
+Client
+######
+
+.. automodule:: google.cloud.ndb.client
+    :members:
+    :show-inheritance:

--- a/ndb/docs/conf.py
+++ b/ndb/docs/conf.py
@@ -207,6 +207,7 @@ epub_exclude_files = ["search.html"]
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/", None),
+    "google-auth": ("https://google-auth.readthedocs.io/en/latest/", None),
     "google-cloud-datastore": (
         "https://googleapis.github.io/google-cloud-python/latest/",
         None,

--- a/ndb/docs/context.rst
+++ b/ndb/docs/context.rst
@@ -1,5 +1,0 @@
-###############
-Runtime Context
-###############
-
-.. autofunction:: google.cloud.ndb.ndb_context

--- a/ndb/docs/index.rst
+++ b/ndb/docs/index.rst
@@ -6,6 +6,7 @@
    :hidden:
    :maxdepth: 2
 
+   client
    key
    model
    query
@@ -16,7 +17,6 @@
    blobstore
    metadata
    stats
-   context
 
 .. automodule:: google.cloud.ndb
     :no-members:

--- a/ndb/src/google/cloud/ndb/__init__.py
+++ b/ndb/src/google/cloud/ndb/__init__.py
@@ -67,7 +67,6 @@ __all__ = [
     "ModelAdapter",
     "ModelAttribute",
     "ModelKey",
-    "ndb_context",
     "non_transactional",
     "PickleProperty",
     "Property",
@@ -205,7 +204,6 @@ from google.cloud.ndb.query import Query
 from google.cloud.ndb.query import QueryIterator
 from google.cloud.ndb.query import QueryOptions
 from google.cloud.ndb.query import RepeatedStructuredPropertyPredicate
-from google.cloud.ndb._runstate import ndb_context
 from google.cloud.ndb.tasklets import add_flow_exception
 from google.cloud.ndb.tasklets import Future
 from google.cloud.ndb.tasklets import get_context

--- a/ndb/src/google/cloud/ndb/_api.py
+++ b/ndb/src/google/cloud/ndb/_api.py
@@ -20,22 +20,30 @@ from google.cloud import _helpers
 from google.cloud import _http
 from google.cloud.datastore_v1.proto import datastore_pb2_grpc
 
+from google.cloud.ndb import _runstate
 
-def stub(client):
-    """Get a stub for the `Google Datastore` API.
 
-    Arguments:
-        client (:class:`~client.Client`): An NDB client instance.
+def stub():
+    """Get the stub for the `Google Datastore` API.
+
+    Gets the stub from the current context, creating one if there isn't one
+    already.
 
     Returns:
         :class:`~google.cloud.datastore_v1.proto.datastore_pb2_grpc.DatastoreStub`:
             The stub instance.
     """
-    if client.secure:
-        channel = _helpers.make_secure_channel(
-            client._credentials, _http.DEFAULT_USER_AGENT, client.host
-        )
-    else:
-        channel = grpc.insecure_channel(client.host)
-    stub = datastore_pb2_grpc.DatastoreStub(channel)
-    return stub
+    state = _runstate.current()
+
+    if state.stub is None:
+        client = state.client
+        if client.secure:
+            channel = _helpers.make_secure_channel(
+                client._credentials, _http.DEFAULT_USER_AGENT, client.host
+            )
+        else:
+            channel = grpc.insecure_channel(client.host)
+
+        state.stub = datastore_pb2_grpc.DatastoreStub(channel)
+
+    return state.stub

--- a/ndb/src/google/cloud/ndb/exceptions.py
+++ b/ndb/src/google/cloud/ndb/exceptions.py
@@ -38,13 +38,13 @@ class ContextError(Error):
     """Indicates an NDB call being made without a context.
 
     Raised whenever an NDB call is made outside of a context
-    established by :func:`~google.cloud.ndb.ndb_context`.
+    established by :meth:`google.cloud.ndb.client.Client.context`.
     """
 
     def __init__(self):
         super(ContextError, self).__init__(
             "No currently running event loop. Asynchronous calls must be made "
-            "in context established by google.cloud.ndb.ndb_context."
+            "in context established by google.cloud.ndb.Client.context."
         )
 
 

--- a/ndb/tests/unit/test__api.py
+++ b/ndb/tests/unit/test__api.py
@@ -16,6 +16,7 @@ from unittest import mock
 
 from google.cloud import _http
 from google.cloud.ndb import _api
+from google.cloud.ndb import _runstate
 
 
 class TestStub:
@@ -30,7 +31,9 @@ class TestStub:
             host="thehost",
             spec=("_credentials", "secure", "host"),
         )
-        stub = _api.stub(client)
+        with _runstate.state_context(client):
+            stub = _api.stub()
+            assert _api.stub() is stub  # one stub per context
         assert stub is datastore_pb2_grpc.DatastoreStub.return_value
         datastore_pb2_grpc.DatastoreStub.assert_called_once_with(channel)
         _helpers.make_secure_channel.assert_called_once_with(
@@ -45,7 +48,8 @@ class TestStub:
         client = mock.Mock(
             secure=False, host="thehost", spec=("secure", "host")
         )
-        stub = _api.stub(client)
+        with _runstate.state_context(client):
+            stub = _api.stub()
         assert stub is datastore_pb2_grpc.DatastoreStub.return_value
         datastore_pb2_grpc.DatastoreStub.assert_called_once_with(channel)
         grpc.insecure_channel.assert_called_once_with("thehost")

--- a/ndb/tests/unit/test__eventloop.py
+++ b/ndb/tests/unit/test__eventloop.py
@@ -300,7 +300,7 @@ class TestEventLoop:
 def test_get_event_loop():
     with pytest.raises(exceptions.ContextError):
         _eventloop.get_event_loop()
-    with _runstate.ndb_context():
+    with _runstate.state_context(None):
         loop = _eventloop.get_event_loop()
         assert isinstance(loop, _eventloop.EventLoop)
         assert _eventloop.get_event_loop() is loop
@@ -311,7 +311,7 @@ def test_add_idle(EventLoop):
     EventLoop.return_value = loop = unittest.mock.Mock(
         spec=("run", "add_idle")
     )
-    with _runstate.ndb_context():
+    with _runstate.state_context(None):
         _eventloop.add_idle("foo", "bar", baz="qux")
         loop.add_idle.assert_called_once_with("foo", "bar", baz="qux")
 
@@ -321,7 +321,7 @@ def test_queue_call(EventLoop):
     EventLoop.return_value = loop = unittest.mock.Mock(
         spec=("run", "queue_call")
     )
-    with _runstate.ndb_context():
+    with _runstate.state_context(None):
         _eventloop.queue_call(42, "foo", "bar", baz="qux")
         loop.queue_call.assert_called_once_with(42, "foo", "bar", baz="qux")
 
@@ -334,7 +334,7 @@ def test_queue_rpc():
 @unittest.mock.patch("google.cloud.ndb._eventloop.EventLoop")
 def test_run(EventLoop):
     EventLoop.return_value = loop = unittest.mock.Mock(spec=("run",))
-    with _runstate.ndb_context():
+    with _runstate.state_context(None):
         _eventloop.run()
         loop.run.assert_called_once_with()
 
@@ -342,7 +342,7 @@ def test_run(EventLoop):
 @unittest.mock.patch("google.cloud.ndb._eventloop.EventLoop")
 def test_run0(EventLoop):
     EventLoop.return_value = loop = unittest.mock.Mock(spec=("run", "run0"))
-    with _runstate.ndb_context():
+    with _runstate.state_context(None):
         _eventloop.run0()
         loop.run0.assert_called_once_with()
 
@@ -350,6 +350,6 @@ def test_run0(EventLoop):
 @unittest.mock.patch("google.cloud.ndb._eventloop.EventLoop")
 def test_run1(EventLoop):
     EventLoop.return_value = loop = unittest.mock.Mock(spec=("run", "run1"))
-    with _runstate.ndb_context():
+    with _runstate.state_context(None):
         _eventloop.run1()
         loop.run1.assert_called_once_with()

--- a/ndb/tests/unit/test__runstate.py
+++ b/ndb/tests/unit/test__runstate.py
@@ -17,14 +17,18 @@ import unittest
 from google.cloud.ndb import _runstate
 
 
-def test_ndb_context():
+def test_state_context():
     assert _runstate.states.current() is None
 
-    with _runstate.ndb_context():
+    client1 = object()
+    client2 = object()
+    with _runstate.state_context(client1):
         one = _runstate.current()
+        assert one.client is client1
 
-        with _runstate.ndb_context():
+        with _runstate.state_context(client2):
             two = _runstate.current()
+            assert two.client is client2
             assert one is not two
             two.eventloop = unittest.mock.Mock(spec=("run",))
             two.eventloop.run.assert_not_called()

--- a/ndb/tests/unit/test_client.py
+++ b/ndb/tests/unit/test_client.py
@@ -20,7 +20,9 @@ from unittest import mock
 from google.auth import credentials
 from google.cloud import environment_vars
 from google.cloud.datastore import _http
+
 from google.cloud.ndb import client as client_module
+from google.cloud.ndb import _runstate
 
 
 @contextlib.contextmanager
@@ -71,3 +73,12 @@ class TestClient:
             client = client_module.Client()
         with pytest.raises(NotImplementedError):
             client._http
+
+    @staticmethod
+    def test__context():
+        with patch_credentials("testing"):
+            client = client_module.Client()
+
+        with client.context():
+            state = _runstate.current()
+            assert state.client is client


### PR DESCRIPTION
As far as the public API is concerned, ``Client.context()`` replaces
``ndb_context``, which has been renamed to ``state_context`` and removed from
the public API. ``_api.stub()`` has been refactored to store the Datastore
stub in the current context.