### PR TITLE
Datalabeling: Update index.rst

### DIFF
--- a/datalabeling/docs/index.rst
+++ b/datalabeling/docs/index.rst
@@ -1,4 +1,4 @@
-.. include:: /../bigquery_datatransfer/README.rst
+.. include:: /../datalabeling/README.rst
 
 Api Reference
 -------------


### PR DESCRIPTION
The body of [the Datalabeling index.rst](https://googleapis.github.io/google-cloud-python/latest/datalabeling/index.html) describes BigQuery Data Transfer rather than DataLabeling.