### PR TITLE
NDB: Implement wait_any and wait_all.

### DIFF
--- a/ndb/src/google/cloud/ndb/tasklets.py
+++ b/ndb/src/google/cloud/ndb/tasklets.py
@@ -41,6 +41,8 @@ __all__ = [
     "tasklet",
     "TaskletFuture",
     "toplevel",
+    "wait_all",
+    "wait_any",
 ]
 
 
@@ -204,6 +206,18 @@ class Future:
         """
         return False
 
+    @staticmethod
+    def wait_any(futures):
+        """Calls :func:`wait_any`."""
+        # For backwards compatibility
+        return wait_any(futures)
+
+    @staticmethod
+    def wait_all(futures):
+        """Calls :func:`wait_all`."""
+        # For backwards compatibility
+        return wait_all(futures)
+
 
 class TaskletFuture(Future):
     """A future which waits on a tasklet.
@@ -364,6 +378,39 @@ def tasklet(wrapped):
         return future
 
     return tasklet_wrapper
+
+
+def wait_any(futures):
+    """Wait for any of several futures to finish.
+
+    Args:
+        futures (Sequence[Future]): The futures to wait on.
+
+    Returns:
+        Future: The first future to be found to have finished.
+    """
+    if not futures:
+        return None
+
+    while True:
+        for future in futures:
+            if future.done():
+                return future
+
+        _eventloop.run1()
+
+
+def wait_all(futures):
+    """Wait for all of several futures to finish.
+
+    Args:
+        futures (Sequence[Future]): The futures to wait on.
+    """
+    if not futures:
+        return
+
+    for future in futures:
+        future.wait()
 
 
 def add_flow_exception(*args, **kwargs):

--- a/ndb/tests/unit/test_tasklets.py
+++ b/ndb/tests/unit/test_tasklets.py
@@ -174,6 +174,51 @@ class TestFuture:
         future = tasklets.Future()
         assert future.cancelled() is False
 
+    @staticmethod
+    @pytest.mark.usefixtures("runstate")
+    def test_wait_any():
+        futures = [tasklets.Future() for _ in range(3)]
+
+        def callback():
+            futures[1].set_result(42)
+
+        _eventloop.add_idle(callback)
+
+        future = tasklets.Future.wait_any(futures)
+        assert future is futures[1]
+        assert future.result() == 42
+
+    @staticmethod
+    def test_wait_any_no_futures():
+        assert tasklets.Future.wait_any(()) is None
+
+    @staticmethod
+    @pytest.mark.usefixtures("runstate")
+    def test_wait_all():
+        futures = [tasklets.Future() for _ in range(3)]
+
+        def make_callback(index, result):
+            def callback():
+                futures[index].set_result(result)
+
+            return callback
+
+        _eventloop.add_idle(make_callback(0, 42))
+        _eventloop.add_idle(make_callback(1, 43))
+        _eventloop.add_idle(make_callback(2, 44))
+
+        tasklets.Future.wait_all(futures)
+        assert futures[0].done()
+        assert futures[0].result() == 42
+        assert futures[1].done()
+        assert futures[1].result() == 43
+        assert futures[2].done()
+        assert futures[2].result() == 44
+
+    @staticmethod
+    def test_wait_all_no_futures():
+        assert tasklets.Future.wait_all(()) is None
+
 
 class TestTaskletFuture:
     @staticmethod
@@ -357,6 +402,55 @@ class Test_tasklet:
         future = regular_function(8)
         assert isinstance(future, tasklets.Future)
         assert future.result() == 11
+
+
+class Test_wait_any:
+    @staticmethod
+    @pytest.mark.usefixtures("runstate")
+    def test_it():
+        futures = [tasklets.Future() for _ in range(3)]
+
+        def callback():
+            futures[1].set_result(42)
+
+        _eventloop.add_idle(callback)
+
+        future = tasklets.wait_any(futures)
+        assert future is futures[1]
+        assert future.result() == 42
+
+    @staticmethod
+    def test_it_no_futures():
+        assert tasklets.wait_any(()) is None
+
+
+class Test_wait_all:
+    @staticmethod
+    @pytest.mark.usefixtures("runstate")
+    def test_it():
+        futures = [tasklets.Future() for _ in range(3)]
+
+        def make_callback(index, result):
+            def callback():
+                futures[index].set_result(result)
+
+            return callback
+
+        _eventloop.add_idle(make_callback(0, 42))
+        _eventloop.add_idle(make_callback(1, 43))
+        _eventloop.add_idle(make_callback(2, 44))
+
+        tasklets.wait_all(futures)
+        assert futures[0].done()
+        assert futures[0].result() == 42
+        assert futures[1].done()
+        assert futures[1].result() == 43
+        assert futures[2].done()
+        assert futures[2].result() == 44
+
+    @staticmethod
+    def test_it_no_futures():
+        assert tasklets.wait_all(()) is None
 
 
 def test_get_context():


### PR DESCRIPTION
These were originally implemented as class methods on the `tasklets.Future` class. I've made them standalone functions in `tasklets` but added static methods to `tasklets.Future` for backwards compatibility. 