### PR TITLE
Core, BigQuery: refactor 'client_info' support.

### DIFF
--- a/api_core/tests/unit/gapic/test_client_info.py
+++ b/api_core/tests/unit/gapic/test_client_info.py
@@ -16,59 +16,6 @@
 from google.api_core.gapic_v1 import client_info
 
 
-def test_constructor_defaults():
-    info = client_info.ClientInfo()
-
-    assert info.python_version is not None
-    assert info.grpc_version is not None
-    assert info.api_core_version is not None
-    assert info.gapic_version is None
-    assert info.client_library_version is None
-
-
-def test_constructor_options():
-    info = client_info.ClientInfo(
-        python_version="1",
-        grpc_version="2",
-        api_core_version="3",
-        gapic_version="4",
-        client_library_version="5",
-        user_agent="6"
-    )
-
-    assert info.python_version == "1"
-    assert info.grpc_version == "2"
-    assert info.api_core_version == "3"
-    assert info.gapic_version == "4"
-    assert info.client_library_version == "5"
-    assert info.user_agent == "6"
-
-
-def test_to_user_agent_minimal():
-    info = client_info.ClientInfo(
-        python_version="1", api_core_version="2", grpc_version=None
-    )
-
-    user_agent = info.to_user_agent()
-
-    assert user_agent == "gl-python/1 gax/2"
-
-
-def test_to_user_agent_full():
-    info = client_info.ClientInfo(
-        python_version="1",
-        grpc_version="2",
-        api_core_version="3",
-        gapic_version="4",
-        client_library_version="5",
-        user_agent="app-name/1.0",
-    )
-
-    user_agent = info.to_user_agent()
-
-    assert user_agent == "app-name/1.0 gl-python/1 grpc/2 gax/3 gapic/4 gccl/5"
-
-
 def test_to_grpc_metadata():
     info = client_info.ClientInfo()
 

--- a/api_core/tests/unit/test_client_info.py
+++ b/api_core/tests/unit/test_client_info.py
@@ -1,0 +1,69 @@
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from google.api_core import client_info
+
+
+def test_constructor_defaults():
+    info = client_info.ClientInfo()
+
+    assert info.python_version is not None
+    assert info.grpc_version is not None
+    assert info.api_core_version is not None
+    assert info.gapic_version is None
+    assert info.client_library_version is None
+
+
+def test_constructor_options():
+    info = client_info.ClientInfo(
+        python_version="1",
+        grpc_version="2",
+        api_core_version="3",
+        gapic_version="4",
+        client_library_version="5",
+        user_agent="6"
+    )
+
+    assert info.python_version == "1"
+    assert info.grpc_version == "2"
+    assert info.api_core_version == "3"
+    assert info.gapic_version == "4"
+    assert info.client_library_version == "5"
+    assert info.user_agent == "6"
+
+
+def test_to_user_agent_minimal():
+    info = client_info.ClientInfo(
+        python_version="1", api_core_version="2", grpc_version=None
+    )
+
+    user_agent = info.to_user_agent()
+
+    assert user_agent == "gl-python/1 gax/2"
+
+
+def test_to_user_agent_full():
+    info = client_info.ClientInfo(
+        python_version="1",
+        grpc_version="2",
+        api_core_version="3",
+        gapic_version="4",
+        client_library_version="5",
+        user_agent="app-name/1.0",
+    )
+
+    user_agent = info.to_user_agent()
+
+    assert user_agent == "app-name/1.0 gl-python/1 grpc/2 gax/3 gapic/4 gccl/5"

--- a/bigquery/google/cloud/bigquery/_http.py
+++ b/bigquery/google/cloud/bigquery/_http.py
@@ -24,6 +24,9 @@ class Connection(_http.JSONConnection):
 
     :type client: :class:`~google.cloud.bigquery.client.Client`
     :param client: The client that owns the current connection.
+
+    :type client_info: :class:`~google.api_core.client_info.ClientInfo`
+    :param client_info: (Optional) instance used to generate user agent.
     """
 
     def __init__(self, client, client_info=None):

--- a/bigquery/google/cloud/bigquery/_http.py
+++ b/bigquery/google/cloud/bigquery/_http.py
@@ -14,7 +14,6 @@
 
 """Create / interact with Google BigQuery connections."""
 
-import google.api_core.gapic_v1.client_info
 from google.cloud import _http
 
 from google.cloud.bigquery import __version__

--- a/bigquery/google/cloud/bigquery/_http.py
+++ b/bigquery/google/cloud/bigquery/_http.py
@@ -28,17 +28,10 @@ class Connection(_http.JSONConnection):
     """
 
     def __init__(self, client, client_info=None):
