### PR TITLE
Accept a string in Table and Dataset constructors.

### DIFF
--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -306,8 +306,13 @@ class Dataset(object):
     https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets
 
     Args:
-        dataset_ref (google.cloud.bigquery.dataset.DatasetReference):
-            a pointer to a dataset
+        dataset_ref (Union[ \
+            :class:`~google.cloud.bigquery.dataset.DatasetReference`, \
+            str, \
+        ]):
+            A pointer to a dataset. If ``dataset_ref`` is a string, it must
+            include both the project ID and the dataset ID, separated by
+            ``.``.
     """
 
     _PROPERTY_TO_API_FIELD = {
@@ -318,6 +323,8 @@ class Dataset(object):
     }
 
     def __init__(self, dataset_ref):
+        if isinstance(dataset_ref, six.string_types):
+            dataset_ref = DatasetReference.from_string(dataset_ref)
         self._properties = {"datasetReference": dataset_ref.to_api_repr(), "labels": {}}
 
     @property

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -348,8 +348,13 @@ class Table(object):
     https://cloud.google.com/bigquery/docs/reference/rest/v2/tables
 
     Args:
-        table_ref (google.cloud.bigquery.table.TableReference):
-            A pointer to a table
+        table_ref (Union[ \
+            :class:`~google.cloud.bigquery.table.TableReference`, \
+            str, \
+        ]):
+            A pointer to a table. If ``table_ref`` is a string, it must
+            included a project ID, dataset ID, and table ID, each separated
+            by ``.``.
         schema (List[google.cloud.bigquery.schema.SchemaField]):
             The table's schema
     """
@@ -367,6 +372,8 @@ class Table(object):
     }
 
     def __init__(self, table_ref, schema=None):
+        if isinstance(table_ref, six.string_types):
+            table_ref = TableReference.from_string(table_ref)
         self._properties = {"tableReference": table_ref.to_api_repr(), "labels": {}}
         # Let the @property do validation.
         if schema is not None:

--- a/bigquery/tests/unit/test_dataset.py
+++ b/bigquery/tests/unit/test_dataset.py
@@ -15,6 +15,7 @@
 import unittest
 
 import mock
+import pytest
 
 
 class TestAccessEntry(unittest.TestCase):
@@ -363,6 +364,16 @@ class TestDataset(unittest.TestCase):
         self.assertIsNone(dataset.description)
         self.assertIsNone(dataset.friendly_name)
         self.assertIsNone(dataset.location)
+
+    def test_ctor_string(self):
+        dataset = self._make_one("some-project.some_dset")
+        self.assertEqual(dataset.project, "some-project")
+        self.assertEqual(dataset.dataset_id, "some_dset")
+
+    def test_ctor_string_wo_project_id(self):
+        with pytest.raises(ValueError):
+            # Project ID is missing.
+            self._make_one("some_dset")
 
     def test_ctor_explicit(self):
         from google.cloud.bigquery.dataset import DatasetReference, AccessEntry

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -504,6 +504,17 @@ class TestTable(unittest.TestCase, _SchemaBase):
 
         self.assertEqual(table.schema, [full_name, age])
 
+    def test_ctor_string(self):
+        table = self._make_one("some-project.some_dset.some_tbl")
+        self.assertEqual(table.project, "some-project")
+        self.assertEqual(table.dataset_id, "some_dset")
+        self.assertEqual(table.table_id, "some_tbl")
+
+    def test_ctor_string_wo_project_id(self):
+        with pytest.raises(ValueError):
+            # Project ID is missing.
+            self._make_one("some_dset.some_tbl")
+
     def test_num_bytes_getter(self):
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
         table_ref = dataset.table(self.TABLE_NAME)


### PR DESCRIPTION
This removes the another need to manually create a TableReference or
DatasetReference. Instead, a developer can pass in a string to the
constructor and then set the needed properties on the resource.

Closes #7477