### PR TITLE
Trace: add VPCSC system test.

### DIFF
--- a/trace/noxfile.py
+++ b/trace/noxfile.py
@@ -121,11 +121,19 @@ def system(session):
     session.install("-e", "../test_utils/")
     session.install("-e", ".")
 
+    # Additional setup for VPCSC system tests
+    env = {
+        "PROJECT_ID": os.environ.get(
+            "PROJECT_ID"
+        ),
+        "GOOGLE_CLOUD_TESTS_VPCSC_OUTSIDE_PERIMETER_PROJECT": "secure-gcp-test-project-4",
+    }
+
     # Run py.test against the system tests.
     if system_test_exists:
-        session.run("py.test", "--quiet", system_test_path, *session.posargs)
+        session.run("py.test", "--quiet", system_test_path, env=env, *session.posargs)
     if system_test_folder_exists:
-        session.run("py.test", "--quiet", system_test_folder_path, *session.posargs)
+        session.run("py.test", "--quiet", system_test_folder_path, env=env, *session.posargs)
 
 
 @nox.session(python="3.7")

--- a/trace/synth.py
+++ b/trace/synth.py
@@ -53,6 +53,6 @@ s.replace("google/**/proto/*_pb2.py", r"(^.*$\n)*", r"# -*- coding: utf-8 -*-\n\
 # Add templated files
 # ----------------------------------------------------------------------------
 templated_files = common.py_library(unit_cov_level=97, cov_level=100)
-s.move(templated_files)
+s.move(templated_files, excludes=["noxfile.py"])
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)

--- a/trace/tests/system/gapic/v1/test_system_trace_service_v1_vpcsc.py
+++ b/trace/tests/system/gapic/v1/test_system_trace_service_v1_vpcsc.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa
+
+import os
+import pytest
+
+from google.api_core import exceptions
+from google.cloud import trace_v1
+
+PROJECT_INSIDE = os.environ.get("PROJECT_ID", None)
+PROJECT_OUTSIDE = os.environ.get(
+    "GOOGLE_CLOUD_TESTS_VPCSC_OUTSIDE_PERIMETER_PROJECT", None
+)
+
+
+class TestVPCServiceControlV1(object):
+    @staticmethod
+    def _is_rejected(call):
+        try:
+            responses = call()
+        except exceptions.PermissionDenied as e:
+            return e.message == "Request is prohibited by organization's policy"
+        except:
+            return False
+        return False
+
+    @pytest.mark.skipif(
+        PROJECT_INSIDE is None, reason="Missing environment variable: PROJECT_ID"
+    )
+    @pytest.mark.skipif(
+        PROJECT_OUTSIDE is None,
+        reason="Missing environment variable: GOOGLE_CLOUD_TESTS_VPCSC_OUTSIDE_PERIMETER_PROJECT",
+    )
+    def test_list_traces(self):
+        client = trace_v1.TraceServiceClient()
+
+        list_inside = lambda: list(client.list_traces(PROJECT_INSIDE))
+        list_outside = lambda: list(client.list_traces(PROJECT_OUTSIDE))
+
+        assert not TestVPCServiceControlV1._is_rejected(list_inside)
+        assert TestVPCServiceControlV1._is_rejected(list_outside)
+
+    @pytest.mark.skipif(
+        PROJECT_INSIDE is None, reason="Missing environment variable: PROJECT_ID"
+    )
+    @pytest.mark.skipif(
+        PROJECT_OUTSIDE is None,
+        reason="Missing environment variable: GOOGLE_CLOUD_TESTS_VPCSC_OUTSIDE_PERIMETER_PROJECT",
+    )
+    def test_get_trace(self):
+        client = trace_v1.TraceServiceClient()
+
+        get_inside = lambda: client.get_trace(PROJECT_INSIDE, "")
+        get_outside = lambda: client.get_trace(PROJECT_OUTSIDE, "")
+
+        assert not TestVPCServiceControlV1._is_rejected(get_inside)
+        assert TestVPCServiceControlV1._is_rejected(get_outside)
+
+    @pytest.mark.skipif(
+        PROJECT_INSIDE is None, reason="Missing environment variable: PROJECT_ID"
+    )
+    @pytest.mark.skipif(
+        PROJECT_OUTSIDE is None,
+        reason="Missing environment variable: GOOGLE_CLOUD_TESTS_VPCSC_OUTSIDE_PERIMETER_PROJECT",
+    )
+    def test_patch_traces(self):
+        client = trace_v1.TraceServiceClient()
+
+        patch_inside = lambda: client.patch_traces(PROJECT_INSIDE, {})
+        patch_outside = lambda: client.patch_traces(PROJECT_OUTSIDE, {})
+
+        assert not TestVPCServiceControlV1._is_rejected(patch_inside)
+        assert TestVPCServiceControlV1._is_rejected(patch_outside)

--- a/trace/tests/system/gapic/v2/test_system_trace_service_v2_vpcsc.py
+++ b/trace/tests/system/gapic/v2/test_system_trace_service_v2_vpcsc.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa
+
+import os
+import pytest
+
+from google.api_core import exceptions
+from google.cloud import trace_v2
+
+PROJECT_INSIDE = os.environ.get("PROJECT_ID", None)
+PROJECT_OUTSIDE = os.environ.get(
+    "GOOGLE_CLOUD_TESTS_VPCSC_OUTSIDE_PERIMETER_PROJECT", None
+)
+
+
+class TestVPCServiceControlV2(object):
+    @staticmethod
+    def _is_rejected(call):
+        try:
+            responses = call()
+        except exceptions.PermissionDenied as e:
+            return e.message == "Request is prohibited by organization's policy"
+        except:
+            pass
+        return False
+
+    @pytest.mark.skipif(
+        PROJECT_INSIDE is None, reason="Missing environment variable: PROJECT_ID"
+    )
+    @pytest.mark.skipif(
+        PROJECT_OUTSIDE is None,
+        reason="Missing environment variable: GOOGLE_CLOUD_TESTS_VPCSC_OUTSIDE_PERIMETER_PROJECT",
+    )
+    def test_batch_write_spans(self):
+        client = trace_v2.TraceServiceClient()
+
+        proejct_inside = client.project_path(PROJECT_INSIDE)
+        proejct_outside = client.project_path(PROJECT_OUTSIDE)
+        spans = []
+
+        write_inside = lambda: client.batch_write_spans(proejct_inside, spans)
+        write_outside = lambda: client.batch_write_spans(proejct_outside, spans)
+
+        assert not TestVPCServiceControlV2._is_rejected(write_inside)
+        assert TestVPCServiceControlV2._is_rejected(write_outside)


### PR DESCRIPTION
This new file is added in order to test client lib compatibility of VPC SC. The tests can be run inside or outside of VPC service perimeter. The input to the script should be the following environment variables.

PROJECT_ID: a project that is inside the VPC perimeter.
GOOGLE_CLOUD_TESTS_VPCSC_OUTSIDE_PERIMETER_PROJECT: a project that is outside the VPC perimeter.