### PR TITLE
Bigtable: Add retry parameter to 'table.read_row()'.

### DIFF
--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -366,7 +366,9 @@ class Table(object):
         """
         row_set = RowSet()
         row_set.add_row_key(row_key)
-        result_iter = iter(self.read_rows(filter_=filter_, row_set=row_set, retry=retry))
+        result_iter = iter(
+            self.read_rows(filter_=filter_, row_set=row_set, retry=retry)
+        )
         row = next(result_iter, None)
         if next(result_iter, None) is not None:
             raise ValueError("More than one row was returned.")

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -334,7 +334,7 @@ class Table(object):
             for cluster_id, value_pb in table_pb.cluster_states.items()
         }
 
-    def read_row(self, row_key, filter_=None):
+    def read_row(self, row_key, filter_=None, retry=DEFAULT_RETRY_READ_ROWS):
         """Read a single row from this table.
 
         For example:
@@ -350,6 +350,14 @@ class Table(object):
         :param filter_: (Optional) The filter to apply to the contents of the
                         row. If unset, returns the entire row.
 
+        :type retry: :class:`~google.api_core.retry.Retry`
+        :param retry:
+            (Optional) Retry delay and deadline arguments. To override, the
+            default value :attr:`DEFAULT_RETRY_READ_ROWS` can be used and
+            modified with the :meth:`~google.api_core.retry.Retry.with_delay`
+            method or the :meth:`~google.api_core.retry.Retry.with_deadline`
+            method.
+
         :rtype: :class:`.PartialRowData`, :data:`NoneType <types.NoneType>`
         :returns: The contents of the row if any chunks were returned in
                   the response, otherwise :data:`None`.
@@ -358,7 +366,7 @@ class Table(object):
         """
         row_set = RowSet()
         row_set.add_row_key(row_key)
-        result_iter = iter(self.read_rows(filter_=filter_, row_set=row_set))
+        result_iter = iter(self.read_rows(filter_=filter_, row_set=row_set, retry=retry))
         row = next(result_iter, None)
         if next(result_iter, None) is not None:
             raise ValueError("More than one row was returned.")

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -569,9 +569,7 @@ class TestTable(unittest.TestCase):
         from google.cloud.bigtable.table import _BigtableRetryableError
 
         credentials = _make_credentials()
-        client = self._make_client(
-            project="project-id", credentials=credentials, admin=True
-        )
+        client = self._make_client(project="project-id", credentials=credentials)
         instance = client.instance(instance_id=self.INSTANCE_ID)
         table = self._make_one(self.TABLE_ID, instance)
         custom_retry = retry.Retry(

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -563,6 +563,91 @@ class TestTable(unittest.TestCase):
         column.append(Cell.from_pb(chunk))
         self._read_row_helper(chunks, expected_result, app_profile_id)
 
+    def test_read_row_retry(self):
+        from google.cloud._testing import _Monkey
+        from google.cloud.bigtable import table as MUT
+        from google.cloud.bigtable.row_set import RowSet
+        from google.cloud.bigtable_v2.gapic import bigtable_client
+        from google.cloud.bigtable_admin_v2.gapic import bigtable_table_admin_client
+        from google.cloud.bigtable.row_filters import RowSampleFilter
+        from google.api_core import retry
+        from google.cloud.bigtable.row_data import Cell
+        from google.cloud.bigtable.row_data import PartialRowData
+
+        app_profile_id = "app-profile-id"
+
+        data_api = bigtable_client.BigtableClient(mock.Mock())
+        table_api = mock.create_autospec(
+            bigtable_table_admin_client.BigtableTableAdminClient
+        )
+        credentials = _make_credentials()
+        client = self._make_client(
+            project="project-id", credentials=credentials, admin=True
+        )
+        instance = client.instance(instance_id=self.INSTANCE_ID)
+        table = self._make_one(self.TABLE_ID, instance, app_profile_id=app_profile_id)
+
+        # Create request_pb
+        request_pb = object()  # Returned by our mock.
+        mock_created = []
+
+        def mock_create_row_request(table_name, **kwargs):
+            mock_created.append((table_name, kwargs))
+            return request_pb
+
+        chunk = _ReadRowsResponseCellChunkPB(
+            row_key=self.ROW_KEY,
+            family_name=self.FAMILY_NAME,
+            qualifier=self.QUALIFIER,
+            timestamp_micros=self.TIMESTAMP_MICROS,
+            value=self.VALUE,
+            commit_row=True,
+        )
+        chunks = [chunk]
+        expected_result = PartialRowData(row_key=self.ROW_KEY)
+        family = expected_result._cells.setdefault(self.FAMILY_NAME, {})
+        column = family.setdefault(self.QUALIFIER, [])
+        column.append(Cell.from_pb(chunk))
+
+        # Create response_iterator
+        if chunks is None:
+            response_iterator = iter(())  # no responses at all
+        else:
+            response_pb = _ReadRowsResponsePB(chunks=chunks)
+            response_iterator = iter([response_pb])
+
+        # Patch the stub used by the API method.
+        client._table_data_client = data_api
+        client._table_admin_client = table_api
+        client._table_data_client.transport.read_rows = mock.Mock(
+            side_effect=[response_iterator]
+        )
+
+        # Perform the method and check the result.
+        filter_obj = RowSampleFilter(0.33)
+        result = None
+        retry_read_row = retry.Retry(predicate=_read_rows_retry_exception)
+        with _Monkey(MUT, _create_row_request=mock_create_row_request):
+            result = table.read_row(self.ROW_KEY, filter_=filter_obj, retry=retry_read_row)
+        row_set = RowSet()
+        row_set.add_row_key(self.ROW_KEY)
+        expected_request = [
+            (
+                table.name,
+                {
+                    "end_inclusive": False,
+                    "row_set": row_set,
+                    "app_profile_id": app_profile_id,
+                    "end_key": None,
+                    "limit": None,
+                    "start_key": None,
+                    "filter_": filter_obj,
+                },
+            )
+        ]
+        self.assertEqual(result, expected_result)
+        self.assertEqual(mock_created, expected_request)
+
     def test_read_row_more_than_one_row_returned(self):
         app_profile_id = "app-profile-id"
         chunk_1 = _ReadRowsResponseCellChunkPB(


### PR DESCRIPTION
Fix #7955 