### PR TITLE
Storage: add 'bucket_policy_only' IAM property

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -1533,7 +1533,7 @@ class Blob(_PropertyMixin):
             raise ValueError("Invalid storage class: %s" % (new_class,))
 
         # Update current blob's storage class prior to rewrite
-        self._patch_property('storageClass', new_class)
+        self._patch_property("storageClass", new_class)
 
         # Execute consecutive rewrite operations until operation is done
         token, _, _ = self.rewrite(self)

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -278,17 +278,24 @@ class IAMConfiguration(dict):
     :type bucket: :class:`Bucket`
     :params bucket: Bucket for which this instance is the policy.
 
-    :type enabled: bool
-    :params enabled: (optional) whether the IAM-only policy is enabled for the bucket.
+    :type bucket_policy_only_enabled: bool
+    :params bucket_policy_only_enabled: (optional) whether the IAM-only policy is enabled for the bucket.
 
-    :type locked_time: :class:`datetime.datetime`
-    :params locked_time: (optional) When the bucket's IAM-only policy was ehabled.  This value should normally only be set by the back-end API.
+    :type bucket_policy_only_locked_time: :class:`datetime.datetime`
+    :params bucket_policy_only_locked_time: (optional) When the bucket's IAM-only policy was ehabled.  This value should normally only be set by the back-end API.
     """
 
-    def __init__(self, bucket, enabled=False, locked_time=None):
-        data = {"bucketPolicyOnly": {"enabled": enabled}}
-        if locked_time is not None:
-            data["bucketPolicyOnly"]["lockedTime"] = _datetime_to_rfc3339(locked_time)
+    def __init__(
+        self,
+        bucket,
+        bucket_policy_only_enabled=False,
+        bucket_policy_only_locked_time=None,
+    ):
+        data = {"bucketPolicyOnly": {"enabled": bucket_policy_only_enabled}}
+        if bucket_policy_only_locked_time is not None:
+            data["bucketPolicyOnly"]["lockedTime"] = _datetime_to_rfc3339(
+                bucket_policy_only_locked_time
+            )
         super(IAMConfiguration, self).__init__(data)
         self._bucket = bucket
 
@@ -319,7 +326,7 @@ class IAMConfiguration(dict):
         return self._bucket
 
     @property
-    def bucket_policy_only(self):
+    def bucket_policy_only_enabled(self):
         """If set, access checks only use bucket-level IAM policies or above.
 
         :rtype: bool
@@ -328,24 +335,24 @@ class IAMConfiguration(dict):
         bpo = self.get("bucketPolicyOnly", {})
         return bpo.get("enabled", False)
 
-    @bucket_policy_only.setter
-    def bucket_policy_only(self, value):
+    @bucket_policy_only_enabled.setter
+    def bucket_policy_only_enabled(self, value):
         bpo = self.setdefault("bucketPolicyOnly", {})
         bpo["enabled"] = bool(value)
         self.bucket._patch_property("iamConfiguration", self)
 
     @property
-    def locked_time(self):
-        """Deadline for changing :attr:`bucket_policy_only` from true to false.
+    def bucket_policy_only_locked_time(self):
+        """Deadline for changing :attr:`bucket_policy_only_enabled` from true to false.
 
-        If the bucket's :attr:`bucket_policy_only` is true, this property
+        If the bucket's :attr:`bucket_policy_only_enabled` is true, this property
         is time time after which that setting becomes immutable.
 
-        If the bucket's :attr:`bucket_policy_only` is false, this property
+        If the bucket's :attr:`bucket_policy_only_enabled` is false, this property
         is ``None``.
 
         :rtype: Union[:class:`datetime.datetime`, None]
