### PR TITLE
BigQuery: Close the to_dataframe progress bar when finished.

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1384,6 +1384,10 @@ class RowIterator(HTTPIterator):
                 progress_bar.total = progress_bar.total or self.total_rows
                 progress_bar.update(len(current_frame))
 
+        if progress_bar is not None:
+            # Indicate that the download has finished.
+            progress_bar.close()
+
         return pandas.concat(frames)
 
     def _to_dataframe_bqstorage(self, bqstorage_client, dtypes):

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -1501,6 +1501,7 @@ class TestRowIterator(unittest.TestCase):
 
             progress_bar_mock.assert_called()
             progress_bar_mock().update.assert_called()
+            progress_bar_mock().close.assert_called_once()
             self.assertEqual(len(df), 4)
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")


### PR DESCRIPTION
Otherwise it stays blue (incomplete) in the `tqdm_notebook` version. Not sure that it makes a difference in plain `tqdm`.