### PR TITLE
NDB: Implement Key.get() and Key.get_async()

### DIFF
--- a/ndb/docs/conf.py
+++ b/ndb/docs/conf.py
@@ -212,6 +212,7 @@ intersphinx_mapping = {
         "https://googleapis.github.io/google-cloud-python/latest/",
         None,
     ),
+    "grpc": ("https://grpc.io/grpc/python/", None),
 }
 
 # Napoleon settings

--- a/ndb/docs/index.rst
+++ b/ndb/docs/index.rst
@@ -10,6 +10,7 @@
    key
    model
    query
+   tasklets
    exceptions
    polymodel
    django-middleware

--- a/ndb/docs/tasklets.rst
+++ b/ndb/docs/tasklets.rst
@@ -1,0 +1,9 @@
+########
+Tasklets
+########
+
+.. automodule:: google.cloud.ndb.tasklets
+    :members:
+    :exclude-members:
+    :undoc-members:
+    :show-inheritance:

--- a/ndb/noxfile.py
+++ b/ndb/noxfile.py
@@ -21,7 +21,7 @@ import os
 
 import nox
 
-
+LOCAL_DEPS = (os.path.join("..", "api_core"), os.path.join("..", "core"))
 NOX_DIR = os.path.abspath(os.path.dirname(__file__))
 DEFAULT_INTERPRETER = "3.7"
 PYPY = "pypy3"
@@ -141,3 +141,39 @@ def doctest(session):
         get_path("docs", "_build", "doctest"),
     ]
     session.run(*run_args)
+
+
+@nox.session(py=DEFAULT_INTERPRETER)
+def system(session):
+    """Run the system test suite."""
+    system_test_path = get_path("tests", "system.py")
+    system_test_folder_path = os.path.join("tests", "system")
+
+    # Sanity check: Only run tests if the environment variable is set.
+    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", ""):
+        session.skip("Credentials must be set via environment variable")
+
+    system_test_exists = os.path.exists(system_test_path)
+    system_test_folder_exists = os.path.exists(system_test_folder_path)
+    # Sanity check: only run tests if found.
+    if not system_test_exists and not system_test_folder_exists:
+        session.skip("System tests were not found")
+
+    # Use pre-release gRPC for system tests.
+    session.install("--pre", "grpcio")
+
+    # Install all test dependencies, then install this package into the
+    # virtualenv's dist-packages.
+    session.install("pytest")
+    for local_dep in LOCAL_DEPS:
+        session.install("-e", local_dep)
+    session.install("-e", get_path("..", "test_utils"))
+    session.install("-e", ".")
+
+    # Run py.test against the system tests.
+    if system_test_exists:
+        session.run("py.test", "--quiet", system_test_path, *session.posargs)
+    if system_test_folder_exists:
+        session.run(
+            "py.test", "--quiet", system_test_folder_path, *session.posargs
+        )

--- a/ndb/src/google/cloud/ndb/__init__.py
+++ b/ndb/src/google/cloud/ndb/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "Client",
     "Context",
     "ContextOptions",
+    "EVENTUAL",
     "EVENTUAL_CONSISTENCY",
     "TransactionOptions",
     "Key",
@@ -125,8 +126,9 @@ from google.cloud.ndb.client import Client
 from google.cloud.ndb.context import AutoBatcher
 from google.cloud.ndb.context import Context
 from google.cloud.ndb.context import ContextOptions
-from google.cloud.ndb.context import EVENTUAL_CONSISTENCY
 from google.cloud.ndb.context import TransactionOptions
+from google.cloud.ndb._datastore_api import EVENTUAL
+from google.cloud.ndb._datastore_api import EVENTUAL_CONSISTENCY
 from google.cloud.ndb.key import Key
 from google.cloud.ndb.model import BlobKey
 from google.cloud.ndb.model import BlobKeyProperty

--- a/ndb/src/google/cloud/ndb/_datastore_api.py
+++ b/ndb/src/google/cloud/ndb/_datastore_api.py
@@ -29,7 +29,7 @@ from google.cloud.ndb import _runstate
 from google.cloud.ndb import tasklets
 
 EVENTUAL = datastore_pb2.ReadOptions.EVENTUAL
-EVENTUAL_CONSISTENCY = EVENTUAL   # Legacy NDB
+EVENTUAL_CONSISTENCY = EVENTUAL  # Legacy NDB
 _NOT_FOUND = object()
 
 
@@ -128,6 +128,7 @@ class _LookupBatch(dict):
             ``{"read_consistency": EVENTUAL}``. Calls with different options
             will be placed in different batches.
     """
+
     def __init__(self, options):
         self.options = options
 
@@ -205,7 +206,8 @@ def _datastore_lookup(keys, read_options):
     """
     client = _runstate.current().client
     request = datastore_pb2.LookupRequest(
-        project_id=client.project, keys=[key for key in keys],
+        project_id=client.project,
+        keys=[key for key in keys],
         read_options=read_options,
     )
 
@@ -239,19 +241,15 @@ def _get_read_options(options):
 
     if transaction is not None and read_consistency is EVENTUAL:
         raise ValueError(
-            "read_consistency must be EVENTUAL when in transaction")
+            "read_consistency must be EVENTUAL when in transaction"
+        )
 
     return datastore_pb2.ReadOptions(
-        read_consistency=read_consistency,
-        transaction=transaction,
+        read_consistency=read_consistency, transaction=transaction
     )
 
 
