### PR TITLE
Allow string for copy sources, query destination, and default dataset

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -54,7 +54,6 @@ from google.cloud.bigquery.table import Table
 from google.cloud.bigquery.table import TableListItem
 from google.cloud.bigquery.table import TableReference
 from google.cloud.bigquery.table import RowIterator
-from google.cloud.bigquery.table import _TABLE_HAS_NO_SCHEMA
 
 
 _DEFAULT_CHUNKSIZE = 1048576  # 1024 * 1024 B = 1 MB
@@ -429,11 +428,11 @@ class Client(ClientWithProject):
         api_response = self._call_api(retry, method="GET", path=dataset_ref.path)
         return Dataset.from_api_repr(api_response)
 
-    def get_table(self, table_ref, retry=DEFAULT_RETRY):
-        """Fetch the table referenced by ``table_ref``.
+    def get_table(self, table, retry=DEFAULT_RETRY):
+        """Fetch the table referenced by ``table``.
 
         Args:
-            table_ref (Union[ \
+            table (Union[ \
                 :class:`~google.cloud.bigquery.table.Table`, \
                 :class:`~google.cloud.bigquery.table.TableReference`, \
                 str, \
@@ -449,7 +448,7 @@ class Client(ClientWithProject):
             google.cloud.bigquery.table.Table:
                 A ``Table`` instance.
         """
-        table_ref = _table_arg_to_table_ref(table_ref, default_project=self.project)
+        table_ref = _table_arg_to_table_ref(table, default_project=self.project)
         api_response = self._call_api(retry, method="GET", path=table_ref.path)
         return Table.from_api_repr(api_response)
 
@@ -964,9 +963,7 @@ class Client(ClientWithProject):
         if isinstance(source_uris, six.string_types):
             source_uris = [source_uris]
 
-        destination = _table_arg_to_table_ref(
-            destination, default_project=self.project
-        )
+        destination = _table_arg_to_table_ref(destination, default_project=self.project)
         load_job = job.LoadJob(job_ref, source_uris, destination, self, job_config)
         load_job._begin(retry=retry)
 
@@ -1042,9 +1039,7 @@ class Client(ClientWithProject):
         if location is None:
             location = self.location
 
-        destination = _table_arg_to_table_ref(
-            destination, default_project=self.project
-        )
+        destination = _table_arg_to_table_ref(destination, default_project=self.project)
         job_ref = job._JobReference(job_id, project=project, location=location)
         load_job = job.LoadJob(job_ref, None, destination, self, job_config)
         job_resource = load_job.to_api_repr()
@@ -1345,9 +1340,7 @@ class Client(ClientWithProject):
             for source in sources
         ]
 
-        destination = _table_arg_to_table_ref(
-            destination, default_project=self.project
-        )
+        destination = _table_arg_to_table_ref(destination, default_project=self.project)
 
         copy_job = job.CopyJob(
             job_ref, sources, destination, client=self, job_config=job_config
@@ -1550,10 +1543,12 @@ class Client(ClientWithProject):
             schema = selected_fields
 
         if len(schema) == 0:
-            raise ValueError((
-                "Could not determine schema for table '{}'. Call client.get_table() "
-                "or pass in a list of schema fields to the selected_fields argument."
-            ).format(table))
+            raise ValueError(
+                (
+                    "Could not determine schema for table '{}'. Call client.get_table() "
+                    "or pass in a list of schema fields to the selected_fields argument."
+                ).format(table)
+            )
 
         json_rows = [_record_field_to_json(schema, row) for row in rows]
 
@@ -1748,10 +1743,12 @@ class Client(ClientWithProject):
 
         # Allow listing rows of an empty table by not raising if the table exists.
         elif len(schema) == 0 and table.created is None:
-            raise ValueError((
-                "Could not determine schema for table '{}'. Call client.get_table() "
-                "or pass in a list of schema fields to the selected_fields argument."
-            ).format(table))
+            raise ValueError(
+                (
+                    "Could not determine schema for table '{}'. Call client.get_table() "
+                    "or pass in a list of schema fields to the selected_fields argument."
+                ).format(table)
+            )
 
         params = {}
         if selected_fields is not None:

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -48,6 +48,7 @@ from google.cloud.bigquery.dataset import DatasetReference
 from google.cloud.bigquery import job
 from google.cloud.bigquery.query import _QueryResults
 from google.cloud.bigquery.retry import DEFAULT_RETRY
+from google.cloud.bigquery.table import _str_or_ref_to_table_ref
 from google.cloud.bigquery.table import Table
 from google.cloud.bigquery.table import TableListItem
 from google.cloud.bigquery.table import TableReference
@@ -379,8 +380,8 @@ class Client(ClientWithProject):
             google.cloud.bigquery.table.Table:
                 A new ``Table`` returned from the service.
         """
-        if isinstance(table, str):
-            table = TableReference.from_string(table, default_project=self.project)
+        table = _str_or_ref_to_table_ref(table, default_project=self.project)
+
         if isinstance(table, TableReference):
             table = Table(table)
 
@@ -446,11 +447,7 @@ class Client(ClientWithProject):
             google.cloud.bigquery.table.Table:
                 A ``Table`` instance.
         """
-        if isinstance(table_ref, str):
-            table_ref = TableReference.from_string(
-                table_ref, default_project=self.project
-            )
-
+        table_ref = _str_or_ref_to_table_ref(table_ref, default_project=self.project)
         api_response = self._call_api(retry, method="GET", path=table_ref.path)
         return Table.from_api_repr(api_response)
 
@@ -653,8 +650,7 @@ class Client(ClientWithProject):
                 Defaults to ``False``. If ``True``, ignore "not found" errors
                 when deleting the table.
         """
-        if isinstance(table, str):
-            table = TableReference.from_string(table, default_project=self.project)
+        table = _str_or_ref_to_table_ref(table, default_project=self.project)
 
         if not isinstance(table, (Table, TableReference)):
             raise TypeError("table must be a Table or a TableReference")
@@ -966,11 +962,9 @@ class Client(ClientWithProject):
         if isinstance(source_uris, six.string_types):
             source_uris = [source_uris]
 
-        if isinstance(destination, str):
-            destination = TableReference.from_string(
-                destination, default_project=self.project
-            )
-
+        destination = _str_or_ref_to_table_ref(
+            destination, default_project=self.project
+        )
         load_job = job.LoadJob(job_ref, source_uris, destination, self, job_config)
         load_job._begin(retry=retry)
 
@@ -1045,11 +1039,9 @@ class Client(ClientWithProject):
         if location is None:
             location = self.location
 
-        if isinstance(destination, str):
-            destination = TableReference.from_string(
-                destination, default_project=self.project
-            )
-
+        destination = _str_or_ref_to_table_ref(
+            destination, default_project=self.project
+        )
         job_ref = job._JobReference(job_id, project=project, location=location)
         load_job = job.LoadJob(job_ref, None, destination, self, job_config)
         job_resource = load_job.to_api_repr()
@@ -1288,6 +1280,7 @@ class Client(ClientWithProject):
             sources (Union[ \
                 :class:`~google.cloud.bigquery.table.TableReference`, \
                 str, \
+                Sequence[str], \
                 Sequence[ \
                     :class:`~google.cloud.bigquery.table.TableReference`], \
             ]):
@@ -1327,18 +1320,18 @@ class Client(ClientWithProject):
             location = self.location
 
         job_ref = job._JobReference(job_id, project=project, location=location)
-
-        if isinstance(sources, str):
-            sources = TableReference.from_string(sources, default_project=self.project)
-
-        if isinstance(destination, str):
-            destination = TableReference.from_string(
-                destination, default_project=self.project
-            )
+        sources = _str_or_ref_to_table_ref(sources, default_project=self.project)
+        destination = _str_or_ref_to_table_ref(
+            destination, default_project=self.project
+        )
 
         if not isinstance(sources, collections_abc.Sequence):
             sources = [sources]
 
+        sources = [
+            _str_or_ref_to_table_ref(source, default_project=self.project)
+            for source in sources
+        ]
         copy_job = job.CopyJob(
             job_ref, sources, destination, client=self, job_config=job_config
         )
@@ -1405,9 +1398,7 @@ class Client(ClientWithProject):
             location = self.location
 
         job_ref = job._JobReference(job_id, project=project, location=location)
-
-        if isinstance(source, str):
-            source = TableReference.from_string(source, default_project=self.project)
+        source = _str_or_ref_to_table_ref(source, default_project=self.project)
 
         if isinstance(destination_uris, six.string_types):
             destination_uris = [destination_uris]
@@ -1529,8 +1520,7 @@ class Client(ClientWithProject):
         Raises:
             ValueError: if table's schema is not set
         """
-        if isinstance(table, str):
-            table = TableReference.from_string(table, default_project=self.project)
+        table = _str_or_ref_to_table_ref(table, default_project=self.project)
 
         if selected_fields is not None:
             schema = selected_fields
@@ -1596,9 +1586,7 @@ class Client(ClientWithProject):
                 identifies the row, and the "errors" key contains a list of
                 the mappings describing one or more problems with the row.
         """
-        if isinstance(table, str):
-            table = TableReference.from_string(table, default_project=self.project)
-
+        table = _str_or_ref_to_table_ref(table, default_project=self.project)
         rows_info = []
         data = {"rows": rows_info}
 
@@ -1647,9 +1635,7 @@ class Client(ClientWithProject):
             List[str]:
                 A list of the partition ids present in the partitioned table
         """
-        if isinstance(table, str):
-            table = TableReference.from_string(table, default_project=self.project)
-
+        table = _str_or_ref_to_table_ref(table, default_project=self.project)
         meta_table = self.get_table(
             TableReference(
                 self.dataset(table.dataset_id, project=table.project),
@@ -1724,8 +1710,7 @@ class Client(ClientWithProject):
                 (this is distinct from the total number of rows in the
                 current page: ``iterator.page.num_items``).
         """
-        if isinstance(table, str):
-            table = TableReference.from_string(table, default_project=self.project)
+        table = _str_or_ref_to_table_ref(table, default_project=self.project)
 
         if selected_fields is not None:
             schema = selected_fields

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -23,6 +23,8 @@ from six.moves import http_client
 import google.api_core.future.polling
 from google.cloud import exceptions
 from google.cloud.exceptions import NotFound
+from google.cloud.bigquery.dataset import Dataset
+from google.cloud.bigquery.dataset import DatasetListItem
 from google.cloud.bigquery.dataset import DatasetReference
 from google.cloud.bigquery.external_config import ExternalConfig
 from google.cloud.bigquery.query import _query_param_from_api_repr
@@ -34,7 +36,7 @@ from google.cloud.bigquery.retry import DEFAULT_RETRY
 from google.cloud.bigquery.schema import SchemaField
 from google.cloud.bigquery.table import _EmptyRowIterator
 from google.cloud.bigquery.table import EncryptionConfiguration
-from google.cloud.bigquery.table import _str_or_ref_to_table_ref
+from google.cloud.bigquery.table import _table_arg_to_table_ref
 from google.cloud.bigquery.table import TableReference
 from google.cloud.bigquery.table import Table
 from google.cloud.bigquery.table import TimePartitioning
@@ -2003,10 +2005,11 @@ class QueryJobConfig(_JobConfig):
 
         The ``dataset`` setter accepts:
 
+        - a :class:`~google.cloud.bigquery.dataset.Dataset`, or
         - a :class:`~google.cloud.bigquery.dataset.DatasetReference`, or
         - a :class:`str` of the fully-qualified dataset ID in standard SQL
           format. The value must included a project ID and dataset ID
-          separated by ``.``.
+          separated by ``.``. For example: ``your-project.your_dataset``.
 
         See
         https://g.co/cloud/bigquery/docs/reference/v2/jobs#configuration.query.defaultDataset
@@ -2025,6 +2028,9 @@ class QueryJobConfig(_JobConfig):
         if isinstance(value, six.string_types):
             value = DatasetReference.from_string(value)
 
+        if isinstance(value, (Dataset, DatasetListItem)):
+            value = value.reference
+
         resource = value.to_api_repr()
         self._set_sub_prop("defaultDataset", resource)
 
@@ -2035,10 +2041,12 @@ class QueryJobConfig(_JobConfig):
 
         The ``destination`` setter accepts:
 
+        - a :class:`~google.cloud.bigquery.table.Table`, or
         - a :class:`~google.cloud.bigquery.table.TableReference`, or
         - a :class:`str` of the fully-qualified table ID in standard SQL
           format. The value must included a project ID, dataset ID, and table
-          ID, each separated by ``.``.
+          ID, each separated by ``.``. For example:
+          ``your-project.your_dataset.your_table``.
 
         See
         https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationTable
@@ -2054,7 +2062,7 @@ class QueryJobConfig(_JobConfig):
             self._set_sub_prop("destinationTable", None)
             return
 
-        value = _str_or_ref_to_table_ref(value)
+        value = _table_arg_to_table_ref(value)
         resource = value.to_api_repr()
         self._set_sub_prop("destinationTable", resource)
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -17,6 +17,7 @@
 import copy
 import threading
 
+import six
 from six.moves import http_client
 
 import google.api_core.future.polling
@@ -33,6 +34,7 @@ from google.cloud.bigquery.retry import DEFAULT_RETRY
 from google.cloud.bigquery.schema import SchemaField
 from google.cloud.bigquery.table import _EmptyRowIterator
 from google.cloud.bigquery.table import EncryptionConfiguration
+from google.cloud.bigquery.table import _str_or_ref_to_table_ref
 from google.cloud.bigquery.table import TableReference
 from google.cloud.bigquery.table import Table
 from google.cloud.bigquery.table import TimePartitioning
@@ -1999,6 +2001,13 @@ class QueryJobConfig(_JobConfig):
         to use for unqualified table names in the query or :data:`None` if not
         set.
 
+        The ``dataset`` setter accepts:
+
+        - a :class:`~google.cloud.bigquery.dataset.DatasetReference`, or
+        - a :class:`str` of the fully-qualified dataset ID in standard SQL
+          format. The value must included a project ID and dataset ID
+          separated by ``.``.
+
         See
         https://g.co/cloud/bigquery/docs/reference/v2/jobs#configuration.query.defaultDataset
         """
@@ -2009,15 +2018,27 @@ class QueryJobConfig(_JobConfig):
 
     @default_dataset.setter
     def default_dataset(self, value):
-        resource = None
-        if value is not None:
-            resource = value.to_api_repr()
+        if value is None:
+            self._set_sub_prop("defaultDataset", None)
+            return
+
+        if isinstance(value, six.string_types):
+            value = DatasetReference.from_string(value)
+
+        resource = value.to_api_repr()
         self._set_sub_prop("defaultDataset", resource)
 
     @property
     def destination(self):
         """google.cloud.bigquery.table.TableReference: table where results are
         written or :data:`None` if not set.
+
+        The ``destination`` setter accepts:
+
+        - a :class:`~google.cloud.bigquery.table.TableReference`, or
+        - a :class:`str` of the fully-qualified table ID in standard SQL
+          format. The value must included a project ID, dataset ID, and table
+          ID, each separated by ``.``.
 
         See
         https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationTable
@@ -2029,9 +2050,12 @@ class QueryJobConfig(_JobConfig):
 
     @destination.setter
     def destination(self, value):
-        resource = None
-        if value is not None:
-            resource = value.to_api_repr()
+        if value is None:
+            self._set_sub_prop("destinationTable", None)
+            return
+
+        value = _str_or_ref_to_table_ref(value)
+        resource = value.to_api_repr()
         self._set_sub_prop("destinationTable", resource)
 
     @property

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -2003,7 +2003,7 @@ class QueryJobConfig(_JobConfig):
         to use for unqualified table names in the query or :data:`None` if not
         set.
 
-        The ``dataset`` setter accepts:
+        The ``default_dataset`` setter accepts:
 
         - a :class:`~google.cloud.bigquery.dataset.Dataset`, or
         - a :class:`~google.cloud.bigquery.dataset.DatasetReference`, or

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1661,3 +1661,12 @@ def _rows_page_start(iterator, page, response):
 
 
 # pylint: enable=unused-argument
+
+
+def _str_or_ref_to_table_ref(value, default_project=None):
+    """Helper to convert a string to TableReference or keep a
+    TableReference unchanged.
+    """
+    if isinstance(value, six.string_types):
+        value = TableReference.from_string(value, default_project=default_project)
+    return value

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1663,10 +1663,27 @@ def _rows_page_start(iterator, page, response):
 # pylint: enable=unused-argument
 
 
-def _str_or_ref_to_table_ref(value, default_project=None):
-    """Helper to convert a string to TableReference or keep a
-    TableReference unchanged.
+def _table_arg_to_table_ref(value, default_project=None):
+    """Helper to convert a string or Table to TableReference.
+
+    This function keeps TableReference and other kinds of objects unchanged.
     """
     if isinstance(value, six.string_types):
         value = TableReference.from_string(value, default_project=default_project)
+    if isinstance(value, (Table, TableListItem)):
+        value = value.reference
     return value
+
+
+def _table_arg_to_table(value, default_project=None):
+    """Helper to convert a string or TableReference to a Table.
+
+    This function keeps Table and other kinds of objects unchanged.
+    """
+    if isinstance(value, six.string_types):
+        value = TableReference.from_string(value, default_project=default_project)
+    if isinstance(value, TableReference):
+        value = Table(value)
+
+    return value
+

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1686,4 +1686,3 @@ def _table_arg_to_table(value, default_project=None):
         value = Table(value)
 
     return value
-

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -3427,7 +3427,7 @@ class TestClient(unittest.TestCase):
         )
 
     def test_insert_rows_wo_schema(self):
-        from google.cloud.bigquery.table import Table, _TABLE_HAS_NO_SCHEMA
+        from google.cloud.bigquery.table import Table
 
         creds = _make_credentials()
         http = object()

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -3443,7 +3443,7 @@ class TestClient(unittest.TestCase):
         with self.assertRaises(ValueError) as exc:
             client.insert_rows(table, ROWS)
 
-        self.assertEqual(exc.exception.args, (_TABLE_HAS_NO_SCHEMA,))
+        self.assertIn("Could not determine schema for table", exc.exception.args[0])
 
     def test_insert_rows_w_schema(self):
         import datetime

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -2820,6 +2820,33 @@ class TestClient(unittest.TestCase):
             method="POST", path="/projects/other-project/jobs", data=resource
         )
 
+    def test_copy_table_w_source_strings(self):
+        creds = _make_credentials()
+        http = object()
+        client = self._make_one(project=self.PROJECT, credentials=creds, _http=http)
+        client._connection = _make_connection({})
+        sources = [
+            "dataset_wo_proj.some_table",
+            "other_project.other_dataset.other_table",
+            client.dataset("dataset_from_ref").table("table_from_ref"),
+        ]
+        destination = "some_project.some_dataset.destination_table"
+
+        job = client.copy_table(sources, destination)
+
+        expected_sources = [
+            client.dataset("dataset_wo_proj").table("some_table"),
+            client.dataset("other_dataset", project="other_project").table(
+                "other_table"
+            ),
+            client.dataset("dataset_from_ref").table("table_from_ref"),
+        ]
+        self.assertEqual(list(job.sources), expected_sources)
+        expected_destination = client.dataset(
+            "some_dataset", project="some_project"
+        ).table("destination_table")
+        self.assertEqual(job.destination, expected_destination)
+
     def test_extract_table(self):
         from google.cloud.bigquery.job import ExtractJob
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -3188,6 +3188,15 @@ class TestQueryJobConfig(unittest.TestCase, _Base):
         expected = dataset.DatasetReference.from_string(default_dataset)
         self.assertEqual(config.default_dataset, expected)
 
+    def test_default_dataset_w_dataset(self):
+        from google.cloud.bigquery import dataset
+
+        default_dataset = "default-proj.default_dset"
+        expected = dataset.DatasetReference.from_string(default_dataset)
+        config = self._make_one()
+        config.default_dataset = dataset.Dataset(expected)
+        self.assertEqual(config.default_dataset, expected)
+
     def test_destinaton_w_string(self):
         from google.cloud.bigquery import table
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -3163,6 +3163,40 @@ class TestQueryJobConfig(unittest.TestCase, _Base):
         self.assertFalse(config.use_query_cache)
         self.assertTrue(config.use_legacy_sql)
 
+    def test_ctor_w_string_default_dataset(self):
+        from google.cloud.bigquery import dataset
+
+        default_dataset = "default-proj.default_dset"
+        config = self._get_target_class()(default_dataset=default_dataset)
+        expected = dataset.DatasetReference.from_string(default_dataset)
+        self.assertEqual(config.default_dataset, expected)
+
+    def test_ctor_w_string_destinaton(self):
+        from google.cloud.bigquery import table
+
+        destination = "dest-proj.dest_dset.dest_tbl"
+        config = self._get_target_class()(destination=destination)
+        expected = table.TableReference.from_string(destination)
+        self.assertEqual(config.destination, expected)
+
+    def test_default_dataset_w_string(self):
+        from google.cloud.bigquery import dataset
+
+        default_dataset = "default-proj.default_dset"
+        config = self._make_one()
+        config.default_dataset = default_dataset
+        expected = dataset.DatasetReference.from_string(default_dataset)
+        self.assertEqual(config.default_dataset, expected)
+
+    def test_destinaton_w_string(self):
+        from google.cloud.bigquery import table
+
+        destination = "dest-proj.dest_dset.dest_tbl"
+        config = self._make_one()
+        config.destination = destination
+        expected = table.TableReference.from_string(destination)
+        self.assertEqual(config.destination, expected)
+
     def test_time_partitioning(self):
         from google.cloud.bigquery import table
 


### PR DESCRIPTION
This removes a few more cases where it was required to create a
`TableReference` or `DatasetReference`.

* Allow a string for `destination` in `QueryJobConfig` .
* Allow a string for `default_dataset` in `QueryJobConfig` .
* Allow a list of strings for `sources` in `Client.copy_table`.

Closes https://github.com/googleapis/google-cloud-python/issues/7558