-        super(Connection, self).__init__(client)
+        super(Connection, self).__init__(client, client_info)
 
-        if client_info is None:
-            client_info = google.api_core.gapic_v1.client_info.ClientInfo(
-                gapic_version=__version__, client_library_version=__version__
-            )
-        else:
-            client_info.gapic_version = __version__
-            client_info.client_library_version = __version__
-        self._client_info = client_info
-        self._extra_headers = {}
+        self._client_info.gapic_version = __version__
+        self._client_info.client_library_version = __version__
 
     API_BASE_URL = "https://www.googleapis.com"
     """The base of the API call URL."""
@@ -48,22 +41,3 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = "{api_base_url}/bigquery/{api_version}{path}"
     """A template for the URL of a particular API call."""
-
-    @property
-    def USER_AGENT(self):
-        return self._client_info.to_user_agent()
-
-    @USER_AGENT.setter
-    def USER_AGENT(self, value):
-        self._client_info.user_agent = value
-
-    @property
-    def _EXTRA_HEADERS(self):
-        self._extra_headers[
-            _http.CLIENT_INFO_HEADER
-        ] = self._client_info.to_user_agent()
-        return self._extra_headers
-
-    @_EXTRA_HEADERS.setter
-    def _EXTRA_HEADERS(self, value):
-        self._extra_headers = value

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1363,7 +1363,7 @@ class Client(ClientWithProject):
         """
         chunk_size = _DEFAULT_CHUNKSIZE
         transport = self._http
-        headers = _get_upload_headers(self._connection.USER_AGENT)
+        headers = _get_upload_headers(self._connection.user_agent)
         upload_url = _RESUMABLE_URL_TEMPLATE.format(project=self.project)
         # TODO: modify ResumableUpload to take a retry.Retry object
         # that it can use for the initial RPC.
@@ -1409,7 +1409,7 @@ class Client(ClientWithProject):
             msg = _READ_LESS_THAN_SIZE.format(size, len(data))
             raise ValueError(msg)
 
-        headers = _get_upload_headers(self._connection.USER_AGENT)
+        headers = _get_upload_headers(self._connection.user_agent)
 
         upload_url = _MULTIPART_URL_TEMPLATE.format(project=self.project)
         upload = MultipartUpload(upload_url, headers=headers)

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -128,7 +128,7 @@ class Client(ClientWithProject):
         default_query_job_config (google.cloud.bigquery.job.QueryJobConfig):
             (Optional) Default ``QueryJobConfig``.
             Will be merged into job configs passed into the ``query`` method.
-        client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+        client_info (google.api_core.client_info.ClientInfo):
             The client info used to send a user-agent string along with API
             requests. If ``None``, then default info will be used. Generally,
             you only need to set this if you're developing your own library

--- a/bigquery/tests/unit/test__http.py
+++ b/bigquery/tests/unit/test__http.py
@@ -57,49 +57,21 @@ class TestConnection(unittest.TestCase):
         client = mock.Mock(_http=http, spec=["_http"])
 
         conn = self._make_one(client)
-        conn.USER_AGENT = "my-application/1.2.3"
+        conn.user_agent = "my-application/1.2.3"
         req_data = "req-data-boring"
         result = conn.api_request("GET", "/rainbow", data=req_data, expect_json=False)
         self.assertEqual(result, data)
 
         expected_headers = {
             "Accept-Encoding": "gzip",
-            base_http.CLIENT_INFO_HEADER: conn.USER_AGENT,
-            "User-Agent": conn.USER_AGENT,
+            base_http.CLIENT_INFO_HEADER: conn.user_agent,
+            "User-Agent": conn.user_agent,
         }
         expected_uri = conn.build_api_url("/rainbow")
         http.request.assert_called_once_with(
             data=req_data, headers=expected_headers, method="GET", url=expected_uri
         )
-        self.assertIn("my-application/1.2.3", conn.USER_AGENT)
-
-    def test_extra_headers(self):
-        from google.cloud import _http as base_http
-
-        http = mock.create_autospec(requests.Session, instance=True)
-        response = requests.Response()
-        response.status_code = 200
-        data = b"brent-spiner"
-        response._content = data
-        http.request.return_value = response
-        client = mock.Mock(_http=http, spec=["_http"])
-
-        conn = self._make_one(client)
-        conn._EXTRA_HEADERS["x-test-header"] = "a test value"
-        req_data = "req-data-boring"
-        result = conn.api_request("GET", "/rainbow", data=req_data, expect_json=False)
-        self.assertEqual(result, data)
-
-        expected_headers = {
-            "Accept-Encoding": "gzip",
-            base_http.CLIENT_INFO_HEADER: conn.USER_AGENT,
-            "User-Agent": conn.USER_AGENT,
-            "x-test-header": "a test value",
-        }
-        expected_uri = conn.build_api_url("/rainbow")
-        http.request.assert_called_once_with(
-            data=req_data, headers=expected_headers, method="GET", url=expected_uri
-        )
+        self.assertIn("my-application/1.2.3", conn.user_agent)
 
     def test_extra_headers_replace(self):
         from google.cloud import _http as base_http
@@ -113,15 +85,15 @@ class TestConnection(unittest.TestCase):
         client = mock.Mock(_http=http, spec=["_http"])
 
         conn = self._make_one(client)
-        conn._EXTRA_HEADERS = {"x-test-header": "a test value"}
+        conn.extra_headers = {"x-test-header": "a test value"}
         req_data = "req-data-boring"
         result = conn.api_request("GET", "/rainbow", data=req_data, expect_json=False)
         self.assertEqual(result, data)
 
         expected_headers = {
             "Accept-Encoding": "gzip",
-            base_http.CLIENT_INFO_HEADER: conn.USER_AGENT,
-            "User-Agent": conn.USER_AGENT,
+            base_http.CLIENT_INFO_HEADER: conn.user_agent,
+            "User-Agent": conn.user_agent,
             "x-test-header": "a test value",
         }
         expected_uri = conn.build_api_url("/rainbow")

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -4518,7 +4518,9 @@ class TestClient(unittest.TestCase):
             self.assertIsNone(rows[2].age, msg=repr(table))
 
     def test_list_rows_error(self):
-        client = self._make_one()
+        creds = _make_credentials()
+        http = object()
+        client = self._make_one(project=self.PROJECT, credentials=creds, _http=http)
 
         # neither Table nor tableReference
         with self.assertRaises(TypeError):

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -54,7 +54,7 @@ def _make_connection(*responses):
     from google.cloud.exceptions import NotFound
 
     mock_conn = mock.create_autospec(google.cloud.bigquery._http.Connection)
-    mock_conn.USER_AGENT = "testing 1.2.3"
+    mock_conn.user_agent = "testing 1.2.3"
     mock_conn.api_request.side_effect = list(responses) + [NotFound("miss")]
     return mock_conn
 
@@ -2752,7 +2752,7 @@ class TestClient(unittest.TestCase):
             + "/jobs?uploadType=resumable"
         )
         self.assertEqual(upload.upload_url, upload_url)
-        expected_headers = _get_upload_headers(conn.USER_AGENT)
+        expected_headers = _get_upload_headers(conn.user_agent)
         self.assertEqual(upload._headers, expected_headers)
         self.assertFalse(upload.finished)
         self.assertEqual(upload._chunk_size, _DEFAULT_CHUNKSIZE)
@@ -2830,7 +2830,7 @@ class TestClient(unittest.TestCase):
             + b"\r\n"
             + b"--==0==--"
         )
-        headers = _get_upload_headers(conn.USER_AGENT)
+        headers = _get_upload_headers(conn.user_agent)
         headers["content-type"] = b'multipart/related; boundary="==0=="'
         fake_transport.request.assert_called_once_with(
             "POST", upload_url, data=payload, headers=headers

--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -58,7 +58,6 @@ class Connection(object):
     """
 
     _user_agent = DEFAULT_USER_AGENT
