### PR TITLE
Firestore: rename 'Query.get' -> 'stream'.

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/collection.py
+++ b/firestore/google/cloud/firestore_v1beta1/collection.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 """Classes for representing collections for the Google Cloud Firestore API."""
-
-
 import random
+import warnings
 
 import six
 
@@ -384,6 +383,15 @@ class CollectionReference(object):
         return query.end_at(document_fields)
 
     def get(self, transaction=None):
+        """Deprecated alias for :meth:`stream`."""
+        warnings.warn(
+            "'Collection.get' is deprecated:  please use 'Collection.stream' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.stream(transaction=transaction)
+
+    def stream(self, transaction=None):
         """Read the documents in this collection.
 
         This sends a ``RunQuery`` RPC and then returns an iterator which
@@ -411,7 +419,7 @@ class CollectionReference(object):
             document that fulfills the query.
         """
         query = query_mod.Query(self)
-        return query.get(transaction=transaction)
+        return query.stream(transaction=transaction)
 
     def on_snapshot(self, callback):
         """Monitor the documents in this collection.

--- a/firestore/google/cloud/firestore_v1beta1/query.py
+++ b/firestore/google/cloud/firestore_v1beta1/query.py
@@ -18,10 +18,9 @@ A :class:`~.firestore_v1beta1.query.Query` can be created directly from
 a :class:`~.firestore_v1beta1.collection.Collection` and that can be
 a more common way to create a query than direct usage of the constructor.
 """
-
-
 import copy
 import math
+import warnings
 
 from google.protobuf import wrappers_pb2
 import six
@@ -696,6 +695,15 @@ class Query(object):
         return query_pb2.StructuredQuery(**query_kwargs)
 
     def get(self, transaction=None):
+        """Deprecated alias for :meth:`stream`."""
+        warnings.warn(
+            "'Query.get' is deprecated:  please use 'Query.stream' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.stream(transaction=transaction)
+
+    def stream(self, transaction=None):
         """Read the documents in the collection that match this query.
 
         This sends a ``RunQuery`` RPC and then returns an iterator which


### PR DESCRIPTION
Leave `Query.get` as a deprecated alias for `Query.stream`.

Closes #6558.