### PR TITLE
Bigtable: Widen range for 'google-cloud-core'.

### DIFF
--- a/bigtable/CHANGELOG.md
+++ b/bigtable/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/google-cloud-bigtable/#history
 
+## 0.32.2
+
+05-14-2019 13:06 PST
+
+
+### Implementation Changes
+- Widen range for 'google-cloud-core'. ([#7970](https://github.com/googleapis/google-cloud-python/pull/7970))
+
 ## 0.32.1
 
 12-17-2018 16:38 PST

--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -30,7 +30,7 @@ version = '0.32.1'
 release_status = 'Development Status :: 4 - Beta'
 dependencies = [
     'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
-    'google-cloud-core >= 0.29.0, < 0.30dev',
+    'google-cloud-core >= 0.29.0, < 2.0dev',
     'grpc-google-iam-v1 >= 0.11.4, < 0.12dev',
 ]
 extras = {

--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -22,7 +22,7 @@ import setuptools
 
 name = 'google-cloud-bigtable'
 description = 'Google Cloud Bigtable API client library'
-version = '0.32.1'
+version = '0.32.2'
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
See #7968, "Prep Releases".

