### PR TITLE
Bigtable, Firestore: fix client_info type in GAPIC-based client docstrings.

### DIFF
--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -102,7 +102,7 @@ class Client(ClientWithProject):
                   interact with the Instance Admin or Table Admin APIs. This
                   requires the :const:`ADMIN_SCOPE`. Defaults to :data:`False`.
 
-    :type: client_info: :class:`google.api_core.client_info.ClientInfo`
+    :type: client_info: :class:`google.api_core.gapic_v1.client_info.ClientInfo`
     :param client_info:
         The client info used to send a user-agent string along with API
         requests. If ``None``, then default info will be used. Generally,

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -70,7 +70,7 @@ class Client(ClientWithProject):
         database (Optional[str]): The database name that the client targets.
             For now, :attr:`DEFAULT_DATABASE` (the default value) is the
             only valid database.
-        client_info (Optional[google.api_core.client_info.ClientInfo]):
+        client_info (Optional[google.api_core.gapic_v1.client_info.ClientInfo]):
             The client info used to send a user-agent string along with API
             requests. If ``None``, then default info will be used. Generally,
             you only need to set this if you're developing your own library


### PR DESCRIPTION
@tswast Addressing your comments which  I missed seeing before merging #7876 / #7877.