### PR TITLE
Dataproc: Add nox session `docs`

### DIFF
--- a/dataproc/docs/README.rst
+++ b/dataproc/docs/README.rst
@@ -1,0 +1,1 @@
+../README.rst

--- a/dataproc/docs/conf.py
+++ b/dataproc/docs/conf.py
@@ -25,7 +25,7 @@ __version__ = "0.1.0"
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-# needs_sphinx = '1.0'
+needs_sphinx = '1.6.3'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -36,6 +36,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
+    'sphinx.ext.todo',
     "sphinx.ext.viewcode",
 ]
 
@@ -47,10 +48,15 @@ autosummary_generate = True
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
+# Allow markdown includes (so releases.md can include CHANGLEOG.md)
+# http://www.sphinx-doc.org/en/master/markdown.html
+source_parsers = {
+   '.md': 'recommonmark.parser.CommonMarkParser',
+}
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-# source_suffix = ['.rst', '.md']
-source_suffix = ".rst"
+source_suffix = ['.rst', '.md']
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
@@ -120,12 +126,20 @@ todo_include_todos = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "sphinx_rtd_theme"
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {
+    #'description': 'Google Cloud Client Libraries for Python',
+    #'github_user': 'GoogleCloudPlatform',
+    #'github_repo': 'google-cloud-python',
+    #'github_banner': True,
+    'font_family': "'Roboto', Georgia, sans",
+    'head_font_family': "'Roboto', Georgia, serif",
+    'code_font_family': "'Roboto Mono', 'Consolas', monospace",
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
@@ -214,6 +228,18 @@ html_theme = "sphinx_rtd_theme"
 # Output file base name for HTML help builder.
 htmlhelp_basename = "google-cloud-dataproc-doc"
 
+
+# -- Options for warnings ------------------------------------------------------
+
+
+suppress_warnings = [
+    # Temporarily suppress ths to avoid "more than one target found for
+    # cross-reference" warning, which are intractable for us to avoid while in
+    # a mono-repo.
+    # See https://github.com/sphinx-doc/sphinx/blob
+    # /2a65ffeef5c107c19084fabdd706cdff3f52d93c/sphinx/domains/python.py#L843
+    'ref.python'
+]
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
@@ -306,10 +332,15 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
 
-# Example configuration for intersphinx: refer to the Python standard library.
+# Configuration for intersphinx:
 intersphinx_mapping = {
-    "python": ("http://python.readthedocs.org/en/latest/", None),
-    "gax": ("https://gax-python.readthedocs.org/en/latest/", None),
+    'google-auth': ('https://google-auth.readthedocs.io/en/stable', None),
+    'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
+    'grpc': ('https://grpc.io/grpc/python/', None),
+    'requests': ('http://docs.python-requests.org/en/master/', None),
+    'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+    'python': ('https://docs.python.org/3', None),
 }
 
 # Napoleon settings

--- a/dataproc/docs/conf.py
+++ b/dataproc/docs/conf.py
@@ -25,7 +25,7 @@ __version__ = "0.1.0"
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.6.3'
+needs_sphinx = "1.6.3"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -36,7 +36,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
-    'sphinx.ext.todo',
+    "sphinx.ext.todo",
     "sphinx.ext.viewcode",
 ]
 
@@ -50,13 +50,11 @@ templates_path = ["_templates"]
 
 # Allow markdown includes (so releases.md can include CHANGLEOG.md)
 # http://www.sphinx-doc.org/en/master/markdown.html
-source_parsers = {
-   '.md': 'recommonmark.parser.CommonMarkParser',
-}
+source_parsers = {".md": "recommonmark.parser.CommonMarkParser"}
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-source_suffix = ['.rst', '.md']
+source_suffix = [".rst", ".md"]
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
@@ -136,9 +134,9 @@ html_theme_options = {
     #'github_user': 'GoogleCloudPlatform',
     #'github_repo': 'google-cloud-python',
     #'github_banner': True,
-    'font_family': "'Roboto', Georgia, sans",
-    'head_font_family': "'Roboto', Georgia, serif",
-    'code_font_family': "'Roboto Mono', 'Consolas', monospace",
+    "font_family": "'Roboto', Georgia, sans",
+    "head_font_family": "'Roboto', Georgia, serif",
+    "code_font_family": "'Roboto Mono', 'Consolas', monospace",
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
@@ -238,7 +236,7 @@ suppress_warnings = [
     # a mono-repo.
     # See https://github.com/sphinx-doc/sphinx/blob
     # /2a65ffeef5c107c19084fabdd706cdff3f52d93c/sphinx/domains/python.py#L843
-    'ref.python'
+    "ref.python"
 ]
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -334,13 +332,13 @@ texinfo_documents = [
 
 # Configuration for intersphinx:
 intersphinx_mapping = {
-    'google-auth': ('https://google-auth.readthedocs.io/en/stable', None),
-    'google-gax': ('https://gax-python.readthedocs.io/en/latest/', None),
-    'grpc': ('https://grpc.io/grpc/python/', None),
-    'requests': ('http://docs.python-requests.org/en/master/', None),
-    'fastavro': ('https://fastavro.readthedocs.io/en/stable/', None),
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
-    'python': ('https://docs.python.org/3', None),
+    "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
+    "google-gax": ("https://gax-python.readthedocs.io/en/latest/", None),
+    "grpc": ("https://grpc.io/grpc/python/", None),
+    "requests": ("http://docs.python-requests.org/en/master/", None),
+    "fastavro": ("https://fastavro.readthedocs.io/en/stable/", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+    "python": ("https://docs.python.org/3", None),
 }
 
 # Napoleon settings

--- a/dataproc/docs/index.rst
+++ b/dataproc/docs/index.rst
@@ -1,5 +1,4 @@
-.. include:: /../dataproc/README.rst
-
+.. include:: README.rst
 
 API Reference
 -------------

--- a/dataproc/noxfile.py
+++ b/dataproc/noxfile.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import
 import os
+import shutil
 
 import nox
 
@@ -138,3 +139,22 @@ def cover(session):
     session.run("coverage", "report", "--show-missing", "--fail-under=100")
 
     session.run("coverage", "erase")
+
+@nox.session(python='3.6')
+def docs(session):
+    """Build the docs."""
+
+    session.install('sphinx', 'alabaster', 'recommonmark')
+    session.install('-e', '.')
+
+    shutil.rmtree(os.path.join('docs', '_build'), ignore_errors=True)
+    session.run(
+        'sphinx-build',
+        '-W',  # warnings as errors
+        '-T',  # show full traceback on exception
+        '-N',  # no colors
+        '-b', 'html',
+        '-d', os.path.join('docs', '_build', 'doctrees', ''),
+        os.path.join('docs', ''),
+        os.path.join('docs', '_build', 'html', ''),
+    )


### PR DESCRIPTION
Adds a nox session `docs` in dataproc which builds the dataproc documentation. This does not break the top-level docs build. This is in preparation for the new documentation site and repo split. 

I'd like to make similar changes in the other directories and wanted to get input on this first.