### PR TITLE
Storage: add support for V4 signed URLs

### DIFF
--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -585,6 +585,10 @@ def generate_signed_url_v4(
     if "host" not in header_names:
         headers["Host"] = "storage.googleapis.com"
 
+    if method.upper() == "RESUMABLE":
+        method = "POST"
+        headers["x-goog-resumable"] = "start"
+
     canonical_headers, ordered_headers = get_canonical_headers(headers)
     canonical_header_string = (
         "\n".join(canonical_headers) + "\n"

--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -583,14 +583,13 @@ def generate_signed_url_v4(
     if "host" not in header_names:
         headers["Host"] = "storage.googleapis.com"
 
-    ordered_headers = sorted(headers.items())
+    ordered_headers = sorted(
+        [(key.lower(), val.strip()) for key, val in headers.items()]
+    )
     canonical_headers = (
-        "\n".join(
-            ["{}:{}".format(key.lower(), val.strip()) for key, val in ordered_headers]
-        )
-        + "\n"
+        "\n".join(["{}:{}".format(key, val) for key, val in ordered_headers]) + "\n"
     )  # Yes, Virginia, the extra newline is part of the spec.
-    signed_headers = ";".join([key.lower() for key, _ in ordered_headers])
+    signed_headers = ";".join([key for key, _ in ordered_headers])
 
     if query_parameters is None:
         query_parameters = {}

--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -399,6 +399,6 @@ def generate_signed_url_v4(
     signature_bytes = credentials.sign_bytes(string_to_sign.encode("ascii"))
     signature = binascii.hexlify(signature_bytes).decode("ascii")
 
-    return "{}{}?{}&x-goog-signature={}".format(
+    return "{}{}?{}&X-Goog-Signature={}".format(
         api_access_endpoint, resource, canonical_query_string, signature
     )

--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -109,7 +109,7 @@ def get_expiration_seconds(expiration):
     return expiration
 
 
-def generate_signed_url(
+def generate_signed_url_v2(
     credentials,
     resource,
     expiration,
@@ -121,7 +121,7 @@ def generate_signed_url(
     response_disposition=None,
     generation=None,
 ):
-    """Generate signed URL to provide query-string auth'n to a resource.
+    """Generate a V2 signed URL to provide query-string auth'n to a resource.
 
     .. note::
 

--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -221,10 +221,12 @@ def generate_signed_url_v2(
         canonicalized_resource = "{0}".format(resource)
 
     if query_parameters is not None:
-        normalized_qp = list(sorted(
-            (key.lower(), value and value.strip() or "")
-            for key, value in query_parameters.items()
-        ))
+        normalized_qp = list(
+            sorted(
+                (key.lower(), value and value.strip() or "")
+                for key, value in query_parameters.items()
+            )
+        )
         encoded_qp = six.moves.urllib.parse.urlencode(normalized_qp)
         canonicalized_resource = "{}?{}".format(canonicalized_resource, encoded_qp)
     else:
@@ -242,7 +244,9 @@ def generate_signed_url_v2(
     )
 
     # Set the right query parameters.
-    signed_query_params = get_signed_query_params(credentials, expiration, string_to_sign)
+    signed_query_params = get_signed_query_params(
+        credentials, expiration, string_to_sign
+    )
 
     if response_type is not None:
         signed_query_params["response-content-type"] = response_type

--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -18,6 +18,7 @@ import binascii
 import collections
 import datetime
 import hashlib
+import re
 
 import six
 
@@ -438,6 +439,8 @@ def generate_signed_url_v2(
 
 SEVEN_DAYS = 7 * 24 * 60 * 60  # max age for V4 signed URLs.
 DEFAULT_ENDPOINT = "https://storage.googleapis.com"
+MULTIPLE_SPACES_RE = r"\s+"
+MULTIPLE_SPACES = re.compile(MULTIPLE_SPACES_RE)
 
 
 def generate_signed_url_v4(
@@ -584,7 +587,10 @@ def generate_signed_url_v4(
         headers["Host"] = "storage.googleapis.com"
 
     ordered_headers = sorted(
-        [(key.lower(), val.strip()) for key, val in headers.items()]
+        [
+            (key.lower(), MULTIPLE_SPACES.sub(" ", val.strip()))
+            for key, val in headers.items()
+        ]
     )
     canonical_headers = (
         "\n".join(["{}:{}".format(key, val) for key, val in ordered_headers]) + "\n"

--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -197,6 +197,8 @@ def generate_signed_url_v2(
         (Optional) Additional HTTP headers to be included as part of the
         signed URLs.  See:
         https://cloud.google.com/storage/docs/xml-api/reference-headers
+        Requests using the signed URL *must* pass the specified header
+        (name and value) with each request for the URL.
 
     :type query_parameters: dict
     :param query_parameters:
@@ -355,6 +357,8 @@ def generate_signed_url_v4(
         (Optional) Additional HTTP headers to be included as part of the
         signed URLs.  See:
         https://cloud.google.com/storage/docs/xml-api/reference-headers
+        Requests using the signed URL *must* pass the specified header
+        (name and value) with each request for the URL.
 
     :type query_parameters: dict
     :param query_parameters:

--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -52,7 +52,7 @@ def ensure_signed_credentials(credentials):
         )
 
 
-def get_signed_query_params(credentials, expiration, string_to_sign):
+def get_signed_query_params_v2(credentials, expiration, string_to_sign):
     """Gets query parameters for creating a signed URL.
 
     :type credentials: :class:`google.auth.credentials.Signing`
@@ -321,7 +321,7 @@ def generate_signed_url_v2(
     string_to_sign = "\n".join(elements_to_sign)
 
     # Set the right query parameters.
-    signed_query_params = get_signed_query_params(
+    signed_query_params = get_signed_query_params_v2(
         credentials, expiration, string_to_sign
     )
 

--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -348,6 +348,12 @@ def generate_signed_url_v4(
     if headers is None:
         headers = {}
 
+    if content_type is not None:
+        headers["Content-Type"] = content_type
+
+    if content_md5 is not None:
+        headers["Content-MD5"] = content_md5
+
     ordered_headers = sorted(headers.items())
     canonical_headers = "\n".join(
         ["{}:{}".format(key.lower(), val.strip()) for key, val in ordered_headers]

--- a/storage/google/cloud/storage/_signing.py
+++ b/storage/google/cloud/storage/_signing.py
@@ -572,6 +572,10 @@ def generate_signed_url_v4(
     if content_md5 is not None:
         headers["Content-MD5"] = content_md5
 
+    header_names = [key.lower() for key in headers]
+    if "host" not in header_names:
+        headers["Host"] = "storage.googleapis.com"
+
     ordered_headers = sorted(headers.items())
     canonical_headers = "\n".join(
         ["{}:{}".format(key.lower(), val.strip()) for key, val in ordered_headers]

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -54,7 +54,7 @@ from google.cloud.exceptions import NotFound
 from google.api_core.iam import Policy
 from google.cloud.storage._helpers import _PropertyMixin
 from google.cloud.storage._helpers import _scalar_property
-from google.cloud.storage._signing import generate_signed_url
+from google.cloud.storage._signing import generate_signed_url_v2
 from google.cloud.storage.acl import ACL
 from google.cloud.storage.acl import ObjectACL
 
@@ -387,7 +387,7 @@ class Blob(_PropertyMixin):
             client = self._require_client(client)
             credentials = client._credentials
 
-        return generate_signed_url(
+        return generate_signed_url_v2(
             credentials,
             resource=resource,
             api_access_endpoint=_API_ACCESS_ENDPOINT,

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -97,6 +97,12 @@ _NUM_RETRIES_MESSAGE = (
 _READ_LESS_THAN_SIZE = (
     "Size {:d} was specified but the file-like object only had " "{:d} bytes remaining."
 )
+_SIGNED_URL_V2_DEFAULT_MESSAGE = (
+    "You have generated a signed URL using the default v2 signing "
+    "implementation. In the future, this will default to v4. "
+    "You may experience breaking changes if you use longer than 7 day "
+    "expiration times with v4. To opt-in to the behavior specify version='v2'."
+)
 
 _DEFAULT_CHUNKSIZE = 104857600  # 1024 * 1024 B * 100 = 100 MB
 _MAX_MULTIPART_SIZE = 8388608  # 8 MB
@@ -316,7 +322,7 @@ class Blob(_PropertyMixin):
         query_parameters=None,
         client=None,
         credentials=None,
-        version="v2",
+        version=None,
     ):
         """Generates a signed URL for this blob.
 
@@ -421,7 +427,10 @@ class Blob(_PropertyMixin):
         :returns: A signed URL you can use to access the resource
                   until expiration.
         """
-        if version not in ("v2", "v4"):
+        if version is None:
+            version = "v2"
+            warnings.warn(DeprecationWarning(_SIGNED_URL_V2_DEFAULT_MESSAGE))
+        elif version not in ("v2", "v4"):
             raise ValueError("'version' must be either 'v2' or 'v4'")
 
         resource = "/{bucket_name}/{quoted_name}".format(

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -377,6 +377,8 @@ class Blob(_PropertyMixin):
             (Optional) Additional HTTP headers to be included as part of the
             signed URLs.  See:
             https://cloud.google.com/storage/docs/xml-api/reference-headers
+            Requests using the signed URL *must* pass the specified header
+            (name and value) with each request for the URL.
 
         :type query_parameters: dict
         :param query_parameters:

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -350,7 +350,7 @@ class Blob(_PropertyMixin):
                         two must be passed.
 
         :type api_access_endpoint: str
-        :param api_access_endpoint: Optional URI base. Defaults to empty string.
+        :param api_access_endpoint: Optional URI base.
 
         :type method: str
         :param method: The HTTP verb that will be used when requesting the URL.

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -419,7 +419,6 @@ class Blob(_PropertyMixin):
         """
         if version is None:
             version = "v2"
-            warnings.warn(DeprecationWarning(_SIGNED_URL_V2_DEFAULT_MESSAGE))
         elif version not in ("v2", "v4"):
             raise ValueError("'version' must be either 'v2' or 'v4'")
 

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -303,7 +303,8 @@ class Blob(_PropertyMixin):
 
     def generate_signed_url(
         self,
-        expiration,
+        expiration=None,
+        max_age=None,
         api_access_endpoint=_API_ACCESS_ENDPOINT,
         method="GET",
         content_md5=None,
@@ -338,8 +339,15 @@ class Blob(_PropertyMixin):
         accessible blobs, but don't want to require users to explicitly
         log in.
 
-        :type expiration: int, long, datetime.datetime, datetime.timedelta
-        :param expiration: When the signed URL should expire.
+        :type expiration: Union[Integer, datetime.datetime, datetime.timedelta]
+        :param expiration: Point in time when the signed URL should expire.
+                           Exclusive with :arg:`max_age`: exactly one of the
+                           two must be passed.
+
+        :type max_age: Integer
+        :param max_age: Max number of seconds until the signature expires.
+                        Exclusive with :arg:`expiration`: exactly one of the
+                        two must be passed.
 
         :type api_access_endpoint: str
         :param api_access_endpoint: Optional URI base. Defaults to empty string.
@@ -403,6 +411,8 @@ class Blob(_PropertyMixin):
                         Must be one of 'v2' | 'v4'.
 
         :raises: :exc:`ValueError` when version is invalid.
+        :raises: :exc:`ValueError` when both :arg:`expiration` and
+                 :arg:`max_age` are passed, or when neither is passed.
         :raises: :exc:`TypeError` when expiration is not a valid type.
         :raises: :exc:`AttributeError` if credentials is not an instance
                 of :class:`google.auth.credentials.Signing`.
@@ -431,6 +441,7 @@ class Blob(_PropertyMixin):
             credentials,
             resource=resource,
             expiration=expiration,
+            max_age=max_age,
             api_access_endpoint=api_access_endpoint,
             method=method.upper(),
             content_md5=content_md5,

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -97,12 +97,6 @@ _NUM_RETRIES_MESSAGE = (
 _READ_LESS_THAN_SIZE = (
     "Size {:d} was specified but the file-like object only had " "{:d} bytes remaining."
 )
-_SIGNED_URL_V2_DEFAULT_MESSAGE = (
-    "You have generated a signed URL using the default v2 signing "
-    "implementation. In the future, this will default to v4. "
-    "You may experience breaking changes if you use longer than 7 day "
-    "expiration times with v4. To opt-in to the behavior specify version='v2'."
-)
 
 _DEFAULT_CHUNKSIZE = 104857600  # 1024 * 1024 B * 100 = 100 MB
 _MAX_MULTIPART_SIZE = 8388608  # 8 MB

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -304,11 +304,15 @@ class Blob(_PropertyMixin):
     def generate_signed_url(
         self,
         expiration,
+        api_access_endpoint=_API_ACCESS_ENDPOINT,
         method="GET",
+        content_md5=None,
         content_type=None,
-        generation=None,
         response_disposition=None,
         response_type=None,
+        generation=None,
+        headers=None,
+        query_parameters=None,
         client=None,
         credentials=None,
         version="v2",
@@ -337,16 +341,19 @@ class Blob(_PropertyMixin):
         :type expiration: int, long, datetime.datetime, datetime.timedelta
         :param expiration: When the signed URL should expire.
 
+        :type api_access_endpoint: str
+        :param api_access_endpoint: Optional URI base. Defaults to empty string.
+
         :type method: str
         :param method: The HTTP verb that will be used when requesting the URL.
+
+        :type content_md5: str
+        :param content_md5: (Optional) The MD5 hash of the object referenced by
+                            ``resource``.
 
         :type content_type: str
         :param content_type: (Optional) The content type of the object
                              referenced by ``resource``.
-
-        :type generation: str
-        :param generation: (Optional) A value that indicates which generation
-                           of the resource to fetch.
 
         :type response_disposition: str
         :param response_disposition: (Optional) Content disposition of
@@ -360,6 +367,22 @@ class Blob(_PropertyMixin):
         :param response_type: (Optional) Content type of responses to requests
                               for the signed URL. Used to over-ride the content
                               type of the underlying blob/object.
+
+        :type generation: str
+        :param generation: (Optional) A value that indicates which generation
+                           of the resource to fetch.
+
+        :type headers: dict
+        :param headers:
+            (Optional) Additional HTTP headers to be included as part of the
+            signed URLs.  See:
+            https://cloud.google.com/storage/docs/xml-api/reference-headers
+
+        :type query_parameters: dict
+        :param query_parameters:
+            (Optional) Additional query paramtersto be included as part of the
+            signed URLs.  See:
+            https://cloud.google.com/storage/docs/xml-api/reference-headers#query
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
@@ -398,29 +421,24 @@ class Blob(_PropertyMixin):
             credentials = client._credentials
 
         if version == "v2":
-            return generate_signed_url_v2(
-                credentials,
-                resource=resource,
-                api_access_endpoint=_API_ACCESS_ENDPOINT,
-                expiration=expiration,
-                method=method.upper(),
-                content_type=content_type,
-                response_type=response_type,
-                response_disposition=response_disposition,
-                generation=generation,
-            )
+            helper = generate_signed_url_v2
         else:
-            return generate_signed_url_v4(
-                credentials,
-                resource=resource,
-                api_access_endpoint=_API_ACCESS_ENDPOINT,
-                expiration=expiration,
-                method=method.upper(),
-                content_type=content_type,
-                response_type=response_type,
-                response_disposition=response_disposition,
-                generation=generation,
-            )
+            helper = generate_signed_url_v4
+
+        return helper(
+            credentials,
+            resource=resource,
+            expiration=expiration,
+            api_access_endpoint=api_access_endpoint,
+            method=method.upper(),
+            content_md5=content_md5,
+            content_type=content_type,
+            response_type=response_type,
+            response_disposition=response_disposition,
+            generation=generation,
+            headers=headers,
+            query_parameters=query_parameters,
+        )
 
     def exists(self, client=None):
         """Determines whether or not this blob exists.

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -310,7 +310,6 @@ class Blob(_PropertyMixin):
     def generate_signed_url(
         self,
         expiration=None,
-        max_age=None,
         api_access_endpoint=_API_ACCESS_ENDPOINT,
         method="GET",
         content_md5=None,
@@ -347,13 +346,6 @@ class Blob(_PropertyMixin):
 
         :type expiration: Union[Integer, datetime.datetime, datetime.timedelta]
         :param expiration: Point in time when the signed URL should expire.
-                           Exclusive with :arg:`max_age`: exactly one of the
-                           two must be passed.
-
-        :type max_age: Integer
-        :param max_age: Max number of seconds until the signature expires.
-                        Exclusive with :arg:`expiration`: exactly one of the
-                        two must be passed.
 
         :type api_access_endpoint: str
         :param api_access_endpoint: Optional URI base.
@@ -417,8 +409,6 @@ class Blob(_PropertyMixin):
                         Must be one of 'v2' | 'v4'.
 
         :raises: :exc:`ValueError` when version is invalid.
-        :raises: :exc:`ValueError` when both :arg:`expiration` and
-                 :arg:`max_age` are passed, or when neither is passed.
         :raises: :exc:`TypeError` when expiration is not a valid type.
         :raises: :exc:`AttributeError` if credentials is not an instance
                 of :class:`google.auth.credentials.Signing`.
@@ -450,7 +440,6 @@ class Blob(_PropertyMixin):
             credentials,
             resource=resource,
             expiration=expiration,
-            max_age=max_age,
             api_access_endpoint=api_access_endpoint,
             method=method.upper(),
             content_md5=content_md5,

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -37,6 +37,7 @@ from google.cloud.storage._signing import generate_signed_url_v2
 from google.cloud.storage._signing import generate_signed_url_v4
 from google.cloud.storage.acl import BucketACL
 from google.cloud.storage.acl import DefaultObjectACL
+from google.cloud.storage.blob import _SIGNED_URL_V2_DEFAULT_MESSAGE
 from google.cloud.storage.blob import Blob
 from google.cloud.storage.notification import BucketNotification
 from google.cloud.storage.notification import NONE_PAYLOAD_FORMAT
@@ -1983,7 +1984,7 @@ class Bucket(_PropertyMixin):
         query_parameters=None,
         client=None,
         credentials=None,
-        version="v2",
+        version=None,
     ):
         """Generates a signed URL for this bucket.
 
@@ -2063,7 +2064,10 @@ class Bucket(_PropertyMixin):
         :returns: A signed URL you can use to access the resource
                   until expiration.
         """
-        if version not in ("v2", "v4"):
+        if version is None:
+            version = "v2"
+            warnings.warn(DeprecationWarning(_SIGNED_URL_V2_DEFAULT_MESSAGE))
+        elif version not in ("v2", "v4"):
             raise ValueError("'version' must be either 'v2' or 'v4'")
 
         resource = "/{bucket_name}".format(bucket_name=self.name)

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -37,7 +37,6 @@ from google.cloud.storage._signing import generate_signed_url_v2
 from google.cloud.storage._signing import generate_signed_url_v4
 from google.cloud.storage.acl import BucketACL
 from google.cloud.storage.acl import DefaultObjectACL
-from google.cloud.storage.blob import _SIGNED_URL_V2_DEFAULT_MESSAGE
 from google.cloud.storage.blob import Blob
 from google.cloud.storage.notification import BucketNotification
 from google.cloud.storage.notification import NONE_PAYLOAD_FORMAT
@@ -2056,7 +2055,6 @@ class Bucket(_PropertyMixin):
         """
         if version is None:
             version = "v2"
-            warnings.warn(DeprecationWarning(_SIGNED_URL_V2_DEFAULT_MESSAGE))
         elif version not in ("v2", "v4"):
             raise ValueError("'version' must be either 'v2' or 'v4'")
 

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -33,6 +33,8 @@ from google.cloud.storage import _signing
 from google.cloud.storage._helpers import _PropertyMixin
 from google.cloud.storage._helpers import _scalar_property
 from google.cloud.storage._helpers import _validate_name
+from google.cloud.storage._signing import generate_signed_url_v2
+from google.cloud.storage._signing import generate_signed_url_v4
 from google.cloud.storage.acl import BucketACL
 from google.cloud.storage.acl import DefaultObjectACL
 from google.cloud.storage.blob import Blob
@@ -45,6 +47,7 @@ _LOCATION_SETTER_MESSAGE = (
     "valid before the bucket is created. Instead, pass the location "
     "to `Bucket.create`."
 )
+_API_ACCESS_ENDPOINT = "https://storage.googleapis.com"
 
 
 def _blobs_page_start(iterator, page, response):
@@ -1969,3 +1972,118 @@ class Bucket(_PropertyMixin):
             method="POST", path=path, query_params=query_params, _target_object=self
         )
         self._set_properties(api_response)
+
+    def generate_signed_url(
+        self,
+        expiration=None,
+        max_age=None,
+        api_access_endpoint=_API_ACCESS_ENDPOINT,
+        method="GET",
+        headers=None,
+        query_parameters=None,
+        client=None,
+        credentials=None,
+        version="v2",
+    ):
+        """Generates a signed URL for this bucket.
+
+        .. note::
+
+            If you are on Google Compute Engine, you can't generate a signed
+            URL using GCE service account. Follow `Issue 50`_ for updates on
+            this. If you'd like to be able to generate a signed URL from GCE,
+            you can use a standard service account from a JSON file rather
+            than a GCE service account.
+
+        .. _Issue 50: https://github.com/GoogleCloudPlatform/\
+                      google-auth-library-python/issues/50
+
+        If you have a bucket that you want to allow access to for a set
+        amount of time, you can use this method to generate a URL that
+        is only valid within a certain time period.
+
+        This is particularly useful if you don't want publicly
+        accessible buckets, but don't want to require users to explicitly
+        log in.
+
+        :type expiration: Union[Integer, datetime.datetime, datetime.timedelta]
+        :param expiration: Point in time when the signed URL should expire.
+                           Exclusive with :arg:`max_age`: exactly one of the
+                           two must be passed.
+
+        :type max_age: Integer
+        :param max_age: Max number of seconds until the signature expires.
+                        Exclusive with :arg:`expiration`: exactly one of the
+                        two must be passed.
+
+        :type api_access_endpoint: str
+        :param api_access_endpoint: Optional URI base.
+
+        :type method: str
+        :param method: The HTTP verb that will be used when requesting the URL.
+
+        :type headers: dict
+        :param headers:
+            (Optional) Additional HTTP headers to be included as part of the
+            signed URLs.  See:
+            https://cloud.google.com/storage/docs/xml-api/reference-headers
+            Requests using the signed URL *must* pass the specified header
+            (name and value) with each request for the URL.
+
+        :type query_parameters: dict
+        :param query_parameters:
+            (Optional) Additional query paramtersto be included as part of the
+            signed URLs.  See:
+            https://cloud.google.com/storage/docs/xml-api/reference-headers#query
+
+        :type client: :class:`~google.cloud.storage.client.Client` or
+                      ``NoneType``
+        :param client: (Optional) The client to use.  If not passed, falls back
+                       to the ``client`` stored on the blob's bucket.
+
+
+        :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
+                           :class:`NoneType`
+        :param credentials: (Optional) The OAuth2 credentials to use to sign
+                            the URL. Defaults to the credentials stored on the
+                            client used.
+
+        :type version: str
+        :param version: (Optional) The version of signed credential to create.
+                        Must be one of 'v2' | 'v4'.
+
+        :raises: :exc:`ValueError` when version is invalid.
+        :raises: :exc:`ValueError` when both :arg:`expiration` and
+                 :arg:`max_age` are passed, or when neither is passed.
+        :raises: :exc:`TypeError` when expiration is not a valid type.
+        :raises: :exc:`AttributeError` if credentials is not an instance
+                of :class:`google.auth.credentials.Signing`.
+
+        :rtype: str
+        :returns: A signed URL you can use to access the resource
+                  until expiration.
+        """
+        if version not in ("v2", "v4"):
+            raise ValueError("'version' must be either 'v2' or 'v4'")
+
+        resource = "/{bucket_name}".format(bucket_name=self.name)
+
+        if credentials is None:
+            client = self._require_client(client)
+            credentials = client._credentials
+
+        if version == "v2":
+            helper = generate_signed_url_v2
+        else:
+            helper = generate_signed_url_v4
+
+        return helper(
+            credentials,
+            resource=resource,
+            expiration=expiration,
+            max_age=max_age,
+            api_access_endpoint=api_access_endpoint,
+            method=method.upper(),
+            headers=headers,
+            query_parameters=query_parameters,
+        )

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -1977,7 +1977,6 @@ class Bucket(_PropertyMixin):
     def generate_signed_url(
         self,
         expiration=None,
-        max_age=None,
         api_access_endpoint=_API_ACCESS_ENDPOINT,
         method="GET",
         headers=None,
@@ -2009,13 +2008,6 @@ class Bucket(_PropertyMixin):
 
         :type expiration: Union[Integer, datetime.datetime, datetime.timedelta]
         :param expiration: Point in time when the signed URL should expire.
-                           Exclusive with :arg:`max_age`: exactly one of the
-                           two must be passed.
-
-        :type max_age: Integer
-        :param max_age: Max number of seconds until the signature expires.
-                        Exclusive with :arg:`expiration`: exactly one of the
-                        two must be passed.
 
         :type api_access_endpoint: str
         :param api_access_endpoint: Optional URI base.
@@ -2054,8 +2046,6 @@ class Bucket(_PropertyMixin):
                         Must be one of 'v2' | 'v4'.
 
         :raises: :exc:`ValueError` when version is invalid.
-        :raises: :exc:`ValueError` when both :arg:`expiration` and
-                 :arg:`max_age` are passed, or when neither is passed.
         :raises: :exc:`TypeError` when expiration is not a valid type.
         :raises: :exc:`AttributeError` if credentials is not an instance
                 of :class:`google.auth.credentials.Signing`.
@@ -2085,7 +2075,6 @@ class Bucket(_PropertyMixin):
             credentials,
             resource=resource,
             expiration=expiration,
-            max_age=max_age,
             api_access_endpoint=api_access_endpoint,
             method=method.upper(),
             headers=headers,

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -783,6 +783,9 @@ class TestStorageSignURLs(TestStorageFiles):
     def test_create_signed_read_url_v2(self):
         self._create_signed_read_url_helper()
 
+    def test_create_signed_read_url_v4(self):
+        self._create_signed_read_url_helper(version="v4")
+
     def test_create_signed_read_url_v2_w_expiration(self):
         now = datetime.datetime.utcnow()
         delta = datetime.timedelta(seconds=10)

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -780,11 +780,9 @@ class TestStorageSignURLs(unittest.TestCase):
 
         self._create_signed_list_blobs_url_helper(expiration=now + delta, version="v2")
 
-    @pytest.mark.skip(reason="Back-end case-flattening bug: revisit 2019-04-03")
     def test_create_signed_list_blobs_url_v4(self):
         self._create_signed_list_blobs_url_helper(version="v4")
 
-    @pytest.mark.skip(reason="Back-end case-flattening bug: revisit 2019-04-03")
     def test_create_signed_list_blobs_url_v4_w_expiration(self):
         now = datetime.datetime.utcnow()
         delta = datetime.timedelta(seconds=10)

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -729,7 +729,7 @@ class TestStorageSignURLs(TestStorageFiles):
 
         if (
             type(Config.CLIENT._credentials)
-            is not google.oauth2.service_account.credentials
+            is not google.oauth2.service_account.Credentials
         ):
             self.skipTest("Signing tests requires a service account credential")
 

--- a/storage/tests/unit/test__signing.py
+++ b/storage/tests/unit/test__signing.py
@@ -320,7 +320,10 @@ class Test_get_canonical_headers(unittest.TestCase):
         expected = ["bar:baz,bam,qux", "foo:Foo 1.2.3"]
         self.assertEqual(self._call_fut(headers), expected)
 
-    # TODO:  handle folded line values?
+    def test_w_embedded_ws(self):
+        headers = {"foo": "Foo\n1.2.3", "Bar": "   baz   bam   qux   "}
+        expected = ["bar:baz bam qux", "foo:Foo 1.2.3"]
+        self.assertEqual(self._call_fut(headers), expected)
 
 
 class Test_canonicalize(unittest.TestCase):

--- a/storage/tests/unit/test__signing.py
+++ b/storage/tests/unit/test__signing.py
@@ -261,10 +261,10 @@ class Test_generate_signed_url_v2(unittest.TestCase):
         self._generate_helper(headers={"x-goog-foo": "bar"})
 
     def test_w_custom_query_parameters_w_string_value(self):
-        self._generate_helper(query_parameters={"delimiter": "/"})
+        self._generate_helper(query_parameters={"bar": "/"})
 
     def test_w_custom_query_parameters_w_none_value(self):
-        self._generate_helper(query_parameters={"acl": None})
+        self._generate_helper(query_parameters={"qux": None})
 
     def test_with_google_credentials(self):
         resource = "/name/path"
@@ -399,10 +399,10 @@ class Test_generate_signed_url_v4(unittest.TestCase):
         self._generate_helper(headers={"x-goog-foo": "bar"})
 
     def test_w_custom_query_parameters_w_string_value(self):
-        self._generate_helper(query_parameters={"delimiter": "/"})
+        self._generate_helper(query_parameters={"bar": "/"})
 
     def test_w_custom_query_parameters_w_none_value(self):
-        self._generate_helper(query_parameters={"acl": None})
+        self._generate_helper(query_parameters={"qux": None})
 
 
 def _make_credentials(signer_email=None):

--- a/storage/tests/unit/test__signing.py
+++ b/storage/tests/unit/test__signing.py
@@ -264,7 +264,7 @@ class Test_generate_signed_url_v4(unittest.TestCase):
         self.assertEqual(params["X-Goog-Expires"], str(expiration))
 
         signed = binascii.hexlify(credentials.sign_bytes.return_value).decode("ascii")
-        self.assertEqual(params["x-goog-signature"], signed)
+        self.assertEqual(params["X-Goog-Signature"], signed)
 
         if response_type is not None:
             self.assertEqual(params["response-content-type"], response_type)

--- a/storage/tests/unit/test__signing.py
+++ b/storage/tests/unit/test__signing.py
@@ -148,7 +148,6 @@ class Test_generate_signed_url_v2(unittest.TestCase):
     ):
         from six.moves.urllib.parse import urlencode
 
-        endpoint = "http://api.example.com"
         resource = "/name/path"
         credentials = _make_credentials(signer_email="service@example.com")
         credentials.sign_bytes.return_value = b"DEADBEEF"

--- a/storage/tests/unit/test__signing.py
+++ b/storage/tests/unit/test__signing.py
@@ -681,6 +681,7 @@ def _run_conformance_test(resource, test_data):
 
     assert url == test_data["expectedUrl"]
 
+
 @pytest.mark.parametrize("test_data", _CLIENT_TESTS)
 @pytest.mark.skip(reason="Bucketless URLs not yet supported")
 def test_conformance_client(test_data):

--- a/storage/tests/unit/test__signing.py
+++ b/storage/tests/unit/test__signing.py
@@ -102,12 +102,12 @@ class Test_get_expiration_seconds(unittest.TestCase):
         utcnow.assert_called_once_with()
 
 
-class Test_get_signed_query_params(unittest.TestCase):
+class Test_get_signed_query_params_v2(unittest.TestCase):
     @staticmethod
     def _call_fut(credentials, expiration, string_to_sign):
-        from google.cloud.storage._signing import get_signed_query_params
+        from google.cloud.storage._signing import get_signed_query_params_v2
 
-        return get_signed_query_params(credentials, expiration, string_to_sign)
+        return get_signed_query_params_v2(credentials, expiration, string_to_sign)
 
     def test_it(self):
         sig_bytes = b"DEADBEEF"

--- a/storage/tests/unit/test__signing.py
+++ b/storage/tests/unit/test__signing.py
@@ -83,6 +83,7 @@ class Test_get_expiration_seconds_v2(unittest.TestCase):
         when = dummy_utcnow + delta
         expiration = _utc_seconds(when)
         self.assertEqual(result, expiration)
+        utcnow.assert_called_once_with()
 
     def test_w_expiration_int(self):
         self.assertEqual(self._call_fut(123, None), 123)
@@ -181,7 +182,8 @@ class Test_get_expiration_seconds_v4(unittest.TestCase):
 
         with patch as utcnow:
             with self.assertRaises(ValueError):
-                result = self._call_fut(expiration_seconds, None)
+                self._call_fut(expiration_seconds, None)
+        utcnow.assert_called_once_with()
 
     def test_w_expiration_int(self):
         dummy_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0)

--- a/storage/tests/unit/test__signing.py
+++ b/storage/tests/unit/test__signing.py
@@ -302,13 +302,19 @@ class Test_get_canonical_headers(unittest.TestCase):
 
     def test_w_none(self):
         headers = None
-        expected = []
-        self.assertEqual(self._call_fut(headers), expected)
+        expected_canonical = []
+        expected_ordered = []
+        canonical, ordered = self._call_fut(headers)
+        self.assertEqual(canonical, expected_canonical)
+        self.assertEqual(ordered, expected_ordered)
 
     def test_w_dict(self):
         headers = {"foo": "Foo 1.2.3", "Bar": " baz,bam,qux   "}
-        expected = ["bar:baz,bam,qux", "foo:Foo 1.2.3"]
-        self.assertEqual(self._call_fut(headers), expected)
+        expected_canonical = ["bar:baz,bam,qux", "foo:Foo 1.2.3"]
+        expected_ordered = [tuple(item.split(":")) for item in expected_canonical]
+        canonical, ordered = self._call_fut(headers)
+        self.assertEqual(canonical, expected_canonical)
+        self.assertEqual(ordered, expected_ordered)
 
     def test_w_list_and_multiples(self):
         headers = [
@@ -317,13 +323,19 @@ class Test_get_canonical_headers(unittest.TestCase):
             ("Bar", "bam"),
             ("Bar", "qux   "),
         ]
-        expected = ["bar:baz,bam,qux", "foo:Foo 1.2.3"]
-        self.assertEqual(self._call_fut(headers), expected)
+        expected_canonical = ["bar:baz,bam,qux", "foo:Foo 1.2.3"]
+        expected_ordered = [tuple(item.split(":")) for item in expected_canonical]
+        canonical, ordered = self._call_fut(headers)
+        self.assertEqual(canonical, expected_canonical)
+        self.assertEqual(ordered, expected_ordered)
 
     def test_w_embedded_ws(self):
         headers = {"foo": "Foo\n1.2.3", "Bar": "   baz   bam   qux   "}
-        expected = ["bar:baz bam qux", "foo:Foo 1.2.3"]
-        self.assertEqual(self._call_fut(headers), expected)
+        expected_canonical = ["bar:baz bam qux", "foo:Foo 1.2.3"]
+        expected_ordered = [tuple(item.split(":")) for item in expected_canonical]
+        canonical, ordered = self._call_fut(headers)
+        self.assertEqual(canonical, expected_canonical)
+        self.assertEqual(ordered, expected_ordered)
 
 
 class Test_canonicalize(unittest.TestCase):

--- a/storage/tests/unit/test__signing.py
+++ b/storage/tests/unit/test__signing.py
@@ -616,6 +616,9 @@ class Test_generate_signed_url_v4(unittest.TestCase):
     def test_w_generation(self):
         self._generate_helper(generation=12345)
 
+    def test_w_custom_host_header(self):
+        self._generate_helper(headers={"Host": "api.example.com"})
+
     def test_w_custom_headers(self):
         self._generate_helper(headers={"x-goog-foo": "bar"})
 

--- a/storage/tests/unit/test__signing.py
+++ b/storage/tests/unit/test__signing.py
@@ -126,12 +126,12 @@ class Test_get_signed_query_params(unittest.TestCase):
         credentials.sign_bytes.assert_called_once_with(string_to_sign)
 
 
-class Test_generate_signed_url(unittest.TestCase):
+class Test_generate_signed_url_v2(unittest.TestCase):
     @staticmethod
     def _call_fut(*args, **kwargs):
-        from google.cloud.storage._signing import generate_signed_url
+        from google.cloud.storage._signing import generate_signed_url_v2
 
-        return generate_signed_url(*args, **kwargs)
+        return generate_signed_url_v2(*args, **kwargs)
 
     def _generate_helper(
         self, response_type=None, response_disposition=None, generation=None

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -377,7 +377,6 @@ class Test_Blob(unittest.TestCase):
         query_parameters=None,
         credentials=None,
         expiration=None,
-        max_age=None,
     ):
         from six.moves.urllib import parse
         from google.cloud._helpers import UTC
@@ -387,7 +386,7 @@ class Test_Blob(unittest.TestCase):
 
         delta = datetime.timedelta(hours=1)
 
-        if expiration is None and max_age is None:
+        if expiration is None:
             expiration = datetime.datetime.utcnow().replace(tzinfo=UTC) + delta
 
         connection = _Connection()
@@ -401,13 +400,13 @@ class Test_Blob(unittest.TestCase):
             effective_version = version
 
         to_patch = "google.cloud.storage.blob.generate_signed_url_{}".format(
-            effective_version)
+            effective_version
+        )
 
         with mock.patch(to_patch) as signer:
             with warnings.catch_warnings(record=True) as warned:
                 signed_uri = blob.generate_signed_url(
                     expiration=expiration,
-                    max_age=max_age,
                     api_access_endpoint=api_access_endpoint,
                     method=method,
                     credentials=credentials,
@@ -439,7 +438,6 @@ class Test_Blob(unittest.TestCase):
         expected_kwargs = {
             "resource": expected_resource,
             "expiration": expiration,
-            "max_age": max_age,
             "api_access_endpoint": api_access_endpoint,
             "method": method.upper(),
             "content_md5": content_md5,
@@ -467,9 +465,6 @@ class Test_Blob(unittest.TestCase):
 
         expiration = datetime.datetime.utcnow().replace(tzinfo=UTC)
         self._generate_signed_url_v2_helper(expiration=expiration)
-
-    def test_generate_signed_url_v2_w_max_age(self):
-        self._generate_signed_url_v2_helper(max_age=3600)
 
     def test_generate_signed_url_v2_w_non_ascii_name(self):
         BLOB_NAME = u"\u0410\u043a\u043a\u043e\u0440\u0434\u044b.txt"

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -524,14 +524,14 @@ class Test_Blob(unittest.TestCase):
         self._generate_signed_url_v4_helper(credentials=credentials)
 
     @mock.patch(
-        "google.cloud.storage._signing.get_signed_query_params",
+        "google.cloud.storage._signing.get_signed_query_params_v2",
         return_value={
             "GoogleAccessId": "service-account-name",
             "Expires": 12345,
             "Signature": "signed-data",
         },
     )
-    def test_generate_resumable_signed_url(self, mock_get_signed_query_params):
+    def test_generate_resumable_signed_url(self, mock_get_signed_query_params_v2):
         """
         Verify correct behavior of resumable upload URL generation
         """
@@ -544,7 +544,7 @@ class Test_Blob(unittest.TestCase):
             _make_credentials(), "a-bucket", expiry, method="RESUMABLE"
         )
 
-        self.assertTrue(mock_get_signed_query_params.called)
+        self.assertTrue(mock_get_signed_query_params_v2.called)
         self.assertGreater(len(signed_url), 0)
         self.assertIn("a-bucket", signed_url)
         self.assertIn("GoogleAccessId", signed_url)

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -443,7 +443,6 @@ class Test_Blob(unittest.TestCase):
         self._generate_signed_url_v2_helper(blob_name=BLOB_NAME)
 
     def test_generate_signed_url_v2_w_endpoint(self):
-        credentials = object()
         self._generate_signed_url_v2_helper(
             api_access_endpoint="https://api.example.com/v1"
         )
@@ -492,7 +491,6 @@ class Test_Blob(unittest.TestCase):
         self._generate_signed_url_v4_helper(blob_name=BLOB_NAME)
 
     def test_generate_signed_url_v4_w_endpoint(self):
-        credentials = object()
         self._generate_signed_url_v4_helper(
             api_access_endpoint="https://api.example.com/v1"
         )

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -20,7 +20,6 @@ import json
 import os
 import tempfile
 import unittest
-import warnings
 
 import google.cloud.storage.blob
 import mock
@@ -404,27 +403,20 @@ class Test_Blob(unittest.TestCase):
         )
 
         with mock.patch(to_patch) as signer:
-            with warnings.catch_warnings(record=True) as warned:
-                signed_uri = blob.generate_signed_url(
-                    expiration=expiration,
-                    api_access_endpoint=api_access_endpoint,
-                    method=method,
-                    credentials=credentials,
-                    content_md5=content_md5,
-                    content_type=content_type,
-                    response_type=response_type,
-                    response_disposition=response_disposition,
-                    generation=generation,
-                    headers=headers,
-                    query_parameters=query_parameters,
-                    version=version,
-                )
-
-        if version is None:
-            self.assertEqual(len(warned), 1)
-            self.assertIs(warned[0].category, DeprecationWarning)
-        else:
-            self.assertEqual(len(warned), 0)
+            signed_uri = blob.generate_signed_url(
+                expiration=expiration,
+                api_access_endpoint=api_access_endpoint,
+                method=method,
+                credentials=credentials,
+                content_md5=content_md5,
+                content_type=content_type,
+                response_type=response_type,
+                response_disposition=response_disposition,
+                generation=generation,
+                headers=headers,
+                query_parameters=query_parameters,
+                version=version,
+            )
 
         self.assertEqual(signed_uri, signer.return_value)
 

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -364,7 +364,7 @@ class Test_Blob(unittest.TestCase):
         )
 
         SIGNER = _Signer()
-        with mock.patch("google.cloud.storage.blob.generate_signed_url", new=SIGNER):
+        with mock.patch("google.cloud.storage.blob.generate_signed_url_v2", new=SIGNER):
             signed_uri = blob.generate_signed_url(EXPIRATION, credentials=credentials)
             self.assertEqual(signed_uri, URI)
 
@@ -402,7 +402,7 @@ class Test_Blob(unittest.TestCase):
 
         SIGNER = _Signer()
         CONTENT_TYPE = "text/html"
-        with mock.patch("google.cloud.storage.blob.generate_signed_url", new=SIGNER):
+        with mock.patch("google.cloud.storage.blob.generate_signed_url_v2", new=SIGNER):
             signed_url = blob.generate_signed_url(EXPIRATION, content_type=CONTENT_TYPE)
             self.assertEqual(signed_url, URI)
 
@@ -437,7 +437,7 @@ class Test_Blob(unittest.TestCase):
         )
 
         SIGNER = _Signer()
-        with mock.patch("google.cloud.storage.blob.generate_signed_url", new=SIGNER):
+        with mock.patch("google.cloud.storage.blob.generate_signed_url_v2", new=SIGNER):
             signed_url = blob.generate_signed_url(EXPIRATION, method="get")
             self.assertEqual(signed_url, URI)
 
@@ -468,7 +468,7 @@ class Test_Blob(unittest.TestCase):
         )
 
         SIGNER = _Signer()
-        with mock.patch("google.cloud.storage.blob.generate_signed_url", new=SIGNER):
+        with mock.patch("google.cloud.storage.blob.generate_signed_url_v2", new=SIGNER):
             signed_url = blob.generate_signed_url(EXPIRATION)
             self.assertEqual(signed_url, URI)
 
@@ -498,7 +498,7 @@ class Test_Blob(unittest.TestCase):
         )
 
         SIGNER = _Signer()
-        with mock.patch("google.cloud.storage.blob.generate_signed_url", new=SIGNER):
+        with mock.patch("google.cloud.storage.blob.generate_signed_url_v2", new=SIGNER):
             signed_url = blob.generate_signed_url(EXPIRATION)
             self.assertEqual(signed_url, URI)
 
@@ -528,7 +528,7 @@ class Test_Blob(unittest.TestCase):
         )
 
         SIGNER = _Signer()
-        with mock.patch("google.cloud.storage.blob.generate_signed_url", new=SIGNER):
+        with mock.patch("google.cloud.storage.blob.generate_signed_url_v2", new=SIGNER):
             signed_uri = blob.generate_signed_url(EXPIRATION, method="POST")
             self.assertEqual(signed_uri, URI)
 
@@ -559,11 +559,11 @@ class Test_Blob(unittest.TestCase):
         Verify correct behavior of resumable upload URL generation
         """
         from google.cloud.storage._signing import get_expiration_seconds
-        from google.cloud.storage._signing import generate_signed_url
+        from google.cloud.storage._signing import generate_signed_url_v2
 
         expiry = get_expiration_seconds(datetime.timedelta(hours=1))
 
-        signed_url = generate_signed_url(
+        signed_url = generate_signed_url_v2(
             _make_credentials(), "a-bucket", expiry, method="RESUMABLE"
         )
 

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -410,7 +410,8 @@ class Test_Blob(unittest.TestCase):
         else:
             expected_creds = credentials
 
-        expected_resource = parse.quote("/name/{}".format(blob_name))
+        encoded_name = blob_name.encode("utf-8")
+        expected_resource = "/name/{}".format(parse.quote(encoded_name))
         expected_kwargs = {
             "resource": expected_resource,
             "expiration": EXPIRATION,

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -2597,7 +2597,6 @@ class Test_Bucket(unittest.TestCase):
         query_parameters=None,
         credentials=None,
         expiration=None,
-        max_age=None,
     ):
         from six.moves.urllib import parse
         from google.cloud._helpers import UTC
@@ -2607,7 +2606,7 @@ class Test_Bucket(unittest.TestCase):
 
         delta = datetime.timedelta(hours=1)
 
-        if expiration is None and max_age is None:
+        if expiration is None:
             expiration = datetime.datetime.utcnow().replace(tzinfo=UTC) + delta
 
         connection = _Connection()
@@ -2620,13 +2619,13 @@ class Test_Bucket(unittest.TestCase):
             effective_version = version
 
         to_patch = "google.cloud.storage.bucket.generate_signed_url_{}".format(
-            effective_version)
+            effective_version
+        )
 
         with mock.patch(to_patch) as signer:
             with warnings.catch_warnings(record=True) as warned:
                 signed_uri = bucket.generate_signed_url(
                     expiration=expiration,
-                    max_age=max_age,
                     api_access_endpoint=api_access_endpoint,
                     method=method,
                     credentials=credentials,
@@ -2653,7 +2652,6 @@ class Test_Bucket(unittest.TestCase):
         expected_kwargs = {
             "resource": expected_resource,
             "expiration": expiration,
-            "max_age": max_age,
             "api_access_endpoint": api_access_endpoint,
             "method": method.upper(),
             "headers": headers,
@@ -2676,9 +2674,6 @@ class Test_Bucket(unittest.TestCase):
 
         expiration = datetime.datetime.utcnow().replace(tzinfo=UTC)
         self._generate_signed_url_v2_helper(expiration=expiration)
-
-    def test_generate_signed_url_v2_w_max_age(self):
-        self._generate_signed_url_v2_helper(max_age=3600)
 
     def test_generate_signed_url_v2_w_endpoint(self):
         self._generate_signed_url_v2_helper(

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -2573,6 +2573,168 @@ class Test_Bucket(unittest.TestCase):
             {"ifMetagenerationMatch": 1234, "userProject": user_project},
         )
 
+    def test_generate_signed_url_w_invalid_version(self):
+        expiration = "2014-10-16T20:34:37.000Z"
+        connection = _Connection()
+        client = _Client(connection)
+        bucket = self._make_one(name="bucket_name", client=client)
+        with self.assertRaises(ValueError):
+            bucket.generate_signed_url(expiration, version="nonesuch")
+
+    def _generate_signed_url_helper(
+        self,
+        version,
+        bucket_name="bucket-name",
+        api_access_endpoint=None,
+        method="GET",
+        content_md5=None,
+        content_type=None,
+        response_type=None,
+        response_disposition=None,
+        generation=None,
+        headers=None,
+        query_parameters=None,
+        credentials=None,
+        expiration=None,
+        max_age=None,
+    ):
+        from six.moves.urllib import parse
+        from google.cloud._helpers import UTC
+        from google.cloud.storage.blob import _API_ACCESS_ENDPOINT
+
+        api_access_endpoint = api_access_endpoint or _API_ACCESS_ENDPOINT
+
+        delta = datetime.timedelta(hours=1)
+
+        if expiration is None and max_age is None:
+            expiration = datetime.datetime.utcnow().replace(tzinfo=UTC) + delta
+
+        connection = _Connection()
+        client = _Client(connection)
+        bucket = self._make_one(name=bucket_name, client=client)
+        to_patch = "google.cloud.storage.bucket.generate_signed_url_{}".format(version)
+
+        with mock.patch(to_patch) as signer:
+            signed_uri = bucket.generate_signed_url(
+                expiration=expiration,
+                max_age=max_age,
+                api_access_endpoint=api_access_endpoint,
+                method=method,
+                credentials=credentials,
+                headers=headers,
+                query_parameters=query_parameters,
+                version=version,
+            )
+
+        self.assertEqual(signed_uri, signer.return_value)
+
+        if credentials is None:
+            expected_creds = client._credentials
+        else:
+            expected_creds = credentials
+
+        encoded_name = bucket_name.encode("utf-8")
+        expected_resource = "/{}".format(parse.quote(encoded_name))
+        expected_kwargs = {
+            "resource": expected_resource,
+            "expiration": expiration,
+            "max_age": max_age,
+            "api_access_endpoint": api_access_endpoint,
+            "method": method.upper(),
+            "headers": headers,
+            "query_parameters": query_parameters,
+        }
+        signer.assert_called_once_with(expected_creds, **expected_kwargs)
+
+    def _generate_signed_url_v2_helper(self, **kw):
+        version = "v2"
+        self._generate_signed_url_helper(version, **kw)
+
+    def test_generate_signed_url_v2_w_defaults(self):
+        self._generate_signed_url_v2_helper()
+
+    def test_generate_signed_url_v2_w_expiration(self):
+        from google.cloud._helpers import UTC
+
+        expiration = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        self._generate_signed_url_v2_helper(expiration=expiration)
+
+    def test_generate_signed_url_v2_w_max_age(self):
+        self._generate_signed_url_v2_helper(max_age=3600)
+
+    def test_generate_signed_url_v2_w_endpoint(self):
+        self._generate_signed_url_v2_helper(
+            api_access_endpoint="https://api.example.com/v1"
+        )
+
+    def test_generate_signed_url_v2_w_method(self):
+        self._generate_signed_url_v2_helper(method="POST")
+
+    def test_generate_signed_url_v2_w_lowercase_method(self):
+        self._generate_signed_url_v2_helper(method="get")
+
+    def test_generate_signed_url_v2_w_content_md5(self):
+        self._generate_signed_url_v2_helper(content_md5="FACEDACE")
+
+    def test_generate_signed_url_v2_w_content_type(self):
+        self._generate_signed_url_v2_helper(content_type="text.html")
+
+    def test_generate_signed_url_v2_w_response_type(self):
+        self._generate_signed_url_v2_helper(response_type="text.html")
+
+    def test_generate_signed_url_v2_w_response_disposition(self):
+        self._generate_signed_url_v2_helper(response_disposition="inline")
+
+    def test_generate_signed_url_v2_w_generation(self):
+        self._generate_signed_url_v2_helper(generation=12345)
+
+    def test_generate_signed_url_v2_w_headers(self):
+        self._generate_signed_url_v2_helper(headers={"x-goog-foo": "bar"})
+
+    def test_generate_signed_url_v2_w_credentials(self):
+        credentials = object()
+        self._generate_signed_url_v2_helper(credentials=credentials)
+
+    def _generate_signed_url_v4_helper(self, **kw):
+        version = "v4"
+        self._generate_signed_url_helper(version, **kw)
+
+    def test_generate_signed_url_v4_w_defaults(self):
+        self._generate_signed_url_v2_helper()
+
+    def test_generate_signed_url_v4_w_endpoint(self):
+        self._generate_signed_url_v4_helper(
+            api_access_endpoint="https://api.example.com/v1"
+        )
+
+    def test_generate_signed_url_v4_w_method(self):
+        self._generate_signed_url_v4_helper(method="POST")
+
+    def test_generate_signed_url_v4_w_lowercase_method(self):
+        self._generate_signed_url_v4_helper(method="get")
+
+    def test_generate_signed_url_v4_w_content_md5(self):
+        self._generate_signed_url_v4_helper(content_md5="FACEDACE")
+
+    def test_generate_signed_url_v4_w_content_type(self):
+        self._generate_signed_url_v4_helper(content_type="text.html")
+
+    def test_generate_signed_url_v4_w_response_type(self):
+        self._generate_signed_url_v4_helper(response_type="text.html")
+
+    def test_generate_signed_url_v4_w_response_disposition(self):
+        self._generate_signed_url_v4_helper(response_disposition="inline")
+
+    def test_generate_signed_url_v4_w_generation(self):
+        self._generate_signed_url_v4_helper(generation=12345)
+
+    def test_generate_signed_url_v4_w_headers(self):
+        self._generate_signed_url_v4_helper(headers={"x-goog-foo": "bar"})
+
+    def test_generate_signed_url_v4_w_credentials(self):
+        credentials = object()
+        self._generate_signed_url_v4_helper(credentials=credentials)
+
 
 class _Connection(object):
     _delete_bucket = False
@@ -2612,6 +2774,13 @@ class _Connection(object):
 
 class _Client(object):
     def __init__(self, connection, project=None):
-        self._connection = connection
         self._base_connection = connection
         self.project = project
+
+    @property
+    def _connection(self):
+        return self._base_connection
+
+    @property
+    def _credentials(self):
+        return self._base_connection.credentials

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -14,7 +14,6 @@
 
 import datetime
 import unittest
-import warnings
 
 import mock
 
@@ -2623,22 +2622,15 @@ class Test_Bucket(unittest.TestCase):
         )
 
         with mock.patch(to_patch) as signer:
-            with warnings.catch_warnings(record=True) as warned:
-                signed_uri = bucket.generate_signed_url(
-                    expiration=expiration,
-                    api_access_endpoint=api_access_endpoint,
-                    method=method,
-                    credentials=credentials,
-                    headers=headers,
-                    query_parameters=query_parameters,
-                    version=version,
-                )
-
-        if version is None:
-            self.assertEqual(len(warned), 1)
-            self.assertIs(warned[0].category, DeprecationWarning)
-        else:
-            self.assertEqual(len(warned), 0)
+            signed_uri = bucket.generate_signed_url(
+                expiration=expiration,
+                api_access_endpoint=api_access_endpoint,
+                method=method,
+                credentials=credentials,
+                headers=headers,
+                query_parameters=query_parameters,
+                version=version,
+            )
 
         self.assertEqual(signed_uri, signer.return_value)
 

--- a/storage/tests/unit/url_signer_v4_test_account.json
+++ b/storage/tests/unit/url_signer_v4_test_account.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "dummy-project-id",
+  "private_key_id": "ffffffffffffffffffffffffffffffffffffffff",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCsPzMirIottfQ2\nryjQmPWocSEeGo7f7Q4/tMQXHlXFzo93AGgU2t+clEj9L5loNhLVq+vk+qmnyDz5\nQ04y8jVWyMYzzGNNrGRW/yaYqnqlKZCy1O3bmnNjV7EDbC/jE1ZLBY0U3HaSHfn6\nS9ND8MXdgD0/ulRTWwq6vU8/w6i5tYsU7n2LLlQTl1fQ7/emO9nYcCFJezHZVa0H\nmeWsdHwWsok0skwQYQNIzP3JF9BpR5gJT2gNge6KopDesJeLoLzaX7cUnDn+CAnn\nLuLDwwSsIVKyVxhBFsFXPplgpaQRwmGzwEbf/Xpt9qo26w2UMgn30jsOaKlSeAX8\ncS6ViF+tAgMBAAECggEACKRuJCP8leEOhQziUx8Nmls8wmYqO4WJJLyk5xUMUC22\nSI4CauN1e0V8aQmxnIc0CDkFT7qc9xBmsMoF+yvobbeKrFApvlyzNyM7tEa/exh8\nDGD/IzjbZ8VfWhDcUTwn5QE9DCoon9m1sG+MBNlokB3OVOt8LieAAREdEBG43kJu\nyQTOkY9BGR2AY1FnAl2VZ/jhNDyrme3tp1sW1BJrawzR7Ujo8DzlVcS2geKA9at7\n55ua5GbHz3hfzFgjVXDfnkWzId6aHypUyqHrSn1SqGEbyXTaleKTc6Pgv0PgkJjG\nhZazWWdSuf1T5Xbs0OhAK9qraoAzT6cXXvMEvvPt6QKBgQDXcZKqJAOnGEU4b9+v\nOdoh+nssdrIOBNMu1m8mYbUVYS1aakc1iDGIIWNM3qAwbG+yNEIi2xi80a2RMw2T\n9RyCNB7yqCXXVKLBiwg9FbKMai6Vpk2bWIrzahM9on7AhCax/X2AeOp+UyYhFEy6\nUFG4aHb8THscL7b515ukSuKb5QKBgQDMq+9PuaB0eHsrmL6q4vHNi3MLgijGg/zu\nAXaPygSYAwYW8KglcuLZPvWrL6OG0+CrfmaWTLsyIZO4Uhdj7MLvX6yK7IMnagvk\nL3xjgxSklEHJAwi5wFeJ8ai/1MIuCn8p2re3CbwISKpvf7Sgs/W4196P4vKvTiAz\njcTiSYFIKQKBgCjMpkS4O0TakMlGTmsFnqyOneLmu4NyIHgfPb9cA4n/9DHKLKAT\noaWxBPgatOVWs7RgtyGYsk+XubHkpC6f3X0+15mGhFwJ+CSE6tN+l2iF9zp52vqP\nQwkjzm7+pdhZbmaIpcq9m1K+9lqPWJRz/3XXuqi+5xWIZ7NaxGvRjqaNAoGAdK2b\nutZ2y48XoI3uPFsuP+A8kJX+CtWZrlE1NtmS7tnicdd19AtfmTuUL6fz0FwfW4Su\nlQZfPT/5B339CaEiq/Xd1kDor+J7rvUHM2+5p+1A54gMRGCLRv92FQ4EON0RC1o9\nm2I4SHysdO3XmjmdXmfp4BsgAKJIJzutvtbqlakCgYB+Cb10z37NJJ+WgjDt+yT2\nyUNH17EAYgWXryfRgTyi2POHuJitd64Xzuy6oBVs3wVveYFM6PIKXlj8/DahYX5I\nR2WIzoCNLL3bEZ+nC6Jofpb4kspoAeRporj29SgesK6QBYWHWX2H645RkRGYGpDo\n51gjy9m/hSNqBbH2zmh04A==\n-----END PRIVATE KEY-----\n",
+  "client_email": "test-iam-credentials@dummy-project-id.iam.gserviceaccount.com",
+  "client_id": "000000000000000000000",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com"
+}

--- a/storage/tests/unit/url_signer_v4_test_data.json
+++ b/storage/tests/unit/url_signer_v4_test_data.json
@@ -67,6 +67,34 @@
     },
 
     {
+        "description": "Headers should be trimmed",
+        "bucket": "test-bucket",
+        "object": "test-object",
+        "headers": {
+            "leading": "    xyz",
+            "trailing": "abc    ",
+            "collapsed": "abc    def"
+        },
+        "method": "GET",
+        "expiration": 10,
+        "timestamp": "20190201T090000Z",
+        "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=collapsed%3Bhost%3Bleading%3Btrailing&X-Goog-Signature=1839511d6238d9ac2bbcbba8b23515b3757db35dfa7b8f9bc4b8b4aa270224df747c812526f1a3bcf294d67ed84cd14e074c36bc090e0a542782934a7c925af4a5ea68123e97533704ce8b08ccdf5fe6b412f89c9fc4de243e29abdb098382c5672188ee3f6fef7131413e252c78e7a35658825ad842a50609e9cc463731e17284ff7a14824c989f87cef22fb99dfec20cfeed69d8b3a08f00b43b8284eecd535e50e982b05cd74c5750cd5f986cfc21a2a05f7f3ab7fc31bd684ed1b823b64d29281e923fc6580c49005552ca19c253de087d9d2df881144e44eda40965cfdb4889bf3a35553c9809f4ed20b8355be481b92b9618952b6a04f3017b36053e15"
+    },
+
+    {
+        "description": "Header value with multiple inline values",
+        "bucket": "test-bucket",
+        "object": "test-object",
+        "headers": {
+            "multiple": " xyz ,  abc, def  , xyz   "
+        },
+        "method": "GET",
+        "expiration": 10,
+        "timestamp": "20190201T090000Z",
+        "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bmultiple&X-Goog-Signature=5cc113735625341f59c7203f0c2c9febc95ba6af6b9c38814f8e523214712087dc0996e4960d273ae1889f248ac1e58d4d19cb3a69ad7670e9a8ca1b434e878f59339dc7006cf32dfd715337e9f593e0504371839174962a08294586e0c78160a7aa303397888c8350637c6af3b32ac310886cc4590bfda9ca561ee58fb5b8ec56bc606d2ada6e7df31f4276e9dcb96bcaea39dc2cd096f3fad774f9c4b30e317ad43736c05f76831437f44e8726c1e90d3f6c9827dc273f211f32fc85658dfc5d357eb606743a6b00a29e519eef1bebaf9db3e8f4b1f5f9afb648ad06e60bc42fa8b57025056697c874c9ea76f5a73201c9717ea43e54713ff3502ff3fc626b"
+    },
+
+    {
         "description": "Customer-supplied encryption key",
         "bucket": "test-bucket",
         "object": "test-object",

--- a/storage/tests/unit/url_signer_v4_test_data.json
+++ b/storage/tests/unit/url_signer_v4_test_data.json
@@ -53,6 +53,20 @@
     },
 
     {
+        "description": "Simple headers",
+        "bucket": "test-bucket",
+        "object": "test-object",
+        "headers": {
+            "foo": "foo-value",
+            "BAR": "BAR-value"
+        },
+        "method": "GET",
+        "expiration": 10,
+        "timestamp": "20190201T090000Z",
+        "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=bar%3Bfoo%3Bhost&X-Goog-Signature=68ecd3b008328ed30d91e2fe37444ed7b9b03f28ed4424555b5161980531ef87db1c3a5bc0265aad5640af30f96014c94fb2dba7479c41bfe1c020eb90c0c6d387d4dd09d4a5df8b60ea50eb6b01cdd786a1e37020f5f95eb8f9b6cd3f65a1f8a8a65c9fcb61ea662959efd9cd73b683f8d8804ef4d6d9b2852419b013368842731359d7f9e6d1139032ceca75d5e67cee5fd0192ea2125e5f2955d38d3d50cf116f3a52e6a62de77f6207f5b95aaa1d7d0f8a46de89ea72e7ea30f21286318d7eba0142232b0deb3a1dc9e1e812a981c66b5ffda3c6b01a8a9d113155792309fd53a3acfd054ca7776e8eec28c26480cd1e3c812f67f91d14217f39a606669d"
+    },
+
+    {
         "description": "Customer-supplied encryption key",
         "bucket": "test-bucket",
         "object": "test-object",

--- a/storage/tests/unit/url_signer_v4_test_data.json
+++ b/storage/tests/unit/url_signer_v4_test_data.json
@@ -1,0 +1,70 @@
+﻿[
+    {
+        "description": "Simple GET",
+        "bucket": "test-bucket",
+        "object": "test-object",
+        "method": "GET",
+        "expiration": 10,
+        "timestamp": "20190201T090000Z",
+        "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=95e6a13d43a1d1962e667f17397f2b80ac9bdd1669210d5e08e0135df9dff4e56113485dbe429ca2266487b9d1796ebdee2d7cf682a6ef3bb9fbb4c351686fba90d7b621cf1c4eb1fdf126460dd25fa0837dfdde0a9fd98662ce60844c458448fb2b352c203d9969cb74efa4bdb742287744a4f2308afa4af0e0773f55e32e92973619249214b97283b2daa14195244444e33f938138d1e5f561088ce8011f4986dda33a556412594db7c12fc40e1ff3f1bedeb7a42f5bcda0b9567f17f65855f65071fabb88ea12371877f3f77f10e1466fff6ff6973b74a933322ff0949ce357e20abe96c3dd5cfab42c9c83e740a4d32b9e11e146f0eb3404d2e975896f74"
+    },
+
+    {
+        "description": "Simple PUT",
+        "bucket": "test-bucket",
+        "object": "test-object",
+        "method": "PUT",
+        "expiration": 10,
+        "timestamp": "20190201T090000Z",
+        "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=8adff1d4285739e31aa68e73767a46bc5511fde377497dbe08481bf5ceb34e29cc9a59921748d8ec3dd4085b7e9b7772a952afedfcdaecb3ae8352275b8b7c867f204e3db85076220a3127a8a9589302fc1181eae13b9b7fe41109ec8cdc93c1e8bac2d7a0cc32a109ca02d06957211326563ab3d3e678a0ba296e298b5fc5e14593c99d444c94724cc4be97015dbff1dca377b508fa0cb7169195de98d0e4ac96c42b918d28c8d92d33e1bd125ce0fb3cd7ad2c45dae65c22628378f6584971b8bf3945b26f2611eb651e9b6a8648970c1ecf386bb71327b082e7296c4e1ee2fc0bdd8983da80af375c817fb1ad491d0bc22c0f51dba0d66e2cffbc90803e47"
+    },
+
+    {
+        "description": "POST for resumable uploads",
+        "bucket": "test-bucket",
+        "object": "test-object",
+        "method": "POST",
+        "expiration": 10,
+        "headers": {
+            "x-goog-resumable": "start"
+        },
+        "timestamp": "20190201T090000Z",
+        "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bx-goog-resumable&X-Goog-Signature=4a6d39b23343cedf4c30782aed4b384001828c79ffa3a080a481ea01a640dea0a0ceb58d67a12cef3b243c3f036bb3799c6ee88e8db3eaf7d0bdd4b70a228d0736e07eaa1ee076aff5c6ce09dff1f1f03a0d8ead0d2893408dd3604fdabff553aa6d7af2da67cdba6790006a70240f96717b98f1a6ccb24f00940749599be7ef72aaa5358db63ddd54b2de9e2d6d6a586eac4fe25f36d86fc6ab150418e9c6fa01b732cded226c6d62fc95b72473a4cc55a8257482583fe66d9ab6ede909eb41516a8690946c3e87b0f2052eb0e97e012a14b2f721c42e6e19b8a1cd5658ea36264f10b9b1ada66b8ed5bf7ed7d1708377ac6e5fe608ae361fb594d2e5b24c54"
+    },
+
+    {
+        "description": "Vary expiration and timestamp",
+        "bucket": "test-bucket",
+        "object": "test-object",
+        "method": "GET",
+        "expiration": 20,
+        "timestamp": "20190301T090000Z",
+        "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190301%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190301T090000Z&X-Goog-Expires=20&X-Goog-SignedHeaders=host&X-Goog-Signature=9669ed5b10664dc594c758296580662912cf4bcc5a4ba0b6bf055bcbf6f34eed7bdad664f534962174a924741a0c273a4f67bc1847cef20192a6beab44223bd9d4fbbd749c407b79997598c30f82ddc269ff47ec09fa3afe74e00616d438df0d96a7d8ad0adacfad1dc3286f864d924fe919fb0dce45d3d975c5afe8e13af2db9cc37ba77835f92f7669b61e94c6d562196c1274529e76cfff1564cc2cad7d5387dc8e12f7a5dfd925685fe92c30b43709eee29fa2f66067472cee5423d1a3a4182fe8cea75c9329d181dc6acad7c393cd04f8bf5bc0515127d8ebd65d80c08e19ad03316053ea60033fd1b1fd85a69c576415da3bf0a3718d9ea6d03e0d66f0"
+    },
+
+    {
+        "description": "Vary bucket and object",
+        "bucket": "test-bucket2",
+        "object": "test-object2",
+        "method": "GET",
+        "expiration": 10,
+        "timestamp": "20190201T090000Z",
+        "expectedUrl": "https://storage.googleapis.com/test-bucket2/test-object2?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=36e3d58dfd3ec1d2dd2f24b5ee372a71e811ffaa2162a2b871d26728d0354270bc116face87127532969c4a3967ed05b7309af741e19c7202f3167aa8c2ac420b61417d6451442bb91d7c822cd17be8783f01e05372769c88913561d27e6660dd8259f0081a71f831be6c50283626cbf04494ac10c394b29bb3bce74ab91548f58a37118a452693cf0483d77561fc9cac8f1765d2c724994cca46a83517a10157ee0347a233a2aaeae6e6ab5e204ff8fc5f54f90a3efdb8301d9fff5475d58cd05b181affd657f48203f4fb133c3a3d355b8eefbd10d5a0a5fd70d06e9515460ad74e22334b2cba4b29cae4f6f285cdb92d8f3126d7a1479ca3bdb69c207d860"
+    },
+
+    {
+        "description": "Customer-supplied encryption key",
+        "bucket": "test-bucket",
+        "object": "test-object",
+        "headers":
+        {
+            "X-Goog-Encryption-Key": "key",
+            "X-Goog-Encryption-Key-Sha256": "key-hash",
+            "X-Goog-Encryption-Algorithm": "AES256"
+        },
+        "method": "GET",
+        "expiration": 10,
+        "timestamp": "20190201T090000Z",
+        "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bx-goog-encryption-algorithm%3Bx-goog-encryption-key%3Bx-goog-encryption-key-sha256&X-Goog-Signature=278a1c5a3bad248637054a047014760353942433955871031ed08f515b54588654ad033e91f046ab202b68673030e117d1b786c325e870238b035ba75b3feed560a17aff9bab6bddebd4a31a52cb68b214e27d3b0bd886502c6b36b164306fe88b5a07c6063592afe746b2a5d205dbe90dd5386b94f0a78f75d9f53ee884e18f476e8fc2eb1dd910ce0b4ae1f5d7b09876ef9bf983f539c028429e14bad3c75dbd4ed1ae37856f6d6f8a1805eaf8b52a0d6fc993902e4c1ee8de477661f7b67c3663000474cb00e178189789b2a3ed6bd21b4ade684fca8108ac4dd106acb17f5954d045775f7aa5a98ebda5d3075e11a8ea49c64c6ad1481e463e8c9f11f704"
+    }
+]

--- a/storage/tests/unit/url_signer_v4_test_data.json
+++ b/storage/tests/unit/url_signer_v4_test_data.json
@@ -66,5 +66,15 @@
         "expiration": 10,
         "timestamp": "20190201T090000Z",
         "expectedUrl": "https://storage.googleapis.com/test-bucket/test-object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host%3Bx-goog-encryption-algorithm%3Bx-goog-encryption-key%3Bx-goog-encryption-key-sha256&X-Goog-Signature=278a1c5a3bad248637054a047014760353942433955871031ed08f515b54588654ad033e91f046ab202b68673030e117d1b786c325e870238b035ba75b3feed560a17aff9bab6bddebd4a31a52cb68b214e27d3b0bd886502c6b36b164306fe88b5a07c6063592afe746b2a5d205dbe90dd5386b94f0a78f75d9f53ee884e18f476e8fc2eb1dd910ce0b4ae1f5d7b09876ef9bf983f539c028429e14bad3c75dbd4ed1ae37856f6d6f8a1805eaf8b52a0d6fc993902e4c1ee8de477661f7b67c3663000474cb00e178189789b2a3ed6bd21b4ade684fca8108ac4dd106acb17f5954d045775f7aa5a98ebda5d3075e11a8ea49c64c6ad1481e463e8c9f11f704"
+    },
+
+    {
+        "description": "List Objects",
+        "bucket": "test-bucket",
+        "object": "",
+        "method": "GET",
+        "expiration": 10,
+        "timestamp": "20190201T090000Z",
+        "expectedUrl": "https://storage.googleapis.com/test-bucket?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam.gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host&X-Goog-Signature=6dbe94f8e52b2b8a9a476b1c857efa474e09944e2b52b925800316e094a7169d8dbe0df9c0ac08dabb22ac7e827470ceccd65f5a3eadba2a4fb9beebfe37f0d9bb1e552b851fa31a25045bdf019e507f5feb44f061551ef1aeb18dcec0e38ba2e2f77d560a46eaace9c56ed9aa642281301a9d848b0eb30749e34bc7f73a3d596240533466ff9b5f289cd0d4c845c7d96b82a35a5abd0c3aff83e4440ee6873e796087f43545544dc8c01afe1d79c726696b6f555371e491980e7ec145cca0803cf562c38f3fa1d724242f5dea25aac91d74ec9ddd739ff65523627763eaef25cd1f95ad985aaf0079b7c74eb5bcb2870a9b137a7b2c8e41fbe838c95872f75b"
     }
 ]


### PR DESCRIPTION
Partial support for the new feature:  adds a `version` argument to `Blob.generate_signed_url`, and uses it to switch between the two signing algorithms.

Remaining work:
- [x] Improve assertions for how variations in calling are handled (different methods, headers, etc.)  See the data-driven tests in https://github.com/googleapis/google-cloud-dotnet/pull/2882 for examples (even better, work out how to share them like the Firestore conformance tests).
- [x] Add system tests for V4 blob signed URLs.
- [x] Add `Bucket.generate_signed_url`, to permit listing bucket contents.
- [x] Add system test for resumable upload using V4 blob signed URL.

Deferred work:
- Add system tests for V4 bucket signed URLs (in place, but currently skipped due to back-end case-flattening issue for the `X-Goog-Signed` header) (#7625).
- Add support for signing URLs on GCE following Frank's [Ruby PoC](https://gist.github.com/frankyn/1a537900c0689903f157740a0a9e36aa#file-v4_signed_urls-rb-L56-L68). (#7267)
- Add system tests for CSEK upload / download using V4 blob-signed URLs (blocked by a similar back-end bug as above). (#7626).

No longer in scope:

- ~Add `Client.generate_signed_url`, to permit listing buckets.~