### PR TITLE
Firestore: add support for CollectionGroup queries.

### DIFF
--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -238,6 +238,13 @@ class Client(ClientWithProject):
         else:
             path = document_path
 
+        # DocumentReference takes a relative path. Strip the database string if present.
+        base_path = self._database_string
+        joined_path = _helpers.DOCUMENT_PATH_DELIMITER.join(path)
+        if joined_path.startswith(base_path):
+            joined_path = joined_path[len(base_path):]
+        path = joined_path.split(_helpers.DOCUMENT_PATH_DELIMITER)
+
         return DocumentReference(*path, client=self)
 
     @staticmethod

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -194,13 +194,16 @@ class Client(ClientWithProject):
         Every collection or subcollection with this ID as the last segment of its
         path will be included. Cannot contain a slash.
         @returns {Query} The created Query.
-        """    
-        if '/' in collection_id:
-            raise ValueError("Invalid collection_id " + collection_id + ". Collection IDs must not contain '/'.")
-        
+        """
+        if "/" in collection_id:
+            raise ValueError(
+                "Invalid collection_id "
+                + collection_id
+                + ". Collection IDs must not contain '/'."
+            )
+
         collection = self.collection(collection_id)
         return query.Query(collection, all_descendants=True)
-  
 
     def document(self, *document_path):
         """Get a reference to a document in a collection.
@@ -242,7 +245,7 @@ class Client(ClientWithProject):
         base_path = self._database_string
         joined_path = _helpers.DOCUMENT_PATH_DELIMITER.join(path)
         if joined_path.startswith(base_path):
-            joined_path = joined_path[len(base_path):]
+            joined_path = joined_path[len(base_path) :]
         path = joined_path.split(_helpers.DOCUMENT_PATH_DELIMITER)
 
         return DocumentReference(*path, client=self)

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -26,6 +26,7 @@ In the hierarchy of API concepts
 from google.cloud.client import ClientWithProject
 
 from google.cloud.firestore_v1 import _helpers
+from google.cloud.firestore_v1 import query
 from google.cloud.firestore_v1 import types
 from google.cloud.firestore_v1.batch import WriteBatch
 from google.cloud.firestore_v1.collection import CollectionReference
@@ -178,6 +179,28 @@ class Client(ClientWithProject):
             path = collection_path
 
         return CollectionReference(*path, client=self)
+
+    def collection_group(self, collection_id):
+        """
+        Creates and returns a new Query that includes all documents in the
+        database that are contained in a collection or subcollection with the
+        given collection_id.
+   
+        .. code-block:: python
+        
+            >>> query = firestore.collection_group('mygroup')
+
+        @param {string} collectionId Identifies the collections to query over.
+        Every collection or subcollection with this ID as the last segment of its
+        path will be included. Cannot contain a slash.
+        @returns {Query} The created Query.
+        """    
+        if '/' in collection_id:
+            raise ValueError("Invalid collection_id " + collection_id + ". Collection IDs must not contain '/'.")
+        
+        collection = self.collection(collection_id)
+        return query.Query(collection, all_descendants=True)
+  
 
     def document(self, *document_path):
         """Get a reference to a document in a collection.

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -242,7 +242,7 @@ class Client(ClientWithProject):
             path = document_path
 
         # DocumentReference takes a relative path. Strip the database string if present.
-        base_path = self._database_string
+        base_path = self._database_string + "/documents/"
         joined_path = _helpers.DOCUMENT_PATH_DELIMITER.join(path)
         if joined_path.startswith(base_path):
             joined_path = joined_path[len(base_path) :]

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -185,9 +185,9 @@ class Client(ClientWithProject):
         Creates and returns a new Query that includes all documents in the
         database that are contained in a collection or subcollection with the
         given collection_id.
-   
+
         .. code-block:: python
-        
+
             >>> query = firestore.collection_group('mygroup')
 
         @param {string} collectionId Identifies the collections to query over.

--- a/firestore/google/cloud/firestore_v1/query.py
+++ b/firestore/google/cloud/firestore_v1/query.py
@@ -430,6 +430,7 @@ class Query(object):
             "orders": self._orders,
             "limit": self._limit,
             "offset": self._offset,