-    _extra_headers = None
 
     def __init__(self, client, client_info=None):
         self._client = client
@@ -67,6 +66,7 @@ class Connection(object):
             client_info = ClientInfo()
 
         self._client_info = client_info
+        self._extra_headers = {}
 
     @property
     def USER_AGENT(self):
@@ -122,9 +122,7 @@ class Connection(object):
         :rtype: dict
         :returns: header keys / values
         """
-        result = self._extra_headers.copy() if self._extra_headers else {}
-        result[CLIENT_INFO_HEADER] = self.user_agent
-        return result
+        return self._extra_headers
 
     @extra_headers.setter
     def extra_headers(self, value):
@@ -265,6 +263,7 @@ class JSONConnection(Connection):
         if content_type:
             headers["Content-Type"] = content_type
 
+        headers[CLIENT_INFO_HEADER] = self.user_agent
         headers["User-Agent"] = self.user_agent
 
         return self._do_request(method, url, headers, data, target_object)

--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -16,6 +16,7 @@
 
 import json
 import platform
+import warnings
 
 from pkg_resources import get_distribution
 from six.moves.urllib.parse import urlencode
@@ -34,6 +35,16 @@ DEFAULT_USER_AGENT = "gcloud-python/{0}".format(
 CLIENT_INFO_HEADER = "X-Goog-API-Client"
 CLIENT_INFO_TEMPLATE = "gl-python/" + platform.python_version() + " gccl/{}"
 
+_USER_AGENT_ALL_CAPS_DEPRECATED = """\
+The 'USER_AGENT' class-level attribute is deprecated.  Please use
+'user_agent' instead.
+"""
+
+_EXTRA_HEADERS_ALL_CAPS_DEPRECATED = """\
+The '_EXTRA_HEADERS' class-level attribute is deprecated.  Please use
+'extra_headers' instead.
+"""
+
 
 class Connection(object):
     """A generic connection to Google Cloud Platform.
