### PR TITLE
Bigtable: Add channel to client. Avoid using same channel by data and admin client

### DIFF
--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -63,12 +63,7 @@ READ_ONLY_SCOPE = "https://www.googleapis.com/auth/bigtable.data.readonly"
 def _create_gapic_client(client_class):
     def inner(self):
         if self._emulator_host is None:
-            if self._channel is not None:
-                return client_class(channel=self._channel, client_info=_CLIENT_INFO)
-            else:
-                return client_class(
-                    credentials=self._credentials, client_info=_CLIENT_INFO
-                )
+            return client_class(credentials=self._credentials, client_info=_CLIENT_INFO)
         else:
             return client_class(
                 channel=self._emulator_channel, client_info=_CLIENT_INFO
@@ -209,9 +204,14 @@ class Client(ClientWithProject):
                 raise ValueError(
                     "Same channel cannot be used for an Admin client and Data client."
                 )
-            self._table_data_client = _create_gapic_client(bigtable_v2.BigtableClient)(
-                self
-            )
+            if self._channel is not None:
+                self._table_data_client = bigtable_v2.BigtableClient(
+                    channel=self._channel, client_info=_CLIENT_INFO
+                )
+            else:
+                self._table_data_client = bigtable_v2.BigtableClient(
+                    credentials=self._credentials, client_info=_CLIENT_INFO
+                )
         return self._table_data_client
 
     @property
@@ -237,9 +237,14 @@ class Client(ClientWithProject):
                 raise ValueError(
                     "Same channel cannot be used for an Admin client and Data client."
                 )
-            self._table_admin_client = _create_gapic_client(
-                bigtable_admin_v2.BigtableTableAdminClient
-            )(self)
+            if self._channel is not None:
+                self._table_admin_client = bigtable_admin_v2.BigtableTableAdminClient(
+                    channel=self._channel, client_info=_CLIENT_INFO
+                )
+            else:
+                self._table_admin_client = bigtable_admin_v2.BigtableTableAdminClient(
+                    credentials=self._credentials, client_info=_CLIENT_INFO
+                )
         return self._table_admin_client
 
     @property
@@ -265,9 +270,14 @@ class Client(ClientWithProject):
                 raise ValueError(
                     "Same channel cannot be used for an Admin client and Data client."
                 )
-            self._instance_admin_client = _create_gapic_client(
-                bigtable_admin_v2.BigtableInstanceAdminClient
-            )(self)
+            if self._channel is not None:
+                self._instance_admin_client = bigtable_admin_v2.BigtableInstanceAdminClient(
+                    channel=self._channel, client_info=_CLIENT_INFO
+                )
+            else:
+                self._instance_admin_client = bigtable_admin_v2.BigtableInstanceAdminClient(
+                    credentials=self._credentials, client_info=_CLIENT_INFO
+                )
         return self._instance_admin_client
 
     def instance(self, instance_id, display_name=None, instance_type=None, labels=None):

--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -63,7 +63,12 @@ READ_ONLY_SCOPE = "https://www.googleapis.com/auth/bigtable.data.readonly"
 def _create_gapic_client(client_class):
     def inner(self):
         if self._emulator_host is None:
-            return client_class(credentials=self._credentials, client_info=_CLIENT_INFO)
+            if self._channel is not None:
+                return client_class(channel=self._channel, client_info=_CLIENT_INFO)
+            else:
+                return client_class(
+                    credentials=self._credentials, client_info=_CLIENT_INFO
+                )
         else:
             return client_class(
                 channel=self._emulator_channel, client_info=_CLIENT_INFO
@@ -197,6 +202,8 @@ class Client(ClientWithProject):
         :returns: A BigtableClient object.
         """
         if self._table_data_client is None:
+            if self._admin and self._channel is not None:
+                raise ValueError("Client is an admin client and not a data client.")
             self._table_data_client = _create_gapic_client(bigtable_v2.BigtableClient)(
                 self
             )

--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -202,8 +202,13 @@ class Client(ClientWithProject):
         :returns: A BigtableClient object.
         """
         if self._table_data_client is None:
-            if self._admin and self._channel is not None:
-                raise ValueError("Client is an admin client and not a data client.")
+            if self._channel is not None and (
+                self._table_admin_client is not None
+                or self._instance_admin_client is not None
+            ):
+                raise ValueError(
+                    "Same channel cannot be used for an Admin client and Data client."
+                )
             self._table_data_client = _create_gapic_client(bigtable_v2.BigtableClient)(
                 self
             )
@@ -228,6 +233,10 @@ class Client(ClientWithProject):
         if self._table_admin_client is None:
             if not self._admin:
                 raise ValueError("Client is not an admin client.")
+            elif self._channel is not None and self._table_data_client is not None:
+                raise ValueError(
+                    "Same channel cannot be used for an Admin client and Data client."
+                )
             self._table_admin_client = _create_gapic_client(
                 bigtable_admin_v2.BigtableTableAdminClient
             )(self)
@@ -252,6 +261,10 @@ class Client(ClientWithProject):
         if self._instance_admin_client is None:
             if not self._admin:
                 raise ValueError("Client is not an admin client.")
+            elif self._channel is not None and self._table_data_client is not None:
+                raise ValueError(
+                    "Same channel cannot be used for an Admin client and Data client."
+                )
             self._instance_admin_client = _create_gapic_client(
                 bigtable_admin_v2.BigtableInstanceAdminClient
             )(self)

--- a/bigtable/tests/unit/test_client.py
+++ b/bigtable/tests/unit/test_client.py
@@ -218,6 +218,56 @@ class TestClient(unittest.TestCase):
         table_admin_client = client.table_admin_client
         self.assertIsInstance(table_admin_client, BigtableTableAdminClient)
 
+    def test_table_admin_client_table_data_client_w_admin_flag_channel(self):
+        import warnings
+        from google.cloud.bigtable_admin_v2 import BigtableTableAdminClient
+
+        channel = mock.Mock()
+        client = self._make_one(project=self.PROJECT, channel=channel, admin=True)
+
+        with warnings.catch_warnings():
+            table_admin_client = client.table_admin_client
+
+        self.assertIsInstance(table_admin_client, BigtableTableAdminClient)
+        table_data_client = None
+        with self.assertRaises(ValueError):
+            table_data_client = client.table_data_client
+        self.assertIsNone(table_data_client)
+        self.assertIsNone(client._table_data_client)
+
+    def test_instance_admin_client_table_data_client_w_admin_flag_channel(self):
+        import warnings
+        from google.cloud.bigtable_admin_v2 import BigtableInstanceAdminClient
+
+        channel = mock.Mock()
+        client = self._make_one(project=self.PROJECT, channel=channel, admin=True)
+
+        with warnings.catch_warnings():
+            instance_admin_client = client.instance_admin_client
+
+        self.assertIsInstance(instance_admin_client, BigtableInstanceAdminClient)
+        table_data_client = None
+        with self.assertRaises(ValueError):
+            table_data_client = client.table_data_client
+        self.assertIsNone(table_data_client)
+        self.assertIsNone(client._table_data_client)
+
+    def test_instance_admin_client_table_admin_client_w_admin_flag_channel(self):
+        import warnings
+        from google.cloud.bigtable_admin_v2 import BigtableInstanceAdminClient
+        from google.cloud.bigtable_admin_v2 import BigtableTableAdminClient
+
+        channel = mock.Mock()
+        client = self._make_one(project=self.PROJECT, channel=channel, admin=True)
+
+        with warnings.catch_warnings():
+            instance_admin_client = client.instance_admin_client
+        self.assertIsInstance(instance_admin_client, BigtableInstanceAdminClient)
+
+        with warnings.catch_warnings():
+            table_admin_client = client.table_admin_client
+        self.assertIsInstance(table_admin_client, BigtableTableAdminClient)
+
     def test_table_admin_client_initialized(self):
         credentials = _make_credentials()
         client = self._make_one(


### PR DESCRIPTION
See #6278.
This is initial commit to review the code and approach.

This code will enable channel to be used while creating client.
And will try to avoid data client and admin client to use same channel.
Data client does not need admin scope to create client, 