### PR TITLE
Prevent error when time partitioning is populated with empty dict

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1787,7 +1787,7 @@ class TimePartitioning(object):
         """google.cloud.bigquery.table.TimePartitioningType: The type of time
         partitioning to use.
         """
-        return self._properties["type"]
+        return self._properties.get("type")
 
     @type_.setter
     def type_(self, value):
@@ -1849,7 +1849,7 @@ class TimePartitioning(object):
             google.cloud.bigquery.table.TimePartitioning:
                 The ``TimePartitioning`` object.
         """
-        instance = cls(api_repr["type"])
+        instance = cls()
         instance._properties = api_repr
         return instance
 

--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -141,8 +141,10 @@ def lint(session):
     serious code quality issues.
     """
 
-    session.install("black", "flake8", *LOCAL_DEPS)
-    session.install(".")
+    session.install("black", "flake8")
+    for local_dep in LOCAL_DEPS:
+        session.install("-e", local_dep)
+    session.install("-e", ".")
     session.run("flake8", os.path.join("google", "cloud", "bigquery"))
     session.run("flake8", "tests")
     session.run("flake8", os.path.join("docs", "snippets.py"))

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -2260,8 +2260,6 @@ class TestTimePartitioning(unittest.TestCase):
         self.assertTrue(time_partitioning.require_partition_filter)
 
     def test_from_api_repr_empty(self):
-        from google.cloud.bigquery.table import TimePartitioningType
-
         klass = self._get_target_class()
 
         # Even though there are required properties according to the API
@@ -2288,8 +2286,6 @@ class TestTimePartitioning(unittest.TestCase):
         self.assertIsNone(time_partitioning.require_partition_filter)
 
     def test_from_api_repr_doesnt_override_type(self):
-        from google.cloud.bigquery.table import TimePartitioningType
-
         klass = self._get_target_class()
         api_repr = {"type": "HOUR"}
         time_partitioning = klass.from_api_repr(api_repr)

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -2259,6 +2259,22 @@ class TestTimePartitioning(unittest.TestCase):
         self.assertEqual(time_partitioning.expiration_ms, 10000)
         self.assertTrue(time_partitioning.require_partition_filter)
 
+    def test_from_api_repr_empty(self):
+        from google.cloud.bigquery.table import TimePartitioningType
+
+        klass = self._get_target_class()
+
+        # Even though there are required properties according to the API
+        # specification, sometimes time partitioning is populated as an empty
+        # object. See internal bug 131167013.
+        api_repr = {}
+        time_partitioning = klass.from_api_repr(api_repr)
+
+        self.assertIsNone(time_partitioning.type_)
+        self.assertIsNone(time_partitioning.field)
+        self.assertIsNone(time_partitioning.expiration_ms)
+        self.assertIsNone(time_partitioning.require_partition_filter)
+
     def test_from_api_repr_minimal(self):
         from google.cloud.bigquery.table import TimePartitioningType
 
@@ -2270,6 +2286,14 @@ class TestTimePartitioning(unittest.TestCase):
         self.assertIsNone(time_partitioning.field)
         self.assertIsNone(time_partitioning.expiration_ms)
         self.assertIsNone(time_partitioning.require_partition_filter)
+
+    def test_from_api_repr_doesnt_override_type(self):
+        from google.cloud.bigquery.table import TimePartitioningType
+
+        klass = self._get_target_class()
+        api_repr = {"type": "HOUR"}
+        time_partitioning = klass.from_api_repr(api_repr)
+        self.assertEqual(time_partitioning.type_, "HOUR")
 
     def test_from_api_repr_explicit(self):
         from google.cloud.bigquery.table import TimePartitioningType

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -871,6 +871,54 @@ class TestTable(unittest.TestCase, _SchemaBase):
         with self.assertRaises(ValueError):
             table._build_resource(["bad"])
 
+    def test_time_partitioning_getter(self):
+        from google.cloud.bigquery.table import TimePartitioning
+        from google.cloud.bigquery.table import TimePartitioningType
+
+        dataset = DatasetReference(self.PROJECT, self.DS_ID)
+        table_ref = dataset.table(self.TABLE_NAME)
+        table = self._make_one(table_ref)
+
+        table._properties["timePartitioning"] = {
+            "type": "DAY",
+            "field": "col1",
+            "expirationMs": "123456",
+            "requirePartitionFilter": False,
+        }
+        self.assertIsInstance(table.time_partitioning, TimePartitioning)
+        self.assertEqual(table.time_partitioning.type_, TimePartitioningType.DAY)
+        self.assertEqual(table.time_partitioning.field, "col1")
+        self.assertEqual(table.time_partitioning.expiration_ms, 123456)
+        self.assertFalse(table.time_partitioning.require_partition_filter)
+
+    def test_time_partitioning_getter_w_none(self):
+        dataset = DatasetReference(self.PROJECT, self.DS_ID)
+        table_ref = dataset.table(self.TABLE_NAME)
+        table = self._make_one(table_ref)
+
+        table._properties["timePartitioning"] = None
+        self.assertIsNone(table.time_partitioning)
+
+        del table._properties["timePartitioning"]
+        self.assertIsNone(table.time_partitioning)
+
+    def test_time_partitioning_getter_w_empty(self):
+        from google.cloud.bigquery.table import TimePartitioning
+
+        dataset = DatasetReference(self.PROJECT, self.DS_ID)
+        table_ref = dataset.table(self.TABLE_NAME)
+        table = self._make_one(table_ref)
+
+        # Even though there are required properties according to the API
+        # specification, sometimes time partitioning is populated as an empty
+        # object. See internal bug 131167013.
+        table._properties["timePartitioning"] = {}
+        self.assertIsInstance(table.time_partitioning, TimePartitioning)
+        self.assertIsNone(table.time_partitioning.type_)
+        self.assertIsNone(table.time_partitioning.field)
+        self.assertIsNone(table.time_partitioning.expiration_ms)
+        self.assertIsNone(table.time_partitioning.require_partition_filter)
+
     def test_time_partitioning_setter(self):
         from google.cloud.bigquery.table import TimePartitioning
         from google.cloud.bigquery.table import TimePartitioningType


### PR DESCRIPTION
As reported in internal bug 131167013, calling `table.time_partitioning`
can sometimes fail with `KeyError: 'type'` when attempting to read this
property on a non-partitioned table.