### PR TITLE
BigQuery: fix lint.

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1382,7 +1382,7 @@ class RowIterator(HTTPIterator):
 
     def to_dataframe(self, bqstorage_client=None, dtypes=None):
         """Create a pandas DataFrame by loading all pages of a query.
-           
+
 
         Args:
             bqstorage_client ( \


### PR DESCRIPTION
W293 blank line contains whitespace.