### PR TITLE
Add 'authentication_method' to 'PushConfig' (via synth).

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/gapic/publisher_client_config.py
+++ b/pubsub/google/cloud/pubsub_v1/gapic/publisher_client_config.py
@@ -2,9 +2,10 @@ config = {
     "interfaces": {
         "google.pubsub.v1.Publisher": {
             "retry_codes": {
-                "idempotent": ["DEADLINE_EXCEEDED", "UNAVAILABLE"],
-                "non_idempotent": [],
-                "one_plus_delivery": [
+                "idempotent": ["ABORTED", "UNAVAILABLE", "UNKNOWN"],
+                "non_idempotent": ["UNAVAILABLE"],
+                "none": [],
+                "publish": [
                     "ABORTED",
                     "CANCELLED",
                     "DEADLINE_EXCEEDED",
@@ -37,17 +38,17 @@ config = {
             "methods": {
                 "CreateTopic": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "idempotent",
+                    "retry_codes_name": "non_idempotent",
                     "retry_params_name": "default",
                 },
                 "UpdateTopic": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "idempotent",
+                    "retry_codes_name": "non_idempotent",
                     "retry_params_name": "default",
                 },
                 "Publish": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "one_plus_delivery",
+                    "retry_codes_name": "publish",
                     "retry_params_name": "messaging",
                     "bundling": {
                         "element_count_threshold": 10,
@@ -74,7 +75,7 @@ config = {
                 },
                 "DeleteTopic": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "idempotent",
+                    "retry_codes_name": "non_idempotent",
                     "retry_params_name": "default",
                 },
                 "SetIamPolicy": {

--- a/pubsub/google/cloud/pubsub_v1/gapic/subscriber_client_config.py
+++ b/pubsub/google/cloud/pubsub_v1/gapic/subscriber_client_config.py
@@ -2,14 +2,9 @@ config = {
     "interfaces": {
         "google.pubsub.v1.Subscriber": {
             "retry_codes": {
-                "idempotent": ["DEADLINE_EXCEEDED", "UNAVAILABLE"],
-                "pull": [
-                    "DEADLINE_EXCEEDED",
-                    "INTERNAL",
-                    "RESOURCE_EXHAUSTED",
-                    "UNAVAILABLE",
-                ],
-                "non_idempotent": [],
+                "idempotent": ["ABORTED", "UNAVAILABLE", "UNKNOWN"],
+                "non_idempotent": ["UNAVAILABLE"],
+                "none": [],
             },
             "retry_params": {
                 "default": {
@@ -53,7 +48,7 @@ config = {
                 },
                 "UpdateSubscription": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "idempotent",
+                    "retry_codes_name": "non_idempotent",
                     "retry_params_name": "default",
                 },
                 "ListSubscriptions": {
@@ -63,7 +58,7 @@ config = {
                 },
                 "DeleteSubscription": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "idempotent",
+                    "retry_codes_name": "non_idempotent",
                     "retry_params_name": "default",
                 },
                 "ModifyAckDeadline": {
@@ -73,17 +68,17 @@ config = {
                 },
                 "Acknowledge": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "idempotent",
+                    "retry_codes_name": "non_idempotent",
                     "retry_params_name": "messaging",
                 },
                 "Pull": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "pull",
+                    "retry_codes_name": "idempotent",
                     "retry_params_name": "messaging",
                 },
                 "StreamingPull": {
                     "timeout_millis": 900000,
-                    "retry_codes_name": "pull",
+                    "retry_codes_name": "none",
                     "retry_params_name": "streaming_messaging",
                 },
                 "ModifyPushConfig": {
@@ -98,22 +93,22 @@ config = {
                 },
                 "CreateSnapshot": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "idempotent",
+                    "retry_codes_name": "non_idempotent",
                     "retry_params_name": "default",
                 },
                 "UpdateSnapshot": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "idempotent",
+                    "retry_codes_name": "non_idempotent",
                     "retry_params_name": "default",
                 },
                 "DeleteSnapshot": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "idempotent",
+                    "retry_codes_name": "non_idempotent",
                     "retry_params_name": "default",
                 },
                 "Seek": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "non_idempotent",
+                    "retry_codes_name": "idempotent",
                     "retry_params_name": "default",
                 },
                 "SetIamPolicy": {

--- a/pubsub/google/cloud/pubsub_v1/proto/pubsub.proto
+++ b/pubsub/google/cloud/pubsub_v1/proto/pubsub.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC.
+// Copyright 2019 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ option java_outer_classname = "PubsubProto";
 option java_package = "com.google.pubsub.v1";
 option php_namespace = "Google\\Cloud\\PubSub\\V1";
 option ruby_package = "Google::Cloud::PubSub::V1";
-
 
 // The service that an application uses to manipulate topics, and to send
 // messages to a topic.
@@ -79,7 +78,8 @@ service Publisher {
   }
 
   // Lists the names of the subscriptions on this topic.
-  rpc ListTopicSubscriptions(ListTopicSubscriptionsRequest) returns (ListTopicSubscriptionsResponse) {
+  rpc ListTopicSubscriptions(ListTopicSubscriptionsRequest)
+      returns (ListTopicSubscriptionsResponse) {
     option (google.api.http) = {
       get: "/v1/{topic=projects/*/topics/*}/subscriptions"
     };
@@ -94,7 +94,8 @@ service Publisher {
   // <b>BETA:</b> This feature is part of a beta release. This API might be
   // changed in backward-incompatible ways and is not recommended for production
   // use. It is not subject to any SLA or deprecation policy.
-  rpc ListTopicSnapshots(ListTopicSnapshotsRequest) returns (ListTopicSnapshotsResponse) {
+  rpc ListTopicSnapshots(ListTopicSnapshotsRequest)
+      returns (ListTopicSnapshotsResponse) {
     option (google.api.http) = {
       get: "/v1/{topic=projects/*/topics/*}/snapshots"
     };
@@ -125,9 +126,10 @@ service Subscriber {
   // If the name is not provided in the request, the server will assign a random
   // name for this subscription on the same project as the topic, conforming
   // to the
-  // [resource name format](https://cloud.google.com/pubsub/docs/admin#resource_names).
-  // The generated name is populated in the returned Subscription object.
-  // Note that for REST API requests, you must specify a name in the request.
+  // [resource name
+  // format](https://cloud.google.com/pubsub/docs/admin#resource_names). The
+  // generated name is populated in the returned Subscription object. Note that
+  // for REST API requests, you must specify a name in the request.
   rpc CreateSubscription(Subscription) returns (Subscription) {
     option (google.api.http) = {
       put: "/v1/{name=projects/*/subscriptions/*}"
@@ -152,7 +154,8 @@ service Subscriber {
   }
 
   // Lists matching subscriptions.
-  rpc ListSubscriptions(ListSubscriptionsRequest) returns (ListSubscriptionsResponse) {
+  rpc ListSubscriptions(ListSubscriptionsRequest)
+      returns (ListSubscriptionsResponse) {
     option (google.api.http) = {
       get: "/v1/{project=projects/*}/subscriptions"
     };
@@ -163,7 +166,8 @@ service Subscriber {
   // `NOT_FOUND`. After a subscription is deleted, a new one may be created with
   // the same name, but the new one has no association with the old
   // subscription or its topic unless the same topic is specified.
-  rpc DeleteSubscription(DeleteSubscriptionRequest) returns (google.protobuf.Empty) {
+  rpc DeleteSubscription(DeleteSubscriptionRequest)
+      returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v1/{subscription=projects/*/subscriptions/*}"
     };
@@ -174,7 +178,8 @@ service Subscriber {
   // subscriber, or to make the message available for redelivery if the
   // processing was interrupted. Note that this does not modify the
   // subscription-level `ackDeadlineSeconds` used for subsequent messages.
-  rpc ModifyAckDeadline(ModifyAckDeadlineRequest) returns (google.protobuf.Empty) {
+  rpc ModifyAckDeadline(ModifyAckDeadlineRequest)
+      returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/v1/{subscription=projects/*/subscriptions/*}:modifyAckDeadline"
       body: "*"
@@ -212,8 +217,8 @@ service Subscriber {
   // reassign server-side resources, in which case, the client should
   // re-establish the stream. Flow control can be achieved by configuring the
   // underlying RPC channel.
-  rpc StreamingPull(stream StreamingPullRequest) returns (stream StreamingPullResponse) {
-  }
+  rpc StreamingPull(stream StreamingPullRequest)
+      returns (stream StreamingPullResponse) {}
 
   // Modifies the `PushConfig` for a specified subscription.
   //
@@ -221,7 +226,8 @@ service Subscriber {
   // an empty `PushConfig`) or vice versa, or change the endpoint URL and other
   // attributes of a push subscription. Messages will accumulate for delivery
   // continuously through the call regardless of changes to the `PushConfig`.
-  rpc ModifyPushConfig(ModifyPushConfigRequest) returns (google.protobuf.Empty) {
+  rpc ModifyPushConfig(ModifyPushConfigRequest)
+      returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/v1/{subscription=projects/*/subscriptions/*}:modifyPushConfig"
       body: "*"
@@ -275,9 +281,10 @@ service Subscriber {
   // the request, the server will assign a random
   // name for this snapshot on the same project as the subscription, conforming
   // to the
-  // [resource name format](https://cloud.google.com/pubsub/docs/admin#resource_names).
-  // The generated name is populated in the returned Snapshot object. Note that
-  // for REST API requests, you must specify a name in the request.
+  // [resource name
+  // format](https://cloud.google.com/pubsub/docs/admin#resource_names). The
+  // generated name is populated in the returned Snapshot object. Note that for
+  // REST API requests, you must specify a name in the request.
   rpc CreateSnapshot(CreateSnapshotRequest) returns (Snapshot) {
     option (google.api.http) = {
       put: "/v1/{name=projects/*/snapshots/*}"
@@ -576,7 +583,8 @@ message Subscription {
   // messages are not expunged from the subscription's backlog, even if they are
   // acknowledged, until they fall out of the `message_retention_duration`
   // window. This must be true if you would like to
-  // <a href="https://cloud.google.com/pubsub/docs/replay-overview#seek_to_a_time">
+  // <a
+  // href="https://cloud.google.com/pubsub/docs/replay-overview#seek_to_a_time">
   // Seek to a timestamp</a>.
   // <br><br>
   // <b>BETA:</b> This feature is part of a beta release. This API might be
@@ -651,6 +659,42 @@ message PushConfig {
   // * `v1beta1`: uses the push format defined in the v1beta1 Pub/Sub API.
   // * `v1` or `v1beta2`: uses the push format defined in the v1 Pub/Sub API.
   map<string, string> attributes = 2;
+
+  // An authentication method used by push endpoints to verify the source of
+  // push requests. This can be used with push endpoints that are private by
+  // default to allow requests only from the Cloud Pub/Sub system, for example.
+  // This field is optional and should be set only by users interested in
+  // authenticated push.
+  // <b>EXPERIMENTAL:</b> This field a part of a closed alpha that may not be
+  // accessible to all users. It may be changed in backward-incompatible ways
+  // and is not subject to any SLA or deprecation policy.  It is not recommended
+  // for production use.
+  oneof authentication_method {
+    // If specified, Pub/Sub will generate and attach an OIDC JWT token as an
+    // `Authorization` header in the HTTP request for every pushed message.
+    OidcToken oidc_token = 3;
+  }
+
+  // Contains information needed for generating an
+  // [OpenID Connect
+  // token](https://developers.google.com/identity/protocols/OpenIDConnect).
+  message OidcToken {
+    // [Service account
+    // email](https://cloud.google.com/iam/docs/service-accounts)
+    // to be used for generating the OIDC token. The caller (for
+    // CreateSubscription, UpdateSubscription, and ModifyPushConfig calls) must
+    // have the iam.serviceAccounts.actAs permission for the service account.
+    // See https://cloud.google.com/iam/docs/understanding-roles#service-accounts-roles.
+    string service_account_email = 1;
+
+    // Audience to be used when generating OIDC token. The audience claim
+    // identifies the recipients that the JWT is intended for. The audience
+    // value is a single case-sensitive string. Having multiple values (array)
+    // for the audience field is not supported. More info about the OIDC JWT
+    // token audience here: https://tools.ietf.org/html/rfc7519#section-4.1.3
+    // Note: if not specified, the Push endpoint URL will be used.
+    string audience = 2;
+  }
 }
 
 // A message and its corresponding acknowledgment ID.
@@ -836,9 +880,9 @@ message StreamingPullResponse {
 }
 
 // Request for the `CreateSnapshot` method.<br><br>
-// <b>BETA:</b> This feature is part of a beta release. This API might be changed in
-// backward-incompatible ways and is not recommended for production use.
-// It is not subject to any SLA or deprecation policy.
+// <b>BETA:</b> This feature is part of a beta release. This API might be
+// changed in backward-incompatible ways and is not recommended for production
+// use. It is not subject to any SLA or deprecation policy.
 message CreateSnapshotRequest {
   // Optional user-provided name for this snapshot.
   // If the name is not provided in the request, the server will assign a random
@@ -992,6 +1036,4 @@ message SeekRequest {
 }
 
 // Response for the `Seek` method (this response is empty).
-message SeekResponse {
-
-}
+message SeekResponse {}

--- a/pubsub/google/cloud/pubsub_v1/proto/pubsub_pb2.py
+++ b/pubsub/google/cloud/pubsub_v1/proto/pubsub_pb2.py
@@ -29,7 +29,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         "\n\024com.google.pubsub.v1B\013PubsubProtoP\001Z6google.golang.org/genproto/googleapis/pubsub/v1;pubsub\370\001\001\252\002\026Google.Cloud.PubSub.V1\312\002\026Google\\Cloud\\PubSub\\V1\352\002\031Google::Cloud::PubSub::V1"
     ),
     serialized_pb=_b(
-        '\n)google/cloud/pubsub_v1/proto/pubsub.proto\x12\x10google.pubsub.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto";\n\x14MessageStoragePolicy\x12#\n\x1b\x61llowed_persistence_regions\x18\x01 \x03(\t"\xc1\x01\n\x05Topic\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x33\n\x06labels\x18\x02 \x03(\x0b\x32#.google.pubsub.v1.Topic.LabelsEntry\x12\x46\n\x16message_storage_policy\x18\x03 \x01(\x0b\x32&.google.pubsub.v1.MessageStoragePolicy\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"\xdb\x01\n\rPubsubMessage\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x12\x43\n\nattributes\x18\x02 \x03(\x0b\x32/.google.pubsub.v1.PubsubMessage.AttributesEntry\x12\x12\n\nmessage_id\x18\x03 \x01(\t\x12\x30\n\x0cpublish_time\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01" \n\x0fGetTopicRequest\x12\r\n\x05topic\x18\x01 \x01(\t"m\n\x12UpdateTopicRequest\x12&\n\x05topic\x18\x01 \x01(\x0b\x32\x17.google.pubsub.v1.Topic\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask"R\n\x0ePublishRequest\x12\r\n\x05topic\x18\x01 \x01(\t\x12\x31\n\x08messages\x18\x02 \x03(\x0b\x32\x1f.google.pubsub.v1.PubsubMessage"&\n\x0fPublishResponse\x12\x13\n\x0bmessage_ids\x18\x01 \x03(\t"K\n\x11ListTopicsRequest\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"V\n\x12ListTopicsResponse\x12\'\n\x06topics\x18\x01 \x03(\x0b\x32\x17.google.pubsub.v1.Topic\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"U\n\x1dListTopicSubscriptionsRequest\x12\r\n\x05topic\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"P\n\x1eListTopicSubscriptionsResponse\x12\x15\n\rsubscriptions\x18\x01 \x03(\t\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"Q\n\x19ListTopicSnapshotsRequest\x12\r\n\x05topic\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"H\n\x1aListTopicSnapshotsResponse\x12\x11\n\tsnapshots\x18\x01 \x03(\t\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"#\n\x12\x44\x65leteTopicRequest\x12\r\n\x05topic\x18\x01 \x01(\t"\x84\x03\n\x0cSubscription\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05topic\x18\x02 \x01(\t\x12\x31\n\x0bpush_config\x18\x04 \x01(\x0b\x32\x1c.google.pubsub.v1.PushConfig\x12\x1c\n\x14\x61\x63k_deadline_seconds\x18\x05 \x01(\x05\x12\x1d\n\x15retain_acked_messages\x18\x07 \x01(\x08\x12=\n\x1amessage_retention_duration\x18\x08 \x01(\x0b\x32\x19.google.protobuf.Duration\x12:\n\x06labels\x18\t \x03(\x0b\x32*.google.pubsub.v1.Subscription.LabelsEntry\x12=\n\x11\x65xpiration_policy\x18\x0b \x01(\x0b\x32".google.pubsub.v1.ExpirationPolicy\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01":\n\x10\x45xpirationPolicy\x12&\n\x03ttl\x18\x01 \x01(\x0b\x32\x19.google.protobuf.Duration"\x98\x01\n\nPushConfig\x12\x15\n\rpush_endpoint\x18\x01 \x01(\t\x12@\n\nattributes\x18\x02 \x03(\x0b\x32,.google.pubsub.v1.PushConfig.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"S\n\x0fReceivedMessage\x12\x0e\n\x06\x61\x63k_id\x18\x01 \x01(\t\x12\x30\n\x07message\x18\x02 \x01(\x0b\x32\x1f.google.pubsub.v1.PubsubMessage".\n\x16GetSubscriptionRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t"\x82\x01\n\x19UpdateSubscriptionRequest\x12\x34\n\x0csubscription\x18\x01 \x01(\x0b\x32\x1e.google.pubsub.v1.Subscription\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask"R\n\x18ListSubscriptionsRequest\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"k\n\x19ListSubscriptionsResponse\x12\x35\n\rsubscriptions\x18\x01 \x03(\x0b\x32\x1e.google.pubsub.v1.Subscription\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"1\n\x19\x44\x65leteSubscriptionRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t"b\n\x17ModifyPushConfigRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t\x12\x31\n\x0bpush_config\x18\x02 \x01(\x0b\x32\x1c.google.pubsub.v1.PushConfig"U\n\x0bPullRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t\x12\x1a\n\x12return_immediately\x18\x02 \x01(\x08\x12\x14\n\x0cmax_messages\x18\x03 \x01(\x05"L\n\x0cPullResponse\x12<\n\x11received_messages\x18\x01 \x03(\x0b\x32!.google.pubsub.v1.ReceivedMessage"_\n\x18ModifyAckDeadlineRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t\x12\x0f\n\x07\x61\x63k_ids\x18\x04 \x03(\t\x12\x1c\n\x14\x61\x63k_deadline_seconds\x18\x03 \x01(\x05";\n\x12\x41\x63knowledgeRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t\x12\x0f\n\x07\x61\x63k_ids\x18\x02 \x03(\t"\xa4\x01\n\x14StreamingPullRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t\x12\x0f\n\x07\x61\x63k_ids\x18\x02 \x03(\t\x12\x1f\n\x17modify_deadline_seconds\x18\x03 \x03(\x05\x12\x1f\n\x17modify_deadline_ack_ids\x18\x04 \x03(\t\x12#\n\x1bstream_ack_deadline_seconds\x18\x05 \x01(\x05"U\n\x15StreamingPullResponse\x12<\n\x11received_messages\x18\x01 \x03(\x0b\x32!.google.pubsub.v1.ReceivedMessage"\xaf\x01\n\x15\x43reateSnapshotRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0csubscription\x18\x02 \x01(\t\x12\x43\n\x06labels\x18\x03 \x03(\x0b\x32\x33.google.pubsub.v1.CreateSnapshotRequest.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"v\n\x15UpdateSnapshotRequest\x12,\n\x08snapshot\x18\x01 \x01(\x0b\x32\x1a.google.pubsub.v1.Snapshot\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask"\xbf\x01\n\x08Snapshot\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05topic\x18\x02 \x01(\t\x12/\n\x0b\x65xpire_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x36\n\x06labels\x18\x04 \x03(\x0b\x32&.google.pubsub.v1.Snapshot.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"&\n\x12GetSnapshotRequest\x12\x10\n\x08snapshot\x18\x01 \x01(\t"N\n\x14ListSnapshotsRequest\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"_\n\x15ListSnapshotsResponse\x12-\n\tsnapshots\x18\x01 \x03(\x0b\x32\x1a.google.pubsub.v1.Snapshot\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t")\n\x15\x44\x65leteSnapshotRequest\x12\x10\n\x08snapshot\x18\x01 \x01(\t"m\n\x0bSeekRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t\x12*\n\x04time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00\x12\x12\n\x08snapshot\x18\x03 \x01(\tH\x00\x42\x08\n\x06target"\x0e\n\x0cSeekResponse2\xbf\x08\n\tPublisher\x12j\n\x0b\x43reateTopic\x12\x17.google.pubsub.v1.Topic\x1a\x17.google.pubsub.v1.Topic")\x82\xd3\xe4\x93\x02#\x1a\x1e/v1/{name=projects/*/topics/*}:\x01*\x12}\n\x0bUpdateTopic\x12$.google.pubsub.v1.UpdateTopicRequest\x1a\x17.google.pubsub.v1.Topic"/\x82\xd3\xe4\x93\x02)2$/v1/{topic.name=projects/*/topics/*}:\x01*\x12\x82\x01\n\x07Publish\x12 .google.pubsub.v1.PublishRequest\x1a!.google.pubsub.v1.PublishResponse"2\x82\xd3\xe4\x93\x02,"\'/v1/{topic=projects/*/topics/*}:publish:\x01*\x12o\n\x08GetTopic\x12!.google.pubsub.v1.GetTopicRequest\x1a\x17.google.pubsub.v1.Topic"\'\x82\xd3\xe4\x93\x02!\x12\x1f/v1/{topic=projects/*/topics/*}\x12\x80\x01\n\nListTopics\x12#.google.pubsub.v1.ListTopicsRequest\x1a$.google.pubsub.v1.ListTopicsResponse"\'\x82\xd3\xe4\x93\x02!\x12\x1f/v1/{project=projects/*}/topics\x12\xb2\x01\n\x16ListTopicSubscriptions\x12/.google.pubsub.v1.ListTopicSubscriptionsRequest\x1a\x30.google.pubsub.v1.ListTopicSubscriptionsResponse"5\x82\xd3\xe4\x93\x02/\x12-/v1/{topic=projects/*/topics/*}/subscriptions\x12\xa2\x01\n\x12ListTopicSnapshots\x12+.google.pubsub.v1.ListTopicSnapshotsRequest\x1a,.google.pubsub.v1.ListTopicSnapshotsResponse"1\x82\xd3\xe4\x93\x02+\x12)/v1/{topic=projects/*/topics/*}/snapshots\x12t\n\x0b\x44\x65leteTopic\x12$.google.pubsub.v1.DeleteTopicRequest\x1a\x16.google.protobuf.Empty"\'\x82\xd3\xe4\x93\x02!*\x1f/v1/{topic=projects/*/topics/*}2\xf9\x11\n\nSubscriber\x12\x86\x01\n\x12\x43reateSubscription\x12\x1e.google.pubsub.v1.Subscription\x1a\x1e.google.pubsub.v1.Subscription"0\x82\xd3\xe4\x93\x02*\x1a%/v1/{name=projects/*/subscriptions/*}:\x01*\x12\x92\x01\n\x0fGetSubscription\x12(.google.pubsub.v1.GetSubscriptionRequest\x1a\x1e.google.pubsub.v1.Subscription"5\x82\xd3\xe4\x93\x02/\x12-/v1/{subscription=projects/*/subscriptions/*}\x12\xa0\x01\n\x12UpdateSubscription\x12+.google.pubsub.v1.UpdateSubscriptionRequest\x1a\x1e.google.pubsub.v1.Subscription"=\x82\xd3\xe4\x93\x02\x37\x32\x32/v1/{subscription.name=projects/*/subscriptions/*}:\x01*\x12\x9c\x01\n\x11ListSubscriptions\x12*.google.pubsub.v1.ListSubscriptionsRequest\x1a+.google.pubsub.v1.ListSubscriptionsResponse".\x82\xd3\xe4\x93\x02(\x12&/v1/{project=projects/*}/subscriptions\x12\x90\x01\n\x12\x44\x65leteSubscription\x12+.google.pubsub.v1.DeleteSubscriptionRequest\x1a\x16.google.protobuf.Empty"5\x82\xd3\xe4\x93\x02/*-/v1/{subscription=projects/*/subscriptions/*}\x12\xa3\x01\n\x11ModifyAckDeadline\x12*.google.pubsub.v1.ModifyAckDeadlineRequest\x1a\x16.google.protobuf.Empty"J\x82\xd3\xe4\x93\x02\x44"?/v1/{subscription=projects/*/subscriptions/*}:modifyAckDeadline:\x01*\x12\x91\x01\n\x0b\x41\x63knowledge\x12$.google.pubsub.v1.AcknowledgeRequest\x1a\x16.google.protobuf.Empty"D\x82\xd3\xe4\x93\x02>"9/v1/{subscription=projects/*/subscriptions/*}:acknowledge:\x01*\x12\x84\x01\n\x04Pull\x12\x1d.google.pubsub.v1.PullRequest\x1a\x1e.google.pubsub.v1.PullResponse"=\x82\xd3\xe4\x93\x02\x37"2/v1/{subscription=projects/*/subscriptions/*}:pull:\x01*\x12\x66\n\rStreamingPull\x12&.google.pubsub.v1.StreamingPullRequest\x1a\'.google.pubsub.v1.StreamingPullResponse"\x00(\x01\x30\x01\x12\xa0\x01\n\x10ModifyPushConfig\x12).google.pubsub.v1.ModifyPushConfigRequest\x1a\x16.google.protobuf.Empty"I\x82\xd3\xe4\x93\x02\x43">/v1/{subscription=projects/*/subscriptions/*}:modifyPushConfig:\x01*\x12~\n\x0bGetSnapshot\x12$.google.pubsub.v1.GetSnapshotRequest\x1a\x1a.google.pubsub.v1.Snapshot"-\x82\xd3\xe4\x93\x02\'\x12%/v1/{snapshot=projects/*/snapshots/*}\x12\x8c\x01\n\rListSnapshots\x12&.google.pubsub.v1.ListSnapshotsRequest\x1a\'.google.pubsub.v1.ListSnapshotsResponse"*\x82\xd3\xe4\x93\x02$\x12"/v1/{project=projects/*}/snapshots\x12\x83\x01\n\x0e\x43reateSnapshot\x12\'.google.pubsub.v1.CreateSnapshotRequest\x1a\x1a.google.pubsub.v1.Snapshot",\x82\xd3\xe4\x93\x02&\x1a!/v1/{name=projects/*/snapshots/*}:\x01*\x12\x8c\x01\n\x0eUpdateSnapshot\x12\'.google.pubsub.v1.UpdateSnapshotRequest\x1a\x1a.google.pubsub.v1.Snapshot"5\x82\xd3\xe4\x93\x02/2*/v1/{snapshot.name=projects/*/snapshots/*}:\x01*\x12\x80\x01\n\x0e\x44\x65leteSnapshot\x12\'.google.pubsub.v1.DeleteSnapshotRequest\x1a\x16.google.protobuf.Empty"-\x82\xd3\xe4\x93\x02\'*%/v1/{snapshot=projects/*/snapshots/*}\x12\x84\x01\n\x04Seek\x12\x1d.google.pubsub.v1.SeekRequest\x1a\x1e.google.pubsub.v1.SeekResponse"=\x82\xd3\xe4\x93\x02\x37"2/v1/{subscription=projects/*/subscriptions/*}:seek:\x01*B\xae\x01\n\x14\x63om.google.pubsub.v1B\x0bPubsubProtoP\x01Z6google.golang.org/genproto/googleapis/pubsub/v1;pubsub\xf8\x01\x01\xaa\x02\x16Google.Cloud.PubSub.V1\xca\x02\x16Google\\Cloud\\PubSub\\V1\xea\x02\x19Google::Cloud::PubSub::V1b\x06proto3'
+        '\n)google/cloud/pubsub_v1/proto/pubsub.proto\x12\x10google.pubsub.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto";\n\x14MessageStoragePolicy\x12#\n\x1b\x61llowed_persistence_regions\x18\x01 \x03(\t"\xc1\x01\n\x05Topic\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x33\n\x06labels\x18\x02 \x03(\x0b\x32#.google.pubsub.v1.Topic.LabelsEntry\x12\x46\n\x16message_storage_policy\x18\x03 \x01(\x0b\x32&.google.pubsub.v1.MessageStoragePolicy\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"\xdb\x01\n\rPubsubMessage\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x12\x43\n\nattributes\x18\x02 \x03(\x0b\x32/.google.pubsub.v1.PubsubMessage.AttributesEntry\x12\x12\n\nmessage_id\x18\x03 \x01(\t\x12\x30\n\x0cpublish_time\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01" \n\x0fGetTopicRequest\x12\r\n\x05topic\x18\x01 \x01(\t"m\n\x12UpdateTopicRequest\x12&\n\x05topic\x18\x01 \x01(\x0b\x32\x17.google.pubsub.v1.Topic\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask"R\n\x0ePublishRequest\x12\r\n\x05topic\x18\x01 \x01(\t\x12\x31\n\x08messages\x18\x02 \x03(\x0b\x32\x1f.google.pubsub.v1.PubsubMessage"&\n\x0fPublishResponse\x12\x13\n\x0bmessage_ids\x18\x01 \x03(\t"K\n\x11ListTopicsRequest\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"V\n\x12ListTopicsResponse\x12\'\n\x06topics\x18\x01 \x03(\x0b\x32\x17.google.pubsub.v1.Topic\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"U\n\x1dListTopicSubscriptionsRequest\x12\r\n\x05topic\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"P\n\x1eListTopicSubscriptionsResponse\x12\x15\n\rsubscriptions\x18\x01 \x03(\t\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"Q\n\x19ListTopicSnapshotsRequest\x12\r\n\x05topic\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"H\n\x1aListTopicSnapshotsResponse\x12\x11\n\tsnapshots\x18\x01 \x03(\t\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"#\n\x12\x44\x65leteTopicRequest\x12\r\n\x05topic\x18\x01 \x01(\t"\x84\x03\n\x0cSubscription\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05topic\x18\x02 \x01(\t\x12\x31\n\x0bpush_config\x18\x04 \x01(\x0b\x32\x1c.google.pubsub.v1.PushConfig\x12\x1c\n\x14\x61\x63k_deadline_seconds\x18\x05 \x01(\x05\x12\x1d\n\x15retain_acked_messages\x18\x07 \x01(\x08\x12=\n\x1amessage_retention_duration\x18\x08 \x01(\x0b\x32\x19.google.protobuf.Duration\x12:\n\x06labels\x18\t \x03(\x0b\x32*.google.pubsub.v1.Subscription.LabelsEntry\x12=\n\x11\x65xpiration_policy\x18\x0b \x01(\x0b\x32".google.pubsub.v1.ExpirationPolicy\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01":\n\x10\x45xpirationPolicy\x12&\n\x03ttl\x18\x01 \x01(\x0b\x32\x19.google.protobuf.Duration"\xad\x02\n\nPushConfig\x12\x15\n\rpush_endpoint\x18\x01 \x01(\t\x12@\n\nattributes\x18\x02 \x03(\x0b\x32,.google.pubsub.v1.PushConfig.AttributesEntry\x12<\n\noidc_token\x18\x03 \x01(\x0b\x32&.google.pubsub.v1.PushConfig.OidcTokenH\x00\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a<\n\tOidcToken\x12\x1d\n\x15service_account_email\x18\x01 \x01(\t\x12\x10\n\x08\x61udience\x18\x02 \x01(\tB\x17\n\x15\x61uthentication_method"S\n\x0fReceivedMessage\x12\x0e\n\x06\x61\x63k_id\x18\x01 \x01(\t\x12\x30\n\x07message\x18\x02 \x01(\x0b\x32\x1f.google.pubsub.v1.PubsubMessage".\n\x16GetSubscriptionRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t"\x82\x01\n\x19UpdateSubscriptionRequest\x12\x34\n\x0csubscription\x18\x01 \x01(\x0b\x32\x1e.google.pubsub.v1.Subscription\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask"R\n\x18ListSubscriptionsRequest\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"k\n\x19ListSubscriptionsResponse\x12\x35\n\rsubscriptions\x18\x01 \x03(\x0b\x32\x1e.google.pubsub.v1.Subscription\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"1\n\x19\x44\x65leteSubscriptionRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t"b\n\x17ModifyPushConfigRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t\x12\x31\n\x0bpush_config\x18\x02 \x01(\x0b\x32\x1c.google.pubsub.v1.PushConfig"U\n\x0bPullRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t\x12\x1a\n\x12return_immediately\x18\x02 \x01(\x08\x12\x14\n\x0cmax_messages\x18\x03 \x01(\x05"L\n\x0cPullResponse\x12<\n\x11received_messages\x18\x01 \x03(\x0b\x32!.google.pubsub.v1.ReceivedMessage"_\n\x18ModifyAckDeadlineRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t\x12\x0f\n\x07\x61\x63k_ids\x18\x04 \x03(\t\x12\x1c\n\x14\x61\x63k_deadline_seconds\x18\x03 \x01(\x05";\n\x12\x41\x63knowledgeRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t\x12\x0f\n\x07\x61\x63k_ids\x18\x02 \x03(\t"\xa4\x01\n\x14StreamingPullRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t\x12\x0f\n\x07\x61\x63k_ids\x18\x02 \x03(\t\x12\x1f\n\x17modify_deadline_seconds\x18\x03 \x03(\x05\x12\x1f\n\x17modify_deadline_ack_ids\x18\x04 \x03(\t\x12#\n\x1bstream_ack_deadline_seconds\x18\x05 \x01(\x05"U\n\x15StreamingPullResponse\x12<\n\x11received_messages\x18\x01 \x03(\x0b\x32!.google.pubsub.v1.ReceivedMessage"\xaf\x01\n\x15\x43reateSnapshotRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0csubscription\x18\x02 \x01(\t\x12\x43\n\x06labels\x18\x03 \x03(\x0b\x32\x33.google.pubsub.v1.CreateSnapshotRequest.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"v\n\x15UpdateSnapshotRequest\x12,\n\x08snapshot\x18\x01 \x01(\x0b\x32\x1a.google.pubsub.v1.Snapshot\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask"\xbf\x01\n\x08Snapshot\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05topic\x18\x02 \x01(\t\x12/\n\x0b\x65xpire_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x36\n\x06labels\x18\x04 \x03(\x0b\x32&.google.pubsub.v1.Snapshot.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"&\n\x12GetSnapshotRequest\x12\x10\n\x08snapshot\x18\x01 \x01(\t"N\n\x14ListSnapshotsRequest\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"_\n\x15ListSnapshotsResponse\x12-\n\tsnapshots\x18\x01 \x03(\x0b\x32\x1a.google.pubsub.v1.Snapshot\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t")\n\x15\x44\x65leteSnapshotRequest\x12\x10\n\x08snapshot\x18\x01 \x01(\t"m\n\x0bSeekRequest\x12\x14\n\x0csubscription\x18\x01 \x01(\t\x12*\n\x04time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00\x12\x12\n\x08snapshot\x18\x03 \x01(\tH\x00\x42\x08\n\x06target"\x0e\n\x0cSeekResponse2\xbf\x08\n\tPublisher\x12j\n\x0b\x43reateTopic\x12\x17.google.pubsub.v1.Topic\x1a\x17.google.pubsub.v1.Topic")\x82\xd3\xe4\x93\x02#\x1a\x1e/v1/{name=projects/*/topics/*}:\x01*\x12}\n\x0bUpdateTopic\x12$.google.pubsub.v1.UpdateTopicRequest\x1a\x17.google.pubsub.v1.Topic"/\x82\xd3\xe4\x93\x02)2$/v1/{topic.name=projects/*/topics/*}:\x01*\x12\x82\x01\n\x07Publish\x12 .google.pubsub.v1.PublishRequest\x1a!.google.pubsub.v1.PublishResponse"2\x82\xd3\xe4\x93\x02,"\'/v1/{topic=projects/*/topics/*}:publish:\x01*\x12o\n\x08GetTopic\x12!.google.pubsub.v1.GetTopicRequest\x1a\x17.google.pubsub.v1.Topic"\'\x82\xd3\xe4\x93\x02!\x12\x1f/v1/{topic=projects/*/topics/*}\x12\x80\x01\n\nListTopics\x12#.google.pubsub.v1.ListTopicsRequest\x1a$.google.pubsub.v1.ListTopicsResponse"\'\x82\xd3\xe4\x93\x02!\x12\x1f/v1/{project=projects/*}/topics\x12\xb2\x01\n\x16ListTopicSubscriptions\x12/.google.pubsub.v1.ListTopicSubscriptionsRequest\x1a\x30.google.pubsub.v1.ListTopicSubscriptionsResponse"5\x82\xd3\xe4\x93\x02/\x12-/v1/{topic=projects/*/topics/*}/subscriptions\x12\xa2\x01\n\x12ListTopicSnapshots\x12+.google.pubsub.v1.ListTopicSnapshotsRequest\x1a,.google.pubsub.v1.ListTopicSnapshotsResponse"1\x82\xd3\xe4\x93\x02+\x12)/v1/{topic=projects/*/topics/*}/snapshots\x12t\n\x0b\x44\x65leteTopic\x12$.google.pubsub.v1.DeleteTopicRequest\x1a\x16.google.protobuf.Empty"\'\x82\xd3\xe4\x93\x02!*\x1f/v1/{topic=projects/*/topics/*}2\xf9\x11\n\nSubscriber\x12\x86\x01\n\x12\x43reateSubscription\x12\x1e.google.pubsub.v1.Subscription\x1a\x1e.google.pubsub.v1.Subscription"0\x82\xd3\xe4\x93\x02*\x1a%/v1/{name=projects/*/subscriptions/*}:\x01*\x12\x92\x01\n\x0fGetSubscription\x12(.google.pubsub.v1.GetSubscriptionRequest\x1a\x1e.google.pubsub.v1.Subscription"5\x82\xd3\xe4\x93\x02/\x12-/v1/{subscription=projects/*/subscriptions/*}\x12\xa0\x01\n\x12UpdateSubscription\x12+.google.pubsub.v1.UpdateSubscriptionRequest\x1a\x1e.google.pubsub.v1.Subscription"=\x82\xd3\xe4\x93\x02\x37\x32\x32/v1/{subscription.name=projects/*/subscriptions/*}:\x01*\x12\x9c\x01\n\x11ListSubscriptions\x12*.google.pubsub.v1.ListSubscriptionsRequest\x1a+.google.pubsub.v1.ListSubscriptionsResponse".\x82\xd3\xe4\x93\x02(\x12&/v1/{project=projects/*}/subscriptions\x12\x90\x01\n\x12\x44\x65leteSubscription\x12+.google.pubsub.v1.DeleteSubscriptionRequest\x1a\x16.google.protobuf.Empty"5\x82\xd3\xe4\x93\x02/*-/v1/{subscription=projects/*/subscriptions/*}\x12\xa3\x01\n\x11ModifyAckDeadline\x12*.google.pubsub.v1.ModifyAckDeadlineRequest\x1a\x16.google.protobuf.Empty"J\x82\xd3\xe4\x93\x02\x44"?/v1/{subscription=projects/*/subscriptions/*}:modifyAckDeadline:\x01*\x12\x91\x01\n\x0b\x41\x63knowledge\x12$.google.pubsub.v1.AcknowledgeRequest\x1a\x16.google.protobuf.Empty"D\x82\xd3\xe4\x93\x02>"9/v1/{subscription=projects/*/subscriptions/*}:acknowledge:\x01*\x12\x84\x01\n\x04Pull\x12\x1d.google.pubsub.v1.PullRequest\x1a\x1e.google.pubsub.v1.PullResponse"=\x82\xd3\xe4\x93\x02\x37"2/v1/{subscription=projects/*/subscriptions/*}:pull:\x01*\x12\x66\n\rStreamingPull\x12&.google.pubsub.v1.StreamingPullRequest\x1a\'.google.pubsub.v1.StreamingPullResponse"\x00(\x01\x30\x01\x12\xa0\x01\n\x10ModifyPushConfig\x12).google.pubsub.v1.ModifyPushConfigRequest\x1a\x16.google.protobuf.Empty"I\x82\xd3\xe4\x93\x02\x43">/v1/{subscription=projects/*/subscriptions/*}:modifyPushConfig:\x01*\x12~\n\x0bGetSnapshot\x12$.google.pubsub.v1.GetSnapshotRequest\x1a\x1a.google.pubsub.v1.Snapshot"-\x82\xd3\xe4\x93\x02\'\x12%/v1/{snapshot=projects/*/snapshots/*}\x12\x8c\x01\n\rListSnapshots\x12&.google.pubsub.v1.ListSnapshotsRequest\x1a\'.google.pubsub.v1.ListSnapshotsResponse"*\x82\xd3\xe4\x93\x02$\x12"/v1/{project=projects/*}/snapshots\x12\x83\x01\n\x0e\x43reateSnapshot\x12\'.google.pubsub.v1.CreateSnapshotRequest\x1a\x1a.google.pubsub.v1.Snapshot",\x82\xd3\xe4\x93\x02&\x1a!/v1/{name=projects/*/snapshots/*}:\x01*\x12\x8c\x01\n\x0eUpdateSnapshot\x12\'.google.pubsub.v1.UpdateSnapshotRequest\x1a\x1a.google.pubsub.v1.Snapshot"5\x82\xd3\xe4\x93\x02/2*/v1/{snapshot.name=projects/*/snapshots/*}:\x01*\x12\x80\x01\n\x0e\x44\x65leteSnapshot\x12\'.google.pubsub.v1.DeleteSnapshotRequest\x1a\x16.google.protobuf.Empty"-\x82\xd3\xe4\x93\x02\'*%/v1/{snapshot=projects/*/snapshots/*}\x12\x84\x01\n\x04Seek\x12\x1d.google.pubsub.v1.SeekRequest\x1a\x1e.google.pubsub.v1.SeekResponse"=\x82\xd3\xe4\x93\x02\x37"2/v1/{subscription=projects/*/subscriptions/*}:seek:\x01*B\xae\x01\n\x14\x63om.google.pubsub.v1B\x0bPubsubProtoP\x01Z6google.golang.org/genproto/googleapis/pubsub/v1;pubsub\xf8\x01\x01\xaa\x02\x16Google.Cloud.PubSub.V1\xca\x02\x16Google\\Cloud\\PubSub\\V1\xea\x02\x19Google::Cloud::PubSub::V1b\x06proto3'
     ),
     dependencies=[
         google_dot_api_dot_annotations__pb2.DESCRIPTOR,
@@ -1303,6 +1303,62 @@ _PUSHCONFIG_ATTRIBUTESENTRY = _descriptor.Descriptor(
     serialized_end=698,
 )
 
+_PUSHCONFIG_OIDCTOKEN = _descriptor.Descriptor(
+    name="OidcToken",
+    full_name="google.pubsub.v1.PushConfig.OidcToken",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="service_account_email",
+            full_name="google.pubsub.v1.PushConfig.OidcToken.service_account_email",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="audience",
+            full_name="google.pubsub.v1.PushConfig.OidcToken.audience",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=2165,
+    serialized_end=2225,
+)
+
 _PUSHCONFIG = _descriptor.Descriptor(
     name="PushConfig",
     full_name="google.pubsub.v1.PushConfig",
@@ -1346,17 +1402,43 @@ _PUSHCONFIG = _descriptor.Descriptor(
             serialized_options=None,
             file=DESCRIPTOR,
         ),
+        _descriptor.FieldDescriptor(
+            name="oidc_token",
+            full_name="google.pubsub.v1.PushConfig.oidc_token",
+            index=2,
+            number=3,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
     ],
     extensions=[],
-    nested_types=[_PUSHCONFIG_ATTRIBUTESENTRY],
+    nested_types=[_PUSHCONFIG_ATTRIBUTESENTRY, _PUSHCONFIG_OIDCTOKEN],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,
     syntax="proto3",
     extension_ranges=[],
-    oneofs=[],
+    oneofs=[
+        _descriptor.OneofDescriptor(
+            name="authentication_method",
+            full_name="google.pubsub.v1.PushConfig.authentication_method",
+            index=0,
+            containing_type=None,
+            fields=[],
+        )
+    ],
     serialized_start=1949,
-    serialized_end=2101,
+    serialized_end=2250,
 )
 
 
@@ -1412,8 +1494,8 @@ _RECEIVEDMESSAGE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=2103,
-    serialized_end=2186,
+    serialized_start=2252,
+    serialized_end=2335,
 )
 
 
@@ -1451,8 +1533,8 @@ _GETSUBSCRIPTIONREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=2188,
-    serialized_end=2234,
+    serialized_start=2337,
+    serialized_end=2383,
 )
 
 
@@ -1508,8 +1590,8 @@ _UPDATESUBSCRIPTIONREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=2237,
-    serialized_end=2367,
+    serialized_start=2386,
+    serialized_end=2516,
 )
 
 
@@ -1583,8 +1665,8 @@ _LISTSUBSCRIPTIONSREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=2369,
-    serialized_end=2451,
+    serialized_start=2518,
+    serialized_end=2600,
 )
 
 
@@ -1640,8 +1722,8 @@ _LISTSUBSCRIPTIONSRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=2453,
-    serialized_end=2560,
+    serialized_start=2602,
+    serialized_end=2709,
 )
 
 
@@ -1679,8 +1761,8 @@ _DELETESUBSCRIPTIONREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=2562,
-    serialized_end=2611,
+    serialized_start=2711,
+    serialized_end=2760,
 )
 
 
@@ -1736,8 +1818,8 @@ _MODIFYPUSHCONFIGREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=2613,
-    serialized_end=2711,
+    serialized_start=2762,
+    serialized_end=2860,
 )
 
 
@@ -1811,8 +1893,8 @@ _PULLREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=2713,
-    serialized_end=2798,
+    serialized_start=2862,
+    serialized_end=2947,
 )
 
 
@@ -1850,8 +1932,8 @@ _PULLRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=2800,
-    serialized_end=2876,
+    serialized_start=2949,
+    serialized_end=3025,
 )
 
 
@@ -1925,8 +2007,8 @@ _MODIFYACKDEADLINEREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=2878,
-    serialized_end=2973,
+    serialized_start=3027,
+    serialized_end=3122,
 )
 
 
@@ -1982,8 +2064,8 @@ _ACKNOWLEDGEREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=2975,
-    serialized_end=3034,
+    serialized_start=3124,
+    serialized_end=3183,
 )
 
 
@@ -2093,8 +2175,8 @@ _STREAMINGPULLREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=3037,
-    serialized_end=3201,
+    serialized_start=3186,
+    serialized_end=3350,
 )
 
 
@@ -2132,8 +2214,8 @@ _STREAMINGPULLRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=3203,
-    serialized_end=3288,
+    serialized_start=3352,
+    serialized_end=3437,
 )
 
 
@@ -2263,8 +2345,8 @@ _CREATESNAPSHOTREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=3291,
-    serialized_end=3466,
+    serialized_start=3440,
+    serialized_end=3615,
 )
 
 
@@ -2320,8 +2402,8 @@ _UPDATESNAPSHOTREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=3468,
-    serialized_end=3586,
+    serialized_start=3617,
+    serialized_end=3735,
 )
 
 
@@ -2469,8 +2551,8 @@ _SNAPSHOT = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=3589,
-    serialized_end=3780,
+    serialized_start=3738,
+    serialized_end=3929,
 )
 
 
@@ -2508,8 +2590,8 @@ _GETSNAPSHOTREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=3782,
-    serialized_end=3820,
+    serialized_start=3931,
+    serialized_end=3969,
 )
 
 
@@ -2583,8 +2665,8 @@ _LISTSNAPSHOTSREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=3822,
-    serialized_end=3900,
+    serialized_start=3971,
+    serialized_end=4049,
 )
 
 
@@ -2640,8 +2722,8 @@ _LISTSNAPSHOTSRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=3902,
-    serialized_end=3997,
+    serialized_start=4051,
+    serialized_end=4146,
 )
 
 
@@ -2679,8 +2761,8 @@ _DELETESNAPSHOTREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=3999,
-    serialized_end=4040,
+    serialized_start=4148,
+    serialized_end=4189,
 )
 
 
@@ -2762,8 +2844,8 @@ _SEEKREQUEST = _descriptor.Descriptor(
             fields=[],
         )
     ],
-    serialized_start=4042,
-    serialized_end=4151,
+    serialized_start=4191,
+    serialized_end=4300,
 )
 
 
@@ -2782,8 +2864,8 @@ _SEEKRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=4153,
-    serialized_end=4167,
+    serialized_start=4302,
+    serialized_end=4316,
 )
 
 _TOPIC_LABELSENTRY.containing_type = _TOPIC
@@ -2813,7 +2895,15 @@ _EXPIRATIONPOLICY.fields_by_name[
     "ttl"
 ].message_type = google_dot_protobuf_dot_duration__pb2._DURATION
 _PUSHCONFIG_ATTRIBUTESENTRY.containing_type = _PUSHCONFIG
+_PUSHCONFIG_OIDCTOKEN.containing_type = _PUSHCONFIG
 _PUSHCONFIG.fields_by_name["attributes"].message_type = _PUSHCONFIG_ATTRIBUTESENTRY
+_PUSHCONFIG.fields_by_name["oidc_token"].message_type = _PUSHCONFIG_OIDCTOKEN
+_PUSHCONFIG.oneofs_by_name["authentication_method"].fields.append(
+    _PUSHCONFIG.fields_by_name["oidc_token"]
+)
+_PUSHCONFIG.fields_by_name["oidc_token"].containing_oneof = _PUSHCONFIG.oneofs_by_name[
+    "authentication_method"
+]
 _RECEIVEDMESSAGE.fields_by_name["message"].message_type = _PUBSUBMESSAGE
 _UPDATESUBSCRIPTIONREQUEST.fields_by_name["subscription"].message_type = _SUBSCRIPTION
 _UPDATESUBSCRIPTIONREQUEST.fields_by_name[
@@ -3409,6 +3499,38 @@ PushConfig = _reflection.GeneratedProtocolMessageType(
                 # @@protoc_insertion_point(class_scope:google.pubsub.v1.PushConfig.AttributesEntry)
             ),
         ),
+        OidcToken=_reflection.GeneratedProtocolMessageType(
+            "OidcToken",
+            (_message.Message,),
+            dict(
+                DESCRIPTOR=_PUSHCONFIG_OIDCTOKEN,
+                __module__="google.cloud.pubsub_v1.proto.pubsub_pb2",
+                __doc__="""Contains information needed for generating an `OpenID Connect
+    token <https://developers.google.com/identity/protocols/OpenIDConnect>`__.
+    
+    
+    Attributes:
+        service_account_email:
+            `Service account email
+            <https://cloud.google.com/iam/docs/service-accounts>`__ to be
+            used for generating the OIDC token. The caller (for
+            CreateSubscription, UpdateSubscription, and ModifyPushConfig
+            calls) must have the iam.serviceAccounts.actAs permission for
+            the service account. See
+            https://cloud.google.com/iam/docs/understanding-roles#service-
+            accounts-roles.
+        audience:
+            Audience to be used when generating OIDC token. The audience
+            claim identifies the recipients that the JWT is intended for.
+            The audience value is a single case-sensitive string. Having
+            multiple values (array) for the audience field is not
+            supported. More info about the OIDC JWT token audience here:
+            https://tools.ietf.org/html/rfc7519#section-4.1.3 Note: if not
+            specified, the Push endpoint URL will be used.
+    """,
+                # @@protoc_insertion_point(class_scope:google.pubsub.v1.PushConfig.OidcToken)
+            ),
+        ),
         DESCRIPTOR=_PUSHCONFIG,
         __module__="google.cloud.pubsub_v1.proto.pubsub_pb2",
         __doc__="""Configuration for a push delivery endpoint.
@@ -3438,12 +3560,27 @@ PushConfig = _reflection.GeneratedProtocolMessageType(
           uses the push format defined in the v1beta1 Pub/Sub API. -
           ``v1`` or ``v1beta2``: uses the push format defined in the v1
           Pub/Sub    API.
+      authentication_method:
+          An authentication method used by push endpoints to verify the
+          source of push requests. This can be used with push endpoints
+          that are private by default to allow requests only from the
+          Cloud Pub/Sub system, for example. This field is optional and
+          should be set only by users interested in authenticated push.
+          EXPERIMENTAL: This field a part of a closed alpha that may not
+          be accessible to all users. It may be changed in backward-
+          incompatible ways and is not subject to any SLA or deprecation
+          policy. It is not recommended for production use.
+      oidc_token:
+          If specified, Pub/Sub will generate and attach an OIDC JWT
+          token as an ``Authorization`` header in the HTTP request for
+          every pushed message.
   """,
         # @@protoc_insertion_point(class_scope:google.pubsub.v1.PushConfig)
     ),
 )
 _sym_db.RegisterMessage(PushConfig)
 _sym_db.RegisterMessage(PushConfig.AttributesEntry)
+_sym_db.RegisterMessage(PushConfig.OidcToken)
 
 ReceivedMessage = _reflection.GeneratedProtocolMessageType(
     "ReceivedMessage",
@@ -4068,8 +4205,8 @@ _PUBLISHER = _descriptor.ServiceDescriptor(
     file=DESCRIPTOR,
     index=0,
     serialized_options=None,
-    serialized_start=4170,
-    serialized_end=5257,
+    serialized_start=4319,
+    serialized_end=5406,
     methods=[
         _descriptor.MethodDescriptor(
             name="CreateTopic",
@@ -4172,8 +4309,8 @@ _SUBSCRIBER = _descriptor.ServiceDescriptor(
     file=DESCRIPTOR,
     index=1,
     serialized_options=None,
-    serialized_start=5260,
-    serialized_end=7557,
+    serialized_start=5409,
+    serialized_end=7706,
     methods=[
         _descriptor.MethodDescriptor(
             name="CreateSubscription",

--- a/pubsub/google/cloud/pubsub_v1/proto/pubsub_pb2_grpc.py
+++ b/pubsub/google/cloud/pubsub_v1/proto/pubsub_pb2_grpc.py
@@ -297,9 +297,10 @@ class SubscriberServicer(object):
     If the name is not provided in the request, the server will assign a random
     name for this subscription on the same project as the topic, conforming
     to the
-    [resource name format](https://cloud.google.com/pubsub/docs/admin#resource_names).
-    The generated name is populated in the returned Subscription object.
-    Note that for REST API requests, you must specify a name in the request.
+    [resource name
+    format](https://cloud.google.com/pubsub/docs/admin#resource_names). The
+    generated name is populated in the returned Subscription object. Note that
+    for REST API requests, you must specify a name in the request.
     """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
@@ -444,9 +445,10 @@ class SubscriberServicer(object):
     the request, the server will assign a random
     name for this snapshot on the same project as the subscription, conforming
     to the
-    [resource name format](https://cloud.google.com/pubsub/docs/admin#resource_names).
-    The generated name is populated in the returned Snapshot object. Note that
-    for REST API requests, you must specify a name in the request.
+    [resource name
+    format](https://cloud.google.com/pubsub/docs/admin#resource_names). The
+    generated name is populated in the returned Snapshot object. Note that for
+    REST API requests, you must specify a name in the request.
     """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")

--- a/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -41,6 +41,7 @@ _RETRYABLE_STREAM_ERRORS = (
     exceptions.InternalServerError,
     exceptions.Unknown,
     exceptions.GatewayTimeout,
+    exceptions.Aborted,
 )
 
 

--- a/pubsub/noxfile.py
+++ b/pubsub/noxfile.py
@@ -45,6 +45,10 @@ def blacken(session):
     """Run black.
 
     Format code to uniform standard.
+    
+    This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
+    That run uses an image that doesn't have 3.6 installed. Before updating this
+    check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
     """
     session.install("black")
     session.run(

--- a/pubsub/synth.metadata
+++ b/pubsub/synth.metadata
@@ -1,26 +1,26 @@
 {
-  "updateTime": "2019-02-01T01:07:16.579788Z",
+  "updateTime": "2019-03-14T17:14:10.475230Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.16.7",
-        "dockerImage": "googleapis/artman@sha256:d6c8ced606eb49973ca95d2af7c55a681acc042db0f87d135968349e7bf6dd80"
+        "version": "0.16.17",
+        "dockerImage": "googleapis/artman@sha256:7231f27272231a884e09edb5953148c85ecd8467780d33c4a35c3e507885715b"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "acb5253cd11cd43cab93eb153d6e48ba0fa5303d",
-        "internalRef": "231786007"
+        "sha": "d05a746ba27b89374c7407c88c0d5dabfb0afc7c",
+        "internalRef": "238372434"
       }
     },
     {
       "template": {
         "name": "python_library",
         "origin": "synthtool.gcp",
-        "version": "2019.1.16"
+        "version": "2019.2.26"
       }
     }
   ],


### PR DESCRIPTION
Add `ABORT` to the set of retryable stream errors, per updates to the googleapis GAPIC config.

Pick up proto linting / comment changes.

Closes #7399.