### PR TITLE
Remove typo in Table.from_api_repr docstring.

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -821,8 +821,6 @@ class Table(object):
         Args:
             resource (Dict[str, object]):
                 Table resource representation from the API
-            dataset (google.cloud.bigquery.dataset.Dataset):
-                The dataset containing the table.
 
         Returns:
             google.cloud.bigquery.table.Table: Table parsed from ``resource``.


### PR DESCRIPTION
The `from_api_repr` method does not take a `Dataset` object.