### PR TITLE
Use temporary file in load_table_from_dataframe

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -24,6 +24,7 @@ except ImportError:  # Python 2.7
 import functools
 import gzip
 import os
+import tempfile
 import uuid
 
 import six
@@ -1123,11 +1124,10 @@ class Client(ClientWithProject):
 
         Raises:
             ImportError:
-                If a usable parquet engine cannot be found. This method
-                requires :mod:`pyarrow` to be installed.
+                If a usable parquet engine cannot be found. requires
+                :mod:`pyarrow` or :mod:`fastparquet` to be installed.
         """
-        buffer = six.BytesIO()
-        dataframe.to_parquet(buffer)
+        job_id = _make_job_id(job_id, job_id_prefix)
 
         if job_config is None:
             job_config = job.LoadJobConfig()
@@ -1136,17 +1136,27 @@ class Client(ClientWithProject):
         if location is None:
             location = self.location
 
-        return self.load_table_from_file(
-            buffer,
-            destination,
-            num_retries=num_retries,
-            rewind=True,
-            job_id=job_id,
-            job_id_prefix=job_id_prefix,
-            location=location,
-            project=project,
-            job_config=job_config,
-        )
+        tmpfd, tmppath = tempfile.mkstemp(suffix="_job_{}.parquet".format(job_id[:8]))
+        os.close(tmpfd)
+
+        try:
+            dataframe.to_parquet(tmppath)
+
+            with open(tmppath, "rb") as parquet_file:
+                return self.load_table_from_file(
+                    parquet_file,
+                    destination,
+                    num_retries=num_retries,
+                    rewind=True,
+                    job_id=job_id,
+                    job_id_prefix=job_id_prefix,
+                    location=location,
+                    project=project,
+                    job_config=job_config,
+                )
+
+        finally:
+            os.remove(tmppath)
 
     def _do_resumable_upload(self, stream, metadata, num_retries):
         """Perform a resumable upload.

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1124,8 +1124,9 @@ class Client(ClientWithProject):
 
         Raises:
             ImportError:
-                If a usable parquet engine cannot be found. requires
-                :mod:`pyarrow` or :mod:`fastparquet` to be installed.
+                If a usable parquet engine cannot be found. This method
+                requires :mod:`pyarrow` or :mod:`fastparquet` to be
+                installed.
         """
         job_id = _make_job_id(job_id, job_id_prefix)
 

--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -123,7 +123,7 @@ def snippets(session):
         session.install('-e', local_dep)
     session.install('-e', os.path.join('..', 'storage'))
     session.install('-e', os.path.join('..', 'test_utils'))
-    session.install('-e', '.[pandas, pyarrow]')
+    session.install('-e', '.[pandas, pyarrow, fastparquet]')
 
     # Run py.test against the snippets tests.
     session.run(

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -39,6 +39,7 @@ extras = {
     # Exclude PyArrow dependency from Windows Python 2.7.
     'pyarrow: platform_system != "Windows" or python_version >= "3.4"':
         'pyarrow>=0.4.1',
+    'fastparquet': ['fastparquet', 'python-snappy'],
 }
 
 

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -4658,7 +4658,7 @@ class TestClientUpload(object):
             self.TABLE_REF,
             num_retries=_DEFAULT_NUM_RETRIES,
             rewind=True,
-            job_id=None,
+            job_id=mock.ANY,
             job_id_prefix=None,
             location=None,
             project=None,
@@ -4666,9 +4666,7 @@ class TestClientUpload(object):
         )
 
         sent_file = load_table_from_file.mock_calls[0][1][1]
-        sent_bytes = sent_file.getvalue()
-        assert isinstance(sent_bytes, bytes)
-        assert len(sent_bytes) > 0
+        assert sent_file.closed
 
         sent_config = load_table_from_file.mock_calls[0][2]["job_config"]
         assert sent_config.source_format == job.SourceFormat.PARQUET
@@ -4695,7 +4693,7 @@ class TestClientUpload(object):
             self.TABLE_REF,
             num_retries=_DEFAULT_NUM_RETRIES,
             rewind=True,
-            job_id=None,
+            job_id=mock.ANY,
             job_id_prefix=None,
             location=self.LOCATION,
             project=None,
@@ -4703,9 +4701,7 @@ class TestClientUpload(object):
         )
 
         sent_file = load_table_from_file.mock_calls[0][1][1]
-        sent_bytes = sent_file.getvalue()
-        assert isinstance(sent_bytes, bytes)
-        assert len(sent_bytes) > 0
+        assert sent_file.closed
 
         sent_config = load_table_from_file.mock_calls[0][2]["job_config"]
         assert sent_config.source_format == job.SourceFormat.PARQUET
@@ -4735,7 +4731,7 @@ class TestClientUpload(object):
             self.TABLE_REF,
             num_retries=_DEFAULT_NUM_RETRIES,
             rewind=True,
-            job_id=None,
+            job_id=mock.ANY,
             job_id_prefix=None,
             location=self.LOCATION,
             project=None,


### PR DESCRIPTION
This fixes a bug where `load_table_from_dataframe` could not be used
with the `fastparquet` library. It should also use less memory when
uploading large dataframes.

Fixes #7543 