### PR TITLE
Call get_table automatically in list_rows if the schema is not available

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1752,5 +1752,9 @@ def _table_arg_to_table(value, default_project=None):
         value = TableReference.from_string(value, default_project=default_project)
     if isinstance(value, TableReference):
         value = Table(value)
+    if isinstance(value, TableListItem):
+        newvalue = Table(value.reference)
+        newvalue._properties = value._properties
+        value = newvalue
 
     return value


### PR DESCRIPTION
This is kinder than raising an error message saying to call get_table
yourself. Also, it guarantees the schema is as up-to-date as possible.

This also fixes an issue where rows could not be listed on the
TableListItem objects that are returned from list_tables.