### PR TITLE
Add `Operation.deserialize`.

### DIFF
--- a/api_core/google/api_core/operation.py
+++ b/api_core/google/api_core/operation.py
@@ -101,6 +101,18 @@ class Operation(polling.PollingFuture):
             self._metadata_type, self._operation.metadata
         )
 
+    @classmethod
+    def deserialize(self, payload):
+        """Deserialize a ``google.longrunning.Operation`` protocol buffer.
+
+        Args:
+            payload (bytes): A serialized operation protocol buffer.
+
+        Returns:
+            ~.operations_pb2.Operation: An Operation protobuf object.
+        """
+        return operations_pb2.Operation.FromString(payload)
+
     def _set_result_from_operation(self):
         """Set the result or exception from the operation if it is complete."""
         # This must be done in a lock to prevent the polling thread

--- a/api_core/tests/unit/test_operation.py
+++ b/api_core/tests/unit/test_operation.py
@@ -231,3 +231,11 @@ def test_from_gapic():
     assert future._metadata_type == struct_pb2.Struct
     assert future.operation.name == TEST_OPERATION_NAME
     assert future.done
+
+
+def test_deserialize():
+    op = make_operation_proto(name="foobarbaz")
+    serialized = op.SerializeToString()
+    deserialized_op = operation.Operation.deserialize(serialized)
+    assert op.name == deserialized_op.name
+    assert type(op) is type(deserialized_op)


### PR DESCRIPTION
This commit adds a `deserialize` method to the Operation object. The class method is a helper to deserialize the serialized protobuf operation messages.

We previously released this in `1.6.0a1` so I could make sure this was needed and the correct thing before committing to it. I am now requesting that we promote it. :-)