### PR TITLE
bigtable: fix lint

### DIFF
--- a/bigtable/google/cloud/bigtable/batcher.py
+++ b/bigtable/google/cloud/bigtable/batcher.py
@@ -144,7 +144,7 @@ class MutationsBatcher(object):
 
     def flush(self):
         """ Sends the current. batch to Cloud Bigtable. """
-        if len(self.rows) is not 0:
+        if len(self.rows) != 0:
             self.table.mutate_rows(self.rows)
             self.total_mutation_count = 0
             self.total_size = 0


### PR DESCRIPTION
Fix lint
`is not` to `!=` as per flake8 F632 code