### PR TITLE
Bigtable: cleanup unused variable and add deprecation warnings for to be removed features

### DIFF
--- a/bigtable/google/cloud/bigtable/instance.py
+++ b/bigtable/google/cloud/bigtable/instance.py
@@ -29,11 +29,17 @@ from google.api_core.exceptions import NotFound
 
 from google.cloud.bigtable.policy import Policy
 
+import warnings
 
-_EXISTING_INSTANCE_LOCATION_ID = "see-existing-cluster"
 _INSTANCE_NAME_RE = re.compile(
     r"^projects/(?P<project>[^/]+)/" r"instances/(?P<instance_id>[a-z][-a-z0-9]*)$"
 )
+
+_INSTANCE_CREATE_WARNING = """
+Use of `instance.create({0}, {1}, {2})` will be depricated.
+Please replace with
+`cluster = instance.cluster({0}, {1}, {2})`
+`instance.create(clusters=[cluster])`."""
 
 
 class Instance(object):
@@ -276,6 +282,14 @@ class Instance(object):
         """
 
         if clusters is None:
+            warnings.warn(
+                _INSTANCE_CREATE_WARNING.format(
+                    "location_id", "serve_nodes", "default_storage_type"
+                ),
+                PendingDeprecationWarning,
+                stacklevel=2,
+            )
+
             cluster_id = "{}-cluster".format(self.instance_id)
 
             clusters = [

--- a/bigtable/google/cloud/bigtable/instance.py
+++ b/bigtable/google/cloud/bigtable/instance.py
@@ -286,7 +286,7 @@ class Instance(object):
                 _INSTANCE_CREATE_WARNING.format(
                     "location_id", "serve_nodes", "default_storage_type"
                 ),
-                PendingDeprecationWarning,
+                DeprecationWarning,
                 stacklevel=2,
             )
 

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -42,6 +42,8 @@ from google.cloud.bigtable_admin_v2.proto import (
     bigtable_table_admin_pb2 as table_admin_messages_v2_pb2,
 )
 
+import warnings
+
 
 # Maximum number of mutations in bulk (MutateRowsRequest message):
 # (https://cloud.google.com/bigtable/docs/reference/data/rpc/
@@ -467,6 +469,11 @@ class Table(object):
         :rtype: :class:`.PartialRowData`
         :returns: A :class:`.PartialRowData` for each row returned
         """