@@ -42,15 +53,71 @@ class Connection(object):
     :param client: The client that owns the current connection.
     """
 
-    USER_AGENT = DEFAULT_USER_AGENT
-    _EXTRA_HEADERS = {}
-    """Headers to be sent with every request.
-
-    Intended to be over-ridden by subclasses.
-    """
+    _user_agent = DEFAULT_USER_AGENT
+    _extra_headers = None
 
     def __init__(self, client):
         self._client = client
+
+    @property
+    def USER_AGENT(self):
+        """Deprecated:  get / set user agent sent by connection.
+
+        :rtype: str
+        :returns: user agent
+        """
+        warnings.warn(
+            _USER_AGENT_ALL_CAPS_DEPRECATED, DeprecationWarning, stacklevel=2)
+        return self.user_agent
+
+    @USER_AGENT.setter
+    def USER_AGENT(self, value):
+        warnings.warn(
+            _USER_AGENT_ALL_CAPS_DEPRECATED, DeprecationWarning, stacklevel=2)
+        self.user_agent = value
+
+    @property
+    def user_agent(self):
+        """Get / set user agent sent by connection.
+
+        :rtype: str
+        :returns: user agent
+        """
+        return self._user_agent
+
+    @user_agent.setter
+    def user_agent(self, value):
+        self._user_agent = value
+
+    @property
+    def _EXTRA_HEADERS(self):
+        """Deprecated:  get / set extra headers sent by connection.
+
+        :rtype: dict
+        :returns: header keys / values
+        """
+        warnings.warn(
+            _EXTRA_HEADERS_ALL_CAPS_DEPRECATED, DeprecationWarning, stacklevel=2)
+        return self.extra_headers
+
+    @_EXTRA_HEADERS.setter
+    def _EXTRA_HEADERS(self, value):
+        warnings.warn(
+            _EXTRA_HEADERS_ALL_CAPS_DEPRECATED, DeprecationWarning, stacklevel=2)
+        self.extra_headers = value
+
+    @property
+    def extra_headers(self):
+        """Get / set extra headers sent by connection.
+
+        :rtype: dict
+        :returns: header keys / values
+        """
+        return self._extra_headers or {}
+
+    @extra_headers.setter
+    def extra_headers(self, value):
+        self._extra_headers = value
 
     @property
     def credentials(self):
@@ -181,13 +248,13 @@ class JSONConnection(Connection):
         :returns: The HTTP response.
         """
         headers = headers or {}
-        headers.update(self._EXTRA_HEADERS)
+        headers.update(self.extra_headers)
         headers["Accept-Encoding"] = "gzip"
 
         if content_type:
             headers["Content-Type"] = content_type
 