+            "all_descendants": self._all_descendants,
         }
         if start:
             query_kwargs["start_at"] = cursor_pair

--- a/firestore/google/cloud/firestore_v1/query.py
+++ b/firestore/google/cloud/firestore_v1/query.py
@@ -142,7 +142,7 @@ class Query(object):
         self._offset = offset
         self._start_at = start_at
         self._end_at = end_at
-        self._all_descendants=all_descendants
+        self._all_descendants = all_descendants
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
@@ -690,8 +690,7 @@ class Query(object):
             "select": projection,
             "from": [
                 query_pb2.StructuredQuery.CollectionSelector(
-                    collection_id=self._parent.id,
-                    all_descendants=self._all_descendants,
+                    collection_id=self._parent.id, all_descendants=self._all_descendants
                 )
             ],
             "where": self._filters_pb(),

--- a/firestore/google/cloud/firestore_v1/query.py
+++ b/firestore/google/cloud/firestore_v1/query.py
@@ -111,6 +111,10 @@ class Query(object):
             any matching documents will be included in the result set.
             When the query is formed, the document values
             will be used in the order given by ``orders``.
+        all_descendants (Optional[bool]): When false, selects only collections
+            that are immediate children of the `parent` specified in the
+            containing `RunQueryRequest`. When true, selects all descendant
+            collections.
     """
 
     ASCENDING = "ASCENDING"
@@ -128,7 +132,7 @@ class Query(object):
         offset=None,
         start_at=None,
         end_at=None,
-        all_descendants=None,
+        all_descendants=False,
     ):
         self._parent = parent
         self._projection = projection
@@ -205,6 +209,7 @@ class Query(object):
             offset=self._offset,
             start_at=self._start_at,
             end_at=self._end_at,
+            all_descendants=self._all_descendants,
         )
 
     def where(self, field_path, op_string, value):
@@ -272,6 +277,7 @@ class Query(object):
             offset=self._offset,
             start_at=self._start_at,
             end_at=self._end_at,
+            all_descendants=self._all_descendants,
         )
 
     @staticmethod
@@ -323,6 +329,7 @@ class Query(object):
             offset=self._offset,
             start_at=self._start_at,
             end_at=self._end_at,
+            all_descendants=self._all_descendants,
         )
 
     def limit(self, count):
@@ -348,6 +355,7 @@ class Query(object):
             offset=self._offset,
             start_at=self._start_at,
             end_at=self._end_at,
+            all_descendants=self._all_descendants,
         )
 
     def offset(self, num_to_skip):
@@ -374,6 +382,7 @@ class Query(object):
             offset=num_to_skip,
             start_at=self._start_at,
             end_at=self._end_at,
+            all_descendants=self._all_descendants,
         )
 
     def _cursor_helper(self, document_fields, before, start):

--- a/firestore/google/cloud/firestore_v1/query.py
+++ b/firestore/google/cloud/firestore_v1/query.py
@@ -156,6 +156,7 @@ class Query(object):
             and self._offset == other._offset
             and self._start_at == other._start_at
             and self._end_at == other._end_at
+            and self._all_descendants == other._all_descendants
         )
 
     @property

--- a/firestore/google/cloud/firestore_v1/query.py
+++ b/firestore/google/cloud/firestore_v1/query.py
@@ -128,6 +128,7 @@ class Query(object):
         offset=None,
         start_at=None,
         end_at=None,
+        all_descendants=None,
     ):
         self._parent = parent
         self._projection = projection
@@ -137,6 +138,7 @@ class Query(object):
         self._offset = offset
         self._start_at = start_at
         self._end_at = end_at
+        self._all_descendants=all_descendants
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
@@ -679,7 +681,8 @@ class Query(object):
             "select": projection,
             "from": [
                 query_pb2.StructuredQuery.CollectionSelector(
-                    collection_id=self._parent.id
+                    collection_id=self._parent.id,
+                    all_descendants=self._all_descendants,
                 )
             ],
             "where": self._filters_pb(),

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -797,6 +797,11 @@ def test_watch_collection(client, cleanup):
             "Expected the last document update to update born: " + str(on_snapshot.born)
         )
 
+def test_collection_group_query(client, cleanup):
+    db = client
+    group = db.collection_group('a')
+    for i in group.stream():
+        print(i)
 
 def test_watch_query(client, cleanup):
     db = client

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -482,6 +482,7 @@ def test_collection_add(client, cleanup):
     assert set(collection2.list_documents()) == {document_ref3, document_ref4}
     assert set(collection3.list_documents()) == {document_ref5}
 
+
 def test_query_stream(client, cleanup):
     sub_collection = "child" + unique_resource_id("-")
     collection = client.collection("collek", "shun", sub_collection)
@@ -632,32 +633,117 @@ def test_query_unary(client, cleanup):
     assert len(data1) == 1
     assert math.isnan(data1[field_name])
 
+
 def test_collection_group_queries(client, cleanup):
-    collection_group = "child" + unique_resource_id("-")
+    collection_group = "col" + unique_resource_id("-")
 
     doc_paths = [
-      'abc/123/' + collection_group + '/cg-doc1',
-      'abc/123/' + collection_group + '/cg-doc2',
-      collection_group + '/cg-doc3',
-      collection_group + '/cg-doc4',
-      'def/456/' + collection_group + '/cg-doc5',
-      collection_group + '/virtual-doc/nested-coll/not-cg-doc',
-      'x' + collection_group + '/not-cg-doc',
-      collection_group + 'x/not-cg-doc',
-      'abc/123/' + collection_group + 'x/not-cg-doc',
-      'abc/123/x' + collection_group + '/not-cg-doc',
-      'abc/' + collection_group
-    ];
-    
+        "abc/123/" + collection_group + "/cg-doc1",
+        "abc/123/" + collection_group + "/cg-doc2",
+        collection_group + "/cg-doc3",
+        collection_group + "/cg-doc4",
+        "def/456/" + collection_group + "/cg-doc5",
+        collection_group + "/virtual-doc/nested-coll/not-cg-doc",
+        "x" + collection_group + "/not-cg-doc",
+        collection_group + "x/not-cg-doc",
+        "abc/123/" + collection_group + "x/not-cg-doc",
+        "abc/123/x" + collection_group + "/not-cg-doc",
+        "abc/" + collection_group,
+    ]
+
     batch = client.batch()
     for doc_path in doc_paths:
         doc_ref = client.document(doc_path)
-        batch.set(doc_ref, {'x': 1});
-    
+        batch.set(doc_ref, {"x": 1})
+
     batch.commit()
 
     results = [i for i in client.collection_group(collection_group).stream()]
-    assert [i.id for i in results] == ['cg-doc1', 'cg-doc2', 'cg-doc3', 'cg-doc4', 'cg-doc5']
+    assert [i.id for i in results] == [
+        "cg-doc1",
+        "cg-doc2",
+        "cg-doc3",
+        "cg-doc4",
+        "cg-doc5",
+    ]
+
+
+# def test_collection_group_queries_startat_endat(client, cleanup):
+#     collection_group = "col" + unique_resource_id("-")
+
+#     doc_paths = [
+#         "a/a/" + collection_group + "/cg-doc1",
+#         "a/b/a/b/" + collection_group + "/cg-doc2",
+#         "a/b/" + collection_group + "/cg-doc3",
+#         "a/b/c/d/" + collection_group + "/cg-doc4",
+#         "a/c/" + collection_group + "/cg-doc5",
+#         collection_group + "/cg-doc6",
+#         "a/b/nope/nope",
+#     ]
+
+#     batch = client.batch()
+#     for doc_path in doc_paths:
+#         doc_ref = client.document(doc_path)
+#         batch.set(doc_ref, {"x": doc_path})
+
+#     batch.commit()
+
+#     query_snapshot = (
+#         client.collection_group(collection_group)
+#         .order_by('documentId')
+#         .start_at("a/b")
+#         .end_at("a/b0")
+#         .stream()
+#     )
+#     assert [i.id for i in query_snapshot], ["cg-doc2", "cg-doc3", "cg-doc4"]
+
+#     query_snapshot = (
+#         firestore.collectionGroup(collectionGroup)
+#         .order_by('documentId')
+#         .start_after("a/b")
+#         .end_before("a/b/" + collection_group + "/cg-doc3")
+#         .stream()
+#     )
+#     assert [i.id for i in query_snapshot], ["cg-doc2"]
+
+
+# def test_collection_group_queries_filters(client, cleanup):
+#     collection_group = "col" + unique_resource_id("-")
+
+#     doc_paths = [
+#         "a/a/" + collection_group + "/cg-doc1",
+#         "a/b/a/b/" + collection_group + "/cg-doc2",
+#         "a/b/" + collection_group + "/cg-doc3",
+#         "a/b/c/d/" + collection_group + "/cg-doc4",
+#         "a/c/" + collection_group + "/cg-doc5",
+#         collection_group + "/cg-doc6",
+#         "a/b/nope/nope",
+#     ]
+
+#     batch = client.batch()
+
+#     for doc_path in doc_paths:
+#         doc_ref = client.document(doc_path)
+#         batch.set(doc_ref, {"x": 1})
+
+#     batch.commit()
+
+#     query_snapshot = (
+#         client.collection_group(collection_group)
+#         .where('documentId', ">=", "a/b")
+#         .where('documentId', "<=", "a/b0")
+#         .stream()
+#     )
+#     assert [i.id for i in query_snapshot], ["cg-doc2", "cg-doc3", "cg-doc4"]
+
+#     query_snapshot = (
+#         client.collection_group(collection_group)
+#         .where('documentId', ">", "a/b")
+#         .where('documentId', "<", "a/b/" + collection_group + "/cg-doc3")
+#         .stream()
+#     )
+#     assert [i.id for i in query_snapshot], ["cg-doc2"]
+
 
 def test_get_all(client, cleanup):
     collection_name = "get-all" + unique_resource_id("-")
@@ -821,6 +907,7 @@ def test_watch_collection(client, cleanup):
         raise AssertionError(
             "Expected the last document update to update born: " + str(on_snapshot.born)
         )
+
 
 def test_watch_query(client, cleanup):
     db = client

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -736,8 +736,8 @@ def test_collection_group_queries_filters(client, cleanup):
 
     query = (
         client.collection_group(collection_group)
-        .where("x", ">=", 1)
-        .where("x", "<=", len(doc_paths) - 1)
+        .where("__name__", ">=", "a/b")
+        .where("__name__", "<=", "a/b0")
     )
     snapshots = list(query.stream())
     found = set(snapshot.id for snapshot in snapshots)
@@ -745,8 +745,8 @@ def test_collection_group_queries_filters(client, cleanup):
 
     query = (
         client.collection_group(collection_group)
-        .where("x", ">", 0)
-        .where("x", "<", 2)
+        .where("__name__", ">", "a/b")
+        .where("__name__", "<", "a/b/{}/cg-doc3".format(collection_group))
     )
     snapshots = list(query.stream())
     found = set(snapshot.id for snapshot in snapshots)

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -661,13 +661,7 @@ def test_collection_group_queries(client, cleanup):
     query = client.collection_group(collection_group)
     snapshots = list(query.stream())
     found = [snapshot.id for snapshot in snapshots]
-    expected = [
-        "cg-doc1",
-        "cg-doc2",
-        "cg-doc3",
-        "cg-doc4",
-        "cg-doc5",
-    ]
+    expected = ["cg-doc1", "cg-doc2", "cg-doc3", "cg-doc4", "cg-doc5"]
     assert found == expected
 
 

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -739,7 +739,9 @@ def test_collection_group_queries_filters(client, cleanup):
     query = (
         client.collection_group(collection_group)
         .where("__name__", ">", client.document("a/b"))
-        .where("__name__", "<", client.document("a/b/{}/cg-doc3".format(collection_group)))
+        .where(
+            "__name__", "<", client.document("a/b/{}/cg-doc3".format(collection_group))
+        )
     )
     snapshots = list(query.stream())
     found = set(snapshot.id for snapshot in snapshots)

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -706,7 +706,6 @@ def test_collection_group_queries_startat_endat(client, cleanup):
     assert found == set(["cg-doc2"])
 
 
-@pytest.mark.skip("where query across group requires custom index.")
 def test_collection_group_queries_filters(client, cleanup):
     collection_group = "b" + unique_resource_id("-")
 
@@ -730,8 +729,8 @@ def test_collection_group_queries_filters(client, cleanup):
 
     query = (
         client.collection_group(collection_group)
-        .where("__name__", ">=", "a/b")
-        .where("__name__", "<=", "a/b0")
+        .where("__name__", ">=", client.document("a/b"))
+        .where("__name__", "<=", client.document("a/b0"))
     )
     snapshots = list(query.stream())
     found = set(snapshot.id for snapshot in snapshots)
@@ -739,8 +738,8 @@ def test_collection_group_queries_filters(client, cleanup):
 
     query = (
         client.collection_group(collection_group)
-        .where("__name__", ">", "a/b")
-        .where("__name__", "<", "a/b/{}/cg-doc3".format(collection_group))
+        .where("__name__", ">", client.document("a/b"))
+        .where("__name__", "<", client.document("a/b/{}/cg-doc3".format(collection_group)))
     )
     snapshots = list(query.stream())
     found = set(snapshot.id for snapshot in snapshots)

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -635,7 +635,7 @@ def test_query_unary(client, cleanup):
 
 
 def test_collection_group_queries(client, cleanup):
-    collection_group = "col" + unique_resource_id("-")
+    collection_group = "b" + unique_resource_id("-")
 
     doc_paths = [
         "abc/123/" + collection_group + "/cg-doc1",
@@ -672,7 +672,7 @@ def test_collection_group_queries(client, cleanup):
 
 
 def test_collection_group_queries_startat_endat(client, cleanup):
-    collection_group = "col" + unique_resource_id("-")
+    collection_group = "b" + unique_resource_id("-")
 
     doc_paths = [
         "a/a/" + collection_group + "/cg-doc1",
@@ -709,12 +709,12 @@ def test_collection_group_queries_startat_endat(client, cleanup):
     )
     snapshots = list(query.stream())
     found = set(snapshot.id for snapshot in snapshots)
-    assert found == set(["cg-doc2", "cg-doc4"])
+    assert found == set(["cg-doc2"])
 
 
 @pytest.mark.skip("where query across group requires custom index.")
 def test_collection_group_queries_filters(client, cleanup):
-    collection_group = "col" + unique_resource_id("-")
+    collection_group = "b" + unique_resource_id("-")
 
     doc_paths = [
         "a/a/" + collection_group + "/cg-doc1",

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -136,10 +136,11 @@ class TestClient(unittest.TestCase):
         client = self._make_default_one()
         query = client.collection_group('collectionId').where('foo', '==', 'bar')
 
+        assert query._all_descendants == True
         assert query._field_filters[0].field.field_path  == 'foo'
         assert query._field_filters[0].value.string_value == 'bar'
         assert query._field_filters[0].op == query._field_filters[0].EQUAL
-        assert query._parent.id == 'collectionId
+        assert query._parent.id == 'collectionId'
 
     def test_collection_group_no_slashes(self):
         from google.cloud.firestore_v1.collection import CollectionReference

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -130,6 +130,24 @@ class TestClient(unittest.TestCase):
         self.assertIs(collection2._client, client)
         self.assertIsInstance(collection2, CollectionReference)
 
+    def test_collection_group(self):
+        from google.cloud.firestore_v1.collection import CollectionReference
+
+        client = self._make_default_one()
+        query = client.collection_group('collectionId').where('foo', '==', 'bar')
+
+        assert query._field_filters[0].field.field_path  == 'foo'
+        assert query._field_filters[0].value.string_value == 'bar'
+        assert query._field_filters[0].op == query._field_filters[0].EQUAL
+        assert query._parent.id == 'collectionId
+
+    def test_collection_group_no_slashes(self):
+        from google.cloud.firestore_v1.collection import CollectionReference
+
+        client = self._make_default_one()
+        with self.assertRaises(ValueError):
+            query = client.collection_group('foo/bar')
+
     def test_document_factory(self):
         from google.cloud.firestore_v1.document import DocumentReference
 

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -134,20 +134,20 @@ class TestClient(unittest.TestCase):
         from google.cloud.firestore_v1.collection import CollectionReference
 
         client = self._make_default_one()
-        query = client.collection_group('collectionId').where('foo', '==', 'bar')
+        query = client.collection_group("collectionId").where("foo", "==", u"bar")
 
         assert query._all_descendants == True
-        assert query._field_filters[0].field.field_path  == 'foo'
-        assert query._field_filters[0].value.string_value == 'bar'
+        assert query._field_filters[0].field.field_path == "foo"
+        assert query._field_filters[0].value.string_value == u"bar"
         assert query._field_filters[0].op == query._field_filters[0].EQUAL
-        assert query._parent.id == 'collectionId'
+        assert query._parent.id == "collectionId"
 
     def test_collection_group_no_slashes(self):
         from google.cloud.firestore_v1.collection import CollectionReference
 
         client = self._make_default_one()
         with self.assertRaises(ValueError):
-            query = client.collection_group('foo/bar')
+            query = client.collection_group("foo/bar")
 
     def test_document_factory(self):
         from google.cloud.firestore_v1.document import DocumentReference

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -167,7 +167,20 @@ class TestClient(unittest.TestCase):
         self.assertIs(document2._client, client)
         self.assertIsInstance(document2, DocumentReference)
 
-    def test_document_factory_nested(self):
+    def test_document_factory_w_absolute_path(self):
+        from google.cloud.firestore_v1.document import DocumentReference
+
+        parts = ("rooms", "roomA")
+        client = self._make_default_one()
+        doc_path = "/".join(parts)
+        to_match = client.document(doc_path)
+        document1 = client.document(to_match._document_path)
+
+        self.assertEqual(document1._path, parts)
+        self.assertIs(document1._client, client)
+        self.assertIsInstance(document1, DocumentReference)
+
+    def test_document_factory_w_nested_path(self):
         from google.cloud.firestore_v1.document import DocumentReference
 
         client = self._make_default_one()

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -131,23 +131,19 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(collection2, CollectionReference)
 
     def test_collection_group(self):
-        from google.cloud.firestore_v1.collection import CollectionReference
-
         client = self._make_default_one()
         query = client.collection_group("collectionId").where("foo", "==", u"bar")
 
-        assert query._all_descendants == True
+        assert query._all_descendants
         assert query._field_filters[0].field.field_path == "foo"
         assert query._field_filters[0].value.string_value == u"bar"
         assert query._field_filters[0].op == query._field_filters[0].EQUAL
         assert query._parent.id == "collectionId"
 
     def test_collection_group_no_slashes(self):
-        from google.cloud.firestore_v1.collection import CollectionReference
-
         client = self._make_default_one()
         with self.assertRaises(ValueError):
-            query = client.collection_group("foo/bar")
+            client.collection_group("foo/bar")
 
     def test_document_factory(self):
         from google.cloud.firestore_v1.document import DocumentReference

--- a/firestore/tests/unit/v1/test_query.py
+++ b/firestore/tests/unit/v1/test_query.py
@@ -190,7 +190,7 @@ class TestQuery(unittest.TestCase):
             query.select(["*"])
 
     def test_select(self):
-        query1 = self._make_one_all_fields()
+        query1 = self._make_one_all_fields(all_descendants=True)
 
         field_paths2 = ["foo", "bar"]
         query2 = query1.select(field_paths2)
@@ -222,7 +222,9 @@ class TestQuery(unittest.TestCase):
         from google.cloud.firestore_v1.proto import document_pb2
         from google.cloud.firestore_v1.proto import query_pb2
 
-        query = self._make_one_all_fields(skip_fields=("field_filters",))
+        query = self._make_one_all_fields(
+            skip_fields=("field_filters",), all_descendants=True
+        )
         new_query = query.where("power.level", ">", 9000)
 
         self.assertIsNot(query, new_query)
@@ -311,7 +313,9 @@ class TestQuery(unittest.TestCase):
         from google.cloud.firestore_v1.gapic import enums
 
         klass = self._get_target_class()
-        query1 = self._make_one_all_fields(skip_fields=("orders",))
+        query1 = self._make_one_all_fields(
+            skip_fields=("orders",), all_descendants=True
+        )
 
         field_path2 = "a"
         query2 = query1.order_by(field_path2)
@@ -335,7 +339,7 @@ class TestQuery(unittest.TestCase):
         self._compare_queries(query2, query3, "_orders")
 
     def test_limit(self):
-        query1 = self._make_one_all_fields()
+        query1 = self._make_one_all_fields(all_descendants=True)
 
         limit2 = 100
         query2 = query1.limit(limit2)
@@ -353,7 +357,7 @@ class TestQuery(unittest.TestCase):
         self._compare_queries(query2, query3, "_limit")
 
     def test_offset(self):
-        query1 = self._make_one_all_fields()
+        query1 = self._make_one_all_fields(all_descendants=True)
 
         offset2 = 23
         query2 = query1.offset(offset2)
@@ -391,6 +395,7 @@ class TestQuery(unittest.TestCase):
     def test__cursor_helper_w_dict(self):
         values = {"a": 7, "b": "foo"}
         query1 = self._make_one(mock.sentinel.parent)
+        query1._all_descendants = True
         query2 = query1._cursor_helper(values, True, True)
 
         self.assertIs(query2._parent, mock.sentinel.parent)
@@ -400,6 +405,7 @@ class TestQuery(unittest.TestCase):
         self.assertIsNone(query2._limit)
         self.assertIsNone(query2._offset)
         self.assertIsNone(query2._end_at)
+        self.assertTrue(query2._all_descendants)
 
         cursor, before = query2._start_at
 
@@ -477,7 +483,9 @@ class TestQuery(unittest.TestCase):
 
     def test_start_at(self):
         collection = self._make_collection("here")
-        query1 = self._make_one_all_fields(parent=collection, skip_fields=("orders",))
+        query1 = self._make_one_all_fields(
+            parent=collection, skip_fields=("orders",), all_descendants=True
+        )
         query2 = query1.order_by("hi")
 
         document_fields3 = {"hi": "mom"}

--- a/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -193,12 +193,10 @@ class StreamingPullManager(object):
         if self._leaser is None:
             return 0
 
-        return max(
-            [
-                self._leaser.message_count / self._flow_control.max_messages,
-                self._leaser.bytes / self._flow_control.max_bytes,
-            ]
-        )
+        messages_percent = self._leaser.message_count / self._flow_control.max_messages
+        bytes_percent = self._leaser.bytes / self._flow_control.max_bytes
+        print(f"{messages_percent}, {bytes_percent}")
+        return max(messages_percent, bytes_percent)
 
     def add_close_callback(self, callback):
         """Schedules a callable when the manager closes.
