### PR TITLE
Add [all] extras to install all extra dependencies

### DIFF
--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -20,10 +20,7 @@ import shutil
 import nox
 
 
-LOCAL_DEPS = (
-    os.path.join('..', 'api_core[grpc]'),
-    os.path.join('..', 'core'),
-)
+LOCAL_DEPS = (os.path.join("..", "api_core[grpc]"), os.path.join("..", "core"))
 
 BLACK_PATHS = ("google", "tests", "docs", "noxfile.py", "setup.py")
 
@@ -42,8 +39,8 @@ def default(session):
         session.install("-e", local_dep)
 
     # Pyarrow does not support Python 3.7
-    dev_install = '.[all]'
-    session.install('-e', dev_install)
+    dev_install = ".[all]"
+    session.install("-e", dev_install)
 
     # IPython does not support Python 2 after version 5.x
     if session.python == "2.7":
@@ -86,10 +83,10 @@ def system(session):
     # Install all test dependencies, then install local packages in place.
     session.install("mock", "pytest")
     for local_dep in LOCAL_DEPS:
-        session.install('-e', local_dep)
-    session.install('-e', os.path.join('..', 'storage'))
-    session.install('-e', os.path.join('..', 'test_utils'))
-    session.install('-e', '.[all]')
+        session.install("-e", local_dep)
+    session.install("-e", os.path.join("..", "storage"))
+    session.install("-e", os.path.join("..", "test_utils"))
+    session.install("-e", ".[all]")
 
     # IPython does not support Python 2 after version 5.x
     if session.python == "2.7":
@@ -114,10 +111,10 @@ def snippets(session):
     # Install all test dependencies, then install local packages in place.
     session.install("mock", "pytest")
     for local_dep in LOCAL_DEPS:
-        session.install('-e', local_dep)
-    session.install('-e', os.path.join('..', 'storage'))
-    session.install('-e', os.path.join('..', 'test_utils'))
-    session.install('-e', '.[all]')
+        session.install("-e", local_dep)
+    session.install("-e", os.path.join("..", "storage"))
+    session.install("-e", os.path.join("..", "test_utils"))
+    session.install("-e", ".[all]")
 
     # Run py.test against the snippets tests.
     session.run("py.test", os.path.join("docs", "snippets.py"), *session.posargs)
@@ -158,6 +155,7 @@ def lint_setup_py(session):
     session.install("docutils", "Pygments")
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
 
+
 @nox.session(python="3.6")
 def blacken(session):
     """Run black.
@@ -173,9 +171,9 @@ def docs(session):
 
     session.install("ipython", "recommonmark", "sphinx", "sphinx_rtd_theme")
     for local_dep in LOCAL_DEPS:
-        session.install('-e', local_dep)
-    session.install('-e', os.path.join('..', 'storage'))
-    session.install('-e', '.[all]')
+        session.install("-e", local_dep)
+    session.install("-e", os.path.join("..", "storage"))
+    session.install("-e", ".[all]")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(

--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -21,11 +21,8 @@ import nox
 
 
 LOCAL_DEPS = (
-    os.path.join("..", "api_core[grpc]"),
-    os.path.join("..", "core"),
-    # TODO: Move bigquery_storage back to dev_install once dtypes feature is
-    #       released. Issue #7049
-    os.path.join("..", "bigquery_storage[pandas,fastavro]"),
+    os.path.join('..', 'api_core[grpc]'),
+    os.path.join('..', 'core'),
 )
 
 BLACK_PATHS = ("google", "tests", "docs", "noxfile.py", "setup.py")
@@ -45,11 +42,8 @@ def default(session):
         session.install("-e", local_dep)
 
     # Pyarrow does not support Python 3.7
-    if session.python == "3.7":
-        dev_install = ".[pandas, tqdm]"
-    else:
-        dev_install = ".[pandas, pyarrow, tqdm]"
-    session.install("-e", dev_install)
+    dev_install = '.[all]'
+    session.install('-e', dev_install)
 
     # IPython does not support Python 2 after version 5.x
     if session.python == "2.7":
@@ -92,10 +86,10 @@ def system(session):
     # Install all test dependencies, then install local packages in place.
     session.install("mock", "pytest")
     for local_dep in LOCAL_DEPS:
-        session.install("-e", local_dep)
-    session.install("-e", os.path.join("..", "storage"))
-    session.install("-e", os.path.join("..", "test_utils"))
-    session.install("-e", ".[pandas]")
+        session.install('-e', local_dep)
+    session.install('-e', os.path.join('..', 'storage'))
+    session.install('-e', os.path.join('..', 'test_utils'))
+    session.install('-e', '.[all]')
 
     # IPython does not support Python 2 after version 5.x
     if session.python == "2.7":
@@ -120,10 +114,10 @@ def snippets(session):
     # Install all test dependencies, then install local packages in place.
     session.install("mock", "pytest")
     for local_dep in LOCAL_DEPS:
-        session.install("-e", local_dep)
-    session.install("-e", os.path.join("..", "storage"))
-    session.install("-e", os.path.join("..", "test_utils"))
-    session.install("-e", ".[pandas, pyarrow, fastparquet]")
+        session.install('-e', local_dep)
+    session.install('-e', os.path.join('..', 'storage'))
+    session.install('-e', os.path.join('..', 'test_utils'))
+    session.install('-e', '.[all]')
 
     # Run py.test against the snippets tests.
     session.run("py.test", os.path.join("docs", "snippets.py"), *session.posargs)
@@ -164,7 +158,6 @@ def lint_setup_py(session):
     session.install("docutils", "Pygments")
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
 
-
 @nox.session(python="3.6")
 def blacken(session):
     """Run black.
