### PR TITLE
Fix typing - `:type kwargs: dict` is not correct

### DIFF
--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -534,7 +534,6 @@ class Client(ClientWithProject):
     def transaction(self, **kwargs):
         """Proxy to :class:`google.cloud.datastore.transaction.Transaction`.
 
-        :type kwargs: dict
         :param kwargs: Keyword arguments to be passed in.
         """
         return Transaction(self, **kwargs)
@@ -607,7 +606,6 @@ class Client(ClientWithProject):
             >>> query_iter.next_page_token is None
             True
 
-        :type kwargs: dict
         :param kwargs: Parameters for initializing and instance of
                        :class:`~google.cloud.datastore.query.Query`.
 


### PR DESCRIPTION
When typing Python code, the special `*args` and `**kwargs` params are typed based on their contents, not what they actually are (a tuple, and a dict) e.g.
```python
def foo(thing: int, *args: str):
    ...
def bar(thing: int, *args: str, **kwargs: Union[int, float]):
    ...

bar(-3, "G", spam=80, eggs=4.4)
foo(44, "abc", "xyz")
```

And in this case, the types are passed to a different func (`Query.__init__`) which has specific arguments, so it is best to not give **kwargs a type, or, better, copy the parameters of that function (but I haven't done this here).
This also applies to `Transaction`.
PS I know this is a stupidly minor change but it annoys me, having to write `noinspection PyTypeChecker` before every datastore query.
:smile: