### PR TITLE
storage: fix failing system tests

### DIFF
--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -87,6 +87,7 @@ def setUpModule():
 def tearDownModule():
     errors = (exceptions.Conflict, exceptions.TooManyRequests)
     retry = RetryErrors(errors, max_tries=9)
+    retry(_empty_bucket(Config.TEST_BUCKET))
     retry(Config.TEST_BUCKET.delete)(force=True)
 
 

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -83,7 +83,7 @@ def setUpModule():
 def tearDownModule():
     errors = (exceptions.Conflict, exceptions.TooManyRequests)
     retry = RetryErrors(errors, max_tries=9)
-    retry(_empty_bucket(Config.TEST_BUCKET))
+    retry(_empty_bucket)(Config.TEST_BUCKET)
     retry(Config.TEST_BUCKET.delete)(force=True)
 
 

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -51,15 +51,11 @@ retry_bad_copy = RetryErrors(exceptions.BadRequest, error_predicate=_bad_copy)
 
 
 def _empty_bucket(bucket):
-    """Empty a bucket of all existing blobs.
-
-    This accounts (partially) for the eventual consistency of the
-    list blobs API call.
-    """
-    for blob in bucket.list_blobs():
+    """Empty a bucket of all existing blobs (including multiple versions)."""
+    for blob in bucket.list_blobs(versions=True):
         try:
             blob.delete()
-        except exceptions.NotFound:  # eventual consistency
+        except exceptions.NotFound:
             pass
 
 


### PR DESCRIPTION
Delete objects and older generations in the bucket. Additionally, remove eventual consistency documentation around list_objects(), the operation is strongly consistent.


Internal bug: 128636162