### PR TITLE
Logging: use 'python-3.6' for 'blacken' run.

### DIFF
--- a/logging/noxfile.py
+++ b/logging/noxfile.py
@@ -52,7 +52,7 @@ def lint(session):
     session.run("flake8", "google", "tests")
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.6")
 def blacken(session):
     """Run black.
 


### PR DESCRIPTION
Closes #7063.

In autosynth runs, the `blacken` step for logging fails with the following:

```
Running session blacken
Session blacken skipped: Python interpreter 3.7 not found.
synthtool > Cleaned up 2 temporary directories.
synthtool > Wrote metadata to synth.metadata.
```