### PR TITLE
Respect timeout on `client.read_rows`. Don't resume on `DEADLINE_EXCEEDED` errors.

### DIFF
--- a/bigquery_storage/google/cloud/bigquery_storage_v1beta1/reader.py
+++ b/bigquery_storage/google/cloud/bigquery_storage_v1beta1/reader.py
@@ -33,7 +33,6 @@ from google.cloud.bigquery_storage_v1beta1 import types
 
 
 _STREAM_RESUMPTION_EXCEPTIONS = (
-    google.api_core.exceptions.DeadlineExceeded,
     google.api_core.exceptions.ServiceUnavailable,
 )
 _FASTAVRO_REQUIRED = "fastavro is required to parse Avro blocks"

--- a/bigquery_storage/google/cloud/bigquery_storage_v1beta1/reader.py
+++ b/bigquery_storage/google/cloud/bigquery_storage_v1beta1/reader.py
@@ -32,9 +32,7 @@ import six
 from google.cloud.bigquery_storage_v1beta1 import types
 
 
-_STREAM_RESUMPTION_EXCEPTIONS = (
-    google.api_core.exceptions.ServiceUnavailable,
-)
+_STREAM_RESUMPTION_EXCEPTIONS = (google.api_core.exceptions.ServiceUnavailable,)
 _FASTAVRO_REQUIRED = "fastavro is required to parse Avro blocks"
 _PANDAS_REQUIRED = "pandas is required to create a DataFrame"
 


### PR DESCRIPTION
DEADLINE_EXCEEDED should not be resumed. Currently, you can set a
timeout on reads, but the reader will reconnect after the timeout value
finishes.

Always resuming the stream masked internal issue 132959978 from clients,
where the default deadline is much too low for read streams.

Wait for the deadline configuration fix for read rows to go in before
merging.