### PR TITLE
NDB: Implement ``TaskletFuture``.

### DIFF
--- a/ndb/src/google/cloud/ndb/__init__.py
+++ b/ndb/src/google/cloud/ndb/__init__.py
@@ -106,7 +106,6 @@ __all__ = [
     "add_flow_exception",
     "Future",
     "get_context",
-    "get_return_value",
     "make_context",
     "make_default_context",
     "MultiFuture",
@@ -207,7 +206,6 @@ from google.cloud.ndb.query import RepeatedStructuredPropertyPredicate
 from google.cloud.ndb.tasklets import add_flow_exception
 from google.cloud.ndb.tasklets import Future
 from google.cloud.ndb.tasklets import get_context
-from google.cloud.ndb.tasklets import get_return_value
 from google.cloud.ndb.tasklets import make_context
 from google.cloud.ndb.tasklets import make_default_context
 from google.cloud.ndb.tasklets import MultiFuture

--- a/ndb/tests/conftest.py
+++ b/ndb/tests/conftest.py
@@ -22,6 +22,7 @@ import os
 
 from google.cloud import environment_vars
 from google.cloud.ndb import model
+from google.cloud.ndb import _runstate
 
 import pytest
 
@@ -68,3 +69,10 @@ def initialize_environment(request, environ):
         environ.pop(environment_vars.GCD_DATASET, None)
         environ.pop(environment_vars.GCD_HOST, None)
         environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+
+
+@pytest.fixture
+def with_runstate_context():
+    client = None
+    with _runstate.state_context(client):
+        yield


### PR DESCRIPTION
``TaskletFuture`` is a ``Future`` subclass which wraps the generator
returned by calling a tasklet and provides a means of advancing the
tasklet when results of dependent futures are ready.