### PR TITLE
Firestore: add client_info support to V1 client.

### DIFF
--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -23,9 +23,11 @@ In the hierarchy of API concepts
 * a :class:`~.firestore_v1.client.Client` owns a
   :class:`~.firestore_v1.document.DocumentReference`
 """
+from google.api_core.gapic_v1 import client_info
 from google.cloud.client import ClientWithProject
 
 from google.cloud.firestore_v1 import _helpers
+from google.cloud.firestore_v1 import __version__
 from google.cloud.firestore_v1 import query
 from google.cloud.firestore_v1 import types
 from google.cloud.firestore_v1.batch import WriteBatch
@@ -47,6 +49,7 @@ _BAD_DOC_TEMPLATE = (
 )
 _ACTIVE_TXN = "There is already an active transaction."
 _INACTIVE_TXN = "There is no active transaction."
+_CLIENT_INFO = client_info.ClientInfo(client_library_version=__version__)
 
 
 class Client(ClientWithProject):
@@ -67,6 +70,11 @@ class Client(ClientWithProject):
         database (Optional[str]): The database name that the client targets.
             For now, :attr:`DEFAULT_DATABASE` (the default value) is the
             only valid database.
+        client_info (Optional[google.api_core.client_info.ClientInfo]):
+            The client info used to send a user-agent string along with API
+            requests. If ``None``, then default info will be used. Generally,
+            you only need to set this if you're developing your own library
+            or partner tool.
     """
 
     SCOPE = (
@@ -79,13 +87,20 @@ class Client(ClientWithProject):
     _database_string_internal = None
     _rpc_metadata_internal = None
 
-    def __init__(self, project=None, credentials=None, database=DEFAULT_DATABASE):
+    def __init__(
+        self,
+        project=None,
+        credentials=None,
+        database=DEFAULT_DATABASE,
+        client_info=_CLIENT_INFO,
+    ):
         # NOTE: This API has no use for the _http argument, but sending it
         #       will have no impact since the _http() @property only lazily
         #       creates a working HTTP object.
         super(Client, self).__init__(
             project=project, credentials=credentials, _http=None
         )
+        self._client_info = client_info
         self._database = database
 
     @property
@@ -98,7 +113,7 @@ class Client(ClientWithProject):
         """
         if self._firestore_api_internal is None:
             self._firestore_api_internal = firestore_client.FirestoreClient(
-                credentials=self._credentials
+                credentials=self._credentials, client_info=self._client_info
             )
 
         return self._firestore_api_internal

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -38,6 +38,7 @@ class TestClient(unittest.TestCase):
         return self._make_one(project=self.PROJECT, credentials=credentials)
 
     def test_constructor(self):
+        from google.cloud.firestore_v1.client import _CLIENT_INFO
         from google.cloud.firestore_v1.client import DEFAULT_DATABASE
 
         credentials = _make_credentials()
@@ -45,16 +46,22 @@ class TestClient(unittest.TestCase):
         self.assertEqual(client.project, self.PROJECT)
         self.assertEqual(client._credentials, credentials)
         self.assertEqual(client._database, DEFAULT_DATABASE)
+        self.assertIs(client._client_info, _CLIENT_INFO)
 
     def test_constructor_explicit(self):
         credentials = _make_credentials()
         database = "now-db"
+        client_info = mock.Mock()
         client = self._make_one(
-            project=self.PROJECT, credentials=credentials, database=database
+            project=self.PROJECT,
+            credentials=credentials,
+            database=database,
+            client_info=client_info,
         )
         self.assertEqual(client.project, self.PROJECT)
         self.assertEqual(client._credentials, credentials)
         self.assertEqual(client._database, database)
+        self.assertIs(client._client_info, client_info)
 
     @mock.patch(
         "google.cloud.firestore_v1.gapic.firestore_client." "FirestoreClient",
@@ -63,11 +70,14 @@ class TestClient(unittest.TestCase):
     )
     def test__firestore_api_property(self, mock_client):
         client = self._make_default_one()
+        client_info = client._client_info = mock.Mock()
         self.assertIsNone(client._firestore_api_internal)
         firestore_api = client._firestore_api
         self.assertIs(firestore_api, mock_client.return_value)
         self.assertIs(firestore_api, client._firestore_api_internal)
-        mock_client.assert_called_once_with(credentials=client._credentials)
+        mock_client.assert_called_once_with(
+            credentials=client._credentials, client_info=client_info
+        )
 
         # Call again to show that it is cached, but call count is still 1.
         self.assertIs(client._firestore_api, mock_client.return_value)


### PR DESCRIPTION
Forward when constructing GAPIC API client object.

Toward #7825.