### PR TITLE
Firestore: use correct environment variable to guard the 'system' part.

### DIFF
--- a/firestore/noxfile.py
+++ b/firestore/noxfile.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import
 import os
+import shutil
 
 import nox
 
@@ -138,3 +139,22 @@ def cover(session):
     session.run("coverage", "report", "--show-missing", "--fail-under=100")
 
     session.run("coverage", "erase")
+
+@nox.session(python="3.7")
+def docs(session):
+    """Build the docs for this library."""
+
+    session.install('-e', '.')
+    session.install('sphinx', 'alabaster', 'recommonmark')
+
+    shutil.rmtree(os.path.join('docs', '_build'), ignore_errors=True)
+    session.run(
+        'sphinx-build',
+        '-W',  # warnings as errors
+        '-T',  # show full traceback on exception
+        '-N',  # no colors
+        '-b', 'html',
+        '-d', os.path.join('docs', '_build', 'doctrees', ''),
+        os.path.join('docs', ''),
+        os.path.join('docs', '_build', 'html', ''),
+    )

--- a/firestore/noxfile.py
+++ b/firestore/noxfile.py
@@ -16,7 +16,6 @@
 
 from __future__ import absolute_import
 import os
-import shutil
 
 import nox
 
@@ -101,7 +100,7 @@ def system(session):
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
     # Sanity check: Only run tests if the environment variable is set.
-    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", ""):
+    if not os.environ.get("FIRESTORE_APPLICATION_CREDENTIALS", ""):
         session.skip("Credentials must be set via environment variable")
 
     system_test_exists = os.path.exists(system_test_path)
@@ -139,22 +138,3 @@ def cover(session):
     session.run("coverage", "report", "--show-missing", "--fail-under=100")
 
     session.run("coverage", "erase")
-
-@nox.session(python="3.7")
-def docs(session):
-    """Build the docs for this library."""
-
-    session.install('-e', '.')
-    session.install('sphinx', 'alabaster', 'recommonmark')
-
-    shutil.rmtree(os.path.join('docs', '_build'), ignore_errors=True)
-    session.run(
-        'sphinx-build',
-        '-W',  # warnings as errors
-        '-T',  # show full traceback on exception
-        '-N',  # no colors
-        '-b', 'html',
-        '-d', os.path.join('docs', '_build', 'doctrees', ''),
-        os.path.join('docs', ''),
-        os.path.join('docs', '_build', 'html', ''),
-    )

--- a/firestore/synth.metadata
+++ b/firestore/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-05-10T12:23:36.801523Z",
+  "updateTime": "2019-05-09T17:10:15.339919Z",
   "sources": [
     {
       "generator": {
@@ -12,15 +12,15 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07883be5bf3c3233095e99d8e92b8094f5d7084a",
-        "internalRef": "247530843"
+        "sha": "2f6e293d9a0097167ed5160fd366403c21b5fa49",
+        "internalRef": "247230302"
       }
     },
     {
       "template": {
         "name": "python_library",
         "origin": "synthtool.gcp",
-        "version": "2019.5.2"
+        "version": "2019.4.10"
       }
     }
   ],

--- a/firestore/synth.py
+++ b/firestore/synth.py
@@ -57,4 +57,10 @@ for version, artman_config in versions:
 templated_files = common.py_library(unit_cov_level=97, cov_level=100)
 s.move(templated_files)
 
+s.replace(
+    "noxfile.py",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "FIRESTORE_APPLICATION_CREDENTIALS",
+)
+
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)


### PR DESCRIPTION
Firestore's system tests use a [different environment variable](https://github.com/googleapis/google-cloud-python/blob/a65ed778770e045c0b26bb98d64cd0beec25703e/firestore/tests/system.py#L37) (because firestore vs. datastore hysterical raisins).