### PR TITLE
Firestore: add 'DocumentReference.path' property.

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/document.py
+++ b/firestore/google/cloud/firestore_v1beta1/document.py
@@ -118,6 +118,15 @@ class DocumentReference(object):
             return NotImplemented
 
     @property
+    def path(self):
+        """Database-relative for this document.
+
+        Returns:
+            str: The document's relative path.
+        """
+        return "/".join(self._path)
+
+    @property
     def _document_path(self):
         """Create and cache the full path for this document.
 

--- a/firestore/tests/unit/test_document.py
+++ b/firestore/tests/unit/test_document.py
@@ -41,8 +41,10 @@ class TestDocumentReference(unittest.TestCase):
             collection_id1, document_id1, collection_id2, document_id2, client=client
         )
         self.assertIs(document._client, client)
-        expected_path = (collection_id1, document_id1, collection_id2, document_id2)
-        self.assertEqual(document._path, expected_path)
+        expected_path = "/".join(
+            (collection_id1, document_id1, collection_id2, document_id2)
+        )
+        self.assertEqual(document.path, expected_path)
 
     def test_constructor_invalid_path(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Returns database-relative path.

Closes #6554.