### PR TITLE
Trace: Widen range for 'google-cloud-core'.

### DIFF
--- a/trace/CHANGELOG.md
+++ b/trace/CHANGELOG.md
@@ -4,10 +4,16 @@
 
 [1]: https://pypi.org/project/google-cloud-trace/#history
 
+## 0.20.3
+
+05-14-2019 12:30 PST
+
+### Implementation Changes
+- Widen range for 'google-cloud-core'.([#7979](https://github.com/googleapis/google-cloud-python/pull/7979))
+
 ## 0.20.2
 
 12-17-2018 17:06 PST
-
 
 ### Documentation
 - Document Python 2 deprecation ([#6910](https://github.com/googleapis/google-cloud-python/pull/6910))

--- a/trace/setup.py
+++ b/trace/setup.py
@@ -30,7 +30,7 @@ version = '0.20.2'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
-    'google-cloud-core >=0.29.0, <0.30dev',
+    'google-cloud-core >=0.29.0, <2.0dev',
 ]
 extras = {
 }

--- a/trace/setup.py
+++ b/trace/setup.py
@@ -22,7 +22,7 @@ import setuptools
 
 name = 'google-cloud-trace'
 description = 'Stackdriver Trace API client library'
-version = '0.20.2'
+version = '0.20.3'
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
See #7968, "Prep Releases".