### PR TITLE
api_core: fix new lint failure

### DIFF
--- a/api_core/tests/unit/test_page_iterator.py
+++ b/api_core/tests/unit/test_page_iterator.py
@@ -514,7 +514,7 @@ class TestGRPCIterator(object):
 
         method.assert_called_with(request)
         assert method.call_count == 2
-        assert request.page_token is "1"
+        assert request.page_token == "1"
 
 
 class GAXPageIterator(object):


### PR DESCRIPTION
```
F632 use ==/!= to compare str, bytes, and int literals.
```