@@ -210,10 +208,12 @@ class StreamingPullManager(object):
 
     def maybe_pause_consumer(self):
         """Check the current load and pause the consumer if needed."""
+        print(self.load)
         if self.load >= 1.0:
             if self._consumer is not None and not self._consumer.is_paused:
                 _LOGGER.debug("Message backlog over load at %.2f, pausing.", self.load)
                 self._consumer.pause()
+                print('paused')
 
     def maybe_resume_consumer(self):
         """Check the current load and resume the consumer if needed."""
@@ -227,6 +227,7 @@ class StreamingPullManager(object):
             return
 
         if self.load < self.flow_control.resume_threshold:
+            print('resuming')
             self._consumer.resume()
         else:
             _LOGGER.debug("Did not resume, current load is %s", self.load)

--- a/pubsub/tests/system.py
+++ b/pubsub/tests/system.py
@@ -65,7 +65,6 @@ def cleanup():
     for to_call, argument in registry:
         to_call(argument)
 
-
 def test_publish_messages(publisher, topic_path, cleanup):
     futures = []
     # Make sure the topic gets deleted.


### PR DESCRIPTION
CollectionGroup queries add support for queries to Firestore that query documents by collection ID rather than by collection path. 

Java: googleapis/google-cloud-java#4652
Node: googleapis/nodejs-firestore#578