-        headers["User-Agent"] = self.USER_AGENT
+        headers["User-Agent"] = self.user_agent
 
         return self._do_request(method, url, headers, data, target_object)
 

--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -21,6 +21,7 @@ import warnings
 from pkg_resources import get_distribution
 from six.moves.urllib.parse import urlencode
 
+from google.api_core.gapic_v1.client_info import ClientInfo
 from google.cloud import exceptions
 
 
@@ -51,13 +52,21 @@ class Connection(object):
 
     :type client: :class:`~google.cloud.client.Client`
     :param client: The client that owns the current connection.
+
+    :type client_info: :class:`~google.api_core.client_info.ClientInfo`
+    :param client_info: (Optional) instance used to generate user agent.
     """
 
     _user_agent = DEFAULT_USER_AGENT
     _extra_headers = None
 
-    def __init__(self, client):
+    def __init__(self, client, client_info=None):
         self._client = client
+
+        if client_info is None:
+            client_info = ClientInfo()
+
+        self._client_info = client_info
 
     @property
     def USER_AGENT(self):

--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -122,7 +122,9 @@ class Connection(object):
         :rtype: dict
         :returns: header keys / values
         """
-        return self._extra_headers or {}
+        result = self._extra_headers.copy() if self._extra_headers else {}
+        result[CLIENT_INFO_HEADER] = self.user_agent
+        return result
 
     @extra_headers.setter
     def extra_headers(self, value):

--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -21,7 +21,7 @@ import warnings
 from pkg_resources import get_distribution
 from six.moves.urllib.parse import urlencode
 
-from google.api_core.gapic_v1.client_info import ClientInfo
+from google.api_core.client_info import ClientInfo
 from google.cloud import exceptions
 
 