-        :returns:  (readonly) Time after which :attr:`bucket_policy_only` will
+        :returns:  (readonly) Time after which :attr:`bucket_policy_only_enabled` will
                    be frozen as true.
         """
         bpo = self.get("bucketPolicyOnly", {})

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -272,82 +272,6 @@ class LifecycleRuleSetStorageClass(dict):
         return instance
 
 
-class IAMConfiguration(dict):
-    """Map a bucket's IAM configuration.
-
-    :type bucket: :class:`Bucket`
-    :params bucket: Bucket for which this instance is the policy.
-
-    :type enabled: bool
-    :params enabled: (optional) whether the IAM-only policy is enabled for the bucket.
-
-    :type locked_time: :class:`datetime.datetime`
-    :params locked_time: (optional) When the bucket's IAM-only policy was ehabled.  This value should normally only be set by the back-end API.
-    """
-
-    def __init__(self, bucket, enabled=False, locked_time=None):
-        data = {"bucketPolicyOnly": {"enabled": enabled}}
-        if locked_time is not None:
-            data["bucketPolicyOnly"]["lockedTime"] = _datetime_to_rfc3339(locked_time)
-        super(IAMConfiguration, self).__init__(data)
-        self._bucket = bucket
-
-    @classmethod
-    def from_api_repr(cls, resource, bucket):
-        """Factory:  construct instance from resource.
-
-        :type bucket: :class:`Bucket`
-        :params bucket: Bucket for which this instance is the policy.
-
-        :type resource: dict
-        :param resource: mapping as returned from API call.
-
-        :rtype: :class:`IAMConfiguration`
-        :returns: Instance created from resource.
-        """
-        instance = cls(bucket)
-        instance.update(resource)
-        return instance
-
-    @property
-    def bucket(self):
-        """Bucket for which this instance is the policy.
-
-        :rtype: :class:`Bucket`
-        :returns: the instance's bucket.
-        """
-        return self._bucket
-
-    @property
-    def bucket_policy_only(self):
-        """Is the bucket configured to allow only IAM policy?
-
-        :rtype: bool
-        :returns: whether the bucket is configured to allow only IAM.
-        """
-        bpo = self.get("bucketPolicyOnly", {})
-        return bpo.get("enabled", False)
-
-    @bucket_policy_only.setter
-    def bucket_policy_only(self, value):
-        bpo = self.setdefault("bucketPolicyOnly", {})
-        bpo["enabled"] = bool(value)
-        self.bucket._patch_property("iamConfiguration", self)
-
-    @property
-    def locked_time(self):
-        """When was the bucket configured to allow only IAM policy?
-
-        :rtype: Union[:class:`datetime.datetime`, None]
-        :returns:  (readonly) the time the bucket's IAM-only policy was set.
-        """
-        bpo = self.get("bucketPolicyOnly", {})
-        stamp = bpo.get("lockedTime")
-        if stamp is not None:
-            stamp = _rfc3339_to_datetime(stamp)
-        return stamp
-
-
 class Bucket(_PropertyMixin):
     """A class representing a Bucket on Cloud Storage.
 
@@ -1211,16 +1135,6 @@ class Bucket(_PropertyMixin):
         return self._properties.get("id")
 
     @property
-    def iam_configuration(self):
-        """Retrieve IAM configuration for this bucket.
-
-        :rtype: :class:`IAMConfiguration`
-        :returns: an instance for managing the bucket's IAM configuration.
-        """
-        info = self._properties.get("iamConfiguration", {})
-        return IAMConfiguration.from_api_repr(info, self)
-
-    @property
     def lifecycle_rules(self):
         """Retrieve or set lifecycle rules configured for this bucket.
 
@@ -1481,6 +1395,48 @@ class Bucket(_PropertyMixin):
         else:
             policy = None
         self._patch_property("retentionPolicy", policy)
+
+    @property
+    def iam_configuration_bucket_policy_only(self):
+        """Get/set whether the bucket is configured to allow only bucket IAM.
+
+        If set, then ACLs are no longer in effect for the bucket or its
+        blobs.
+
+        :rtype: bool
+        :returns: True if the bucket allows only IAM, else false.
+        """
+        iam_config = self._properties.get("iamConfiguration", {})
+        bpo = iam_config.get("bucketPolicyOnly", {})
+        return bpo.get("enabled")
+
+    @iam_configuration_bucket_policy_only.setter
+    def iam_configuration_bucket_policy_only(self, value):
+        """Set whether the bucket is configured to allow only bucket IAM.
+
+        :type value: bool
+        :param value:
+            If true, the bucket will allow only IAM; if false, then the
+            ACLs for the bucket and its blobs will be effective.
+        """
+        iam_config = self._properties.setdefault("iamConfiguration", {})
+        iam_config["bucketPolicyOnly"] = {"enabled": bool(value)}
+        self._patch_property("iamConfiguration", iam_config)
+
+    @property
+    def iam_configuration_locked_time(self):
+        """Time when the bucket was configured to allow only bucket IAM.
+
+        :rtype: datetime.datetime or None
+        :returns:
+            point in time when the bucket was configured to allow only IAM.
+        """
+        iam_config = self._properties.get("iamConfiguration", {})
+        bpo = iam_config.get("bucketPolicyOnly", {})
+        stamp = bpo.get('lockedTime')
+        if stamp is not None:
+            stamp = _rfc3339_to_datetime(stamp)
+        return stamp
 
     @property
     def self_link(self):

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -320,7 +320,7 @@ class IAMConfiguration(dict):
 
     @property
     def bucket_policy_only(self):
-        """Is the bucket configured to allow only IAM policy?
+        """If set, access checks only use bucket-level IAM policies or above.
 
         :rtype: bool
         :returns: whether the bucket is configured to allow only IAM.
@@ -336,10 +336,17 @@ class IAMConfiguration(dict):
 
     @property
     def locked_time(self):
-        """When was the bucket configured to allow only IAM policy?
+        """Deadline for changing :attr:`bucket_policy_only` from true to false.
+
+        If the bucket's :attr:`bucket_policy_only` is true, this property
+        is time time after which that setting becomes immutable.
+
+        If the bucket's :attr:`bucket_policy_only` is false, this property
+        is ``None``.
 
         :rtype: Union[:class:`datetime.datetime`, None]
-        :returns:  (readonly) the time the bucket's IAM-only policy was set.
+        :returns:  (readonly) Time after which :attr:`bucket_policy_only` will
+                   be frozen as true.
         """
         bpo = self.get("bucketPolicyOnly", {})
         stamp = bpo.get("lockedTime")

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -1211,6 +1211,16 @@ class Bucket(_PropertyMixin):
         return self._properties.get("id")
 
     @property
