### PR TITLE
Docs: fix link for 'getting-started-python' repo.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ Example Applications
 -  `getting-started-python`_ - A sample and `tutorial`_ that demonstrates how to build a complete web application using Cloud Datastore, Cloud Storage, and Cloud Pub/Sub and deploy it to Google App Engine or Google Compute Engine.
 -  `google-cloud-python-expenses-demo`_ - A sample expenses demo using Cloud Datastore and Cloud Storage
 
-.. _getting-started-python: https://github.com/googleapis/getting-started-python
+.. _getting-started-python: https://github.com/GoogleCloudPython/getting-started-python
 .. _tutorial: https://cloud.google.com/python
 .. _google-cloud-python-expenses-demo: https://github.com/GoogleCloudPlatform/google-cloud-python-expenses-demo
 


### PR DESCRIPTION
Closes #7488.