### PR TITLE
Remove `folder/*` pattern, since it only matches immediate child files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,28 +6,42 @@
 *                         @crwilcox
 
 # Thea Flowers is the author of the new google.api_core library.
-api_core/*                @theacodes
-core/*                    @theacodes
-docs/core/*               @theacodes
+api_core/                   @theacodes
+core/                       @theacodes
+docs/core/                  @theacodes
 
 # BigQuery suite of APIs
-bigquery/*                @googleapis/api-bigquery
-bigquery_datatransfer/*   @googleapis/api-bigquery
-bigquery_storage/*        @googleapis/api-bigquery
+bigquery/                   @googleapis/api-bigquery
+docs/bigquery/              @googleapis/api-bigquery
+
+bigquery_datatransfer/      @googleapis/api-bigquery
+docs/bigquery_datatransfer/ @googleapis/api-bigquery
+
+bigquery_storage/           @googleapis/api-bigquery
+docs/bigquery_storage/      @googleapis/api-bigquery
 
 # Danny Hermes and Tres Seaver co-authored the BigTable library.
-bigtable/*                @tseaver
+bigtable/                   @tseaver
+docs/bigtable/              @tseaver
 
 # Bill Prin is the primary maintainer of the Stackdriver libraries.
-error_reporting/*         @waprin
-monitoring/*              @waprin @supriyagarg @rimey
-logging/*                 @waprin @tseaver
+error_reporting/            @waprin
+docs/error_reporting/       @waprin
+
+monitoring/                 @waprin @supriyagarg @rimey
+docs/monitoring/            @waprin @supriyagarg @rimey
+
+logging/                    @waprin @tseaver
+docs/logging/               @waprin @tseaver
 
 # Tim Swast is the primary author of Runtime Config.
-runtimeconfig/*           @tswast
+runtimeconfig/              @tswast
+docs/runtimeconfig/         @tswast
 
 # Vikas Kedia is the product owner and Tres Seaver the author for Spanner.
-spanner/*                 @vkedia @tseaver
+spanner/                    @vkedia @tseaver
+docs/spanner/               @vkedia @tseaver
 
 # Doug Greiman and Angela Li are the owners of trace.
-trace/*                   @liyanhui1228 @duggelz
+trace/                      @liyanhui1228 @duggelz
+docs/trace/                 @liyanhui1228 @duggelz


### PR DESCRIPTION
> The `docs/*` pattern will match files like `docs/getting-started.md`
> but not further nested files like `docs/build-app/troubleshooting.md`.

See: https://help.github.com/en/articles/about-code-owners

P.S. I realize this whole file is probably out-of-date. I'm only making this mechanical change so that the right code reviewers get added on BigQuery updates.