### PR TITLE
Spanner: add client_info support to client.

### DIFF
--- a/spanner/google/cloud/spanner_v1/client.py
+++ b/spanner/google/cloud/spanner_v1/client.py
@@ -23,6 +23,7 @@ In the hierarchy of API concepts
 * a :class:`~google.cloud.spanner_v1.instance.Instance` owns a
   :class:`~google.cloud.spanner_v1.database.Database`
 """
+import warnings
 
 from google.api_core.gapic_v1 import client_info
 
@@ -36,7 +37,6 @@ from google.cloud.spanner_admin_instance_v1.gapic.instance_admin_client import (
 
 # pylint: enable=line-too-long
 
-from google.cloud._http import DEFAULT_USER_AGENT
 from google.cloud.client import ClientWithProject
 from google.cloud.spanner_v1 import __version__
 from google.cloud.spanner_v1._helpers import _metadata_with_prefix
@@ -45,6 +45,10 @@ from google.cloud.spanner_v1.instance import Instance
 
 _CLIENT_INFO = client_info.ClientInfo(client_library_version=__version__)
 SPANNER_ADMIN_SCOPE = "https://www.googleapis.com/auth/spanner.admin"
+_USER_AGENT_DEPRECATED = (
+    "The 'user_agent' argument to 'Client' is deprecated / unused. "
+    "Please pass an appropriate 'client_info' instead."
+)
 
 
 class InstanceConfig(object):
@@ -105,7 +109,7 @@ class Client(ClientWithProject):
     :type user_agent: str
     :param user_agent:
         (Deprecated) The user agent to be used with API request.
-        Not used.  Defaults to :const:`DEFAULT_USER_AGENT`.
+        Not used.
 
     :raises: :class:`ValueError <exceptions.ValueError>` if both ``read_only``
              and ``admin`` are :data:`True`
@@ -113,17 +117,14 @@ class Client(ClientWithProject):
 
     _instance_admin_api = None
     _database_admin_api = None
+    user_agent = None
     _SET_PROJECT = True  # Used by from_service_account_json()
 
     SCOPE = (SPANNER_ADMIN_SCOPE,)
     """The scopes required for Google Cloud Spanner."""
 
     def __init__(
-        self,
-        project=None,
-        credentials=None,
-        client_info=_CLIENT_INFO,
-        user_agent=DEFAULT_USER_AGENT,
+        self, project=None, credentials=None, client_info=_CLIENT_INFO, user_agent=None
     ):
         # NOTE: This API has no use for the _http argument, but sending it
         #       will have no impact since the _http() @property only lazily
@@ -132,7 +133,10 @@ class Client(ClientWithProject):
             project=project, credentials=credentials, _http=None
         )
         self._client_info = client_info
-        self.user_agent = user_agent
+
+        if user_agent is not None:
+            warnings.warn(_USER_AGENT_DEPRECATED, DeprecationWarning, stacklevel=2)
+            self.user_agent = user_agent
 
     @property
     def credentials(self):
@@ -190,11 +194,7 @@ class Client(ClientWithProject):
         :rtype: :class:`.Client`
         :returns: A copy of the current client.
         """
