### PR TITLE
Logging: plumb 'Client._client_info' through to GAPIC API wrapper.

### DIFF
--- a/logging/google/cloud/logging/_gapic.py
+++ b/logging/google/cloud/logging/_gapic.py
@@ -17,7 +17,6 @@ client."""
 
 import functools
 
-from google.api_core.gapic_v1 import client_info
 from google.cloud.logging_v2.gapic.config_service_v2_client import ConfigServiceV2Client
 from google.cloud.logging_v2.gapic.logging_service_v2_client import (
     LoggingServiceV2Client,
@@ -31,13 +30,9 @@ from google.cloud.logging_v2.proto.log_entry_pb2 import LogEntry
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.json_format import ParseDict
 
-from google.cloud.logging import __version__
 from google.cloud.logging._helpers import entry_from_resource
 from google.cloud.logging.sink import Sink
 from google.cloud.logging.metric import Metric
-
-
-_CLIENT_INFO = client_info.ClientInfo(client_library_version=__version__)
 
 
 class _LoggingAPI(object):
@@ -544,7 +539,7 @@ def make_logging_api(client):
     :returns: A metrics API instance with the proper credentials.
     """
     generated = LoggingServiceV2Client(
-        credentials=client._credentials, client_info=_CLIENT_INFO
+        credentials=client._credentials, client_info=client._client_info
     )
     return _LoggingAPI(generated, client)
 
@@ -559,7 +554,7 @@ def make_metrics_api(client):
     :returns: A metrics API instance with the proper credentials.
     """
     generated = MetricsServiceV2Client(
-        credentials=client._credentials, client_info=_CLIENT_INFO
+        credentials=client._credentials, client_info=client._client_info
     )
     return _MetricsAPI(generated, client)
 
@@ -574,6 +569,6 @@ def make_sinks_api(client):
     :returns: A metrics API instance with the proper credentials.
     """
     generated = ConfigServiceV2Client(
-        credentials=client._credentials, client_info=_CLIENT_INFO
+        credentials=client._credentials, client_info=client._client_info
     )
     return _SinksAPI(generated, client)

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -87,7 +87,9 @@ class Client(ClientWithProject):
                       This parameter should be considered private, and could
                       change in the future.
 
-    :type client_info: :class:`~google.api_core.client_info.ClientInfo`
+    :type client_info:
+        :class:`google.api_core.client_info.ClientInfo` or
+        :class:`google.api_core.gapic_v1.client_info.ClientInfo`
     :param client_info:
         The client info used to send a user-agent string along with API
         requests. If ``None``, then default info will be used. Generally,

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -121,6 +121,7 @@ class Client(ClientWithProject):
             project=project, credentials=credentials, _http=_http
         )
         self._connection = Connection(self, client_info=client_info)
+        self._client_info = client_info
         if _use_grpc is None:
             self._use_grpc = _USE_GRPC
         else:

--- a/logging/tests/unit/test__gapic.py
+++ b/logging/tests/unit/test__gapic.py
@@ -584,32 +584,32 @@ class Test__log_entry_mapping_to_pb(unittest.TestCase):
 
 @mock.patch("google.cloud.logging._gapic.LoggingServiceV2Client", autospec=True)
 def test_make_logging_api(gapic_client):
-    client = mock.Mock(spec=["_credentials"])
+    client = mock.Mock(spec=["_credentials", "_client_info"])
     api = _gapic.make_logging_api(client)
     assert api._client == client
     assert api._gapic_api == gapic_client.return_value
     gapic_client.assert_called_once_with(
-        credentials=client._credentials, client_info=_gapic._CLIENT_INFO
+        credentials=client._credentials, client_info=client._client_info
     )
 
 
 @mock.patch("google.cloud.logging._gapic.MetricsServiceV2Client", autospec=True)
 def test_make_metrics_api(gapic_client):
-    client = mock.Mock(spec=["_credentials"])
+    client = mock.Mock(spec=["_credentials", "_client_info"])
     api = _gapic.make_metrics_api(client)
     assert api._client == client
     assert api._gapic_api == gapic_client.return_value
     gapic_client.assert_called_once_with(
-        credentials=client._credentials, client_info=_gapic._CLIENT_INFO
+        credentials=client._credentials, client_info=client._client_info
     )
 
 
 @mock.patch("google.cloud.logging._gapic.ConfigServiceV2Client", autospec=True)
 def test_make_sinks_api(gapic_client):
-    client = mock.Mock(spec=["_credentials"])
+    client = mock.Mock(spec=["_credentials", "_client_info"])
     api = _gapic.make_sinks_api(client)
     assert api._client == client
     assert api._gapic_api == gapic_client.return_value
     gapic_client.assert_called_once_with(
-        credentials=client._credentials, client_info=_gapic._CLIENT_INFO
+        credentials=client._credentials, client_info=client._client_info
     )

--- a/logging/tests/unit/test_client.py
+++ b/logging/tests/unit/test_client.py
@@ -63,6 +63,7 @@ class TestClient(unittest.TestCase):
             project=self.PROJECT, credentials=creds, client_info=client_info
         )
         self.assertEqual(client.project, self.PROJECT)
+        self.assertIs(client._client_info, client_info)
         self.assertIsInstance(client._connection, Connection)
         self.assertIs(client._connection._client_info, client_info)
 


### PR DESCRIPTION
Toward #7825.