### PR TITLE
Add `user_agent` property to `ClientInfo`

### DIFF
--- a/api_core/google/api_core/gapic_v1/client_info.py
+++ b/api_core/google/api_core/gapic_v1/client_info.py
@@ -51,6 +51,9 @@ class ClientInfo(object):
             library, generally used if the client library was not generated
             by gapic or if additional functionality was built on top of
             a gapic client library.
+        user_agent (Optional[str]): Prefix to the user agent header. This is
+            used to supply information such as application name or partner tool.
+            Recommended format: ``application-or-tool-ID/major.minor.version``.
     """
 
     def __init__(
@@ -60,18 +63,26 @@ class ClientInfo(object):
         api_core_version=_API_CORE_VERSION,
         gapic_version=None,
         client_library_version=None,
+        user_agent=None,
     ):
         self.python_version = python_version
         self.grpc_version = grpc_version
         self.api_core_version = api_core_version
         self.gapic_version = gapic_version
         self.client_library_version = client_library_version
+        self.user_agent = user_agent
 
     def to_user_agent(self):
         """Returns the user-agent string for this client info."""
+
         # Note: the order here is important as the internal metrics system
         # expects these items to be in specific locations.
-        ua = "gl-python/{python_version} "
+        ua = ""
+
+        if self.user_agent is not None:
+            ua += "{user_agent} "
+
+        ua += "gl-python/{python_version} "
 
         if self.grpc_version is not None:
             ua += "grpc/{grpc_version} "

--- a/api_core/setup.cfg
+++ b/api_core/setup.cfg
@@ -8,3 +8,5 @@ inputs =
 exclude =
     tests/
 output = pytype_output/
+# Workaround for https://github.com/google/pytype/issues/150
+disable = pyi-error

--- a/api_core/tests/unit/gapic/test_client_info.py
+++ b/api_core/tests/unit/gapic/test_client_info.py
@@ -33,6 +33,7 @@ def test_constructor_options():
         api_core_version="3",
         gapic_version="4",
         client_library_version="5",
+        user_agent="6"
     )
 
     assert info.python_version == "1"
@@ -40,6 +41,7 @@ def test_constructor_options():
     assert info.api_core_version == "3"
     assert info.gapic_version == "4"
     assert info.client_library_version == "5"
+    assert info.user_agent == "6"
 
 
 def test_to_user_agent_minimal():
@@ -59,11 +61,12 @@ def test_to_user_agent_full():
         api_core_version="3",
         gapic_version="4",
         client_library_version="5",
+        user_agent="app-name/1.0",
     )
 
     user_agent = info.to_user_agent()
 
-    assert user_agent == "gl-python/1 grpc/2 gax/3 gapic/4 gccl/5"
+    assert user_agent == "app-name/1.0 gl-python/1 grpc/2 gax/3 gapic/4 gccl/5"
 
 
 def test_to_grpc_metadata():


### PR DESCRIPTION
This provides a way for partners to define a prefix identifying their
tool or application, as required by many cloud partnership agreements.