### PR TITLE
PubSub: Propagate RetryError in PublisherClient.publish

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -199,7 +199,7 @@ class Batch(base.Batch):
 
             try:
                 response = self._client.api.publish(self._topic, self._messages)
-            except google.api_core.exceptions.GoogleAPICallError as exc:
+            except google.api_core.exceptions.GoogleAPIError as exc:
                 # We failed to publish, set the exception on all futures and
                 # exit.
                 self._status = base.BatchStatus.ERROR


### PR DESCRIPTION
in `google.cloud.pubsub_v1.publisher._batch.thread.Batch` [`self._client.api.publish(self._topic, self._messages)`](https://github.com/googleapis/google-cloud-python/pull/7071/files#diff-13577f0feaf50916f99888dc4258f6dcL201) may [raise `google.api_core.exceptions.RetryError`](https://github.com/googleapis/google-cloud-python/blob/master/api_core/google/api_core/retry.py#L163).

if `Batch._commit` does not catch an error then `Batch._futures` may never complete.

`google.api_core.exceptions.RetryError` and `google.api_core.exceptions.GoogleAPICallError` are the only inheritors of `google.api_core.exceptions.GoogleAPIError`, so that seemed like the appropriate error to catch.