### PR TITLE
Runtimeconfig: Widen range for 'google-cloud-core'.

### DIFF
--- a/runtimeconfig/CHANGELOG.md
+++ b/runtimeconfig/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/google-cloud-runtimeconfig/#history
 
+## 0.28.4
+
+05-14-2019 12:52 PST
+
+
+### Implementation Changes
+- Widen range for 'google-cloud-core'. ([#7976](https://github.com/googleapis/google-cloud-python/pull/7976))
+
 ## 0.28.3
 
 12-17-2018 17:01 PST

--- a/runtimeconfig/setup.py
+++ b/runtimeconfig/setup.py
@@ -22,7 +22,7 @@ import setuptools
 
 name = 'google-cloud-runtimeconfig'
 description = 'Google Cloud RuntimeConfig API client library'
-version = '0.28.3'
+version = '0.28.4'
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'

--- a/runtimeconfig/setup.py
+++ b/runtimeconfig/setup.py
@@ -30,7 +30,7 @@ version = '0.28.3'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     'google-api-core >= 1.6.0, < 2.0.0dev',
-    'google-cloud-core >= 0.29.0, < 0.30dev',
+    'google-cloud-core >= 0.29.0, < 2.0dev',
 ]
 extras = {
 }


### PR DESCRIPTION
See #7968, "Prep Releases".