@@ -180,9 +173,9 @@ def docs(session):
 
     session.install("ipython", "recommonmark", "sphinx", "sphinx_rtd_theme")
     for local_dep in LOCAL_DEPS:
-        session.install("-e", local_dep)
-    session.install("-e", os.path.join("..", "storage"))
-    session.install("-e", ".[pandas, pyarrow]")
+        session.install('-e', local_dep)
+    session.install('-e', os.path.join('..', 'storage'))
+    session.install('-e', '.[all]')
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -34,8 +34,11 @@ dependencies = [
     "google-resumable-media >= 0.3.1",
 ]
 extras = {
-    "bqstorage": "google-cloud-bigquery-storage >= 0.2.0dev1, <2.0.0dev",
-    "pandas": "pandas>=0.17.1",
+    'bqstorage': [
+        'google-cloud-bigquery-storage >= 0.2.0dev1, <2.0.0dev',
+        'fastavro>=0.21.2',
+    ],
+    'pandas': 'pandas>=0.17.1',
     # Exclude PyArrow dependency from Windows Python 2.7.
     'pyarrow: platform_system != "Windows" or python_version >= "3.4"': "pyarrow>=0.4.1",
     "tqdm": "tqdm >= 4.0.0, <5.0.0dev",

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -34,11 +34,11 @@ dependencies = [
     "google-resumable-media >= 0.3.1",
 ]
 extras = {
-    'bqstorage': [
-        'google-cloud-bigquery-storage >= 0.2.0dev1, <2.0.0dev',
-        'fastavro>=0.21.2',
+    "bqstorage": [
+        "google-cloud-bigquery-storage >= 0.2.0dev1, <2.0.0dev",
+        "fastavro>=0.21.2",
     ],
-    'pandas': 'pandas>=0.17.1',
+    "pandas": "pandas>=0.17.1",
     # Exclude PyArrow dependency from Windows Python 2.7.
     'pyarrow: platform_system != "Windows" or python_version >= "3.4"': "pyarrow>=0.4.1",
     "tqdm": "tqdm >= 4.0.0, <5.0.0dev",

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -42,6 +42,15 @@ extras = {
     "fastparquet": ["fastparquet", "python-snappy"],
 }
 
+all_extras = []
+
+for extra in extras:
+    if isinstance(extras[extra], str):
+        all_extras.append(extras[extra])
+    else:
+        all_extras.extend(extras[extra])
+
+extras["all"] = all_extras
 
 # Setup boilerplate below this line.
 

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -38,20 +38,19 @@ extras = {
         "google-cloud-bigquery-storage >= 0.2.0dev1, <2.0.0dev",
         "fastavro>=0.21.2",
     ],
-    "pandas": "pandas>=0.17.1",
+    "pandas": ["pandas>=0.17.1"],
     # Exclude PyArrow dependency from Windows Python 2.7.
-    'pyarrow: platform_system != "Windows" or python_version >= "3.4"': "pyarrow>=0.4.1",
-    "tqdm": "tqdm >= 4.0.0, <5.0.0dev",
+    'pyarrow: platform_system != "Windows" or python_version >= "3.4"': [
+        "pyarrow>=0.4.1"
+    ],
+    "tqdm": ["tqdm >= 4.0.0, <5.0.0dev"],
     "fastparquet": ["fastparquet", "python-snappy"],
 }
 
 all_extras = []
 
 for extra in extras:
-    if isinstance(extras[extra], str):
-        all_extras.append(extras[extra])
-    else:
-        all_extras.extend(extras[extra])
+    all_extras.extend(extras[extra])
 
 extras["all"] = all_extras
 


### PR DESCRIPTION
An [all] extra will be useful for convenience to get all the "bonus"
features like progress bars, pandas integration, and BigQuery Storage
API integration.

I also blacken the setup.py file and simplify the noxfile by using this
new [all] extra.

This is a pattern I've seen in other projects that have a lot of "extras", such as Apache Airflow (though they have a lot more the `google-cloud-bigquery`).
https://github.com/apache/airflow/blob/6cb735c6d301a5689ff9666349abdb6387abc7a1/setup.py#L335