### PR TITLE
Add option to choose dtypes by column in to_dataframe.

### DIFF
--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -24,7 +24,7 @@ LOCAL_DEPS = (
     os.path.join('..', 'core'),
     # TODO: Move bigquery_storage back to dev_install once dtypes feature is
     #       released. Issue #7049
-    os.path.join('..', 'bigquery_storage'),
+    os.path.join('..', 'bigquery_storage[pandas,fastavro]'),
 )
 
 

--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -22,6 +22,9 @@ import nox
 LOCAL_DEPS = (
     os.path.join('..', 'api_core[grpc]'),
     os.path.join('..', 'core'),
+    # TODO: Move bigquery_storage back to dev_install once dtypes feature is
+    #       released. Issue #7049
+    os.path.join('..', 'bigquery_storage'),
 )
 
 
@@ -40,9 +43,9 @@ def default(session):
 
     # Pyarrow does not support Python 3.7
     if session.python == '3.7':
-        dev_install = '.[bqstorage, pandas]'
+        dev_install = '.[pandas]'
     else:
-        dev_install = '.[bqstorage, pandas, pyarrow]'
+        dev_install = '.[pandas, pyarrow]'
     session.install('-e', dev_install)
 
     # IPython does not support Python 2 after version 5.x

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -34,7 +34,7 @@ dependencies = [
     'google-resumable-media >= 0.3.1',
 ]
 extras = {
-    'bqstorage': 'google-cloud-bigquery-storage<=2.0.0dev',
+    'bqstorage': 'google-cloud-bigquery-storage >= 0.2.0dev1, <2.0.0dev',
     'pandas': 'pandas>=0.17.1',
     # Exclude PyArrow dependency from Windows Python 2.7.
     'pyarrow: platform_system != "Windows" or python_version >= "3.4"':

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -1472,21 +1472,22 @@ class TestRowIterator(unittest.TestCase):
             SchemaField("start_timestamp", "TIMESTAMP"),
             SchemaField("seconds", "INT64"),
             SchemaField("miles", "FLOAT64"),
+            SchemaField("km", "FLOAT64"),
             SchemaField("payment_type", "STRING"),
             SchemaField("complete", "BOOL"),
             SchemaField("date", "DATE"),
         ]
         row_data = [
-            ["1.4338368E9", "420", "1.1", "Cash", "true", "1999-12-01"],
-            ["1.3878117E9", "2580", "17.7", "Cash", "false", "1953-06-14"],
-            ["1.3855653E9", "2280", "4.4", "Credit", "true", "1981-11-04"],
+            ["1.4338368E9", "420", "1.1", "1.77", "Cash", "true", "1999-12-01"],
+            ["1.3878117E9", "2580", "17.7", "28.5", "Cash", "false", "1953-06-14"],
+            ["1.3855653E9", "2280", "4.4", "7.1", "Credit", "true", "1981-11-04"],
         ]
         rows = [{"f": [{"v": field} for field in row]} for row in row_data]
         path = "/foo"
         api_request = mock.Mock(return_value={"rows": rows})
         row_iterator = RowIterator(_mock_client(), api_request, path, schema)
 
-        df = row_iterator.to_dataframe()
+        df = row_iterator.to_dataframe(dtypes={"km": "float16"})
 
         self.assertIsInstance(df, pandas.DataFrame)
         self.assertEqual(len(df), 3)  # verify the number of rows
@@ -1496,6 +1497,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df.start_timestamp.dtype.name, "datetime64[ns, UTC]")
         self.assertEqual(df.seconds.dtype.name, "int64")
         self.assertEqual(df.miles.dtype.name, "float64")
+        self.assertEqual(df.km.dtype.name, "float16")
         self.assertEqual(df.payment_type.dtype.name, "object")
         self.assertEqual(df.complete.dtype.name, "bool")
         self.assertEqual(df.date.dtype.name, "object")

--- a/bigquery_storage/google/cloud/bigquery_storage_v1beta1/reader.py
+++ b/bigquery_storage/google/cloud/bigquery_storage_v1beta1/reader.py
@@ -201,9 +201,7 @@ class ReadRowsStream(object):
         frames = []
         for block in self:
             dataframe = _to_dataframe_with_dtypes(
-                _avro_rows(block, avro_schema),
-                column_names,
-                dtypes
+                _avro_rows(block, avro_schema), column_names, dtypes
             )
             frames.append(dataframe)
         return pandas.concat(frames)

--- a/bigquery_storage/google/cloud/bigquery_storage_v1beta1/reader.py
+++ b/bigquery_storage/google/cloud/bigquery_storage_v1beta1/reader.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import
 
+import collections
 import itertools
 import json
 
@@ -155,11 +156,11 @@ class ReadRowsStream(object):
         if fastavro is None:
             raise ImportError(_FASTAVRO_REQUIRED)
 
