### PR TITLE
Don't mask auth errors in `to_dataframe` with BQ Storage API

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1468,6 +1468,12 @@ class RowIterator(HTTPIterator):
         if bqstorage_client is not None:
             try:
                 return self._to_dataframe_bqstorage(bqstorage_client, dtypes)
+            except google.api_core.exceptions.Forbidden:
+                # Don't hide errors such as insufficient permissions to create
+                # a read session, or the API is not enabled. Both of those are
+                # clearly problems if the developer has explicitly asked for
+                # BigQuery Storage API support.
+                raise
             except google.api_core.exceptions.GoogleAPICallError:
                 # There is a known issue with reading from small anonymous
                 # query results tables, so some errors are expected. Rather

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -1798,7 +1798,6 @@ class TestRowIterator(unittest.TestCase):
         bigquery_storage_v1beta1 is None, "Requires `google-cloud-bigquery-storage`"
     )
     def test_to_dataframe_w_bqstorage_raises_auth_error(self):
-        from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
 
         bqstorage_client = mock.create_autospec(

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -1793,6 +1793,33 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(df.name.dtype.name, "object")
         self.assertEqual(df.age.dtype.name, "int64")
 
+    @unittest.skipIf(pandas is None, "Requires `pandas`")
+    @unittest.skipIf(
+        bigquery_storage_v1beta1 is None, "Requires `google-cloud-bigquery-storage`"
+    )
+    def test_to_dataframe_w_bqstorage_raises_auth_error(self):
+        from google.cloud.bigquery import schema
+        from google.cloud.bigquery import table as mut
+
+        bqstorage_client = mock.create_autospec(
+            bigquery_storage_v1beta1.BigQueryStorageClient
+        )
+        bqstorage_client.create_read_session.side_effect = google.api_core.exceptions.Forbidden(
+            "TEST BigQuery Storage API not enabled. TEST"
+        )
+        path = "/foo"
+        api_request = mock.Mock(return_value={"rows": []})
+        row_iterator = mut.RowIterator(
+            _mock_client(),
+            api_request,
+            path,
+            [],
+            table=mut.Table("proj.dset.tbl"),
+        )
+
+        with pytest.raises(google.api_core.exceptions.Forbidden):
+            row_iterator.to_dataframe(bqstorage_client=bqstorage_client)
+
     @unittest.skipIf(
         bigquery_storage_v1beta1 is None, "Requires `google-cloud-bigquery-storage`"
     )

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -1810,11 +1810,7 @@ class TestRowIterator(unittest.TestCase):
         path = "/foo"
         api_request = mock.Mock(return_value={"rows": []})
         row_iterator = mut.RowIterator(
-            _mock_client(),
-            api_request,
-            path,
-            [],
-            table=mut.Table("proj.dset.tbl"),
+            _mock_client(), api_request, path, [], table=mut.Table("proj.dset.tbl")
         )
 
         with pytest.raises(google.api_core.exceptions.Forbidden):


### PR DESCRIPTION
Don't hide errors such as insufficient permissions to create
a read session, or the API is not enabled. Both of those are
clearly problems if the developer has explicitly asked for
BigQuery Storage API support.

Closes #7661.