-        return self.__class__(
-            project=self.project,
-            credentials=self._credentials,
-            user_agent=self.user_agent,
-        )
+        return self.__class__(project=self.project, credentials=self._credentials)
 
     def list_instance_configs(self, page_size=None, page_token=None):
         """List available instance configurations for the client's project.

--- a/spanner/google/cloud/spanner_v1/client.py
+++ b/spanner/google/cloud/spanner_v1/client.py
@@ -95,9 +95,17 @@ class Client(ClientWithProject):
                         client. If not provided, defaults to the Google
                         Application Default Credentials.
 
+    :type client_info: :class:`google.api_core.client_info.ClientInfo`
+    :param client_info:
+        (Optional) The client info used to send a user-agent string along with
+        API requests. If ``None``, then default info will be used. Generally,
+        you only need to set this if you're developing your own library or
+        partner tool.
+
     :type user_agent: str
-    :param user_agent: (Optional) The user agent to be used with API request.
-                       Defaults to :const:`DEFAULT_USER_AGENT`.
+    :param user_agent:
+        (Deprecated) The user agent to be used with API request.
+        Not used.  Defaults to :const:`DEFAULT_USER_AGENT`.
 
     :raises: :class:`ValueError <exceptions.ValueError>` if both ``read_only``
              and ``admin`` are :data:`True`
@@ -110,13 +118,20 @@ class Client(ClientWithProject):
     SCOPE = (SPANNER_ADMIN_SCOPE,)
     """The scopes required for Google Cloud Spanner."""
 
-    def __init__(self, project=None, credentials=None, user_agent=DEFAULT_USER_AGENT):
+    def __init__(
+        self,
+        project=None,
+        credentials=None,
+        client_info=client_info,
+        user_agent=DEFAULT_USER_AGENT,
+    ):
         # NOTE: This API has no use for the _http argument, but sending it
         #       will have no impact since the _http() @property only lazily
         #       creates a working HTTP object.
         super(Client, self).__init__(
             project=project, credentials=credentials, _http=None
         )
+        self._client_info = client_info
         self.user_agent = user_agent
 
     @property
@@ -153,7 +168,7 @@ class Client(ClientWithProject):
         """Helper for session-related API calls."""
         if self._instance_admin_api is None:
             self._instance_admin_api = InstanceAdminClient(
-                credentials=self.credentials, client_info=_CLIENT_INFO
+                credentials=self.credentials, client_info=self._client_info
             )
         return self._instance_admin_api
 
@@ -162,7 +177,7 @@ class Client(ClientWithProject):
         """Helper for session-related API calls."""
         if self._database_admin_api is None:
             self._database_admin_api = DatabaseAdminClient(
-                credentials=self.credentials, client_info=_CLIENT_INFO
+                credentials=self.credentials, client_info=self._client_info
             )
         return self._database_admin_api
 

--- a/spanner/google/cloud/spanner_v1/client.py
+++ b/spanner/google/cloud/spanner_v1/client.py
@@ -95,7 +95,7 @@ class Client(ClientWithProject):
                         client. If not provided, defaults to the Google
                         Application Default Credentials.
 
-    :type client_info: :class:`google.api_core.client_info.ClientInfo`
+    :type client_info: :class:`google.api_core.gapic_v1.client_info.ClientInfo`
     :param client_info:
         (Optional) The client info used to send a user-agent string along with
         API requests. If ``None``, then default info will be used. Generally,

--- a/spanner/google/cloud/spanner_v1/client.py
+++ b/spanner/google/cloud/spanner_v1/client.py
@@ -122,7 +122,7 @@ class Client(ClientWithProject):
         self,
         project=None,
         credentials=None,
-        client_info=client_info,
+        client_info=_CLIENT_INFO,
         user_agent=DEFAULT_USER_AGENT,
     ):
         # NOTE: This API has no use for the _http argument, but sending it

--- a/spanner/google/cloud/spanner_v1/database.py
+++ b/spanner/google/cloud/spanner_v1/database.py
@@ -19,14 +19,12 @@ import functools
 import re
 import threading
 
-from google.api_core.gapic_v1 import client_info
 import google.auth.credentials
 from google.protobuf.struct_pb2 import Struct
 from google.cloud.exceptions import NotFound
 import six
 
 # pylint: disable=ungrouped-imports
-from google.cloud.spanner_v1 import __version__
 from google.cloud.spanner_v1._helpers import _make_value_pb
 from google.cloud.spanner_v1._helpers import _metadata_with_prefix
 from google.cloud.spanner_v1.batch import Batch
@@ -46,7 +44,6 @@ from google.cloud.spanner_v1.proto.transaction_pb2 import (
 # pylint: enable=ungrouped-imports
 
 
-_CLIENT_INFO = client_info.ClientInfo(client_library_version=__version__)
 SPANNER_DATA_SCOPE = "https://www.googleapis.com/auth/spanner.data"
 
 
@@ -179,8 +176,9 @@ class Database(object):
             credentials = self._instance._client.credentials
             if isinstance(credentials, google.auth.credentials.Scoped):
                 credentials = credentials.with_scopes((SPANNER_DATA_SCOPE,))
+            client_info = self._instance._client._client_info
             self._spanner_api = SpannerClient(
-                credentials=credentials, client_info=_CLIENT_INFO
+                credentials=credentials, client_info=client_info
             )
         return self._spanner_api
 

--- a/spanner/tests/unit/test_client.py
+++ b/spanner/tests/unit/test_client.py
@@ -49,13 +49,22 @@ class TestClient(unittest.TestCase):
         return self._get_target_class()(*args, **kwargs)
 
     def _constructor_test_helper(
-        self, expected_scopes, creds, user_agent=None, expected_creds=None
+        self,
+        expected_scopes,
+        creds,
+        user_agent=None,
+        expected_creds=None,
+        client_info=None,
     ):
         from google.cloud.spanner_v1 import client as MUT
 
         user_agent = user_agent or MUT.DEFAULT_USER_AGENT
+        client_info = client_info or MUT._CLIENT_INFO
         client = self._make_one(
-            project=self.PROJECT, credentials=creds, user_agent=user_agent
+            project=self.PROJECT,
+            credentials=creds,
+            user_agent=user_agent,
+            client_info=client_info,
         )
 
         expected_creds = expected_creds or creds.with_scopes.return_value
@@ -67,6 +76,7 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(client.project, self.PROJECT)
         self.assertEqual(client.user_agent, user_agent)
+        self.assertIs(client._client_info, client_info)
 
     def test_constructor_default_scopes(self):
         from google.cloud.spanner_v1 import client as MUT
@@ -85,6 +95,14 @@ class TestClient(unittest.TestCase):
             expected_scopes, creds, user_agent=CUSTOM_USER_AGENT
         )
 
+    def test_constructor_custom_client_info(self):
+        from google.cloud.spanner_v1 import client as MUT
+
+        client_info = mock.Mock()
+        expected_scopes = (MUT.SPANNER_ADMIN_SCOPE,)
+        creds = _make_credentials()
+        self._constructor_test_helper(expected_scopes, creds, client_info=client_info)
+
     def test_constructor_implicit_credentials(self):
         creds = _make_credentials()
 
@@ -102,10 +120,13 @@ class TestClient(unittest.TestCase):
         self._constructor_test_helper(expected_scopes, creds)
 
     def test_instance_admin_api(self):
-        from google.cloud.spanner_v1.client import _CLIENT_INFO, SPANNER_ADMIN_SCOPE
+        from google.cloud.spanner_v1.client import SPANNER_ADMIN_SCOPE
 
         credentials = _make_credentials()
-        client = self._make_one(project=self.PROJECT, credentials=credentials)
+        client_info = mock.Mock()
+        client = self._make_one(
+            project=self.PROJECT, credentials=credentials, client_info=client_info
+        )
         expected_scopes = (SPANNER_ADMIN_SCOPE,)
 
         inst_module = "google.cloud.spanner_v1.client.InstanceAdminClient"
@@ -119,16 +140,19 @@ class TestClient(unittest.TestCase):
         self.assertIs(again, api)
 
         instance_admin_client.assert_called_once_with(
-            credentials=credentials.with_scopes.return_value, client_info=_CLIENT_INFO
+            credentials=credentials.with_scopes.return_value, client_info=client_info
         )
 
         credentials.with_scopes.assert_called_once_with(expected_scopes)
 
     def test_database_admin_api(self):
-        from google.cloud.spanner_v1.client import _CLIENT_INFO, SPANNER_ADMIN_SCOPE
+        from google.cloud.spanner_v1.client import SPANNER_ADMIN_SCOPE
 
         credentials = _make_credentials()
-        client = self._make_one(project=self.PROJECT, credentials=credentials)
+        client_info = mock.Mock()
+        client = self._make_one(
+            project=self.PROJECT, credentials=credentials, client_info=client_info
+        )
         expected_scopes = (SPANNER_ADMIN_SCOPE,)
 
         db_module = "google.cloud.spanner_v1.client.DatabaseAdminClient"
@@ -142,7 +166,7 @@ class TestClient(unittest.TestCase):
         self.assertIs(again, api)
 
         database_admin_client.assert_called_once_with(
-            credentials=credentials.with_scopes.return_value, client_info=_CLIENT_INFO
+            credentials=credentials.with_scopes.return_value, client_info=client_info
         )
 
         credentials.with_scopes.assert_called_once_with(expected_scopes)

--- a/spanner/tests/unit/test_client.py
+++ b/spanner/tests/unit/test_client.py
@@ -52,19 +52,28 @@ class TestClient(unittest.TestCase):
         self,
         expected_scopes,
         creds,
-        user_agent=None,
         expected_creds=None,
         client_info=None,
+        user_agent=None,
     ):
         from google.cloud.spanner_v1 import client as MUT
 
-        user_agent = user_agent or MUT.DEFAULT_USER_AGENT
-        client_info = client_info or MUT._CLIENT_INFO
+        kwargs = {}
+
+        if client_info is not None:
+            kwargs['client_info'] = expected_client_info = client_info
+        else:
+            expected_client_info = MUT._CLIENT_INFO
+
+        if user_agent is not None:
+            kwargs['user_agent'] = expected_user_agent = user_agent
+        else:
+            expected_user_agent = MUT.DEFAULT_USER_AGENT
+
         client = self._make_one(
             project=self.PROJECT,
             credentials=creds,
-            user_agent=user_agent,
-            client_info=client_info,
+            **kwargs
         )
 
         expected_creds = expected_creds or creds.with_scopes.return_value
@@ -75,8 +84,8 @@ class TestClient(unittest.TestCase):
             creds.with_scopes.assert_called_once_with(expected_scopes)
 
         self.assertEqual(client.project, self.PROJECT)
-        self.assertEqual(client.user_agent, user_agent)
-        self.assertIs(client._client_info, client_info)
+        self.assertIs(client._client_info, expected_client_info)
+        self.assertEqual(client.user_agent, expected_user_agent)
 
     def test_constructor_default_scopes(self):
         from google.cloud.spanner_v1 import client as MUT


### PR DESCRIPTION
Forward through when creating GAPIC API wrappers.

Toward #7825.