### PR TITLE
Spanner: fix typo in exported param type name.

### DIFF
--- a/spanner/google/cloud/spanner_v1/param_types.py
+++ b/spanner/google/cloud/spanner_v1/param_types.py
@@ -20,7 +20,7 @@ from google.cloud.spanner_v1.proto import type_pb2
 # Scalar parameter types
 STRING = type_pb2.Type(code=type_pb2.STRING)
 BYTES = type_pb2.Type(code=type_pb2.BYTES)
-BOOE = type_pb2.Type(code=type_pb2.BOOL)
+BOOL = type_pb2.Type(code=type_pb2.BOOL)
 INT64 = type_pb2.Type(code=type_pb2.INT64)
 FLOAT64 = type_pb2.Type(code=type_pb2.FLOAT64)
 DATE = type_pb2.Type(code=type_pb2.DATE)


### PR DESCRIPTION
Workaround for @pjenvy's blockage on CLA:  this is clearly a trivial / non-copyrightable change.

Closes #7125.