### PR TITLE
NDB: Make ``TaskletFuture`` and ``MultiFuture`` private.

### DIFF
--- a/ndb/MIGRATION_NOTES.md
+++ b/ndb/MIGRATION_NOTES.md
@@ -138,6 +138,8 @@ facing, private API:
 - `eventloop` has been renamed to `_eventloop`.
 - `tasklets.get_return_value` has been renamed to `tasklets._get_return_value`
   and is no longer among top level exports.
+- `tasklets.MultiFuture` has been renamed to `tasklets._MultiFuture`, removed
+  from top level exports, and has a much simpler interface.
 
 ## Bare Metal
 

--- a/ndb/src/google/cloud/ndb/__init__.py
+++ b/ndb/src/google/cloud/ndb/__init__.py
@@ -108,7 +108,6 @@ __all__ = [
     "get_context",
     "make_context",
     "make_default_context",
-    "MultiFuture",
     "QueueFuture",
     "ReducingFuture",
     "Return",
@@ -208,7 +207,6 @@ from google.cloud.ndb.tasklets import Future
 from google.cloud.ndb.tasklets import get_context
 from google.cloud.ndb.tasklets import make_context
 from google.cloud.ndb.tasklets import make_default_context
-from google.cloud.ndb.tasklets import MultiFuture
 from google.cloud.ndb.tasklets import QueueFuture
 from google.cloud.ndb.tasklets import ReducingFuture
 from google.cloud.ndb.tasklets import Return

--- a/ndb/src/google/cloud/ndb/tasklets.py
+++ b/ndb/src/google/cloud/ndb/tasklets.py
@@ -30,7 +30,6 @@ __all__ = [
     "get_context",
     "make_context",
     "make_default_context",
-    "MultiFuture",
     "QueueFuture",
     "ReducingFuture",
     "Return",
@@ -39,7 +38,6 @@ __all__ = [
     "sleep",
     "synctasklet",
     "tasklet",
-    "TaskletFuture",
     "toplevel",
 ]
 
@@ -205,7 +203,7 @@ class Future:
         return False
 
 
-class TaskletFuture(Future):
+class _TaskletFuture(Future):
     """A future which waits on a tasklet.
 
     A future of this type wraps a generator derived from calling a tasklet. A
@@ -219,7 +217,7 @@ class TaskletFuture(Future):
     """
 
     def __init__(self, generator):
-        super(TaskletFuture, self).__init__()
+        super(_TaskletFuture, self).__init__()
         self.generator = generator
 
     def _advance_tasklet(self, send_value=None, error=None):
@@ -263,7 +261,7 @@ class TaskletFuture(Future):
             _eventloop.queue_rpc(yielded, done_callback)
 
         elif isinstance(yielded, (list, tuple)):
-            future = MultiFuture(yielded)
+            future = _MultiFuture(yielded)
             future.add_done_callback(done_callback)
 
         else:
@@ -286,7 +284,7 @@ def _get_return_value(stop):
         return stop.args
 
 
-class MultiFuture(Future):
+class _MultiFuture(Future):
     """A future which depends on multiple other futures.
 
     This future will be done when either all dependencies have results or when
@@ -298,7 +296,7 @@ class MultiFuture(Future):
     """
 
     def __init__(self, dependencies):
-        super(MultiFuture, self).__init__()
+        super(_MultiFuture, self).__init__()
         self._dependencies = dependencies
 
         for dependency in dependencies:
@@ -353,7 +351,7 @@ def tasklet(wrapped):
 
         if isinstance(returned, types.GeneratorType):
             # We have a tasklet
-            future = TaskletFuture(returned)
+            future = _TaskletFuture(returned)
             future._advance_tasklet()
 
         else:

--- a/ndb/tests/unit/test_tasklets.py
+++ b/ndb/tests/unit/test_tasklets.py
@@ -175,11 +175,11 @@ class TestFuture:
         assert future.cancelled() is False
 
 
-class TestTaskletFuture:
+class Test_TaskletFuture:
     @staticmethod
     def test_constructor():
         generator = object()
-        future = tasklets.TaskletFuture(generator)
+        future = tasklets._TaskletFuture(generator)
         assert future.generator is generator
 
     @staticmethod
@@ -191,7 +191,7 @@ class TestTaskletFuture:
 
         generator = generator_function()
         next(generator)  # skip ahead to return
-        future = tasklets.TaskletFuture(generator)
+        future = tasklets._TaskletFuture(generator)
         future._advance_tasklet()
         assert future.result() == 42
 
@@ -206,7 +206,7 @@ class TestTaskletFuture:
 
         generator = generator_function()
         next(generator)  # skip ahead to return
-        future = tasklets.TaskletFuture(generator)
+        future = tasklets._TaskletFuture(generator)
         future._advance_tasklet()
         assert future.exception() is error
 
@@ -217,7 +217,7 @@ class TestTaskletFuture:
             yield 42
 
         generator = generator_function()
-        future = tasklets.TaskletFuture(generator)
+        future = tasklets._TaskletFuture(generator)
         with pytest.raises(RuntimeError):
             future._advance_tasklet()
 
@@ -230,7 +230,7 @@ class TestTaskletFuture:
 
         dependency = tasklets.Future()
         generator = generator_function(dependency)
-        future = tasklets.TaskletFuture(generator)
+        future = tasklets._TaskletFuture(generator)
         future._advance_tasklet()
         dependency.set_result(21)
         assert future.result() == 63
@@ -244,7 +244,7 @@ class TestTaskletFuture:
         error = Exception("Spurious error.")
         dependency = tasklets.Future()
         generator = generator_function(dependency)
-        future = tasklets.TaskletFuture(generator)
+        future = tasklets._TaskletFuture(generator)
         future._advance_tasklet()
         dependency.set_exception(error)
         assert future.exception() is error
@@ -262,7 +262,7 @@ class TestTaskletFuture:
         dependency.exception.return_value = None
         dependency.result.return_value = 8
         generator = generator_function(dependency)
-        future = tasklets.TaskletFuture(generator)
+        future = tasklets._TaskletFuture(generator)
         future._advance_tasklet()
 
         callback = dependency.add_done_callback.call_args[0][0]
@@ -279,18 +279,18 @@ class TestTaskletFuture:
 
         dependencies = (tasklets.Future(), tasklets.Future())
         generator = generator_function(dependencies)
-        future = tasklets.TaskletFuture(generator)
+        future = tasklets._TaskletFuture(generator)
         future._advance_tasklet()
         dependencies[0].set_result(8)
         dependencies[1].set_result(3)
         assert future.result() == 11
 
 
-class TestMultiFuture:
+class Test_MultiFuture:
     @staticmethod
     def test_success():
         dependencies = (tasklets.Future(), tasklets.Future())
-        future = tasklets.MultiFuture(dependencies)
+        future = tasklets._MultiFuture(dependencies)
         dependencies[0].set_result("one")
         dependencies[1].set_result("two")
         assert future.result() == ("one", "two")
@@ -298,7 +298,7 @@ class TestMultiFuture:
     @staticmethod
     def test_error():
         dependencies = (tasklets.Future(), tasklets.Future())
-        future = tasklets.MultiFuture(dependencies)
+        future = tasklets._MultiFuture(dependencies)
         error = Exception("Spurious error.")
         dependencies[0].set_exception(error)
         dependencies[1].set_result("two")
@@ -334,7 +334,7 @@ class Test_tasklet:
 
         dependency = tasklets.Future()
         future = generator(dependency)
-        assert isinstance(future, tasklets.TaskletFuture)
+        assert isinstance(future, tasklets._TaskletFuture)
         dependency.set_result(8)
         assert future.result() == 11
 


### PR DESCRIPTION
In general, I only anticipate users interacting with futures created
for them by NDB, and then only with the interface defined by
``tasklets.Future``.