### PR TITLE
ISS-7199: Fix Pub/Sub publisher hanging if service account does not exist

### DIFF
--- a/pubsub/tests/system/gapic/v1/assets/project-credentials-invalid.json
+++ b/pubsub/tests/system/gapic/v1/assets/project-credentials-invalid.json
@@ -1,0 +1,12 @@
+{
+    "type": "service_account",
+    "project_id": "unknown-project",
+    "private_key_id": "1a2b3c4d5e6f",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCkq0vSRN5uyLuL\n3i/XFk2wE3wt+dqMpF1R8l1eQZlGcqdRY4cV3UvWM4Q3TWGtIxevp8tQPto7RDbA\nhxJk136yL5FfRPd21F2Ac/s0qx1G0F0OH5lB8bpLciyCGAr2yTjTyKZuVO74DiPo\nk24LW0OnL6qjLFKeR1unD9LgV6sHBWoYoPo2zhxIDvnmUe52UOMXjYsYvF6AGS2r\nDBup0AuhDcGjacwHA23IB8ejC34mNamqhVhlHURr8uhhELsUhyJOIfKFc9XoQtTc\n3A1LtwvHe1stkOaaTVuCt/fF7s4bXqTipQq36r4PosjB6ixkITPoAqXMEBd8gDH4\ncc36xYshAgMBAAECggEAINCR94EJ4oHV/fV1CyPCr4fygyb7SnOmtSHbQWFJLiTC\n+xEeZlkHN9RkULD2+g24NqT1ezRLQOxDDPLd04KuGMwp6BZSSjffui1irgg7eVUk\ndiAN5npJaaeC/xnTdYJ79JhTskDyrjQDK+HVWCYDwVlaY9H9VNVbils45sQRrQAx\nXzZ0SKLqWCXHB/Wv5JVXjNxG5/QeiqDk1TVKUvxar8aJqkIxhqkxTxLC5E0d3yDf\njz6mijAex9nGrh9+kx944VTK86qlf4NZzuLcNeBB5YaiJHSHorvrAeKVq1fdHHdU\nZ6TaXOo8Hab2zZ4NwIimHLgG2UZ8jGe7/sYemA2aEQKBgQDRi7ZoYcePCTupcZiO\n+YFVrxVap0RJhNM3nLZ8DrOXuOZ2W0/j8mRJY2WCAbuxeFlRFW5FyI2DCzX1RauW\nvO8GiRxuvMP35lKJAZY/s1h6RIUdXqV/TdFlXj9IBuM2x7EBInCLG9V9/N6/lQFr\nwf3vhp30QUwxMWY/kxm4/IRXpwKBgQDJLLbAlKs6JuioPPZgdlttsDcxsXf0Y3zb\nWzXgrbg3I3veC2qrnJropDiKVVW3ROXb6ZHm7BfF7ROKR0K1G/bnJH0oqmPyMcAg\n2G/Y3xVrNr1S/wJgBXS2wQULXd5XVwqJCLUMFL1+BG9s5e8JlHKkUwC7jXu6pGbb\nS4GwgsJf9wKBgGVq0Eru4C3rUxPsZeD1A1LcHWK1yAgpIC0vTOb4GpXZKLmp8h2q\nCD24vL1SZ2w6ikgDLk7aBRuihmgCY0zefnVUUQ2LkPFfaRzkRrrn62+p0B9p2oGl\nwS3lko0iwD+YIKQi7gN14jtK8ugYjwp/Zo7SQYqhO+YnOYyVfoKYvNjLAoGAcwzH\nV0uuwQsPc2ep33DQyOJGLn04BOQAu9Jl9aBkAeShKlONJafiT7nbPAGhi7YzXpkt\nf8r1rZPv4NzwIXNkuLv9eAw6LICXSDF/hZ/POAmOLLD6Qr/cB8hLgjyks35r4ALC\nx6300OTodHbrRadICQIPITPA1vS+fhuoh7HAR/ECgYB8Sh7ImzqdKRsr+cngJi+1\nLjS35CxczwL8puWeLhjrwaux9O6sKYtNFfI2w6+xZcb2k8XDZlHkww6rQOkYQDnt\naaA+Wo9uVVRQoFE+3D2aEbFt0tdTZfIUKpVPeiix+OOtDgPEibgIQzu9ruAUx7Gd\nqg8kbNw8yt+aGWsQ4FSGmg==\n-----END PRIVATE KEY-----\n",
+    "client_email": "UNKNOWN-service-account@project.iam.gserviceaccount.com",
+    "client_id": "12345",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/UNKNOWN-service-account@project.iam.gserviceaccount.com"
+}

--- a/pubsub/tests/system/gapic/v1/test_system_publisher_v1.py
+++ b/pubsub/tests/system/gapic/v1/test_system_publisher_v1.py
@@ -17,7 +17,12 @@
 import os
 import time
 
+import mock
+import pytest
+
+from google.api_core import exceptions
 from google.cloud import pubsub_v1
+from google.cloud.pubsub_v1.gapic import publisher_client_config
 from google.cloud.pubsub_v1.proto import pubsub_pb2
 
 
@@ -28,3 +33,25 @@ class TestSystemPublisher(object):
         client = pubsub_v1.PublisherClient()
         project = client.project_path(project_id)
         response = client.list_topics(project)
+
+    def test_no_account_no_retry_timeout(self):
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        config_file = os.path.join(
+            script_dir, "assets", "project-credentials-invalid.json"
+        )
+
+        messaging_config = publisher_client_config.config["interfaces"][
+            "google.pubsub.v1.Publisher"
+        ]["retry_params"]["messaging"]
+
+        with mock.patch.dict(messaging_config, total_timeout_millis=10000):
+            client = pubsub_v1.PublisherClient.from_service_account_json(config_file)
+
+        project_id = os.environ["PROJECT_ID"]
+        topic_path = client.topic_path(project_id, "topic_foo")
+        publish_future = client.publish(topic_path, data=b"Hi there!")
+
+        # If the client tries to retry the failed request, the assertion below
+        # will fail with a timeout (RefreshError).
+        with pytest.raises(exceptions.ServiceUnavailable):
+            publish_future.result()


### PR DESCRIPTION
This is a proposed fix for #7199.

### How to test

**Steps to reproduce:**
- Save the code snippet from #7199 to a local Python script.
- Make sure that the configured application credentials are invalid, e.g. by setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to an invalid credentials file (can use the one added by this PR).
- Run the sample script.

**Actual result:**
The script waits "forever" (it is possible to terminate it with <kbd>Ctrl</kbd> + <kbd>C</kbd>, unless if running in a debugger).

**Expected result:**
The script should fail "immediately" with an invalid credentials exception, and should not try to repeat the `publish` request that failed because of it.


**Open questions:**
- [x] ~~If the test fails because of a timeout (because the script _does_ attempt to retry the failed request), the tests do not terminate, because the retry thread does not terminate. Any canonical way around this?~~
Specifying a much shorter retry timeout for the Publisher client did the trick.
- [ ] How likely it is for the server error message to change in the future? The modified retry logic relies on that. Is there perhaps a better way?
- [ ] The Web Risk check fails even after several retries - is this flakiness or a legitimate failure? There is just a Test Fusion Url  in the build log, which I do not have access to.