+    def iam_configuration(self):
+        """Retrieve IAM configuration for this bucket.
+
+        :rtype: :class:`IAMConfiguration`
+        :returns: an instance for managing the bucket's IAM configuration.
+        """
+        info = self._properties.get("iamConfiguration", {})
+        return IAMConfiguration.from_api_repr(info, self)
+
+    @property
     def lifecycle_rules(self):
         """Retrieve or set lifecycle rules configured for this bucket.
 

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -1470,3 +1470,150 @@ class TestRetentionPolicy(unittest.TestCase):
         bucket.retention_period = None
         with self.assertRaises(exceptions.Forbidden):
             bucket.patch()
+
+
+class TestIAMConfiguration(unittest.TestCase):
+    def setUp(self):
+        self.case_buckets_to_delete = []
+
+    def tearDown(self):
+        for bucket_name in self.case_buckets_to_delete:
+            bucket = Config.CLIENT.bucket(bucket_name)
+            retry_429(bucket.delete)(force=True)
+
+    def test_new_bucket_w_bpo(self):
+        new_bucket_name = "new-w-bpo" + unique_resource_id("-")
+        self.assertRaises(
+            exceptions.NotFound, Config.CLIENT.get_bucket, new_bucket_name
+        )
+        bucket = Config.CLIENT.bucket(new_bucket_name)
+        bucket.iam_configuration.bucket_policy_only = True
+        retry_429(bucket.create)()
+        self.case_buckets_to_delete.append(new_bucket_name)
+
+        bucket_acl = bucket.acl
+        with self.assertRaises(exceptions.BadRequest):
+            bucket_acl.reload()
+
+        bucket_acl.loaded = True  # Fake that we somehow loaded the ACL
+        bucket_acl.all().grant_read()
+        with self.assertRaises(exceptions.BadRequest):
+            bucket_acl.save()
+
+        blob_name = "my-blob.txt"
+        blob = bucket.blob(blob_name)
+        payload = b"DEADBEEF"
+        blob.upload_from_string(payload)
+
+        found = bucket.get_blob(blob_name)
+        self.assertEqual(found.download_as_string(), payload)
+
+        blob_acl = blob.acl
+        with self.assertRaises(exceptions.BadRequest):
+            blob_acl.reload()
+
+        blob_acl.loaded = True  # Fake that we somehow loaded the ACL
+        blob_acl.all().grant_read()
+        with self.assertRaises(exceptions.BadRequest):
+            blob_acl.save()
+
+    @unittest.expectedFailure  # Until rollout completes, ETA 2019-01-10
+    def test_existing_bucket_set_bpo(self):
+        import requests
+
+        new_bucket_name = "set-bpo" + unique_resource_id("-")
+        self.assertRaises(
+            exceptions.NotFound, Config.CLIENT.get_bucket, new_bucket_name
+        )
+        bucket = retry_429(Config.CLIENT.create_bucket)(new_bucket_name)
+        self.case_buckets_to_delete.append(new_bucket_name)
+
+        blob_name = "my-blob.txt"
+        blob = bucket.blob(blob_name)
+        payload = b"DEADBEEF"
+        blob.upload_from_string(payload)
+
+        blob.make_public()
+
+        ok_response = requests.get(blob.public_url)
+        self.assertEqual(ok_response.content, payload)
+
+        # XXX: Work around 400 error: "Cannot disable object policies because
+        # default object acls are not empty."
+        response = Config.CLIENT._connection.api_request(
+            method="PATCH",
+            path=bucket.path,
+            data={},
+            query_params={'predefinedDefaultObjectAcl': 'private'},
+            _target_object=bucket,
+        )
+
+        bucket.iam_configuration.bucket_policy_only = True
+        bucket.patch()
+
+        failed_response = requests.get(blob.public_url)
+        #XXX: the request for downloading the object via its public URL does
+        #     *not* fail as of 2019-01-08T18:43:00Z
+        self.assertEqual(failed_response.status_code, 403)
+
+    def test_bpo_set_unset_preserves_acls(self):
+        new_bucket_name = "bpo-acls" + unique_resource_id("-")
+        self.assertRaises(
+            exceptions.NotFound, Config.CLIENT.get_bucket, new_bucket_name
+        )
+        bucket = retry_429(Config.CLIENT.create_bucket)(new_bucket_name)
+        self.case_buckets_to_delete.append(new_bucket_name)
+
+        blob_name = "my-blob.txt"
+        blob = bucket.blob(blob_name)
+        payload = b"DEADBEEF"
+        blob.upload_from_string(payload)
+        blob_policy = blob.get_iam_policy()
+
+        # Preserve ACLs before setting BPO
+        bucket_acl_before = list(bucket.acl)
+        blob_acl_before = list(bucket.acl)
+
+        # XXX: Work around 400 error: "Cannot disable object policies because
+        # default object acls are not empty."
+        response = Config.CLIENT._connection.api_request(
+            method="PATCH",
+            path=bucket.path,
+            data={},
+            query_params={'predefinedDefaultObjectAcl': 'private'},
+            _target_object=bucket,
+        )
+
+        # Set BPO
+        bucket.iam_configuration.bucket_policy_only = True
+        bucket.patch()
+
+        # While BPO is set, cannot get / set ACLs
+        with self.assertRaises(exceptions.BadRequest):
+            bucket.acl.reload()
+
+        # XXX This should raise, but doesn't as of 2018-01-08T19:00:00Z
+        #with self.assertRaises(exceptions.BadRequest):
+        #    bucket.acl.clear()
+
+        # XXX The blob ACL get / set stuff raises 403, rather than 400.
+        #with self.assertRaises(exceptions.BadRequest):
+        with self.assertRaises(exceptions.Forbidden):
+            blob.acl.reload()
+
+        #with self.assertRaises(exceptions.BadRequest):
+        with self.assertRaises(exceptions.Forbidden):
+            blob.acl.clear()
+
+        # Clear BPO
+        bucket.iam_configuration.bucket_policy_only = False
+        bucket.patch()
+
+        # Query ACLs after clearing BPO
+        bucket.acl.reload()
+        bucket_acl_after = list(bucket.acl)
+        blob.acl.reload()
+        blob_acl_after = list(bucket.acl)
+
+        self.assertEqual(bucket_acl_before, bucket_acl_after)
+        self.assertEqual(blob_acl_before, blob_acl_after)

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -1529,7 +1529,6 @@ class TestIAMConfiguration(unittest.TestCase):
         blob = bucket.blob(blob_name)
         payload = b"DEADBEEF"
         blob.upload_from_string(payload)
-        blob_policy = blob.get_iam_policy()
 
         # Preserve ACLs before setting BPO
         bucket_acl_before = list(bucket.acl)

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -1543,19 +1543,6 @@ class TestIAMConfiguration(unittest.TestCase):
         with self.assertRaises(exceptions.BadRequest):
             bucket.acl.reload()
 
-        # XXX This should raise, but doesn't as of 2018-01-08T19:00:00Z
-        #with self.assertRaises(exceptions.BadRequest):
-        #    bucket.acl.clear()
-
-        # XXX The blob ACL get / set stuff raises 403, rather than 400.
-        #with self.assertRaises(exceptions.BadRequest):
-        with self.assertRaises(exceptions.Forbidden):
-            blob.acl.reload()
-
-        #with self.assertRaises(exceptions.BadRequest):
-        with self.assertRaises(exceptions.Forbidden):
-            blob.acl.clear()
-
         # Clear BPO
         bucket.iam_configuration.bucket_policy_only = False
         bucket.patch()

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -1487,7 +1487,7 @@ class TestIAMConfiguration(unittest.TestCase):
             exceptions.NotFound, Config.CLIENT.get_bucket, new_bucket_name
         )
         bucket = Config.CLIENT.bucket(new_bucket_name)
-        bucket.iam_configuration.bucket_policy_only = True
+        bucket.iam_configuration.bucket_policy_only_enabled = True
         retry_429(bucket.create)()
         self.case_buckets_to_delete.append(new_bucket_name)
 
@@ -1536,7 +1536,7 @@ class TestIAMConfiguration(unittest.TestCase):
         blob_acl_before = list(bucket.acl)
 
         # Set BPO
-        bucket.iam_configuration.bucket_policy_only = True
+        bucket.iam_configuration.bucket_policy_only_enabled = True
         bucket.patch()
 
         # While BPO is set, cannot get / set ACLs
@@ -1544,7 +1544,7 @@ class TestIAMConfiguration(unittest.TestCase):
             bucket.acl.reload()
 
         # Clear BPO
-        bucket.iam_configuration.bucket_policy_only = False
+        bucket.iam_configuration.bucket_policy_only_enabled = False
         bucket.patch()
 
         # Query ACLs after clearing BPO

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -1487,7 +1487,7 @@ class TestIAMConfiguration(unittest.TestCase):
             exceptions.NotFound, Config.CLIENT.get_bucket, new_bucket_name
         )
         bucket = Config.CLIENT.bucket(new_bucket_name)
-        bucket.iam_configuration_bucket_policy_only = True
+        bucket.iam_configuration.bucket_policy_only = True
         retry_429(bucket.create)()
         self.case_buckets_to_delete.append(new_bucket_name)
 
@@ -1536,7 +1536,7 @@ class TestIAMConfiguration(unittest.TestCase):
         blob_acl_before = list(bucket.acl)
 
         # Set BPO
-        bucket.iam_configuration_bucket_policy_only = True
+        bucket.iam_configuration.bucket_policy_only = True
         bucket.patch()
 
         # While BPO is set, cannot get / set ACLs
@@ -1557,7 +1557,7 @@ class TestIAMConfiguration(unittest.TestCase):
             blob.acl.clear()
 
         # Clear BPO
-        bucket.iam_configuration_bucket_policy_only = False
+        bucket.iam_configuration.bucket_policy_only = False
         bucket.patch()
 
         # Query ACLs after clearing BPO

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -1487,7 +1487,7 @@ class TestIAMConfiguration(unittest.TestCase):
             exceptions.NotFound, Config.CLIENT.get_bucket, new_bucket_name
         )
         bucket = Config.CLIENT.bucket(new_bucket_name)
-        bucket.iam_configuration.bucket_policy_only = True
+        bucket.iam_configuration_bucket_policy_only = True
         retry_429(bucket.create)()
         self.case_buckets_to_delete.append(new_bucket_name)
 
@@ -1536,7 +1536,7 @@ class TestIAMConfiguration(unittest.TestCase):
         blob_acl_before = list(bucket.acl)
 
         # Set BPO
-        bucket.iam_configuration.bucket_policy_only = True
+        bucket.iam_configuration_bucket_policy_only = True
         bucket.patch()
 
         # While BPO is set, cannot get / set ACLs
@@ -1557,7 +1557,7 @@ class TestIAMConfiguration(unittest.TestCase):
             blob.acl.clear()
 
         # Clear BPO
-        bucket.iam_configuration.bucket_policy_only = False
+        bucket.iam_configuration_bucket_policy_only = False
         bucket.patch()
 
         # Query ACLs after clearing BPO

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -1538,16 +1538,6 @@ class TestIAMConfiguration(unittest.TestCase):
         ok_response = requests.get(blob.public_url)
         self.assertEqual(ok_response.content, payload)
 
-        # XXX: Work around 400 error: "Cannot disable object policies because
-        # default object acls are not empty."
-        response = Config.CLIENT._connection.api_request(
-            method="PATCH",
-            path=bucket.path,
-            data={},
-            query_params={'predefinedDefaultObjectAcl': 'private'},
-            _target_object=bucket,
-        )
-
         bucket.iam_configuration.bucket_policy_only = True
         bucket.patch()
 
@@ -1573,16 +1563,6 @@ class TestIAMConfiguration(unittest.TestCase):
         # Preserve ACLs before setting BPO
         bucket_acl_before = list(bucket.acl)
         blob_acl_before = list(bucket.acl)
-
-        # XXX: Work around 400 error: "Cannot disable object policies because
-        # default object acls are not empty."
-        response = Config.CLIENT._connection.api_request(
-            method="PATCH",
-            path=bucket.path,
-            data={},
-            query_params={'predefinedDefaultObjectAcl': 'private'},
-            _target_object=bucket,
-        )
 
         # Set BPO
         bucket.iam_configuration.bucket_policy_only = True

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -2508,13 +2508,13 @@ class Test_Blob(unittest.TestCase):
             "objectSize": 84,
             "done": False,
             "rewriteToken": TOKEN,
-            "resource": {"storageClass": STORAGE_CLASS}
+            "resource": {"storageClass": STORAGE_CLASS},
         }
         COMPLETE_RESPONSE = {
             "totalBytesRewritten": 84,
             "objectSize": 84,
             "done": True,
-            "resource": {"storageClass": STORAGE_CLASS}
+            "resource": {"storageClass": STORAGE_CLASS},
         }
         response_1 = ({"status": http_client.OK}, INCOMPLETE_RESPONSE)
         response_2 = ({"status": http_client.OK}, COMPLETE_RESPONSE)
@@ -2534,7 +2534,7 @@ class Test_Blob(unittest.TestCase):
             "totalBytesRewritten": 42,
             "objectSize": 42,
             "done": True,
-            "resource": {"storageClass": STORAGE_CLASS}
+            "resource": {"storageClass": STORAGE_CLASS},
         }
         response = ({"status": http_client.OK}, RESPONSE)
         connection = _Connection(response)
@@ -2579,7 +2579,7 @@ class Test_Blob(unittest.TestCase):
             "totalBytesRewritten": 42,
             "objectSize": 42,
             "done": True,
-            "resource": {"storageClass": STORAGE_CLASS}
+            "resource": {"storageClass": STORAGE_CLASS},
         }
         response = ({"status": http_client.OK}, RESPONSE)
         connection = _Connection(response)

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -197,8 +197,8 @@ class Test_IAMConfiguration(unittest.TestCase):
         config = self._make_one(bucket)
 
         self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only)
-        self.assertIsNone(config.locked_time)
+        self.assertFalse(config.bucket_policy_only_enabled)
+        self.assertIsNone(config.bucket_policy_only_locked_time)
 
     def test_ctor_explicit(self):
         import datetime
@@ -207,11 +207,13 @@ class Test_IAMConfiguration(unittest.TestCase):
         bucket = self._make_bucket()
         now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
 
-        config = self._make_one(bucket, enabled=True, locked_time=now)
+        config = self._make_one(
+            bucket, bucket_policy_only_enabled=True, bucket_policy_only_locked_time=now
+        )
 
         self.assertIs(config.bucket, bucket)
-        self.assertTrue(config.bucket_policy_only)
-        self.assertEqual(config.locked_time, now)
+        self.assertTrue(config.bucket_policy_only_enabled)
+        self.assertEqual(config.bucket_policy_only_locked_time, now)
 
     def test_from_api_repr_w_empty_resource(self):
         klass = self._get_target_class()
@@ -221,8 +223,8 @@ class Test_IAMConfiguration(unittest.TestCase):
         config = klass.from_api_repr(resource, bucket)
 
         self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only)
-        self.assertIsNone(config.locked_time)
+        self.assertFalse(config.bucket_policy_only_enabled)
+        self.assertIsNone(config.bucket_policy_only_locked_time)
 
     def test_from_api_repr_w_empty_bpo(self):
         klass = self._get_target_class()
@@ -232,8 +234,8 @@ class Test_IAMConfiguration(unittest.TestCase):
         config = klass.from_api_repr(resource, bucket)
 
         self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only)
-        self.assertIsNone(config.locked_time)
+        self.assertFalse(config.bucket_policy_only_enabled)
+        self.assertIsNone(config.bucket_policy_only_locked_time)
 
     def test_from_api_repr_w_disabled(self):
         klass = self._get_target_class()
@@ -243,8 +245,8 @@ class Test_IAMConfiguration(unittest.TestCase):
         config = klass.from_api_repr(resource, bucket)
 
         self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only)
-        self.assertIsNone(config.locked_time)
+        self.assertFalse(config.bucket_policy_only_enabled)
+        self.assertIsNone(config.bucket_policy_only_locked_time)
 
     def test_from_api_repr_w_enabled(self):
         import datetime
@@ -264,14 +266,14 @@ class Test_IAMConfiguration(unittest.TestCase):
         config = klass.from_api_repr(resource, bucket)
 
         self.assertIs(config.bucket, bucket)
-        self.assertTrue(config.bucket_policy_only)
-        self.assertEqual(config.locked_time, now)
+        self.assertTrue(config.bucket_policy_only_enabled)
+        self.assertEqual(config.bucket_policy_only_locked_time, now)
 
-    def test_bucket_policy_only_setter(self):
+    def test_bucket_policy_only_enabled_setter(self):
         bucket = self._make_bucket()
         config = self._make_one(bucket)
 
-        config.bucket_policy_only = True
+        config.bucket_policy_only_enabled = True
 
         self.assertTrue(config["bucketPolicyOnly"]["enabled"])
         bucket._patch_property.assert_called_once_with("iamConfiguration", config)
@@ -1204,8 +1206,8 @@ class Test_Bucket(unittest.TestCase):
 
         self.assertIsInstance(config, IAMConfiguration)
         self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only)
-        self.assertIsNone(config.locked_time)
+        self.assertFalse(config.bucket_policy_only_enabled)
+        self.assertIsNone(config.bucket_policy_only_locked_time)
 
     def test_iam_configuration_policy_w_entry(self):
         import datetime
@@ -1229,8 +1231,8 @@ class Test_Bucket(unittest.TestCase):
 
         self.assertIsInstance(config, IAMConfiguration)
         self.assertIs(config.bucket, bucket)
-        self.assertTrue(config.bucket_policy_only)
-        self.assertEqual(config.locked_time, now)
+        self.assertTrue(config.bucket_policy_only_enabled)
+        self.assertEqual(config.bucket_policy_only_locked_time, now)
 
     def test_lifecycle_rules_getter_unknown_action_type(self):
         NAME = "name"

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -175,108 +175,6 @@ class Test_LifecycleRuleSetStorageClass(unittest.TestCase):
         self.assertEqual(dict(rule), resource)
 
 
-class Test_IAMConfiguration(unittest.TestCase):
-    @staticmethod
-    def _get_target_class():
-        from google.cloud.storage.bucket import IAMConfiguration
-
-        return IAMConfiguration
-
-    def _make_one(self, bucket, **kw):
-        return self._get_target_class()(bucket, **kw)
-
-    @staticmethod
-    def _make_bucket():
-        from google.cloud.storage.bucket import Bucket
-
-        return mock.create_autospec(Bucket, instance=True)
-
-    def test_ctor_defaults(self):
-        bucket = self._make_bucket()
-
-        config = self._make_one(bucket)
-
-        self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only)
-        self.assertIsNone(config.locked_time)
-
-    def test_ctor_explicit(self):
-        import datetime
-        import pytz
-
-        bucket = self._make_bucket()
-        now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
-
-        config = self._make_one(bucket, enabled=True, locked_time=now)
-
-        self.assertIs(config.bucket, bucket)
-        self.assertTrue(config.bucket_policy_only)
-        self.assertEqual(config.locked_time, now)
-
-    def test_from_api_repr_w_empty_resource(self):
-        klass = self._get_target_class()
-        bucket = self._make_bucket()
-        resource = {}
-
-        config = klass.from_api_repr(resource, bucket)
-
-        self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only)
-        self.assertIsNone(config.locked_time)
-
-    def test_from_api_repr_w_empty_bpo(self):
-        klass = self._get_target_class()
-        bucket = self._make_bucket()
-        resource = {"bucketPolicyOnly": {}}
-
-        config = klass.from_api_repr(resource, bucket)
-
-        self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only)
-        self.assertIsNone(config.locked_time)
-
-    def test_from_api_repr_w_disabled(self):
-        klass = self._get_target_class()
-        bucket = self._make_bucket()
-        resource = {"bucketPolicyOnly": {"enabled": False}}
-
-        config = klass.from_api_repr(resource, bucket)
-
-        self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only)
-        self.assertIsNone(config.locked_time)
-
-    def test_from_api_repr_w_enabled(self):
-        import datetime
-        import pytz
-        from google.cloud._helpers import _datetime_to_rfc3339
-
-        klass = self._get_target_class()
-        bucket = self._make_bucket()
-        now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
-        resource = {
-            "bucketPolicyOnly": {
-                "enabled": True,
-                "lockedTime": _datetime_to_rfc3339(now),
-            }
-        }
-
-        config = klass.from_api_repr(resource, bucket)
-
-        self.assertIs(config.bucket, bucket)
-        self.assertTrue(config.bucket_policy_only)
-        self.assertEqual(config.locked_time, now)
-
-    def test_bucket_policy_only_setter(self):
-        bucket = self._make_bucket()
-        config = self._make_one(bucket)
-
-        config.bucket_policy_only = True
-
-        self.assertTrue(config["bucketPolicyOnly"]["enabled"])
-        bucket._patch_property.assert_called_once_with("iamConfiguration", config)
-
-
 class Test_Bucket(unittest.TestCase):
     @staticmethod
     def _get_target_class():
@@ -1194,44 +1092,6 @@ class Test_Bucket(unittest.TestCase):
             bucket_module._LOCATION_SETTER_MESSAGE, DeprecationWarning, stacklevel=2
         )
 
-    def test_iam_configuration_policy_missing(self):
-        from google.cloud.storage.bucket import IAMConfiguration
-
-        NAME = "name"
-        bucket = self._make_one(name=NAME)
-
-        config = bucket.iam_configuration
-
-        self.assertIsInstance(config, IAMConfiguration)
-        self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only)
-        self.assertIsNone(config.locked_time)
-
-    def test_iam_configuration_policy_w_entry(self):
-        import datetime
-        import pytz
-        from google.cloud._helpers import _datetime_to_rfc3339
-        from google.cloud.storage.bucket import IAMConfiguration
-
-        now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
-        NAME = "name"
-        properties = {
-            "iamConfiguration": {
-                "bucketPolicyOnly": {
-                    "enabled": True,
-                    "lockedTime": _datetime_to_rfc3339(now),
-                }
-            }
-        }
-        bucket = self._make_one(name=NAME, properties=properties)
-
-        config = bucket.iam_configuration
-
-        self.assertIsInstance(config, IAMConfiguration)
-        self.assertIs(config.bucket, bucket)
-        self.assertTrue(config.bucket_policy_only)
-        self.assertEqual(config.locked_time, now)
-
     def test_lifecycle_rules_getter_unknown_action_type(self):
         NAME = "name"
         BOGUS_RULE = {"action": {"type": "Bogus"}, "condition": {"age": 42}}
@@ -1614,6 +1474,103 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(
             bucket._properties["retentionPolicy"]["retentionPeriod"], str(period)
         )
+
+    def test_iam_configuration_bucket_policy_only_w_empty_resource(self):
+        bucket = self._make_one()
+
+        self.assertFalse(bucket.iam_configuration_bucket_policy_only)
+
+    def test_iam_configuration_bucket_policy_only_w_empty_bpo(self):
+        properties = {
+            "iamConfiguration": {
+                "bucketPolicyOnly": {},
+            }
+        }
+        bucket = self._make_one(properties=properties)
+
+        self.assertFalse(bucket.iam_configuration_bucket_policy_only)
+
+    def test_iam_configuration_bucket_policy_only_w_disabled(self):
+        properties = {
+            "iamConfiguration": {
+                "bucketPolicyOnly": {"enabled": False},
+            }
+        }
+        bucket = self._make_one(properties=properties)
+
+        self.assertFalse(bucket.iam_configuration_bucket_policy_only)
+
+    def test_iam_configuration_bucket_policy_only_w_enabled(self):
+        import datetime
+        import pytz
+        from google.cloud._helpers import _datetime_to_rfc3339
+
+        now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+        properties = {
+            "iamConfiguration": {
+                "bucketPolicyOnly": {
+                    "enabled": True,
+                    "lockedTime": _datetime_to_rfc3339(now),
+                }
+            }
+        }
+        bucket = self._make_one(properties=properties)
+
+        self.assertTrue(bucket.iam_configuration_bucket_policy_only)
+
+    def test_iam_configuration_bucket_policy_only_only_setter(self):
+        bucket = self._make_one()
+        bucket._patch_property = mock.Mock()
+
+        bucket.iam_configuration_bucket_policy_only = True
+
+        config = bucket._properties["iamConfiguration"]
+
+        self.assertTrue(config["bucketPolicyOnly"]["enabled"])
+        bucket._patch_property.assert_called_once_with("iamConfiguration", config)
+
+    def test_iam_configuration_locked_time_w_empty_resource(self):
+        bucket = self._make_one()
+
+        self.assertIsNone(bucket.iam_configuration_locked_time)
+
+    def test_iam_configuration_locked_time_w_empty_bpo(self):
+        properties = {
+            "iamConfiguration": {
+                "bucketPolicyOnly": {},
+            }
+        }
+        bucket = self._make_one(properties=properties)
+
+        self.assertIsNone(bucket.iam_configuration_locked_time)
+
+    def test_iam_configuration_locked_time_w_disabled(self):
+        properties = {
+            "iamConfiguration": {
+                "bucketPolicyOnly": {"enabled": False},
+            }
+        }
+        bucket = self._make_one(properties=properties)
+
+        self.assertIsNone(bucket.iam_configuration_locked_time)
+
+    def test_iam_configuration_locked_time_w_enabled(self):
+        import datetime
+        import pytz
+        from google.cloud._helpers import _datetime_to_rfc3339
+
+        now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+        properties = {
+            "iamConfiguration": {
+                "bucketPolicyOnly": {
+                    "enabled": True,
+                    "lockedTime": _datetime_to_rfc3339(now),
+                }
+            }
+        }
+        bucket = self._make_one(properties=properties)
+
+        self.assertEqual(bucket.iam_configuration_locked_time, now)
 
     def test_self_link(self):
         SELF_LINK = "http://example.com/self/"

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -1194,6 +1194,44 @@ class Test_Bucket(unittest.TestCase):
             bucket_module._LOCATION_SETTER_MESSAGE, DeprecationWarning, stacklevel=2
         )
 
+    def test_iam_configuration_policy_missing(self):
+        from google.cloud.storage.bucket import IAMConfiguration
+
+        NAME = "name"
+        bucket = self._make_one(name=NAME)
+
+        config = bucket.iam_configuration
+
+        self.assertIsInstance(config, IAMConfiguration)
+        self.assertIs(config.bucket, bucket)
+        self.assertFalse(config.bucket_policy_only)
+        self.assertIsNone(config.locked_time)
+
+    def test_iam_configuration_policy_w_entry(self):
+        import datetime
+        import pytz
+        from google.cloud._helpers import _datetime_to_rfc3339
+        from google.cloud.storage.bucket import IAMConfiguration
+
+        now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+        NAME = "name"
+        properties = {
+            "iamConfiguration": {
+                "bucketPolicyOnly": {
+                    "enabled": True,
+                    "lockedTime": _datetime_to_rfc3339(now),
+                }
+            }
+        }
+        bucket = self._make_one(name=NAME, properties=properties)
+
+        config = bucket.iam_configuration
+
+        self.assertIsInstance(config, IAMConfiguration)
+        self.assertIs(config.bucket, bucket)
+        self.assertTrue(config.bucket_policy_only)
+        self.assertEqual(config.locked_time, now)
+
     def test_lifecycle_rules_getter_unknown_action_type(self):
         NAME = "name"
         BOGUS_RULE = {"action": {"type": "Bogus"}, "condition": {"age": 42}}


### PR DESCRIPTION
@frankyn Still working on system tests.  I can test creating a new bucket with BPO enabled, but am unable to update a newly-created non-BPO bucket to have BPO set:  the `PATCH` request returns:

```
           google.api_core.exceptions.BadRequest: 400 PATCH https://www.googleapis.com/storage/v1/b/set-bpo-1546903462976?projection=full: Cannot disable object policies because default object acls are not empty

```