-        avro_schema = _avro_schema(read_session)
+        avro_schema, _ = _avro_schema(read_session)
         blocks = (_avro_rows(block, avro_schema) for block in self)
         return itertools.chain.from_iterable(blocks)
 
-    def to_dataframe(self, read_session):
+    def to_dataframe(self, read_session, dtypes=None):
         """Create a :class:`pandas.DataFrame` of all rows in the stream.
 
         This method requires the pandas libary to create a data frame and the
@@ -176,6 +177,13 @@ class ReadRowsStream(object):
                 The read session associated with this read rows stream. This
                 contains the schema, which is required to parse the data
                 blocks.
+            dtypes ( \
+                Map[str, Union[str, pandas.Series.dtype]] \
+            ):
+                Optional. A dictionary of column names pandas ``dtype``s. The
+                provided ``dtype`` is used when constructing the series for
+                the column specified. Otherwise, the default pandas behavior
+                is used.
 
         Returns:
             pandas.DataFrame:
@@ -186,12 +194,29 @@ class ReadRowsStream(object):
         if pandas is None:
             raise ImportError("pandas is required to create a DataFrame")
 
-        avro_schema = _avro_schema(read_session)
+        if dtypes is None:
+            dtypes = {}
+
+        avro_schema, column_names = _avro_schema(read_session)
         frames = []
         for block in self:
-            dataframe = pandas.DataFrame(list(_avro_rows(block, avro_schema)))
+            dataframe = _to_dataframe_with_dtypes(
+                _avro_rows(block, avro_schema),
+                column_names,
+                dtypes
+            )
             frames.append(dataframe)
         return pandas.concat(frames)
+
+
+def _to_dataframe_with_dtypes(rows, column_names, dtypes):
+    columns = collections.defaultdict(list)
+    for row in rows:
+        for column in row:
+            columns[column].append(row[column])
+    for column in dtypes:
+        columns[column] = pandas.Series(columns[column], dtype=dtypes[column])
+    return pandas.DataFrame(columns, columns=column_names)
 
 
 def _avro_schema(read_session):
@@ -206,10 +231,13 @@ def _avro_schema(read_session):
             blocks.
 
     Returns:
-        A parsed Avro schema, using :func:`fastavro.schema.parse_schema`.
+        Tuple[fastavro.schema, Tuple[str]]:
+            A parsed Avro schema, using :func:`fastavro.schema.parse_schema`
+            and the column names for a read session.
     """
     json_schema = json.loads(read_session.avro_schema.schema)
-    return fastavro.parse_schema(json_schema)
+    column_names = tuple((field["name"] for field in json_schema["fields"]))
+    return fastavro.parse_schema(json_schema), column_names
 
 
 def _avro_rows(block, avro_schema):

--- a/bigquery_storage/noxfile.py
+++ b/bigquery_storage/noxfile.py
@@ -43,7 +43,6 @@ def default(session):
     session.run(
         'py.test',
         '--quiet',
-        '--cov=google.cloud.bigquery_storage',
         '--cov=google.cloud.bigquery_storage_v1beta1',
         '--cov=tests.unit',
         '--cov-append',

--- a/bigquery_storage/setup.py
+++ b/bigquery_storage/setup.py
@@ -21,7 +21,7 @@ import setuptools
 
 name = 'google-cloud-bigquery-storage'
 description = 'BigQuery Storage API API client library'
-version = '0.1.1'
+version = '0.2.0dev1'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',

--- a/bigquery_storage/tests/system/test_system.py
+++ b/bigquery_storage/tests/system/test_system.py
@@ -17,6 +17,7 @@
 
 import os
 
+import numpy
 import pytest
 
 from google.cloud import bigquery_storage_v1beta1
@@ -78,11 +79,15 @@ def test_read_rows_to_dataframe(client, project_id):
         stream=session.streams[0]
     )
 
-    frame = client.read_rows(stream_pos).to_dataframe(session)
+    frame = client.read_rows(stream_pos).to_dataframe(
+        session, dtypes={"latitude": numpy.float16}
+    )
 
     # Station ID is a required field (no nulls), so the datatype should always
     # be integer.
     assert frame.station_id.dtype.name == "int64"
+    assert frame.latitude.dtype.name == "float16"
+    assert frame.longitude.dtype.name == "float64"
     assert frame["name"].str.startswith("Central Park").any()
 
 

--- a/bigquery_storage/tests/unit/test_reader.py
+++ b/bigquery_storage/tests/unit/test_reader.py
@@ -283,8 +283,8 @@ def test_to_dataframe_w_scalars(class_under_test):
     got = reader.to_dataframe(read_session)
 
     expected = pandas.DataFrame(
-        list(itertools.chain.from_iterable(SCALAR_BLOCKS)),
-        columns=SCALAR_COLUMN_NAMES)
+        list(itertools.chain.from_iterable(SCALAR_BLOCKS)), columns=SCALAR_COLUMN_NAMES
+    )
     # fastavro provides its own UTC definition, so
     # compare the timestamp columns separately.
     got_ts = got["ts_col"]
