### PR TITLE
Datastore: Widen range for 'google-cloud-core'.

### DIFF
--- a/datastore/CHANGELOG.md
+++ b/datastore/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/google-cloud-datastore/#history
 
+## 1.7.4
+
+05-14-2019 13:04 PST
+
+
+### Implementation Changes
+- Widen range for 'google-cloud-core'. ([#7971](https://github.com/googleapis/google-cloud-python/pull/7971))
+
 ## 1.7.3
 
 12-17-2018 16:45 PST

--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -30,7 +30,7 @@ version = '1.7.3'
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
     'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
-    'google-cloud-core >=0.29.0, <0.30dev',
+    'google-cloud-core >=0.29.0, <2.0dev',
 ]
 extras = {
 }

--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -22,7 +22,7 @@ import setuptools
 
 name = 'google-cloud-datastore'
 description = 'Google Cloud Datastore API client library'
-version = '1.7.3'
+version = '1.7.4'
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
See #7968, "Prep Releases".
