### PR TITLE
BigQuery: avoid errors from unknown fields in Models API.

### DIFF
--- a/bigquery/tests/unit/model/test_model.py
+++ b/bigquery/tests/unit/model/test_model.py
@@ -165,6 +165,22 @@ def test_from_api_repr_w_minimal_resource(target_class):
     assert len(got.label_columns) == 0
 
 
+def test_from_api_repr_w_unknown_fields(target_class):
+    from google.cloud.bigquery import ModelReference
+
+    resource = {
+        "modelReference": {
+            "projectId": "my-project",
+            "datasetId": "my_dataset",
+            "modelId": "my_model",
+        },
+        "thisFieldIsNotInTheProto": "just ignore me",
+    }
+    got = target_class.from_api_repr(resource)
+    assert got.reference == ModelReference.from_string("my-project.my_dataset.my_model")
+    assert got._properties is resource
+
+
 @pytest.mark.parametrize(
     "resource,filter_fields,expected",
     [

--- a/bigquery/tests/unit/model/test_model_reference.py
+++ b/bigquery/tests/unit/model/test_model_reference.py
@@ -37,6 +37,20 @@ def test_from_api_repr(target_class):
     assert got.path == "/projects/my-project/datasets/my_dataset/models/my_model"
 
 
+def test_from_api_repr_w_unknown_fields(target_class):
+    resource = {
+        "projectId": "my-project",
+        "datasetId": "my_dataset",
+        "modelId": "my_model",
+        "thisFieldIsNotInTheProto": "just ignore me",
+    }
+    got = target_class.from_api_repr(resource)
+    assert got.project == "my-project"
+    assert got.dataset_id == "my_dataset"
+    assert got.model_id == "my_model"
+    assert got._properties is resource
+
+
 def test_to_api_repr(target_class):
     ref = target_class.from_string("my-project.my_dataset.my_model")
     got = ref.to_api_repr()


### PR DESCRIPTION
As new fields are added, the JSON -> Protobuf conversion should not
fail. Instead, it should ignore unknown fields. So that this data is not
discarded, use _properties as is the convention in our REST libraries.
It's private, but can be used as a workaround to get access to fields
that haven't yet been added to the client library.

Closes #8082.