-_OPTIONS_SUPPORTED = {
-    "transaction",
-    "read_consistency",
-    "read_policy",
-}
+_OPTIONS_SUPPORTED = {"transaction", "read_consistency", "read_policy"}
 
 _OPTIONS_NOT_IMPLEMENTED = {
     "deadline",

--- a/ndb/src/google/cloud/ndb/_datastore_api.py
+++ b/ndb/src/google/cloud/ndb/_datastore_api.py
@@ -88,7 +88,8 @@ def _get_lookup_batch():
     the batch look up.
 
     Returns:
-        Dict[~datastore_v1.proto.entity_pb2.Key, List[~tasklets.Future]]
+        Dict[bytes, List[~tasklets.Future]]: Mapping of serialized entity keys
+            to futures.
     """
     state = _runstate.current()
     batch = state.batches.get(_BATCH_LOOKUP)
@@ -126,8 +127,8 @@ class BatchLookupCallback:
     """Callback for processing the results of a call to Datastore Lookup.
 
     Args:
-        batch (Dict[~datastore_v1.proto.entity_pb2.Key, List[~tasklets.Future]]):
-            Mapping of keys to futures for the batch request.
+        batch (Dict[bytes, List[~tasklets.Future]]): Mapping of serialized keys
+            to futures for the batch request.
     """
 
     def __init__(self, batch):

--- a/ndb/src/google/cloud/ndb/_runstate.py
+++ b/ndb/src/google/cloud/ndb/_runstate.py
@@ -26,6 +26,7 @@ class State:
         self.eventloop = None
         self.stub = None
         self.batches = {}
+        self.transaction = None
 
 
 class LocalStates(threading.local):

--- a/ndb/src/google/cloud/ndb/context.py
+++ b/ndb/src/google/cloud/ndb/context.py
@@ -15,12 +15,7 @@
 """Context for currently running tasks and transactions."""
 
 
-__all__ = [
-    "AutoBatcher",
-    "Context",
-    "ContextOptions",
-    "TransactionOptions",
-]
+__all__ = ["AutoBatcher", "Context", "ContextOptions", "TransactionOptions"]
 
 
 class AutoBatcher:

--- a/ndb/src/google/cloud/ndb/context.py
+++ b/ndb/src/google/cloud/ndb/context.py
@@ -19,7 +19,6 @@ __all__ = [
     "AutoBatcher",
     "Context",
     "ContextOptions",
-    "EVENTUAL_CONSISTENCY",
     "TransactionOptions",
 ]
 
@@ -43,9 +42,6 @@ class ContextOptions:
 
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
-
-
-EVENTUAL_CONSISTENCY = 1
 
 
 class TransactionOptions:

--- a/ndb/src/google/cloud/ndb/exceptions.py
+++ b/ndb/src/google/cloud/ndb/exceptions.py
@@ -43,8 +43,8 @@ class ContextError(Error):
 
     def __init__(self):
         super(ContextError, self).__init__(
-            "No currently running event loop. Asynchronous calls must be made "
-            "in context established by google.cloud.ndb.Client.context."
+            "No current context. NDB calls must be made in context "
+            "established by google.cloud.ndb.Client.context."
         )
 
 

--- a/ndb/src/google/cloud/ndb/key.py
+++ b/ndb/src/google/cloud/ndb/key.py
@@ -731,7 +731,7 @@ class Key:
                 options have not yet been implemented.
 
         Returns:
-            :class:`tasklets.Future`
+            :class:`~google.cloud.ndb.tasklets.Future`
         """
         from google.cloud.ndb import model  # avoid circular import
 

--- a/ndb/src/google/cloud/ndb/key.py
+++ b/ndb/src/google/cloud/ndb/key.py
@@ -744,7 +744,7 @@ class Key:
         """
         from google.cloud.ndb import model  # avoid circular import
 
-        entity_pb = yield _datastore_api.lookup(self)
+        entity_pb = yield _datastore_api.lookup(self._key)
         return model._entity_from_protobuf(entity_pb)
 
     def delete(self, **ctx_options):

--- a/ndb/src/google/cloud/ndb/key.py
+++ b/ndb/src/google/cloud/ndb/key.py
@@ -705,46 +705,38 @@ class Key:
         raw_bytes = self.serialized()
         return base64.urlsafe_b64encode(raw_bytes).strip(b"=")
 
-    def get(self, **ctx_options):
+    def get(self, **options):
         """Synchronously get the entity for this key.
 
         Returns the retrieved :class:`.Model` or :data:`None` if there is no
         such entity.
 
         Args:
-            ctx_options (Dict[str, Any]): The context options for the request.
-                For example, ``{"read_policy": EVENTUAL_CONSISTENCY}``.
-
-        Raises:
-            NotImplementedError: When ``ctx_options`` is not empty. Context
-                options have not yet been implemented.
+            options (Dict[str, Any]): The options for the request. For
+                example, ``{"read_consistency": EVENTUAL}``.
 
         Returns:
             Union[:class:`.Model`, :data:`None`]
         """
-        return self.get_async(**ctx_options).result()
+        return self.get_async(**options).result()
 
     @tasklets.tasklet
-    def get_async(self, **ctx_options):
+    def get_async(self, **options):
         """Asynchronously get the entity for this key.
 
         The result for the returned future will either be the retrieved
         :class:`.Model` or :data:`None` if there is no such entity.
 
         Args:
-            ctx_options (Dict[str, Any]): The context options for the request.
-                For example, ``{"read_policy": EVENTUAL_CONSISTENCY}``.
-
-        Raises:
-            NotImplementedError: When ``ctx_options`` is not empty. Context
-                options have not yet been implemented.
+            options (Dict[str, Any]): The options for the request. For
+                example, ``{"read_consistency": EVENTUAL}``.
 
         Returns:
             :class:`~google.cloud.ndb.tasklets.Future`
         """
         from google.cloud.ndb import model  # avoid circular import
 
-        entity_pb = yield _datastore_api.lookup(self._key)
+        entity_pb = yield _datastore_api.lookup(self._key, **options)
         if entity_pb is not _datastore_api._NOT_FOUND:
             return model._entity_from_protobuf(entity_pb)
 

--- a/ndb/src/google/cloud/ndb/key.py
+++ b/ndb/src/google/cloud/ndb/key.py
@@ -134,8 +134,17 @@ class Key:
 
     .. testsetup:: *
 
+        from unittest import mock
+        from google.cloud.ndb import _runstate
+        client = mock.Mock(project="testing", spec=("project",))
+        context = _runstate.state_context(client)
+        context.__enter__()
         kind1, id1 = "Parent", "C"
         kind2, id2 = "Child", 42
+
+    .. testcleanup:: *
+
+        context.__exit__(None, None, None)
 
     .. doctest:: key-constructor-primary
 

--- a/ndb/src/google/cloud/ndb/key.py
+++ b/ndb/src/google/cloud/ndb/key.py
@@ -745,7 +745,8 @@ class Key:
         from google.cloud.ndb import model  # avoid circular import
 
         entity_pb = yield _datastore_api.lookup(self._key)
-        return model._entity_from_protobuf(entity_pb)
+        if entity_pb is not _datastore_api._NOT_FOUND:
+            return model._entity_from_protobuf(entity_pb)
 
     def delete(self, **ctx_options):
         """Synchronously delete the entity for this key.

--- a/ndb/src/google/cloud/ndb/model.py
+++ b/ndb/src/google/cloud/ndb/model.py
@@ -16,7 +16,17 @@
 
 .. testsetup:: *
 
+    from unittest import mock
     from google.cloud import ndb
+    from google.cloud.ndb import _runstate
+
+    client = mock.Mock(project="testing", spec=("project",))
+    context = _runstate.state_context(client)
+    context.__enter__()
+
+.. testcleanup:: *
+
+    context.__exit__(None, None, None)
 """
 
 

--- a/ndb/src/google/cloud/ndb/tasklets.py
+++ b/ndb/src/google/cloud/ndb/tasklets.py
@@ -181,12 +181,16 @@ class Future:
             return self._exception.__traceback__
 
     def add_done_callback(self, callback):
-        """Add a callback function to be run upon task completion.
+        """Add a callback function to be run upon task completion. Will run
+        immediately if task has already finished.
 
         Args:
             callback (Callable): The function to execute.
         """
-        self._callbacks.append(callback)
+        if self._done:
+            callback(self)
+        else:
+            self._callbacks.append(callback)
 
     def cancel(self):
         """Cancel the task for this future.

--- a/ndb/src/google/cloud/ndb/tasklets.py
+++ b/ndb/src/google/cloud/ndb/tasklets.py
@@ -175,7 +175,7 @@ class Future:
         attribute of that exception.
 
         Returns:
-            Union[traceback, None]: The traceback, or None.
+            Union[types.TracebackType, None]: The traceback, or None.
         """
         if self._exception:
             return self._exception.__traceback__
@@ -204,7 +204,7 @@ class Future:
         """Get whether task for this future has been cancelled.
 
         Returns:
-            False: Always.
+            :data:`False`: Always.
         """
         return False
 
@@ -214,12 +214,13 @@ class TaskletFuture(Future):
 
     A future of this type wraps a generator derived from calling a tasklet. A
     tasklet's generator is expected to yield future objects, either an instance
-    of :class:`ndb.Future` or :class:`grpc.Future'. The result of each yielded
-    future is then sent back into the generator until the generator has
+    of :class:`Future` or :class:`grpc.Future`. The result of each
+    yielded future is then sent back into the generator until the generator has
     completed and either returned a value or raised an exception.
 
     Args:
-        Generator[Union[ndb.Future, grpc.Future], Any, Any]: The generator.
+        typing.Generator[Union[tasklets.Future, grpc.Future], Any, Any]: The
+            generator.
     """
 
     def __init__(self, generator):
@@ -277,10 +278,10 @@ class TaskletFuture(Future):
 
 
 def _get_return_value(stop):
-    """Inspect StopIteration instance for return value of tasklet.
+    """Inspect `StopIteration` instance for return value of tasklet.
 
     Args:
-        stop (StopIteration): The StopIteration exception for the finished
+        stop (StopIteration): The `StopIteration` exception for the finished
             tasklet.
     """
     if len(stop.args) == 1:
@@ -297,8 +298,8 @@ class MultiFuture(Future):
     one dependency has raised an exception.
 
     Args:
-        dependencies (Sequence[google.cloud.ndb.tasklets.Future]): A sequence
-            of the futures this future depends on.
+        dependencies (typing.Sequence[tasklets.Future]): A sequence of the
+            futures this future depends on.
     """
 
     def __init__(self, dependencies):
@@ -400,7 +401,15 @@ class ReducingFuture:
         raise NotImplementedError
 
 
-Return = StopIteration
+class Return(StopIteration):
+    """Alias for `StopIteration`.
+
+    Older programs written with NDB may ``raise Return(result)`` in a tasklet.
+    This is no longer necessary, but it is included for backwards
+    compatibility. Tasklets should simply ``return`` their result.
+    """
+    # For reasons I don't entirely understand, Sphinx pukes if we just assign:
+    # Return = StopIteration
 
 
 class SerialQueueFuture:

--- a/ndb/src/google/cloud/ndb/tasklets.py
+++ b/ndb/src/google/cloud/ndb/tasklets.py
@@ -408,6 +408,7 @@ class Return(StopIteration):
     This is no longer necessary, but it is included for backwards
     compatibility. Tasklets should simply ``return`` their result.
     """
+
     # For reasons I don't entirely understand, Sphinx pukes if we just assign:
     # Return = StopIteration
 

--- a/ndb/tests/conftest.py
+++ b/ndb/tests/conftest.py
@@ -20,6 +20,8 @@ modules.
 
 import os
 
+from unittest import mock
+
 from google.cloud import environment_vars
 from google.cloud.ndb import model
 from google.cloud.ndb import _runstate
@@ -78,3 +80,11 @@ def runstate():
     client = None
     with _runstate.state_context(client) as state:
         yield state
+
+
+@pytest.fixture()
+def client(runstate):
+    runstate.client = client = mock.Mock(
+        project="testing", namespace=None, spec=("project", "namespace")
+    )
+    return client

--- a/ndb/tests/system/test_system.py
+++ b/ndb/tests/system/test_system.py
@@ -65,6 +65,18 @@ def test_retrieve_entity(ds_entity):
 
 
 @pytest.mark.usefixtures("client_context")
+def test_retrieve_entity_not_found(ds_entity):
+    entity_id = test_utils.system.unique_resource_id()
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+        bar = ndb.StringProperty()
+
+    key = ndb.Key("SomeKind", entity_id)
+    assert key.get() is None
+
+
+@pytest.mark.usefixtures("client_context")
 def test_nested_tasklet(ds_entity):
     entity_id = test_utils.system.unique_resource_id()
     ds_entity("SomeKind", entity_id, foo=42, bar="none")

--- a/ndb/tests/system/test_system.py
+++ b/ndb/tests/system/test_system.py
@@ -1,0 +1,112 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import test_utils.system
+
+from google.cloud import datastore
+from google.cloud import ndb
+
+
+@pytest.fixture
+def ds_entity():
+    keys = []
+    client = datastore.Client()
+
+    def make_entity(*key_args, **entity_kwargs):
+        key = client.key(*key_args)
+        assert client.get(key) is None
+        entity = datastore.Entity(key=key)
+        entity.update(entity_kwargs)
+        client.put(entity)
+
+        keys.append(key)
+        return entity
+
+    yield make_entity
+
+    for key in keys:
+        client.delete(key)
+
+
+@pytest.fixture
+def client_context():
+    client = ndb.Client()
+    with client.context():
+        yield
+
+
+@pytest.mark.usefixtures("client_context")
+def test_retrieve_entity(ds_entity):
+    entity_id = test_utils.system.unique_resource_id()
+    ds_entity("SomeKind", entity_id, foo=42, bar="none")
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+        bar = ndb.StringProperty()
+
+    key = ndb.Key("SomeKind", entity_id)
+    entity = key.get()
+    assert isinstance(entity, SomeKind)
+    assert entity.foo == 42
+    assert entity.bar == "none"
+
+
+@pytest.mark.usefixtures("client_context")
+def test_nested_tasklet(ds_entity):
+    entity_id = test_utils.system.unique_resource_id()
+    ds_entity("SomeKind", entity_id, foo=42, bar="none")
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+        bar = ndb.StringProperty()
+
+    @ndb.tasklet
+    def get_foo(key):
+        entity = yield key.get_async()
+        return entity.foo
+
+    key = ndb.Key("SomeKind", entity_id)
+    assert get_foo(key).result() == 42
+
+
+@pytest.mark.usefixtures("client_context")
+def test_retrieve_two_entities_in_parallel(ds_entity):
+    entity1_id = test_utils.system.unique_resource_id()
+    ds_entity("SomeKind", entity1_id, foo=42, bar="none")
+    entity2_id = test_utils.system.unique_resource_id()
+    ds_entity("SomeKind", entity2_id, foo=65, bar="naan")
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+        bar = ndb.StringProperty()
+
+    key1 = ndb.Key("SomeKind", entity1_id)
+    key2 = ndb.Key("SomeKind", entity2_id)
+
+    @ndb.tasklet
+    def get_two_entities():
+        entity1, entity2 = yield key1.get_async(), key2.get_async()
+        return entity1, entity2
+
+    entity1, entity2 = get_two_entities().result()
+
+    assert isinstance(entity1, SomeKind)
+    assert entity1.foo == 42
+    assert entity1.bar == "none"
+
+    assert isinstance(entity2, SomeKind)
+    assert entity2.foo == 65
+    assert entity2.bar == "naan"

--- a/ndb/tests/unit/test__datastore_api.py
+++ b/ndb/tests/unit/test__datastore_api.py
@@ -79,7 +79,9 @@ class TestLookup:
         batch = runstate.batches[_api._LookupBatch][()]
         assert batch["foo"] == [future1, future2]
         assert batch["bar"] == [future3]
-        runstate.eventloop.add_idle.assert_called_once_with(batch.idle_callback)
+        runstate.eventloop.add_idle.assert_called_once_with(
+            batch.idle_callback
+        )
 
     @staticmethod
     def test_it_with_options(runstate):
@@ -131,7 +133,8 @@ class Test_LookupBatch:
 
         rpc = _datastore_lookup.return_value
         runstate.eventloop.queue_rpc.assert_called_once_with(
-            rpc, batch.lookup_callback)
+            rpc, batch.lookup_callback
+        )
 
     @staticmethod
     def test_lookup_callback_exception():
@@ -287,7 +290,7 @@ def test__datastore_lookup(datastore_pb2, runstate):
     assert _api._datastore_lookup(["foo", "bar"], None) is future
 
     datastore_pb2.LookupRequest.assert_called_once_with(
-        project_id="theproject", keys=["foo", "bar"], read_options=None,
+        project_id="theproject", keys=["foo", "bar"], read_options=None
     )
     runstate.stub.Lookup.future.assert_called_once_with(
         datastore_pb2.LookupRequest.return_value
@@ -295,14 +298,15 @@ def test__datastore_lookup(datastore_pb2, runstate):
 
 
 class Test_check_unsupported_options:
-
     @staticmethod
     def test_supported():
-        _api._check_unsupported_options({
-            "transaction": None,
-            "read_consistency": None,
-            "read_policy": None,
-        })
+        _api._check_unsupported_options(
+            {
+                "transaction": None,
+                "read_consistency": None,
+                "read_policy": None,
+            }
+        )
 
     @staticmethod
     def test_not_implemented():
@@ -334,7 +338,6 @@ class Test_check_unsupported_options:
 
 
 class Test_get_read_options:
-
     @staticmethod
     def test_no_args_no_transaction(runstate):
         assert _api._get_read_options({}) == datastore_pb2.ReadOptions()
@@ -353,18 +356,16 @@ class Test_get_read_options:
 
     @staticmethod
     def test_eventually_consistent(runstate):
-        options = _api._get_read_options({
-            "read_consistency": _api.EVENTUAL
-        })
+        options = _api._get_read_options({"read_consistency": _api.EVENTUAL})
         assert options == datastore_pb2.ReadOptions(
             read_consistency=datastore_pb2.ReadOptions.EVENTUAL
         )
 
     @staticmethod
     def test_eventually_consistent_legacy(runstate):
-        options = _api._get_read_options({
-            "read_policy": _api.EVENTUAL_CONSISTENCY,
-        })
+        options = _api._get_read_options(
+            {"read_policy": _api.EVENTUAL_CONSISTENCY}
+        )
         assert options == datastore_pb2.ReadOptions(
             read_consistency=datastore_pb2.ReadOptions.EVENTUAL
         )
@@ -372,7 +373,6 @@ class Test_get_read_options:
     @staticmethod
     def test_eventually_consistent_with_transaction(runstate):
         with pytest.raises(ValueError):
-            _api._get_read_options({
-                "read_consistency": _api.EVENTUAL,
-                "transaction": b"txfoo",
-            })
+            _api._get_read_options(
+                {"read_consistency": _api.EVENTUAL, "transaction": b"txfoo"}
+            )

--- a/ndb/tests/unit/test__datastore_api.py
+++ b/ndb/tests/unit/test__datastore_api.py
@@ -14,7 +14,10 @@
 
 from unittest import mock
 
+import pytest
+
 from google.cloud import _http
+from google.cloud.datastore_v1.proto import datastore_pb2
 from google.cloud.ndb import _datastore_api as _api
 from google.cloud.ndb import _runstate
 from google.cloud.ndb import tasklets
@@ -65,25 +68,48 @@ def _mock_key(key_str):
     return key
 
 
-def test_lookup(runstate):
-    runstate.eventloop = mock.Mock(spec=("add_idle", "run"))
-    future1 = _api.lookup(_mock_key("foo"))
-    future2 = _api.lookup(_mock_key("foo"))
-    future3 = _api.lookup(_mock_key("bar"))
+class TestLookup:
+    @staticmethod
+    def test_it(runstate):
+        runstate.eventloop = mock.Mock(spec=("add_idle", "run"))
+        future1 = _api.lookup(_mock_key("foo"))
+        future2 = _api.lookup(_mock_key("foo"))
+        future3 = _api.lookup(_mock_key("bar"))
 
-    batch = runstate.batches[_api._BATCH_LOOKUP]
-    assert batch["foo"] == [future1, future2]
-    assert batch["bar"] == [future3]
-    runstate.eventloop.add_idle.assert_called_once_with(
-        _api._perform_batch_lookup
-    )
+        batch = runstate.batches[_api._LookupBatch][()]
+        assert batch["foo"] == [future1, future2]
+        assert batch["bar"] == [future3]
+        runstate.eventloop.add_idle.assert_called_once_with(batch.idle_callback)
+
+    @staticmethod
+    def test_it_with_options(runstate):
+        runstate.eventloop = mock.Mock(spec=("add_idle", "run"))
+        future1 = _api.lookup(_mock_key("foo"))
+        future2 = _api.lookup(_mock_key("foo"), read_consistency=_api.EVENTUAL)
+        future3 = _api.lookup(_mock_key("bar"))
+
+        batches = runstate.batches[_api._LookupBatch]
+        batch1 = batches[()]
+        assert batch1["foo"] == [future1]
+        assert batch1["bar"] == [future3]
+
+        batch2 = batches[(("read_consistency", _api.EVENTUAL),)]
+        assert batch2 == {"foo": [future2]}
+
+        add_idle = runstate.eventloop.add_idle
+        assert add_idle.call_count == 2
+
+    @staticmethod
+    def test_it_with_bad_option(runstate):
+        with pytest.raises(NotImplementedError):
+            _api.lookup(_mock_key("foo"), foo="bar")
 
 
-class Test_perform_batch_lookup:
+class Test_LookupBatch:
     @staticmethod
     @mock.patch("google.cloud.ndb._datastore_api.entity_pb2")
     @mock.patch("google.cloud.ndb._datastore_api._datastore_lookup")
-    def test_it(_datastore_lookup, entity_pb2, runstate):
+    def test_idle_callback(_datastore_lookup, entity_pb2, runstate):
         class MockKey:
             def __init__(self, key=None):
                 self.key = key
@@ -93,39 +119,30 @@ class Test_perform_batch_lookup:
 
         entity_pb2.Key = MockKey
         runstate.eventloop = mock.Mock(spec=("queue_rpc", "run"))
-        runstate.batches[_api._BATCH_LOOKUP] = batch = {
-            "foo": ["one", "two"],
-            "bar": ["three"],
-        }
-        _api._perform_batch_lookup()
-        called_with = _datastore_lookup.call_args[0][0]
-        called_with_keys = set((mock_key.key for mock_key in called_with))
+        batch = _api._LookupBatch({})
+        batch.update({"foo": ["one", "two"], "bar": ["three"]})
+        batch.idle_callback()
+
+        called_with = _datastore_lookup.call_args[0]
+        called_with_keys = set((mock_key.key for mock_key in called_with[0]))
         assert called_with_keys == set(["foo", "bar"])
+        called_with_options = called_with[1]
+        assert called_with_options == datastore_pb2.ReadOptions()
 
         rpc = _datastore_lookup.return_value
-        call_args = runstate.eventloop.queue_rpc.call_args[0]
-        assert call_args[0] == rpc
-        assert call_args[1].batch is batch
+        runstate.eventloop.queue_rpc.assert_called_once_with(
+            rpc, batch.lookup_callback)
 
     @staticmethod
-    @mock.patch("google.cloud.ndb._datastore_api._datastore_lookup")
-    def test_it_no_batch(_datastore_lookup, runstate):
-        runstate.eventloop = mock.Mock(spec=("queue_rpc", "run"))
-        _api._perform_batch_lookup()
-        _datastore_lookup.assert_not_called()
-        runstate.eventloop.queue_rpc.assert_not_called()
-
-
-class TestBatchLookupCallback:
-    @staticmethod
-    def test_exception():
+    def test_lookup_callback_exception():
         future1, future2, future3 = (tasklets.Future() for _ in range(3))
-        batch = {"foo": [future1, future2], "bar": [future3]}
+        batch = _api._LookupBatch({})
+        batch.update({"foo": [future1, future2], "bar": [future3]})
         error = Exception("Spurious error.")
+
         rpc = tasklets.Future()
         rpc.set_exception(error)
-        callback = _api.BatchLookupCallback(batch)
-        callback(rpc)
+        batch.lookup_callback(rpc)
 
         assert future1.exception() is error
         assert future2.exception() is error
@@ -138,7 +155,9 @@ class TestBatchLookupCallback:
             return mock_key
 
         future1, future2, future3 = (tasklets.Future() for _ in range(3))
-        batch = {"foo": [future1, future2], "bar": [future3]}
+        batch = _api._LookupBatch({})
+        batch.update({"foo": [future1, future2], "bar": [future3]})
+
         entity1 = mock.Mock(key=key_pb("foo"), spec=("key",))
         entity2 = mock.Mock(key=key_pb("bar"), spec=("key",))
         response = mock.Mock(
@@ -150,10 +169,10 @@ class TestBatchLookupCallback:
             deferred=[],
             spec=("found", "missing", "deferred"),
         )
+
         rpc = tasklets.Future()
         rpc.set_result(response)
-        callback = _api.BatchLookupCallback(batch)
-        callback(rpc)
+        batch.lookup_callback(rpc)
 
         assert future1.result() is entity1
         assert future2.result() is entity1
@@ -167,7 +186,9 @@ class TestBatchLookupCallback:
             return mock_key
 
         future1, future2, future3 = (tasklets.Future() for _ in range(3))
-        batch = {"foo": [future1, future2], "bar": [future3]}
+        batch = _api._LookupBatch({})
+        batch.update({"foo": [future1, future2], "bar": [future3]})
+
         entity1 = mock.Mock(key=key_pb("foo"), spec=("key",))
         entity2 = mock.Mock(key=key_pb("bar"), spec=("key",))
         response = mock.Mock(
@@ -179,10 +200,10 @@ class TestBatchLookupCallback:
             deferred=[],
             spec=("found", "missing", "deferred"),
         )
+
         rpc = tasklets.Future()
         rpc.set_result(response)
-        callback = _api.BatchLookupCallback(batch)
-        callback(rpc)
+        batch.lookup_callback(rpc)
 
         assert future1.result() is _api._NOT_FOUND
         assert future2.result() is _api._NOT_FOUND
@@ -197,25 +218,28 @@ class TestBatchLookupCallback:
 
         runstate.eventloop = mock.Mock(spec=("add_idle", "run"))
         future1, future2, future3 = (tasklets.Future() for _ in range(3))
-        batch = {"foo": [future1, future2], "bar": [future3]}
+        batch = _api._LookupBatch({})
+        batch.update({"foo": [future1, future2], "bar": [future3]})
+
         response = mock.Mock(
             missing=[],
             found=[],
             deferred=[key_pb("foo"), key_pb("bar")],
             spec=("found", "missing", "deferred"),
         )
+
         rpc = tasklets.Future()
         rpc.set_result(response)
-        callback = _api.BatchLookupCallback(batch)
-        callback(rpc)
+        batch.lookup_callback(rpc)
 
         assert future1.running()
         assert future2.running()
         assert future3.running()
 
-        assert runstate.batches[_api._BATCH_LOOKUP] == batch
+        next_batch = runstate.batches[_api._LookupBatch][()]
+        assert next_batch == batch and next_batch is not batch
         runstate.eventloop.add_idle.assert_called_once_with(
-            _api._perform_batch_lookup
+            next_batch.idle_callback
         )
 
     @staticmethod
@@ -227,7 +251,9 @@ class TestBatchLookupCallback:
 
         runstate.eventloop = mock.Mock(spec=("add_idle", "run"))
         future1, future2, future3 = (tasklets.Future() for _ in range(3))
-        batch = {"foo": [future1], "bar": [future2], "baz": [future3]}
+        batch = _api._LookupBatch({})
+        batch.update({"foo": [future1], "bar": [future2], "baz": [future3]})
+
         entity1 = mock.Mock(key=key_pb("foo"), spec=("key",))
         entity2 = mock.Mock(key=key_pb("bar"), spec=("key",))
         response = mock.Mock(
@@ -236,18 +262,19 @@ class TestBatchLookupCallback:
             deferred=[key_pb("baz")],
             spec=("found", "missing", "deferred"),
         )
+
         rpc = tasklets.Future()
         rpc.set_result(response)
-        callback = _api.BatchLookupCallback(batch)
-        callback(rpc)
+        batch.lookup_callback(rpc)
 
         assert future1.result() is entity1
         assert future2.result() is _api._NOT_FOUND
         assert future3.running()
 
-        assert runstate.batches[_api._BATCH_LOOKUP] == {"baz": [future3]}
+        next_batch = runstate.batches[_api._LookupBatch][()]
+        assert next_batch == {"baz": [future3]}
         runstate.eventloop.add_idle.assert_called_once_with(
-            _api._perform_batch_lookup
+            next_batch.idle_callback
         )
 
 
@@ -255,12 +282,97 @@ class TestBatchLookupCallback:
 def test__datastore_lookup(datastore_pb2, runstate):
     runstate.client = mock.Mock(project="theproject", spec=("project",))
     runstate.stub = mock.Mock(spec=("Lookup",))
-    runstate.stub.return_value = mock.Mock(spec=("future",))
-    _api._datastore_lookup(["foo", "bar"]) is runstate.stub.return_value
+    runstate.stub.Lookup = Lookup = mock.Mock(spec=("future",))
+    future = Lookup.future.return_value
+    assert _api._datastore_lookup(["foo", "bar"], None) is future
 
     datastore_pb2.LookupRequest.assert_called_once_with(
-        project_id="theproject", keys=["foo", "bar"]
+        project_id="theproject", keys=["foo", "bar"], read_options=None,
     )
     runstate.stub.Lookup.future.assert_called_once_with(
         datastore_pb2.LookupRequest.return_value
     )
+
+
+class Test_check_unsupported_options:
+
+    @staticmethod
+    def test_supported():
+        _api._check_unsupported_options({
+            "transaction": None,
+            "read_consistency": None,
+            "read_policy": None,
+        })
+
+    @staticmethod
+    def test_not_implemented():
+        with pytest.raises(NotImplementedError):
+            _api._check_unsupported_options({"deadline": None})
+        with pytest.raises(NotImplementedError):
+            _api._check_unsupported_options({"force_writes": None})
+        with pytest.raises(NotImplementedError):
+            _api._check_unsupported_options({"use_cache": None})
+        with pytest.raises(NotImplementedError):
+            _api._check_unsupported_options({"use_memcache": None})
+        with pytest.raises(NotImplementedError):
+            _api._check_unsupported_options({"use_datastore": None})
+        with pytest.raises(NotImplementedError):
+            _api._check_unsupported_options({"memcache_timeout": None})
+        with pytest.raises(NotImplementedError):
+            _api._check_unsupported_options({"max_memcache_items": None})
+        with pytest.raises(NotImplementedError):
+            _api._check_unsupported_options({"xg": None})
+        with pytest.raises(NotImplementedError):
+            _api._check_unsupported_options({"propagation": None})
+        with pytest.raises(NotImplementedError):
+            _api._check_unsupported_options({"retries": None})
+
+    @staticmethod
+    def test_not_supported():
+        with pytest.raises(NotImplementedError):
+            _api._check_unsupported_options({"say_what": None})
+
+
+class Test_get_read_options:
+
+    @staticmethod
+    def test_no_args_no_transaction(runstate):
+        assert _api._get_read_options({}) == datastore_pb2.ReadOptions()
+
+    @staticmethod
+    def test_no_args_transaction(runstate):
+        runstate.transaction = b"txfoo"
+        options = _api._get_read_options({})
+        assert options == datastore_pb2.ReadOptions(transaction=b"txfoo")
+
+    @staticmethod
+    def test_args_override_transaction(runstate):
+        runstate.transaction = b"txfoo"
+        options = _api._get_read_options({"transaction": b"txbar"})
+        assert options == datastore_pb2.ReadOptions(transaction=b"txbar")
+
+    @staticmethod
+    def test_eventually_consistent(runstate):
+        options = _api._get_read_options({
+            "read_consistency": _api.EVENTUAL
+        })
+        assert options == datastore_pb2.ReadOptions(
+            read_consistency=datastore_pb2.ReadOptions.EVENTUAL
+        )
+
+    @staticmethod
+    def test_eventually_consistent_legacy(runstate):
+        options = _api._get_read_options({
+            "read_policy": _api.EVENTUAL_CONSISTENCY,
+        })
+        assert options == datastore_pb2.ReadOptions(
+            read_consistency=datastore_pb2.ReadOptions.EVENTUAL
+        )
+
+    @staticmethod
+    def test_eventually_consistent_with_transaction(runstate):
+        with pytest.raises(ValueError):
+            _api._get_read_options({
+                "read_consistency": _api.EVENTUAL,
+                "transaction": b"txfoo",
+            })

--- a/ndb/tests/unit/test_context.py
+++ b/ndb/tests/unit/test_context.py
@@ -43,10 +43,6 @@ class TestContextOptions:
             context.ContextOptions()
 
 
-def test_EVENTUAL_CONSISTENCY():
-    assert context.EVENTUAL_CONSISTENCY == 1
-
-
 class TestTransactionOptions:
     @staticmethod
     def test_constructor():

--- a/ndb/tests/unit/test_key.py
+++ b/ndb/tests/unit/test_key.py
@@ -530,6 +530,17 @@ class TestKey:
         _entity_from_protobuf.assert_called_once_with("ds_entity")
 
     @staticmethod
+    @unittest.mock.patch("google.cloud.ndb.key._datastore_api")
+    def test_get_async_not_found(_datastore_api):
+        ds_future = tasklets.Future()
+        _datastore_api.lookup.return_value = ds_future
+
+        key = key_module.Key("a", "b", app="c")
+        future = key.get_async()
+        ds_future.set_result(_datastore_api._NOT_FOUND)
+        assert future.result() is None
+
+    @staticmethod
     def test_delete():
         key = key_module.Key("a", "b", app="c")
         with pytest.raises(NotImplementedError):

--- a/ndb/tests/unit/test_key.py
+++ b/ndb/tests/unit/test_key.py
@@ -510,7 +510,7 @@ class TestKey:
         key = key_module.Key("a", "b", app="c")
         assert key.get() == "the entity"
 
-        _datastore_api.lookup.assert_called_once_with(key)
+        _datastore_api.lookup.assert_called_once_with(key._key)
         _entity_from_protobuf.assert_called_once_with("ds_entity")
 
     @staticmethod
@@ -526,7 +526,7 @@ class TestKey:
         ds_future.set_result("ds_entity")
         assert future.result() == "the entity"
 
-        _datastore_api.lookup.assert_called_once_with(key)
+        _datastore_api.lookup.assert_called_once_with(key._key)
         _entity_from_protobuf.assert_called_once_with("ds_entity")
 
     @staticmethod

--- a/ndb/tests/unit/test_model.py
+++ b/ndb/tests/unit/test_model.py
@@ -1298,6 +1298,7 @@ class TestProperty:
 
 class Test__validate_key:
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test_valid_value():
         value = model.Key("This", 1)
         result = model._validate_key(value)
@@ -1309,6 +1310,7 @@ class Test__validate_key:
             model._validate_key(None)
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test_unchecked_model_type():
         value = model.Key("This", 1)
         entity = object.__new__(model.Model)
@@ -1317,6 +1319,7 @@ class Test__validate_key:
         assert result is value
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test_unchecked_expando_type():
         value = model.Key("This", 1)
         entity = object.__new__(model.Expando)
@@ -1325,6 +1328,7 @@ class Test__validate_key:
         assert result is value
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test_same_kind():
         class Mine(model.Model):
             pass
@@ -1338,6 +1342,7 @@ class Test__validate_key:
         entity._get_kind.assert_called_once_with()
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test_different_kind():
         class Mine(model.Model):
             pass
@@ -1361,6 +1366,7 @@ class TestModelKey:
         assert prop.__dict__ == {"_name": "__key__"}
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test_compare_valid():
         prop = model.ModelKey()
         value = key_module.Key("say", "quay")
@@ -1374,6 +1380,7 @@ class TestModelKey:
             prop == None  # noqa: E711
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test__validate():
         prop = model.ModelKey()
         value = key_module.Key("Up", 909)
@@ -1386,6 +1393,7 @@ class TestModelKey:
             prop._validate(None)
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test__set_value():
         entity = object.__new__(model.Model)
         value = key_module.Key("Map", 8898)
@@ -2249,6 +2257,7 @@ class TestKeyProperty:
         assert repr(prop) == expected
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test__validate():
         kind = "Simple"
         prop = model.KeyProperty("keyp", kind=kind)
@@ -2256,6 +2265,7 @@ class TestKeyProperty:
         assert prop._validate(value) is None
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test__validate_without_kind():
         prop = model.KeyProperty("keyp")
         value = key_module.Key("Foo", "Bar")
@@ -2268,6 +2278,7 @@ class TestKeyProperty:
             prop._validate(None)
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test__validate_partial_key():
         prop = model.KeyProperty("keyp")
         value = key_module.Key("Kynd", None)
@@ -2275,6 +2286,7 @@ class TestKeyProperty:
             prop._validate(value)
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test__validate_wrong_kind():
         prop = model.KeyProperty("keyp", kind="Simple")
         value = key_module.Key("Kynd", 184939)
@@ -2597,6 +2609,7 @@ class TestModel:
         assert entity.__dict__ == {"_values": {}}
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test_constructor_key():
         key = key_module.Key("Foo", "bar")
         entity = model.Model(key=key)
@@ -2606,12 +2619,14 @@ class TestModel:
         assert entity.__dict__ == {"_values": {}, "_entity_key": key}
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test_constructor_key_parts():
         entity = model.Model(id=124)
         key = key_module.Key("Model", 124)
         assert entity.__dict__ == {"_values": {}, "_entity_key": key}
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test_constructor_key_and_key_parts():
         key = key_module.Key("Foo", "bar")
         with pytest.raises(exceptions.BadArgumentError):
@@ -2677,6 +2692,7 @@ class TestModel:
         assert repr(entity) == expected
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test_repr_with_property_named_key():
         ManyFields = ManyFieldsFactory()
         entity = ManyFields(
@@ -2689,6 +2705,7 @@ class TestModel:
         assert repr(entity) == expected
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test_repr_with_property_named_key_not_set():
         ManyFields = ManyFieldsFactory()
         entity = ManyFields(self=909, id="hi", value=None, _id=78)
@@ -2699,6 +2716,7 @@ class TestModel:
         assert repr(entity) == expected
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test_repr_no_property_named_key():
         class NoKeyCollision(model.Model):
             word = model.StringProperty()
@@ -2717,6 +2735,7 @@ class TestModel:
         assert Simple._get_kind() == "Simple"
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test___hash__():
         ManyFields = ManyFieldsFactory()
         entity = ManyFields(self=909, id="hi", value=None, _id=78)
@@ -2724,6 +2743,7 @@ class TestModel:
             hash(entity)
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test___eq__wrong_type():
         class Simple(model.Model):
             pass
@@ -2734,6 +2754,7 @@ class TestModel:
         assert not entity1 == entity2
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test___eq__wrong_key():
         ManyFields = ManyFieldsFactory()
         entity1 = ManyFields(_id=78)
@@ -2750,6 +2771,7 @@ class TestModel:
         assert not entity1 == entity2
 
     @staticmethod
+    @pytest.mark.usefixtures("client")
     def test___eq__same_type_same_key():
         ManyFields = ManyFieldsFactory()
         entity1 = ManyFields(self=909, id="hi", _id=78)

--- a/ndb/tests/unit/test_tasklets.py
+++ b/ndb/tests/unit/test_tasklets.py
@@ -71,6 +71,14 @@ class TestFuture:
         callback2.assert_called_once_with(future)
 
     @staticmethod
+    def test_add_done_callback_already_done():
+        callback = mock.Mock()
+        future = tasklets.Future()
+        future.set_result(42)
+        future.add_done_callback(callback)
+        callback.assert_called_once_with(future)
+
+    @staticmethod
     def test_set_exception():
         future = tasklets.Future()
         error = Exception("Spurious Error")

--- a/ndb/tests/unit/test_tasklets.py
+++ b/ndb/tests/unit/test_tasklets.py
@@ -397,7 +397,7 @@ class TestReducingFuture:
 
 
 def test_Return():
-    assert tasklets.Return is StopIteration
+    assert issubclass(tasklets.Return, StopIteration)
 
 
 class TestSerialQueueFuture:


### PR DESCRIPTION
This includes the first system tests. We can now retrieve an NDB entity from a Datastore backend.

The system tests uncovered a few bugs in some already committed code, and these were fixed. Mostly for this reason, this has a lot more changes than I usually like to include in a single PR. Sorry about that.