### PR TITLE
Spanner: expand API ref for snapshot / transaction.

### DIFF
--- a/spanner/docs/snapshot-api.rst
+++ b/spanner/docs/snapshot-api.rst
@@ -3,6 +3,6 @@ Snapshot API
 
 .. automodule:: google.cloud.spanner_v1.snapshot
   :members:
-  :show-inheritance:
+  :inherited-members:
 
 

--- a/spanner/docs/transaction-api.rst
+++ b/spanner/docs/transaction-api.rst
@@ -3,6 +3,6 @@ Transaction API
 
 .. automodule:: google.cloud.spanner_v1.transaction
   :members:
-  :show-inheritance:
+  :inherited-members:
 
 


### PR DESCRIPTION
Rather than showing the private, and hence non-generated `_SnapshotBase` class, just show the members inherited from it.

Closes #7607.