### PR TITLE
remove gRPC size limit for bigquery storage

### DIFF
--- a/bigquery_storage/google/cloud/bigquery_storage_v1beta1/gapic/transports/big_query_storage_grpc_transport.py
+++ b/bigquery_storage/google/cloud/bigquery_storage_v1beta1/gapic/transports/big_query_storage_grpc_transport.py
@@ -91,11 +91,13 @@ class BigQueryStorageGrpcTransport(object):
             grpc.Channel: A gRPC channel object.
         """
         return google.api_core.grpc_helpers.create_channel(  # pragma: no cover
-            address, credentials=credentials, scopes=cls._OAUTH_SCOPES,
+            address,
+            credentials=credentials,
+            scopes=cls._OAUTH_SCOPES,
             options={
-                'grpc.max_send_message_length': -1,
-                'grpc.max_receive_message_length': -1,
-            }.items()
+                "grpc.max_send_message_length": -1,
+                "grpc.max_receive_message_length": -1,
+            }.items(),
         )
 
     @property

--- a/bigquery_storage/google/cloud/bigquery_storage_v1beta1/gapic/transports/big_query_storage_grpc_transport.py
+++ b/bigquery_storage/google/cloud/bigquery_storage_v1beta1/gapic/transports/big_query_storage_grpc_transport.py
@@ -91,7 +91,11 @@ class BigQueryStorageGrpcTransport(object):
             grpc.Channel: A gRPC channel object.
         """
         return google.api_core.grpc_helpers.create_channel(  # pragma: no cover
-            address, credentials=credentials, scopes=cls._OAUTH_SCOPES
+            address, credentials=credentials, scopes=cls._OAUTH_SCOPES,
+            options={
+                'grpc.max_send_message_length': -1,
+                'grpc.max_receive_message_length': -1,
+            }.items()
         )
 
     @property

--- a/bigquery_storage/synth.py
+++ b/bigquery_storage/synth.py
@@ -75,6 +75,17 @@ s.replace(
     "big_query_storage_client.BigQueryStorageClient",
 )
 
+# The grpc transport channel shouldn't limit the size of a grpc message at the
+# default 4mb.
+s.replace("google/cloud/bigquery_storage_v1beta1/gapic/transports/*_grpc_transport.py",
+    "return google.api_core.grpc_helpers.create_channel\(\n(\s+)address,\n"
+    "\s+credentials=.*,\n\s+scopes=.*,\n",
+    "\g<0>\g<1>options={\n"
+    "\g<1>    'grpc.max_send_message_length': -1,\n"
+    "\g<1>    'grpc.max_receive_message_length': -1,\n"
+    "\g<1>}.items(),\n",
+)
+
 # START: Ignore lint and coverage
 s.replace(
     ["google/cloud/bigquery_storage_v1beta1/gapic/big_query_storage_client.py"],


### PR DESCRIPTION
- currently limited to 4MiB
- compare to https://github.com/googleapis/google-cloud-python/pull/5594/commits/f636c8d7756a470719d114e8d77dd169e39906f3 which does the same for the monitoring API