### PR TITLE
Add dependency for resource proto.

### DIFF
--- a/bigquery_storage/google/cloud/bigquery_storage_v1beta1/proto/storage_pb2.py
+++ b/bigquery_storage/google/cloud/bigquery_storage_v1beta1/proto/storage_pb2.py
@@ -16,6 +16,7 @@ _sym_db = _symbol_database.Default()
 
 
 from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
+from google.api import resource_pb2 as google_dot_api_dot_resource__pb2
 from google.cloud.bigquery_storage_v1beta1.proto import (
     avro_pb2 as google_dot_cloud_dot_bigquery_dot_storage__v1beta1_dot_proto_dot_avro__pb2,
 )
@@ -41,6 +42,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     ),
     dependencies=[
         google_dot_api_dot_annotations__pb2.DESCRIPTOR,
+        google_dot_api_dot_resource__pb2.DESCRIPTOR,
         google_dot_cloud_dot_bigquery_dot_storage__v1beta1_dot_proto_dot_avro__pb2.DESCRIPTOR,
         google_dot_cloud_dot_bigquery_dot_storage__v1beta1_dot_proto_dot_read__options__pb2.DESCRIPTOR,
         google_dot_cloud_dot_bigquery_dot_storage__v1beta1_dot_proto_dot_table__reference__pb2.DESCRIPTOR,

--- a/bigquery_storage/setup.py
+++ b/bigquery_storage/setup.py
@@ -25,6 +25,7 @@ version = '0.2.0'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
+    'googleapis-common-protos >= 1.5.9, < 2.0.0dev',
     'enum34; python_version < "3.4"',
 ]
 extras = {

--- a/bigquery_storage/synth.metadata
+++ b/bigquery_storage/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-03-25T21:54:47.957767Z",
+  "updateTime": "2019-03-27T17:44:10.575389Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "git@github.com:googleapis/googleapis.git",
-        "sha": "e80435a132c53da26f46daf0787035ee63fb942b",
-        "internalRef": "239938670"
+        "sha": "d4d57d766601105478c661132f2687e6984b92d5",
+        "internalRef": "240469931"
       }
     }
   ],

--- a/bigquery_storage/synth.py
+++ b/bigquery_storage/synth.py
@@ -42,20 +42,6 @@ s.move(
     ],
 )
 
-# START: Remove unnecessary dependency on google.api.resource protos.
-s.replace(
-    ["google/cloud/bigquery_storage_v1beta1/proto/storage_pb2.py"],
-    "from google.api import resource_pb2 as google_dot_api_dot_resource__pb2\n",
-    "",
-)
-
-s.replace(
-    ["google/cloud/bigquery_storage_v1beta1/proto/storage_pb2.py"],
-    "google_dot_api_dot_resource__pb2.DESCRIPTOR,",
-    "",
-)
-# END: Remove unnecessary dependency on google.api.resource protos.
-
 s.replace(
     [
         "google/cloud/bigquery_storage_v1beta1/proto/storage_pb2.py",


### PR DESCRIPTION
Turns out that without the latest googleapis-common-protos all the
tests pass, but Sphinx docs builds still fail. Remove the hack I
added to exclude this dependency and bump the minimum version of
googleapis-common-protos instead.

Apologies, I think I broke the docs build with https://github.com/googleapis/google-cloud-python/pull/7550