### PR TITLE
Restore redirect from magics module.

### DIFF
--- a/test_utils/scripts/update_docs.sh
+++ b/test_utils/scripts/update_docs.sh
@@ -24,7 +24,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Function to build the docs.
 function build_docs {
     rm -rf docs/_build/
-    rm -rf docs/bigquery/generated
+    rm -f docs/bigquery/generated/*.rst
     # -W -> warnings as errors
     # -T -> show full traceback on exception
     # -N -> no color


### PR DESCRIPTION
The docs generation script was removing the whole "generated"
directory before. Now it only removes the rst files, which correspond
to the files created by autosummary.