### PR TITLE
API Core: specify a pytype output directory in setup.cfg.

### DIFF
--- a/api_core/setup.cfg
+++ b/api_core/setup.cfg
@@ -7,3 +7,4 @@ inputs =
     google/
 exclude =
     tests/
+output = pytype_output/


### PR DESCRIPTION
The next version of pytype will change the default name of the pytype
output directory from pytype_output to .pytype, and `pytype_output/` is
in google-cloud-python's .gitignore. The easiest way to avoid being
affected by this change is to specify a custom output dir.