### PR TITLE
Fetch credentials for magic github proxy

### DIFF
--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -42,3 +42,23 @@ before_action {
     }
   }
 }
+
+# Fetch magictoken to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "releasetool-magictoken"
+    }
+  }
+}
+
+# Fetch api key to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "magic-github-proxy-api-key"
+    }
+  }
+}


### PR DESCRIPTION
These credentials will be used by the releasetool reporter. 