--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -92,11 +92,11 @@ class Connection(object):
         :rtype: str
         :returns: user agent
         """
-        return self._user_agent
+        return self._client_info.to_user_agent()
 
     @user_agent.setter
     def user_agent(self, value):
-        self._user_agent = value
+        self._client_info.user_agent = value
 
     @property
     def _EXTRA_HEADERS(self):

--- a/core/tests/unit/test__http.py
+++ b/core/tests/unit/test__http.py
@@ -32,7 +32,7 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor_defaults(self):
-        from google.api_core.gapic_v1.client_info import ClientInfo
+        from google.api_core.client_info import ClientInfo
 
         client = object()
         conn = self._make_one(client)

--- a/core/tests/unit/test__http.py
+++ b/core/tests/unit/test__http.py
@@ -75,15 +75,9 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(conn._client_info.user_agent, user_agent)
 
     def test_extra_headers_all_caps_getter_deprecated(self):
-        from google.cloud._http import CLIENT_INFO_HEADER
-
         client = object()
         conn = self._make_one(client)
-        conn._extra_headers = {"foo": "bar"}
-        expected = {
-            CLIENT_INFO_HEADER: conn._client_info.to_user_agent(),
-            "foo": "bar",
-        }
+        expected = conn._extra_headers = {"foo": "bar"}
 
         with mock.patch.object(warnings, "warn", autospec=True) as warn:
             self.assertEqual(conn._EXTRA_HEADERS, expected)
@@ -101,21 +95,13 @@ class TestConnection(unittest.TestCase):
         warn.assert_called_once_with(mock.ANY, DeprecationWarning, stacklevel=2)
 
     def test_extra_headers_getter_default(self):
-        from google.cloud._http import CLIENT_INFO_HEADER
-
         conn = self._make_one(object())
-        expected = {CLIENT_INFO_HEADER: conn._client_info.to_user_agent()}
+        expected = {}
         self.assertEqual(conn.extra_headers, expected)
 
     def test_extra_headers_getter_overridden(self):
-        from google.cloud._http import CLIENT_INFO_HEADER
-
         conn = self._make_one(object())
-        conn._extra_headers = {"foo": "bar"}
-        expected = {
-            CLIENT_INFO_HEADER: conn._client_info.to_user_agent(),
-            "foo": "bar",
-        }
+        expected = conn._extra_headers = {"foo": "bar"}
         self.assertEqual(conn.extra_headers, expected)
 
     def test_extra_headers_setter(self):

--- a/core/tests/unit/test__http.py
+++ b/core/tests/unit/test__http.py
@@ -48,42 +48,31 @@ class TestConnection(unittest.TestCase):
     def test_user_agent_all_caps_getter_deprecated(self):
         client = object()
         conn = self._make_one(client)
-        conn._user_agent = user_agent = 'testing'
 
         with mock.patch.object(warnings, "warn", autospec=True) as warn:
-            self.assertEqual(conn.USER_AGENT, user_agent)
+            self.assertEqual(conn.USER_AGENT, conn._client_info.to_user_agent())
 
         warn.assert_called_once_with(mock.ANY, DeprecationWarning, stacklevel=2)
 
     def test_user_agent_all_caps_setter_deprecated(self):
         conn = self._make_one(object())
-        user_agent = 'testing'
+        user_agent = "testing"
 
         with mock.patch.object(warnings, "warn", autospec=True) as warn:
             conn.USER_AGENT = user_agent
 
-        self.assertEqual(conn._user_agent, user_agent)
+        self.assertEqual(conn._client_info.user_agent, user_agent)
         warn.assert_called_once_with(mock.ANY, DeprecationWarning, stacklevel=2)
 
-    def test_user_agent_getter_default(self):
-        from pkg_resources import get_distribution
-
-        expected = "gcloud-python/{0}".format(
-            get_distribution("google-cloud-core").version
-        )
+    def test_user_agent_getter(self):
         conn = self._make_one(object())
-        self.assertEqual(conn.user_agent, expected)
-
-    def test_user_agent_getter_overridden(self):
-        conn = self._make_one(object())
-        expected = conn._user_agent = "testing"
-        self.assertEqual(conn.user_agent, expected)
+        self.assertEqual(conn.user_agent, conn._client_info.to_user_agent())
 
     def test_user_agent_setter(self):
         conn = self._make_one(object())
-        expected = "testing"
-        conn.user_agent = expected
-        self.assertEqual(conn._user_agent, expected)
+        user_agent = "testing"
+        conn.user_agent = user_agent
+        self.assertEqual(conn._client_info.user_agent, user_agent)
 
     def test_extra_headers_all_caps_getter_deprecated(self):
         client = object()

--- a/core/tests/unit/test__http.py
+++ b/core/tests/unit/test__http.py
@@ -104,6 +104,12 @@ class TestConnection(unittest.TestCase):
         expected = conn._extra_headers = {"foo": "bar"}
         self.assertEqual(conn.extra_headers, expected)
 
+    def test_extra_headers_item_assignment(self):
+        conn = self._make_one(object())
+        expected = {"foo": "bar"}
+        conn.extra_headers["foo"] = "bar"
+        self.assertEqual(conn._extra_headers, expected)
+
     def test_extra_headers_setter(self):
         conn = self._make_one(object())
         expected = {"foo": "bar"}

--- a/core/tests/unit/test__http.py
+++ b/core/tests/unit/test__http.py
@@ -31,9 +31,18 @@ class TestConnection(unittest.TestCase):
     def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
-    def test_constructor(self):
+    def test_constructor_defaults(self):
+        from google.api_core.gapic_v1.client_info import ClientInfo
+
         client = object()
         conn = self._make_one(client)
+        self.assertIs(conn._client, client)
+        self.assertIsInstance(conn._client_info, ClientInfo)
+
+    def test_constructor_explicit(self):
+        client = object()
+        client_info = object()
+        conn = self._make_one(client, client_info=client_info)
         self.assertIs(conn._client, client)
 
     def test_user_agent_all_caps_getter_deprecated(self):

--- a/docs/core/client_info.rst
+++ b/docs/core/client_info.rst
@@ -1,0 +1,11 @@
+Client Information Helpers
+==========================
+
+.. automodule:: google.api_core.client_info
+  :members:
+  :show-inheritance:
+
+.. automodule:: google.api_core.gapic_v1.client_info
+  :members:
+  :show-inheritance:
+

--- a/docs/core/index.rst
+++ b/docs/core/index.rst
@@ -5,15 +5,16 @@ Core
     config
     auth
     client
+    client_info
     exceptions
     helpers
-    retry
-    timeout
-    page_iterator
     iam
     operation
     operations_client
+    page_iterator
     path_template
+    retry
+    timeout
 
 Changelog
 ~~~~~~~~~


### PR DESCRIPTION
Hoist `client_info` support from `google.cloud.bigquery._http.Connection` into core's `google.cloud._http.Connection`.

Toward #7825.