### PR TITLE
Add `client_info` to BigQuery constructor for user-amenable user agent headers

### DIFF
--- a/bigquery/google/cloud/bigquery/_http.py
+++ b/bigquery/google/cloud/bigquery/_http.py
@@ -59,7 +59,9 @@ class Connection(_http.JSONConnection):
 
     @property
     def _EXTRA_HEADERS(self):
-        self._extra_headers[_http.CLIENT_INFO_HEADER] = self._client_info.to_user_agent()
+        self._extra_headers[
+            _http.CLIENT_INFO_HEADER
+        ] = self._client_info.to_user_agent()
         return self._extra_headers
 
     @_EXTRA_HEADERS.setter

--- a/bigquery/google/cloud/bigquery/_http.py
+++ b/bigquery/google/cloud/bigquery/_http.py
@@ -14,12 +14,10 @@
 
 """Create / interact with Google BigQuery connections."""
 
+import google.api_core.gapic_v1.client_info
 from google.cloud import _http
 
 from google.cloud.bigquery import __version__
-
-
-_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
 
 
 class Connection(_http.JSONConnection):
@@ -28,6 +26,19 @@ class Connection(_http.JSONConnection):
     :type client: :class:`~google.cloud.bigquery.client.Client`
     :param client: The client that owns the current connection.
     """
+
+    def __init__(self, client, client_info=None):
+        super(Connection, self).__init__(client)
+
+        if client_info is None:
+            client_info = google.api_core.gapic_v1.client_info.ClientInfo(
+                gapic_version=__version__, client_library_version=__version__
+            )
+        else:
+            client_info.gapic_version = __version__
+            client_info.client_library_version = __version__
+        self._client_info = client_info
+        self._extra_headers = {}
 
     API_BASE_URL = "https://www.googleapis.com"
     """The base of the API call URL."""
@@ -38,4 +49,19 @@ class Connection(_http.JSONConnection):
     API_URL_TEMPLATE = "{api_base_url}/bigquery/{api_version}{path}"
     """A template for the URL of a particular API call."""
 
-    _EXTRA_HEADERS = {_http.CLIENT_INFO_HEADER: _CLIENT_INFO}
+    @property
+    def USER_AGENT(self):
+        return self._client_info.to_user_agent()
+
+    @USER_AGENT.setter
+    def USER_AGENT(self, value):
+        self._client_info.user_agent = value
+
+    @property
+    def _EXTRA_HEADERS(self):
+        self._extra_headers[_http.CLIENT_INFO_HEADER] = self._client_info.to_user_agent()
+        return self._extra_headers
+
+    @_EXTRA_HEADERS.setter
+    def _EXTRA_HEADERS(self, value):
+        self._extra_headers = value

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -128,6 +128,11 @@ class Client(ClientWithProject):
         default_query_job_config (google.cloud.bigquery.job.QueryJobConfig):
             (Optional) Default ``QueryJobConfig``.
             Will be merged into job configs passed into the ``query`` method.
+        client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+            The client info used to send a user-agent string along with API
+            requests. If ``None``, then default info will be used. Generally,
+            you only need to set this if you're developing your own library
+            or partner tool.
 
     Raises:
         google.auth.exceptions.DefaultCredentialsError:
@@ -148,11 +153,12 @@ class Client(ClientWithProject):
         _http=None,
         location=None,
         default_query_job_config=None,
+        client_info=None,
     ):
         super(Client, self).__init__(
             project=project, credentials=credentials, _http=_http
         )
-        self._connection = Connection(self)
+        self._connection = Connection(self, client_info=client_info)
         self._location = location
         self._default_query_job_config = default_query_job_config
 

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -22,6 +22,7 @@ import json
 import unittest
 
 import mock
+import requests
 import six
 from six.moves import http_client
 import pytest
@@ -37,6 +38,7 @@ except (ImportError, AttributeError):  # pragma: NO COVER
     pyarrow = None
 
 import google.api_core.exceptions
+from google.api_core.gapic_v1 import client_info
 import google.cloud._helpers
 from google.cloud.bigquery.dataset import DatasetReference
 
@@ -1319,6 +1321,38 @@ class TestClient(unittest.TestCase):
 
         conn.api_request.assert_called_once_with(method="GET", path="/%s" % path)
         self.assertEqual(table.table_id, self.TABLE_ID)
+
+    def test_get_table_sets_user_agent(self):
+        creds = _make_credentials()
+        http = mock.create_autospec(requests.Session)
+        mock_response = http.request(
+            url=mock.ANY, method=mock.ANY, headers=mock.ANY, data=mock.ANY
+        )
+        http.reset_mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = self._make_table_resource()
+        user_agent_override = client_info.ClientInfo(user_agent="my-application/1.2.3")
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=creds,
+            client_info=user_agent_override,
+            _http=http,
+        )
+
+        table = client.get_table(self.TABLE_REF)
+
+        expected_user_agent = user_agent_override.to_user_agent()
+        http.request.assert_called_once_with(
+            url=mock.ANY,
+            method="GET",
+            headers={
+                "X-Goog-API-Client": expected_user_agent,
+                "Accept-Encoding": "gzip",
+                "User-Agent": expected_user_agent,
+            },
+            data=mock.ANY,
+        )
+        self.assertIn("my-application/1.2.3", expected_user_agent)
 
     def test_update_dataset_w_invalid_field(self):
         from google.cloud.bigquery.dataset import Dataset

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -1339,7 +1339,7 @@ class TestClient(unittest.TestCase):
             _http=http,
         )
 
-        table = client.get_table(self.TABLE_REF)
+        client.get_table(self.TABLE_REF)
 
         expected_user_agent = user_agent_override.to_user_agent()
         http.request.assert_called_once_with(


### PR DESCRIPTION
This aligns BigQuery's behavior regarding the User-Agent and
X-Goog-Api-Client headers with that of the GAPIC-based clients.

Old:

    X-Goog-API-Client: gl-python/3.7.2 gccl/1.11.2
    User-Agent: gcloud-python/0.29.1

New:

    X-Goog-API-Client: optional-application-id/1.2.3 gl-python/3.7.2 grpc/1.20.0 gax/1.9.0 gapic/1.11.2 gccl/1.11.2
    User-Agent: optional-application-id/1.2.3 gl-python/3.7.2 grpc/1.20.0 gax/1.9.0 gapic/1.11.2 gccl/1.11.2

In order to set the `optional-application-id/1.2.3`, the latest version
of `api_core` is required, but since that's an uncommon usecase and it
doesn't break, just ignore the custom User-Agent if an older version is
used, I didn't update the minimum version `setup.py`.

This PR depends on:

- https://github.com/googleapis/google-cloud-python/pull/7799 for unit test purposes.
- https://github.com/googleapis/google-cloud-python/pull/7814 so that people can actuall use this (optional) feature.