@@ -306,28 +306,16 @@ def test_to_dataframe_w_scalars(class_under_test):
 
 def test_to_dataframe_w_dtypes(class_under_test):
     # TODOTODOTODOTODO
-    avro_schema = _bq_to_avro_schema([
-        {"name": "bigfloat", "type": "float64"},
-        {"name": "lilfloat", "type": "float64"},
-    ])
+    avro_schema = _bq_to_avro_schema(
+        [
+            {"name": "bigfloat", "type": "float64"},
+            {"name": "lilfloat", "type": "float64"},
+        ]
+    )
     read_session = _generate_read_session(avro_schema)
     blocks = [
-        [
-            {
-                "bigfloat": 1.25,
-                "lilfloat": 30.5,
-            },
-            {
-                "bigfloat": 2.5,
-                "lilfloat": 21.125,
-            }
-        ],
-        [
-            {
-                "bigfloat": 3.75,
-                "lilfloat": 11.0,
-            }
-        ]
+        [{"bigfloat": 1.25, "lilfloat": 30.5}, {"bigfloat": 2.5, "lilfloat": 21.125}],
+        [{"bigfloat": 3.75, "lilfloat": 11.0}],
     ]
     avro_blocks = _bq_to_avro_blocks(blocks, avro_schema)
 
@@ -341,7 +329,8 @@ def test_to_dataframe_w_dtypes(class_under_test):
             "bigfloat": [1.25, 2.5, 3.75],
             "lilfloat": pandas.Series([30.5, 21.125, 11.0], dtype="float16"),
         },
-        columns=["bigfloat", "lilfloat"])
+        columns=["bigfloat", "lilfloat"],
+    )
     pandas.testing.assert_frame_equal(
         got.reset_index(drop=True),  # reset_index to ignore row labels
         expected.reset_index(drop=True),

--- a/bigquery_storage/tests/unit/test_reader.py
+++ b/bigquery_storage/tests/unit/test_reader.py
@@ -55,6 +55,7 @@ SCALAR_COLUMNS = [
     {"name": "time_col", "type": "time"},
     {"name": "ts_col", "type": "timestamp"},
 ]
+SCALAR_COLUMN_NAMES = [field["name"] for field in SCALAR_COLUMNS]
 SCALAR_BLOCKS = [
     [
         {
@@ -281,7 +282,9 @@ def test_to_dataframe_w_scalars(class_under_test):
     )
     got = reader.to_dataframe(read_session)
 
-    expected = pandas.DataFrame(list(itertools.chain.from_iterable(SCALAR_BLOCKS)))
+    expected = pandas.DataFrame(
+        list(itertools.chain.from_iterable(SCALAR_BLOCKS)),
+        columns=SCALAR_COLUMN_NAMES)
     # fastavro provides its own UTC definition, so
     # compare the timestamp columns separately.
     got_ts = got["ts_col"]
@@ -298,6 +301,50 @@ def test_to_dataframe_w_scalars(class_under_test):
         expected_ts.reset_index(drop=True),
         check_dtype=False,  # fastavro's UTC means different dtype
         check_datetimelike_compat=True,
+    )
+
+
+def test_to_dataframe_w_dtypes(class_under_test):
+    # TODOTODOTODOTODO
+    avro_schema = _bq_to_avro_schema([
+        {"name": "bigfloat", "type": "float64"},
+        {"name": "lilfloat", "type": "float64"},
+    ])
+    read_session = _generate_read_session(avro_schema)
+    blocks = [
+        [
+            {
+                "bigfloat": 1.25,
+                "lilfloat": 30.5,
+            },
+            {
+                "bigfloat": 2.5,
+                "lilfloat": 21.125,
+            }
+        ],
+        [
+            {
+                "bigfloat": 3.75,
+                "lilfloat": 11.0,
+            }
+        ]
+    ]
+    avro_blocks = _bq_to_avro_blocks(blocks, avro_schema)
+
+    reader = class_under_test(
+        avro_blocks, mock_client, bigquery_storage_v1beta1.types.StreamPosition(), {}
+    )
+    got = reader.to_dataframe(read_session, dtypes={"lilfloat": "float16"})
+
+    expected = pandas.DataFrame(
+        {
+            "bigfloat": [1.25, 2.5, 3.75],
+            "lilfloat": pandas.Series([30.5, 21.125, 11.0], dtype="float16"),
+        },
+        columns=["bigfloat", "lilfloat"])
+    pandas.testing.assert_frame_equal(
+        got.reset_index(drop=True),  # reset_index to ignore row labels
+        expected.reset_index(drop=True),
     )
 
 


### PR DESCRIPTION
This allows pandas users to select different sized floats for
performance at the expense of accuracy. With pandas 0.24, it will also
allow pandas users to use the new pandas.Int64Dtype() for nullable
integer columns.

Closes #7049 