### PR TITLE
Add rest of BigQuery DPEs to code owners via team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,10 @@ api_core/*                @theacodes
 core/*                    @theacodes
 docs/core/*               @theacodes
 
-# Tim Swast and Alix Hamilton share responsibility for BigQuery.
-bigquery/*                @tswast @alixhami
+# BigQuery suite of APIs
+bigquery/*                @googleapis/api-bigquery
+bigquery_datatransfer/*   @googleapis/api-bigquery
+bigquery_storage/*        @googleapis/api-bigquery
 
 # Danny Hermes and Tres Seaver co-authored the BigTable library.
 bigtable/*                @tseaver


### PR DESCRIPTION
There are more than one set of BigQuery APIs, add all BigQuery DPEs as code owners to all of them.