### PR TITLE
Show inheritance and inherited members in BQ docs.

### DIFF
--- a/third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/class.rst
+++ b/third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/class.rst
@@ -33,4 +33,6 @@
     <p>
 
 .. autoclass:: {{ objname }}
+   :show-inheritance:
+   :inherited-members:
    :members:


### PR DESCRIPTION
This fixes the issue where the base class for RowIterator could not be navigated to.

![image](https://user-images.githubusercontent.com/247555/52736788-9180cc00-2f7f-11e9-8648-8eed45a53637.png)

Fixes #7293 