### PR TITLE
Specify generation of v1beta1 after auto-attempt to generate v1.

### DIFF
--- a/firestore/synth.py
+++ b/firestore/synth.py
@@ -25,7 +25,7 @@ common = gcp.CommonTemplates()
 library = gapic.py_library(
     "firestore",
     "v1beta1",
-    config_path="/google/firestore/artman_firestore.yaml",
+    config_path="/google/firestore/artman_firestore_v1beta1.yaml",
     artman_output_name="firestore-v1beta1",
 )
 


### PR DESCRIPTION
This fixes #7113 by correcting synth.py to generate v1 and not the old version, v1beta1.