### PR TITLE
Storage: deprecate 'fields' arg to 'Bucket.list_blobs'.

### DIFF
--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -47,6 +47,10 @@ _LOCATION_SETTER_MESSAGE = (
     "valid before the bucket is created. Instead, pass the location "
     "to `Bucket.create`."
 )
+_LIST_BLOBS_FIELDS_MESSAGE = (
+    "The 'fields' argument to 'Bucket.list_blobs' is deprecated, and "
+    "likely broken:  please don't use it."
+)
 _API_ACCESS_ENDPOINT = "https://storage.googleapis.com"
 
 
@@ -780,6 +784,8 @@ class Bucket(_PropertyMixin):
             extra_params["versions"] = versions
 
         if fields is not None:
+            warnings.warn(
+                _LIST_BLOBS_FIELDS_MESSAGE, DeprecationWarning, stacklevel=2)
             extra_params["fields"] = fields
 
         if self.user_project is not None:

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -784,8 +784,7 @@ class Bucket(_PropertyMixin):
             extra_params["versions"] = versions
 
         if fields is not None:
-            warnings.warn(
-                _LIST_BLOBS_FIELDS_MESSAGE, DeprecationWarning, stacklevel=2)
+            warnings.warn(_LIST_BLOBS_FIELDS_MESSAGE, DeprecationWarning, stacklevel=2)
             extra_params["fields"] = fields
 
         if self.user_project is not None:

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -742,7 +742,10 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["path"], "/b/%s/o" % NAME)
         self.assertEqual(kw["query_params"], {"projection": "noAcl"})
 
-    def test_list_blobs_w_all_arguments_and_user_project(self):
+    @mock.patch("warnings.warn")
+    def test_list_blobs_w_all_arguments_and_user_project(self, mock_warn):
+        from google.cloud.storage import bucket as bucket_module
+
         NAME = "name"
         USER_PROJECT = "user-project-123"
         MAX_RESULTS = 10
@@ -781,19 +784,9 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "GET")
         self.assertEqual(kw["path"], "/b/%s/o" % NAME)
         self.assertEqual(kw["query_params"], EXPECTED)
-
-    def test_list_blobs(self):
-        NAME = "name"
-        connection = _Connection({"items": []})
-        client = _Client(connection)
-        bucket = self._make_one(client=client, name=NAME)
-        iterator = bucket.list_blobs()
-        blobs = list(iterator)
-        self.assertEqual(blobs, [])
-        kw, = connection._requested
-        self.assertEqual(kw["method"], "GET")
-        self.assertEqual(kw["path"], "/b/%s/o" % NAME)
-        self.assertEqual(kw["query_params"], {"projection": "noAcl"})
+        mock_warn.assert_called_once_with(
+            bucket_module._LIST_BLOBS_FIELDS_MESSAGE, DeprecationWarning, stacklevel=2
+        )
 
     def test_list_notifications(self):
         from google.cloud.storage.notification import BucketNotification


### PR DESCRIPTION
Closes #7875.