### PR TITLE
google-cloud-python/talent - Broken talent client library documentation link

### DIFF
--- a/talent/README.rst
+++ b/talent/README.rst
@@ -9,7 +9,7 @@ delete job postings, as well as search jobs based on keywords and filters.
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _Cloud Talent Solution API: https://cloud.google.com/jobs
-.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/jobs/usage.html
+.. _Client Library Documentation: https://googleapis.github.io/google-cloud-python/latest/talent/index.html
 .. _Product Documentation:  https://cloud.google.com/jobs
 
 Quick Start


### PR DESCRIPTION
The current [client library documentation link](https://googleapis.github.io/google-cloud-python/latest/jobs/usage.html) throws a 404 error. Changed to proper redirection [link](https://googleapis.github.io/google-cloud-python/latest/talent/index.html).