### PR TITLE
BigQuery: Fixed pandas DataFrames being returned with incorrect index.

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1408,7 +1408,7 @@ class RowIterator(HTTPIterator):
             # Indicate that the download has finished.
             progress_bar.close()
 
-        return pandas.concat(frames)
+        return pandas.concat(frames, ignore_index=True)
 
     def _to_dataframe_bqstorage_stream(
         self, bqstorage_client, dtypes, columns, session, stream, worker_queue
@@ -1585,7 +1585,7 @@ class RowIterator(HTTPIterator):
 
         # Update the progress bar one last time to close it.
         self._process_progress_updates(progress_queue, progress_bar)
-        return pandas.concat(frames)
+        return pandas.concat(frames, ignore_index=True)
 
     def _get_progress_bar(self, progress_bar_type):
         """Construct a tqdm progress bar object, if tqdm is installed."""


### PR DESCRIPTION
When loading large datasets from BIgQuery as pandas DataFrames, sometimes the index contains duplicates. This happens when the results are collected as multiple DataFrames and then concatenated without resetting the index.

As an example, we get `0, 1` repeated in the index:

```python
In [1]: import pandas as pd
In [2]: x = pd.DataFrame({"a": [1, 2]})
   ...: pd.concat([x, x])
Out[2]:
   a
0  1
1  2
0  1
1  2
```
which has some unintended consequences when we try to subset:

```python
In [3]: pd.concat([x, x]).loc[0]
Out[3]:
   a
0  1
0  1
```
Instead, by setting `ignore_index=True` we get:
```python
In [4]: pd.concat([x, x], ignore_index=True)
Out[4]:
   a
0  1
1  2
2  1
3  2
```

From the pandas documentation https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.concat.html:

> **ignore_index** : boolean, default False
If True, do not use the index values along the concatenation axis. The resulting axis will be labeled 0, …, n - 1. **This is useful if you are concatenating objects where the concatenation axis does not have meaningful indexing information**. Note the index values on the other axes are still respected in the join.

In our case the indexes really don't have any meaningful information.

### Reproducible example

We can see this in action by running the following query on the `crypto-dash` dataset:
```python
from google.cloud import bigquery
bq_client = bigquery.Client()

query = """
SELECT
  block_timestamp_month
FROM
  `bigquery-public-data.crypto_dash.transactions`
LIMIT
  1000000
"""
data = bq_client.query(query).result().to_dataframe()
```

and then checking if the indexes are unique:

```python
print(data.index.is_unique)
> False
```

I have replicated the problem with two different unit tests, and fixed it in this PR.