### PR TITLE
Firestore: fix watch against nested collections (issue #7515).

### DIFF
--- a/firestore/google/cloud/firestore_v1/watch.py
+++ b/firestore/google/cloud/firestore_v1/watch.py
@@ -352,7 +352,7 @@ class Watch(object):
         cls, query, snapshot_callback, snapshot_class_instance, reference_class_instance
     ):
         query_target = firestore_pb2.Target.QueryTarget(
-            parent=query._client._database_string, structured_query=query._to_protobuf()
+            parent=query._parent._parent_info()[0], structured_query=query._to_protobuf()
         )
 
         return cls(


### PR DESCRIPTION
Fix for issue mentioned in the issue #7515, by replacing the parent info of query target from the url to the root of the database, to actual query parent, stored in its parent info.

Collection query holds an `_parent` variable pointing to the Document/CollectionReference, which holds info about database path in the `_parent_info()`, which returns tuple containing:

1. url to the parent object
2. url to self

Thus, returning first value from `_parent_info()`, instead of url to root of database fixes the bug.