### PR TITLE
BigQuery: ensure that `KeyboardInterrupt` during `to_dataframe`no longer hangs.

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -66,6 +66,7 @@ _NO_TQDM_ERROR = (
 )
 _TABLE_HAS_NO_SCHEMA = 'Table has no schema:  call "client.get_table()"'
 _MARKER = object()
+_PROGRESS_INTERVAL = 1.0  # Time between download status updates, in seconds.
 
 
 def _reference_getter(table):
@@ -1421,16 +1422,56 @@ class RowIterator(HTTPIterator):
         if not session.streams:
             return pandas.DataFrame(columns=columns)
 
+        # Use finished to notify worker threads when to quit. See:
+        # https://stackoverflow.com/a/29237343/101923
+        finished = False
+
         def get_dataframe(stream):
             position = bigquery_storage_v1beta1.types.StreamPosition(stream=stream)
-            rowstream = bqstorage_client.read_rows(position)
-            return rowstream.to_dataframe(session, dtypes=dtypes)
+            rowstream = bqstorage_client.read_rows(position).rows(session)
+
+            frames = []
+            for page in rowstream.pages:
+                if finished:
+                    return
+                frames.append(page.to_dataframe(dtypes=dtypes))
+
+            # Avoid errors on unlucky streams with no blocks. pandas.concat
+            # will fail on an empty list.
+            if not frames:
+                return pandas.DataFrame(columns=columns)
+
+            # page.to_dataframe() does not preserve column order. Rearrange at
+            # the end using manually-parsed schema.
+            return pandas.concat(frames)[columns]
+
+        def get_frames(pool):
+            frames = []
+
+            # Manually submit jobs and wait for download to complete rather
+            # than using pool.map because pool.map continues running in the
+            # background even if there is an exception on the main thread.
+            not_done = [
+                pool.submit(get_dataframe, stream) for stream in session.streams
+            ]
+
+            while not_done:
+                done, not_done = concurrent.futures.wait(
+                    not_done, timeout=_PROGRESS_INTERVAL
+                )
+                frames.extend([future.result() for future in done])
+            return frames
 
         with concurrent.futures.ThreadPoolExecutor() as pool:
-            frames = pool.map(get_dataframe, session.streams)
+            try:
+                frames = get_frames(pool)
+            finally:
+                # No need for a lock because reading/replacing a variable is
+                # defined to be an atomic operation in the Python language
+                # definition (enforced by the global interpreter lock).
+                finished = True
 
-        # rowstream.to_dataframe() does not preserve column order. Rearrange at
-        # the end using manually-parsed schema.
+        # Use [columns] to ensure column order matches manually-parsed schema.
         return pandas.concat(frames)[columns]
 
     def _get_progress_bar(self, progress_bar_type):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1387,6 +1387,27 @@ class RowIterator(HTTPIterator):
 
         return pandas.concat(frames)
 
+    def _to_dataframe_bqstorage_stream(
+        self, bqstorage_client, dtypes, columns, session, stream
+    ):
+        position = bigquery_storage_v1beta1.types.StreamPosition(stream=stream)
+        rowstream = bqstorage_client.read_rows(position).rows(session)
+
+        frames = []
+        for page in rowstream.pages:
+            if self._to_dataframe_finished:
+                return
+            frames.append(page.to_dataframe(dtypes=dtypes))
+
+        # Avoid errors on unlucky streams with no blocks. pandas.concat
+        # will fail on an empty list.
+        if not frames:
+            return pandas.DataFrame(columns=columns)
+
+        # page.to_dataframe() does not preserve column order. Rearrange at
+        # the end using manually-parsed schema.
+        return pandas.concat(frames)[columns]
+
     def _to_dataframe_bqstorage(self, bqstorage_client, dtypes):
         """Use (faster, but billable) BQ Storage API to construct DataFrame."""
         if bigquery_storage_v1beta1 is None:
@@ -1422,28 +1443,9 @@ class RowIterator(HTTPIterator):
         if not session.streams:
             return pandas.DataFrame(columns=columns)
 
-        # Use finished to notify worker threads when to quit. See:
-        # https://stackoverflow.com/a/29237343/101923
-        finished = False
-
-        def get_dataframe(stream):
-            position = bigquery_storage_v1beta1.types.StreamPosition(stream=stream)
-            rowstream = bqstorage_client.read_rows(position).rows(session)
-
-            frames = []
-            for page in rowstream.pages:
-                if finished:
-                    return
-                frames.append(page.to_dataframe(dtypes=dtypes))
-
-            # Avoid errors on unlucky streams with no blocks. pandas.concat
-            # will fail on an empty list.
-            if not frames:
-                return pandas.DataFrame(columns=columns)
-
-            # page.to_dataframe() does not preserve column order. Rearrange at
-            # the end using manually-parsed schema.
-            return pandas.concat(frames)[columns]
+        # Use _to_dataframe_finished to notify worker threads when to quit.
+        # See: https://stackoverflow.com/a/29237343/101923
+        self._to_dataframe_finished = False
 
         def get_frames(pool):
             frames = []
@@ -1451,8 +1453,17 @@ class RowIterator(HTTPIterator):
             # Manually submit jobs and wait for download to complete rather
             # than using pool.map because pool.map continues running in the
             # background even if there is an exception on the main thread.
+            # See: https://github.com/googleapis/google-cloud-python/pull/7698
             not_done = [
-                pool.submit(get_dataframe, stream) for stream in session.streams
+                pool.submit(
+                    self._to_dataframe_bqstorage_stream,
+                    bqstorage_client,
+                    dtypes,
+                    columns,
+                    session,
+                    stream,
+                )
+                for stream in session.streams
             ]
 
             while not_done:
@@ -1469,10 +1480,9 @@ class RowIterator(HTTPIterator):
                 # No need for a lock because reading/replacing a variable is
                 # defined to be an atomic operation in the Python language
                 # definition (enforced by the global interpreter lock).
-                finished = True
+                self._to_dataframe_finished = True
 
-        # Use [columns] to ensure column order matches manually-parsed schema.
-        return pandas.concat(frames)[columns]
+        return pandas.concat(frames)
 
     def _get_progress_bar(self, progress_bar_type):
         """Construct a tqdm progress bar object, if tqdm is installed."""

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -37,7 +37,7 @@ dependencies = [
 ]
 extras = {
     "bqstorage": [
-        "google-cloud-bigquery-storage >= 0.2.0dev1, <2.0.0dev",
+        "google-cloud-bigquery-storage >= 0.4.0, <2.0.0dev",
         "fastavro>=0.21.2",
     ],
     "pandas": ["pandas>=0.17.1"],


### PR DESCRIPTION
I noticed in manually testing `to_dataframe` that it would stop
the current cell when I hit Ctrl-C, but data kept on downloading in the
background. Trying to exit the Python shell, I'd notice that it would
hang until I pressed Ctrl-C a few more times.

Rather than get the DataFrame for each stream in one big chunk, loop
through each block and exit if the function needs to quit early. This
follows the pattern at https://stackoverflow.com/a/29237343/101923

This depends on:

* ~https://github.com/googleapis/google-cloud-python/pull/7680, new `.pages` feature in BQ Storage client~
* https://github.com/googleapis/google-cloud-python/pull/7726, aligns optional import for BQ Storage client with pattern used elsewhere in the client.
