### PR TITLE
BigQuery: harden 'ArrayQueryParameter.from_api_repr' against missing 'parameterValue'.

### DIFF
--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -230,7 +230,9 @@ class ArrayQueryParameter(_AbstractQueryParameter):
     def _from_api_repr_scalar(cls, resource):
         name = resource.get("name")
         array_type = resource["parameterType"]["arrayType"]["type"]
-        values = [value["value"] for value in resource["parameterValue"]["arrayValues"]]
+        parameter_value = resource.get("parameterValue", {})
+        array_values = parameter_value.get("arrayValues", ())
+        values = [value["value"] for value in array_values]
         converted = [
             _QUERY_PARAMS_FROM_JSON[array_type](value, None) for value in values
         ]

--- a/bigquery/tests/unit/test_query.py
+++ b/bigquery/tests/unit/test_query.py
@@ -362,6 +362,18 @@ class Test_ArrayQueryParameter(unittest.TestCase):
         self.assertEqual(param.array_type, "INT64")
         self.assertEqual(param.values, [1, 2])
 
+    def test_from_api_repr_wo_values(self):
+        # Back-end may not send back values for empty array params. See #7309
+        RESOURCE = {
+            "name": "foo",
+            "parameterType": {"type": "ARRAY", "arrayType": {"type": "INT64"}},
+        }
+        klass = self._get_target_class()
+        param = klass.from_api_repr(RESOURCE)
+        self.assertEqual(param.name, "foo")
+        self.assertEqual(param.array_type, "INT64")
+        self.assertEqual(param.values, [])
+
     def test_from_api_repr_w_struct_type(self):
         from google.cloud.bigquery.query import StructQueryParameter
 


### PR DESCRIPTION
Closes #7309.