### PR TITLE
Add dependency on protobuf.

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -29,10 +29,11 @@ version = "1.11.1"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
+    'enum34; python_version < "3.4"',
     "google-api-core >= 1.6.0, < 2.0.0dev",
     "google-cloud-core >= 0.29.0, < 0.30dev",
     "google-resumable-media >= 0.3.1",
-    'enum34; python_version < "3.4"',
+    "protobuf >= 3.6.0",
 ]
 extras = {
     "bqstorage": "google-cloud-bigquery-storage >= 0.2.0dev1, <2.0.0dev",


### PR DESCRIPTION
This is required for the generated classes from the Models API.

Closes #7667