### PR TITLE
Storage: ensure that 'Blob.reload' passes encryption headers.

### DIFF
--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -86,6 +86,14 @@ class _PropertyMixin(object):
             client = self.client
         return client
 
+    def _encryption_headers(self):
+        """Return any encryption headers needed to fetch the object.
+
+        :rtype: dict
+        :returns: a mapping of encryption-related headers.
+        """
+        return {}
+
     def reload(self, client=None):
         """Reload properties from Cloud Storage.
 
@@ -103,7 +111,11 @@ class _PropertyMixin(object):
         if self.user_project is not None:
             query_params["userProject"] = self.user_project
         api_response = client._connection.api_request(
-            method="GET", path=self.path, query_params=query_params, _target_object=self
+            method="GET",
+            path=self.path,
+            query_params=query_params,
+            headers=self._encryption_headers(),
+            _target_object=self
         )
         self._set_properties(api_response)
 

--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -89,6 +89,10 @@ class _PropertyMixin(object):
     def _encryption_headers(self):
         """Return any encryption headers needed to fetch the object.
 
+        .. note::
+           Defined here because :meth:`reload` calls it, but this method is
+           really only relevant for :class:`~google.cloud.storage.blob.Blob`.
+
         :rtype: dict
         :returns: a mapping of encryption-related headers.
         """

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -257,6 +257,14 @@ class Blob(_PropertyMixin):
         """
         return self.bucket.user_project
 
+    def _encryption_headers(self):
+        """Return any encryption headers needed to fetch the object.
+
+        :rtype: List(Tuple(str, str))
+        :returns: a list of tuples to be passed as headers.
+        """
+        return _get_encryption_headers(self._encryption_key)
+
     @property
     def public_url(self):
         """The public URL for this blob.

--- a/storage/tests/unit/test__helpers.py
+++ b/storage/tests/unit/test__helpers.py
@@ -55,6 +55,10 @@ class Test_PropertyMixin(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             mixin.user_project
 
+    def test__encryption_headers(self):
+        mixin = self._make_one()
+        self.assertEqual(mixin._encryption_headers(), {})
+
     def test_reload(self):
         connection = _Connection({"foo": "Foo"})
         client = _Client(connection)
@@ -72,6 +76,7 @@ class Test_PropertyMixin(unittest.TestCase):
                 "method": "GET",
                 "path": "/path",
                 "query_params": {"projection": "noAcl"},
+                "headers": {},
                 "_target_object": derived,
             },
         )
@@ -95,6 +100,7 @@ class Test_PropertyMixin(unittest.TestCase):
                 "method": "GET",
                 "path": "/path",
                 "query_params": {"projection": "noAcl", "userProject": user_project},
+                "headers": {},
                 "_target_object": derived,
             },
         )

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -280,6 +280,27 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(blob_name, bucket=bucket)
         self.assertEqual(blob.user_project, user_project)
 
+    def test__encryption_headers_wo_encryption_key(self):
+        BLOB_NAME = "blob-name"
+        bucket = _Bucket()
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
+        expected = {}
+        self.assertEqual(blob._encryption_headers(), expected)
+
+    def test__encryption_headers_w_encryption_key(self):
+        key = b"aa426195405adee2c8081bb9e7e74b19"
+        header_key_value = "YWE0MjYxOTU0MDVhZGVlMmM4MDgxYmI5ZTdlNzRiMTk="
+        header_key_hash_value = "V3Kwe46nKc3xLv96+iJ707YfZfFvlObta8TQcx2gpm0="
+        BLOB_NAME = "blob-name"
+        bucket = _Bucket()
+        blob = self._make_one(BLOB_NAME, bucket=bucket, encryption_key=key)
+        expected = {
+            "X-Goog-Encryption-Algorithm": "AES256",
+            "X-Goog-Encryption-Key": header_key_value,
+            "X-Goog-Encryption-Key-Sha256": header_key_hash_value,
+        }
+        self.assertEqual(blob._encryption_headers(), expected)
+
     def test_public_url(self):
         BLOB_NAME = "blob-name"
         bucket = _Bucket()

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -669,9 +669,13 @@ class Test_Bucket(unittest.TestCase):
         self.assertIs(blob.bucket, bucket)
         self.assertEqual(blob.name, BLOB_NAME)
         kw, = connection._requested
+        expected_qp = {
+            "userProject": USER_PROJECT,
+            "projection": "noAcl",
+        }
         self.assertEqual(kw["method"], "GET")
         self.assertEqual(kw["path"], "/b/%s/o/%s" % (NAME, BLOB_NAME))
-        self.assertEqual(kw["query_params"], {"userProject": USER_PROJECT})
+        self.assertEqual(kw["query_params"], expected_qp)
 
     def test_get_blob_hit_with_kwargs(self):
         from google.cloud.storage.blob import _get_encryption_headers


### PR DESCRIPTION
Closes #7440.