### PR TITLE
Refactor table() methods into shared implementation.

### DIFF
--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -24,6 +24,19 @@ from google.cloud.bigquery import _helpers
 from google.cloud.bigquery.table import TableReference
 
 
+def _get_table_reference(self, table_id):
+    """Constructs a TableReference.
+
+    Args:
+        table_id (str): The ID of the table.
+
+    Returns:
+        google.cloud.bigquery.table.TableReference:
+            A table reference for a table in this dataset.
+    """
+    return TableReference(self, table_id)
+
+
 class AccessEntry(object):
     """Represents grant of an access role to an entity.
 
@@ -191,17 +204,7 @@ class DatasetReference(object):
         """str: URL path for the dataset based on project and dataset ID."""
         return "/projects/%s/datasets/%s" % (self.project, self.dataset_id)
 
-    def table(self, table_id):
-        """Constructs a TableReference.
-
-        Args:
-            table_id (str): The ID of the table.
-
-        Returns:
-            google.cloud.bigquery.table.TableReference:
-                A table reference for a table in this dataset.
-        """
-        return TableReference(self, table_id)
+    table = _get_table_reference
 
     @classmethod
     def from_api_repr(cls, resource):
@@ -578,17 +581,7 @@ class Dataset(object):
 
         return partial
 
-    def table(self, table_id):
-        """Constructs a TableReference.
-
-        Args:
-            table_id (str): the ID of the table.
-
-        Returns:
-            google.cloud.bigquery.table.TableReference:
-                A TableReference for a table in this dataset.
-        """
-        return TableReference(self.reference, table_id)
+    table = _get_table_reference
 
     def __repr__(self):
         return "Dataset({})".format(repr(self.reference))
@@ -668,14 +661,4 @@ class DatasetListItem(object):
         """
         return DatasetReference(self.project, self.dataset_id)
 
-    def table(self, table_id):
-        """Constructs a TableReference.
-
-        Args:
-            table_id (str): the ID of the table.
-
-        Returns:
-            google.cloud.bigquery.table.TableReference:
-                A TableReference for a table in this dataset.
-        """
-        return TableReference(self.reference, table_id)
+    table = _get_table_reference


### PR DESCRIPTION
The method and docstring for the table() method are identical for
Dataset, DatasetReference, and DatasetListItem. This commit moves the
implementation to a shared method to reduce code duplication.