### PR TITLE
Bigtable: ensure that 'Policy.etag' is text.

### DIFF
--- a/bigtable/google/cloud/bigtable/policy.py
+++ b/bigtable/google/cloud/bigtable/policy.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from google.api_core.iam import Policy as BasePolicy
-from google.cloud._helpers import _to_bytes
+from google.cloud._helpers import _bytes_to_unicode
 
 """IAM roles supported by Bigtable Instance resource"""
 BIGTABLE_ADMIN_ROLE = "roles/bigtable.admin"
@@ -73,7 +73,9 @@ class Policy(BasePolicy):
 
     def __init__(self, etag=None, version=None):
         BasePolicy.__init__(
-            self, etag=etag if etag is None else _to_bytes(etag), version=version
+            self,
+            etag=etag if etag is None else _bytes_to_unicode(etag),
+            version=version,
         )
 
     @property

--- a/bigtable/tests/unit/test_policy.py
+++ b/bigtable/tests/unit/test_policy.py
@@ -39,10 +39,24 @@ class TestPolicy(unittest.TestCase):
 
     def test_ctor_explicit(self):
         VERSION = 17
-        ETAG = b"ETAG"
+        ETAG = u"ETAG"
         empty = frozenset()
         policy = self._make_one(ETAG, VERSION)
         self.assertEqual(policy.etag, ETAG)
+        self.assertEqual(policy.version, VERSION)
+        self.assertEqual(policy.bigtable_admins, empty)
+        self.assertEqual(policy.bigtable_readers, empty)
+        self.assertEqual(policy.bigtable_users, empty)
+        self.assertEqual(policy.bigtable_viewers, empty)
+        self.assertEqual(len(policy), 0)
+        self.assertEqual(dict(policy), {})
+
+    def test_ctor_w_bytes_etag(self):
+        VERSION = 17
+        ETAG = b"ETAG"
+        empty = frozenset()
+        policy = self._make_one(ETAG, VERSION)
+        self.assertEqual(policy.etag, ETAG.decode("UTF-8"))
         self.assertEqual(policy.version, VERSION)
         self.assertEqual(policy.bigtable_admins, empty)
         self.assertEqual(policy.bigtable_readers, empty)


### PR DESCRIPTION
Closes #7369.