### PR TITLE
Pub/Sub: staticmethod check

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/_gapic.py
+++ b/pubsub/google/cloud/pubsub_v1/_gapic.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 import functools
+import inspect
 
 
 def add_methods(source_class, blacklist=()):
@@ -25,28 +26,20 @@ def add_methods(source_class, blacklist=()):
     not added.
     """
 
-    def wrap(wrapped_fx):
+    def wrap(wrapped_fx, lookup_fx):
         """Wrap a GAPIC method; preserve its name and docstring."""
-        # If this is a static or class method, then we need to *not*
+        # If this is a static or class method, then we do *not*
         # send self as the first argument.
         #
-        # Similarly, for instance methods, we need to send self.api rather
+        # For instance methods, we need to send self.api rather
         # than self, since that is where the actual methods were declared.
-        instance_method = True
 
-        # If this is a bound method it's a classmethod.
-        self = getattr(wrapped_fx, "__self__", None)
-        if issubclass(type(self), type):
-            instance_method = False
-
-        # Okay, we have figured out what kind of method this is; send
-        # down the correct wrapper function.
-        if instance_method:
+        if isinstance(lookup_fx, classmethod) or isinstance(lookup_fx, staticmethod):
+            fx = lambda *a, **kw: wrapped_fx(*a, **kw)  # noqa
+            return staticmethod(functools.wraps(wrapped_fx)(fx))
+        else:
             fx = lambda self, *a, **kw: wrapped_fx(self.api, *a, **kw)  # noqa
             return functools.wraps(wrapped_fx)(fx)
-
-        fx = lambda *a, **kw: wrapped_fx(*a, **kw)  # noqa
-        return staticmethod(functools.wraps(wrapped_fx)(fx))
 
     def actual_decorator(cls):
         # Reflectively iterate over most of the methods on the source class
@@ -66,7 +59,10 @@ def add_methods(source_class, blacklist=()):
                 continue
 
             # Add a wrapper method to this object.
-            fx = wrap(getattr(source_class, name))
+            lookup_fx = source_class.__dict__[name]
+            wrapped_fx = getattr(source_class, name)
+            fx = wrap(wrapped_fx, lookup_fx)
+
             setattr(cls, name, fx)
 
         # Return the augmented class.

--- a/pubsub/google/cloud/pubsub_v1/_gapic.py
+++ b/pubsub/google/cloud/pubsub_v1/_gapic.py
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2019, Google LLC All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -59,8 +59,7 @@ def add_methods(source_class, blacklist=()):
 
             # Add a wrapper method to this object.
             lookup_fx = source_class.__dict__[name]
-            wrapped_fx = getattr(source_class, name)
-            fx = wrap(wrapped_fx, lookup_fx)
+            fx = wrap(attr, lookup_fx)
 
             setattr(cls, name, fx)
 

--- a/pubsub/google/cloud/pubsub_v1/_gapic.py
+++ b/pubsub/google/cloud/pubsub_v1/_gapic.py
@@ -33,7 +33,7 @@ def add_methods(source_class, blacklist=()):
         # For instance methods, we need to send self.api rather
         # than self, since that is where the actual methods were declared.
 
-        if isinstance(lookup_fx, classmethod) or isinstance(lookup_fx, staticmethod):
+        if isinstance(lookup_fx, (classmethod, staticmethod)):
             fx = lambda *a, **kw: wrapped_fx(*a, **kw)  # noqa
             return staticmethod(functools.wraps(wrapped_fx)(fx))
         else:

--- a/pubsub/google/cloud/pubsub_v1/_gapic.py
+++ b/pubsub/google/cloud/pubsub_v1/_gapic.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import
 
 import functools
-import inspect
 
 
 def add_methods(source_class, blacklist=()):

--- a/pubsub/tests/unit/pubsub_v1/test__gapic.py
+++ b/pubsub/tests/unit/pubsub_v1/test__gapic.py
@@ -36,7 +36,7 @@ class SourceClass(object):
         return "source class blacklisted method"
 
 
-def test__gapic():
+def test_add_method():
     @_gapic.add_methods(SourceClass, ("blacklisted_method",))
     class Foo(object):
         def __init__(self):
@@ -58,5 +58,6 @@ def test__gapic():
     assert foo.class_method() == "source class class method"
 
     # The decorator changes the behavior of instance methods of the wrapped class.
-    # method() is called upon an instance of the Source Class.
+    # method() is called on an instance of the Source Class (stored as an
+    # attribute on the wrapped class).
     assert foo.method() == "source class instance method"

--- a/pubsub/tests/unit/pubsub_v1/test__gapic.py
+++ b/pubsub/tests/unit/pubsub_v1/test__gapic.py
@@ -18,47 +18,45 @@ from google.cloud.pubsub_v1 import _gapic
 
 class SourceClass(object):
     def __init__(self):
-        self.x = 'x'
+        self.x = "x"
 
     def method(self):
-        return 'source class instance method'
+        return "source class instance method"
 
     @staticmethod
     def static_method():
-        return 'source class static method'
+        return "source class static method"
 
     @classmethod
     def class_method(cls):
-        return 'source class class method'
+        return "source class class method"
 
     @classmethod
     def blacklisted_method(cls):
-        return 'source class blacklisted method'
+        return "source class blacklisted method"
 
 
 def test__gapic():
-
     @_gapic.add_methods(SourceClass, ("blacklisted_method",))
     class Foo(object):
         def __init__(self):
             self.api = SourceClass()
 
         def method(self):
-            return 'foo class instance method'
-
+            return "foo class instance method"
 
     foo = Foo()
 
     # Any method that's callable and not blacklisted is "inherited".
-    assert set(['method', 'static_method', 'class_method']) <= set(dir(foo))
-    assert 'blacklisted_method' not in dir(foo)
+    assert set(["method", "static_method", "class_method"]) <= set(dir(foo))
+    assert "blacklisted_method" not in dir(foo)
 
     # Source Class's static and class methods become static methods.
     assert type(Foo.__dict__["static_method"]) == staticmethod
-    assert foo.static_method() == 'source class static method'
+    assert foo.static_method() == "source class static method"
     assert type(Foo.__dict__["class_method"]) == staticmethod
-    assert foo.class_method() == 'source class class method'
+    assert foo.class_method() == "source class class method"
 
     # The decorator changes the behavior of instance methods of the wrapped class.
-    # method() is called upon an instance of the Source Class. 
-    assert foo.method() == 'source class instance method'
+    # method() is called upon an instance of the Source Class.
+    assert foo.method() == "source class instance method"

--- a/pubsub/tests/unit/pubsub_v1/test__gapic.py
+++ b/pubsub/tests/unit/pubsub_v1/test__gapic.py
@@ -1,0 +1,64 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from google.cloud.pubsub_v1 import _gapic
+
+
+class SourceClass(object):
+    def __init__(self):
+        self.x = 'x'
+
+    def method(self):
+        return 'source class instance method'
+
+    @staticmethod
+    def static_method():
+        return 'source class static method'
+
+    @classmethod
+    def class_method(cls):
+        return 'source class class method'
+
+    @classmethod
+    def blacklisted_method(cls):
+        return 'source class blacklisted method'
+
+
+def test__gapic():
+
+    @_gapic.add_methods(SourceClass, ("blacklisted_method",))
+    class Foo(object):
+        def __init__(self):
+            self.api = SourceClass()
+
+        def method(self):
+            return 'foo class instance method'
+
+
+    foo = Foo()
+
+    # Any method that's callable and not blacklisted is "inherited".
+    assert set(['method', 'static_method', 'class_method']) <= set(dir(foo))
+    assert 'blacklisted_method' not in dir(foo)
+
+    # Source Class's static and class methods become static methods.
+    assert type(Foo.__dict__["static_method"]) == staticmethod
+    assert foo.static_method() == 'source class static method'
+    assert type(Foo.__dict__["class_method"]) == staticmethod
+    assert foo.class_method() == 'source class class method'
+
+    # The decorator changes the behavior of instance methods of the wrapped class.
+    # method() is called upon an instance of the Source Class. 
+    assert foo.method() == 'source class instance method'


### PR DESCRIPTION
The GAPIC wrapper (code snippet below with comments) in [`pubsub/google/cloud/pubsub_v1/_gapic`](https://github.com/googleapis/google-cloud-python/blob/master/pubsub/google/cloud/pubsub_v1/_gapic.py) falsely recognizes static methods as instance methods. 

```python
    def wrap(wrapped_fx):
        """Wrap a GAPIC method; preserve its name and docstring."""
        # If this is a static or class method, then we need to *not*
        # send self as the first argument.
        #
        # Similarly, for instance methods, we need to send self.api rather
        # than self, since that is where the actual methods were declared.
        instance_method = True

        # If this is a bound method it's a classmethod. 
        self = getattr(wrapped_fx, "__self__", None) # <-- this would return None for staticmethod
        if issubclass(type(self), type):             # <-- this would return False for staticmethod
            instance_method = False                  # <-- resulting in instance_method = True for staticmethod

        # Okay, we have figured out what kind of method this is; send
        # down the correct wrapper function.
        if instance_method:
            fx = lambda self, *a, **kw: wrapped_fx(self.api, *a, **kw)  # noqa
            return functools.wraps(wrapped_fx)(fx)

        fx = lambda *a, **kw: wrapped_fx(*a, **kw)  # noqa
        return staticmethod(functools.wraps(wrapped_fx)(fx))
```

The PR adds a check for **static methods** and aims to make the code more readable. 