+        warnings.warn(
+            "`yield_rows()` is depricated; use `red_rows()` instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.read_rows(**kwargs)
 
     def mutate_rows(self, rows, retry=DEFAULT_RETRY):

--- a/bigtable/tests/unit/test_instance.py
+++ b/bigtable/tests/unit/test_instance.py
@@ -292,6 +292,7 @@ class TestInstance(unittest.TestCase):
     def test_create(self):
         from google.cloud.bigtable import enums
         from google.cloud.bigtable_admin_v2.types import instance_pb2
+        import warnings
 
         credentials = _make_credentials()
         client = self._make_client(
@@ -308,7 +309,8 @@ class TestInstance(unittest.TestCase):
         client._instance_admin_client = instance_api
         serve_nodes = 3
 
-        result = instance.create(location_id=self.LOCATION_ID, serve_nodes=serve_nodes)
+        with warnings.catch_warnings(record=True) as warned:    
+            result = instance.create(location_id=self.LOCATION_ID, serve_nodes=serve_nodes)
 
         cluster_pb = instance_pb2.Cluster(
             location=instance_api.location_path(self.PROJECT, self.LOCATION_ID),
@@ -327,6 +329,9 @@ class TestInstance(unittest.TestCase):
             instance=instance_pb,
             clusters={cluster_id: cluster_pb},
         )
+
+        self.assertEqual(len(warned), 1)
+        self.assertIs(warned[0].category, DeprecationWarning)
 
         self.assertIs(result, response)
 

--- a/bigtable/tests/unit/test_instance.py
+++ b/bigtable/tests/unit/test_instance.py
@@ -309,8 +309,10 @@ class TestInstance(unittest.TestCase):
         client._instance_admin_client = instance_api
         serve_nodes = 3
 
-        with warnings.catch_warnings(record=True) as warned:    
-            result = instance.create(location_id=self.LOCATION_ID, serve_nodes=serve_nodes)
+        with warnings.catch_warnings(record=True) as warned:
+            result = instance.create(
+                location_id=self.LOCATION_ID, serve_nodes=serve_nodes
+            )
 
         cluster_pb = instance_pb2.Cluster(
             location=instance_api.location_path(self.PROJECT, self.LOCATION_ID),

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -801,8 +801,13 @@ class TestTable(unittest.TestCase):
 
         rows = []
         with warnings.catch_warnings(record=True) as warned:
-            for row in table.yield_rows(start_key=self.ROW_KEY_1, end_key=self.ROW_KEY_2):
+            for row in table.yield_rows(
+                start_key=self.ROW_KEY_1, end_key=self.ROW_KEY_2
+            ):
                 rows.append(row)
+
+        self.assertEqual(len(warned), 1)
+        self.assertIs(warned[0].category, DeprecationWarning)
 
         result = rows[1]
         self.assertEqual(result.row_key, self.ROW_KEY_2)
@@ -873,7 +878,7 @@ class TestTable(unittest.TestCase):
         with warnings.catch_warnings(record=True) as warned:
             for row in table.yield_rows(row_set=row_set):
                 rows.append(row)
-        
+
         self.assertEqual(len(warned), 1)
         self.assertIs(warned[0].category, DeprecationWarning)
 

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -752,6 +752,7 @@ class TestTable(unittest.TestCase):
     def test_yield_retry_rows(self):
         from google.cloud.bigtable_v2.gapic import bigtable_client
         from google.cloud.bigtable_admin_v2.gapic import bigtable_table_admin_client
+        import warnings
 
         data_api = bigtable_client.BigtableClient(mock.Mock())
         table_api = bigtable_table_admin_client.BigtableTableAdminClient(mock.Mock())
@@ -799,8 +800,9 @@ class TestTable(unittest.TestCase):
         )
 
         rows = []
-        for row in table.yield_rows(start_key=self.ROW_KEY_1, end_key=self.ROW_KEY_2):
-            rows.append(row)
+        with warnings.catch_warnings(record=True) as warned:
+            for row in table.yield_rows(start_key=self.ROW_KEY_1, end_key=self.ROW_KEY_2):
+                rows.append(row)
 
         result = rows[1]
         self.assertEqual(result.row_key, self.ROW_KEY_2)
@@ -810,6 +812,7 @@ class TestTable(unittest.TestCase):
         from google.cloud.bigtable_admin_v2.gapic import bigtable_table_admin_client
         from google.cloud.bigtable.row_set import RowSet
         from google.cloud.bigtable.row_set import RowRange
+        import warnings
 
         data_api = bigtable_client.BigtableClient(mock.Mock())
         table_api = bigtable_table_admin_client.BigtableTableAdminClient(mock.Mock())
@@ -866,8 +869,13 @@ class TestTable(unittest.TestCase):
             RowRange(start_key=self.ROW_KEY_1, end_key=self.ROW_KEY_2)
         )
         row_set.add_row_key(self.ROW_KEY_3)
-        for row in table.yield_rows(row_set=row_set):
-            rows.append(row)
+
+        with warnings.catch_warnings(record=True) as warned:
+            for row in table.yield_rows(row_set=row_set):
+                rows.append(row)
+        
+        self.assertEqual(len(warned), 1)
+        self.assertIs(warned[0].category, DeprecationWarning)
 
         self.assertEqual(rows[0].row_key, self.ROW_KEY_1)
         self.assertEqual(rows[1].row_key, self.ROW_KEY_2)


### PR DESCRIPTION
Fixes #7531 
* some cleanup
* add deprecation warnings for backwards compatible features that will go away