### PR TITLE
Translation: Change system test.

### DIFF
--- a/translate/tests/system.py
+++ b/translate/tests/system.py
@@ -61,10 +61,10 @@ class TestTranslate(unittest.TestCase):
         self.assertEqual(len(values), len(translations))
 
         self.assertEqual(translations[0]["detectedSourceLanguage"].lower(), "hr")
-        self.assertEqual(translations[0]["translatedText"].lower(), "fünfzehn")
+        self.assertEqual(translations[0]["translatedText"].lower(), u"f\xfcnfzehn")
 
         self.assertEqual(translations[1]["detectedSourceLanguage"], "eo")
-        self.assertEqual(translations[1]["translatedText"].lower(), "fünfzehn")
+        self.assertEqual(translations[1]["translatedText"].lower(), u"f\xfcnfzehn")
 
         self.assertEqual(translations[2]["detectedSourceLanguage"], "es")
         self.assertEqual(translations[2]["translatedText"].lower(), u"ich heiße jeff")

--- a/translate/tests/system.py
+++ b/translate/tests/system.py
@@ -54,19 +54,17 @@ class TestTranslate(unittest.TestCase):
         self.assertEqual(detections[2]["language"], "fr")
 
     def test_translate(self):
-        values = ["hvala ti", "dankon", "Me llamo Jeff", "My name is Jeff"]
+        values = ["petnaest", "dek kvin", "Me llamo Jeff", "My name is Jeff"]
         translations = Config.CLIENT.translate(
             values, target_language="de", model="nmt"
         )
         self.assertEqual(len(values), len(translations))
 
         self.assertEqual(translations[0]["detectedSourceLanguage"].lower(), "hr")
-        self.assertEqual(translations[0]["translatedText"].lower(), "danke")
+        self.assertEqual(translations[0]["translatedText"].lower(), "fünfzehn")
 
         self.assertEqual(translations[1]["detectedSourceLanguage"], "eo")
-        # For some reason this is translated as both "dank" and "danke"
-        # in a seemingly non-deterministic way.
-        self.assertIn(translations[1]["translatedText"].lower(), ("dank", "danke"))
+        self.assertEqual(translations[1]["translatedText"].lower(), "fünfzehn")
 
         self.assertEqual(translations[2]["detectedSourceLanguage"], "es")
         self.assertEqual(translations[2]["translatedText"].lower(), u"ich heiße jeff")

--- a/translate/tests/system.py
+++ b/translate/tests/system.py
@@ -61,10 +61,10 @@ class TestTranslate(unittest.TestCase):
         self.assertEqual(len(values), len(translations))
 
         self.assertEqual(translations[0]["detectedSourceLanguage"].lower(), "hr")
-        self.assertEqual(translations[0]["translatedText"].lower(), u"f\xfcnfzehn")
+        self.assertEqual(translations[0]["translatedText"].lower(), u"fünfzehn")
 
         self.assertEqual(translations[1]["detectedSourceLanguage"], "eo")
-        self.assertEqual(translations[1]["translatedText"].lower(), u"f\xfcnfzehn")
+        self.assertEqual(translations[1]["translatedText"].lower(), u"fünfzehn")
 
         self.assertEqual(translations[2]["detectedSourceLanguage"], "es")
         self.assertEqual(translations[2]["translatedText"].lower(), u"ich heiße jeff")


### PR DESCRIPTION
Fixes #7892.

`hvala ti` (Croatian) and `dankon` (Esperanto) mean `thank you`. This word seems to be susceptible to changing translations. I've changed them to `petnaest` and `dek kvin` which mean `fifteen`.