### PR TITLE
Core: update dep on 'api_core' >= 1.11.0.

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -28,7 +28,7 @@ version = "0.29.1"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 4 - Beta"
-dependencies = ["google-api-core >= 1.0.0, < 2.0.0dev"]
+dependencies = ["google-api-core >= 1.11.0, < 2.0.0dev"]
 extras = {"grpc": "grpcio >= 1.8.2"}
 
 


### PR DESCRIPTION
Toward #7968.

Needed for new 'client_info' support.