### PR TITLE
PubSub: Propagate subscribe callback errors to main thread

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/client.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/client.py
@@ -209,6 +209,6 @@ class Client(object):
 
         future = futures.StreamingPullFuture(manager)
 
-        manager.open(callback)
+        manager.open(callback=callback, on_callback_error=future.set_exception)
 
         return future

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_subscriber_client.py
@@ -72,7 +72,9 @@ def test_subscribe(manager_open):
     assert isinstance(future, futures.StreamingPullFuture)
 
     assert future._manager._subscription == "sub_name_a"
-    manager_open.assert_called_once_with(mock.ANY, mock.sentinel.callback)
+    manager_open.assert_called_once_with(
+        mock.ANY, mock.sentinel.callback, future.set_exception
+    )
 
 
 @mock.patch(
@@ -97,4 +99,6 @@ def test_subscribe_options(manager_open):
     assert future._manager._subscription == "sub_name_a"
     assert future._manager.flow_control == flow_control
     assert future._manager._scheduler == scheduler
-    manager_open.assert_called_once_with(mock.ANY, mock.sentinel.callback)
+    manager_open.assert_called_once_with(
+        mock.ANY, mock.sentinel.callback, future.set_exception
+    )


### PR DESCRIPTION
Closes #7917.

This PR implements a user request to propagate exceptions from streaming pull callbacks to the main thread awaiting the result of the future returned by the `subscriber.subscribe()` call.

### How to test

**Steps to reproduce:**
- Prerequsite: Have a working service account, pubsub topic, and subscription created.
- Publish a message to the topic.
- Run the sample subscriber code posted under the [issue](https://github.com/googleapis/google-cloud-python/issues/7917) (adjust subscription name as necessary).

**Actual result (before the fix):**
- Nothing happens in the main thread. The exception is raised in the callback, but the main thread keeps waiting for for `fut.result()`.

**Expected result (after the fix):**
- An exception from the callback is propagated to `fut.result()`, and the main thread exists almost immediately after the callback is invoked.