### PR TITLE
Firestore: normalize docstring class refs.

### DIFF
--- a/firestore/docs/batch.rst
+++ b/firestore/docs/batch.rst
@@ -1,6 +1,6 @@
 Batches
 ~~~~~~~
 
-.. automodule:: google.cloud.firestore_v1beta1.batch
+.. automodule:: google.cloud.firestore_v1.batch
   :members:
   :show-inheritance:

--- a/firestore/docs/client.rst
+++ b/firestore/docs/client.rst
@@ -1,6 +1,6 @@
 Client
 ~~~~~~
 
-.. automodule:: google.cloud.firestore_v1beta1.client
+.. automodule:: google.cloud.firestore_v1.client
   :members:
   :show-inheritance:

--- a/firestore/docs/collection.rst
+++ b/firestore/docs/collection.rst
@@ -1,6 +1,6 @@
 Collections
 ~~~~~~~~~~~
 
-.. automodule:: google.cloud.firestore_v1beta1.collection
+.. automodule:: google.cloud.firestore_v1.collection
   :members:
   :show-inheritance:

--- a/firestore/docs/document.rst
+++ b/firestore/docs/document.rst
@@ -1,6 +1,6 @@
 Documents
 ~~~~~~~~~
 
-.. automodule:: google.cloud.firestore_v1beta1.document
+.. automodule:: google.cloud.firestore_v1.document
   :members:
   :show-inheritance:

--- a/firestore/docs/field_path.rst
+++ b/firestore/docs/field_path.rst
@@ -1,7 +1,7 @@
 Field Paths
 ~~~~~~~~~~~
 
-.. automodule:: google.cloud.firestore_v1beta1.field_path
+.. automodule:: google.cloud.firestore_v1.field_path
   :members:
   :show-inheritance:
 

--- a/firestore/docs/query.rst
+++ b/firestore/docs/query.rst
@@ -1,6 +1,6 @@
 Queries
 ~~~~~~~
 
-.. automodule:: google.cloud.firestore_v1beta1.query
+.. automodule:: google.cloud.firestore_v1.query
   :members:
   :show-inheritance:

--- a/firestore/docs/transaction.rst
+++ b/firestore/docs/transaction.rst
@@ -1,7 +1,7 @@
 Transactions
 ~~~~~~~~~~~~
 
-.. automodule:: google.cloud.firestore_v1beta1.transaction
+.. automodule:: google.cloud.firestore_v1.transaction
   :inherited-members:
   :members:
   :show-inheritance:

--- a/firestore/docs/transforms.rst
+++ b/firestore/docs/transforms.rst
@@ -1,6 +1,6 @@
 Transforms
 ~~~~~~~~~~
 
-.. automodule:: google.cloud.firestore_v1beta1.transforms
+.. automodule:: google.cloud.firestore_v1.transforms
   :members:
   :show-inheritance:

--- a/firestore/docs/types.rst
+++ b/firestore/docs/types.rst
@@ -1,6 +1,6 @@
 Types
 ~~~~~
 
-.. automodule:: google.cloud.firestore_v1beta1.types
+.. automodule:: google.cloud.firestore_v1.types
   :members:
   :show-inheritance:

--- a/firestore/google/cloud/firestore_v1/_helpers.py
+++ b/firestore/google/cloud/firestore_v1/_helpers.py
@@ -220,12 +220,12 @@ def reference_value_to_document(reference_value, client):
 
     Args:
         reference_value (str): A document reference value.
-        client (~.firestore_v1.client.Client): A client that has
-            a document factory.
+        client (:class:`~google.cloud.firestore_v1.client.Client`):
+            A client that has a document factory.
 
     Returns:
-        ~.firestore_v1.document.DocumentReference: The document
-        corresponding to ``reference_value``.
+        :class:`~google.cloud.firestore_v1.document.DocumentReference`:
+            The document corresponding to ``reference_value``.
 
     Raises:
         ValueError: If the ``reference_value`` is not of the expected
@@ -255,8 +255,8 @@ def decode_value(value, client):
     Args:
         value (google.cloud.firestore_v1.types.Value): A
             Firestore protobuf to be decoded / parsed / converted.
-        client (~.firestore_v1.client.Client): A client that has
-            a document factory.
+        client (:class:`~google.cloud.firestore_v1.client.Client`):
+            A client that has a document factory.
 
     Returns:
         Union[NoneType, bool, int, float, datetime.datetime, \
@@ -301,8 +301,8 @@ def decode_dict(value_fields, client):
     Args:
         value_fields (google.protobuf.pyext._message.MessageMapContainer): A
             protobuf map of Firestore ``Value``-s.
-        client (~.firestore_v1.client.Client): A client that has
-            a document factory.
+        client (:class:`~google.cloud.firestore_v1.client.Client`):
+            A client that has a document factory.
 
     Returns:
         Dict[str, Union[NoneType, bool, int, float, datetime.datetime, \
@@ -851,9 +851,9 @@ def pbs_for_update(document_path, field_updates, option):
         document_path (str): A fully-qualified document path.
         field_updates (dict): Field names or paths to update and values
             to update with.
-        option (optional[~.firestore_v1.client.WriteOption]): A
-           write option to make assertions / preconditions on the server
-           state of the document before applying changes.
+        option (optional[:class:`~google.cloud.firestore_v1.client.WriteOption`]):
+            A write option to make assertions / preconditions on the server
+            state of the document before applying changes.
 
     Returns:
         List[google.cloud.firestore_v1.types.Write]: One
@@ -890,9 +890,9 @@ def pb_for_delete(document_path, option):
 
     Args:
         document_path (str): A fully-qualified document path.
-        option (optional[~.firestore_v1.client.WriteOption]): A
-           write option to make assertions / preconditions on the server
-           state of the document before applying changes.
+        option (optional[:class:`~google.cloud.firestore_v1.client.WriteOption`]):
+            A write option to make assertions / preconditions on the server
+            state of the document before applying changes.
 
     Returns:
         google.cloud.firestore_v1.types.Write: A
@@ -916,9 +916,9 @@ def get_transaction_id(transaction, read_operation=True):
     """Get the transaction ID from a ``Transaction`` object.
 
     Args:
-        transaction (Optional[~.firestore_v1.transaction.\
-            Transaction]): An existing transaction that this query will
-            run in.
+        transaction (Optional[:class:`~google.cloud.firestore_v1.transaction.\
+            Transaction`]):
+            An existing transaction that this query will run in.
         read_operation (Optional[bool]): Indicates if the transaction ID
             will be used in a read operation. Defaults to :data:`True`.
 

--- a/firestore/google/cloud/firestore_v1/_helpers.py
+++ b/firestore/google/cloud/firestore_v1/_helpers.py
@@ -979,7 +979,7 @@ class LastUpdateOption(WriteOption):
     """Option used to assert a "last update" condition on a write operation.
 
     This will typically be created by
-    :meth:`~.firestore_v1.client.Client.write_option`.
+    :meth:`~google.cloud.firestore_v1.client.Client.write_option`.
 
     Args:
         last_update_time (google.protobuf.timestamp_pb2.Timestamp): A
@@ -1019,7 +1019,7 @@ class ExistsOption(WriteOption):
     """Option used to assert existence on a write operation.
 
     This will typically be created by
-    :meth:`~.firestore_v1.client.Client.write_option`.
+    :meth:`~google.cloud.firestore_v1.client.Client.write_option`.
 
     Args:
         exists (bool): Indicates if the document being modified

--- a/firestore/google/cloud/firestore_v1/batch.py
+++ b/firestore/google/cloud/firestore_v1/batch.py
@@ -26,8 +26,8 @@ class WriteBatch(object):
     e.g. :meth:`~google.cloud.firestore_v1.document.DocumentReference.create`.
 
     Args:
-        client (~.firestore_v1.client.Client): The client that
-            created this batch.
+        client (:class:`~google.cloud.firestore_v1.client.Client`):
+            The client that created this batch.
     """
 
     def __init__(self, client):
@@ -54,8 +54,8 @@ class WriteBatch(object):
         batch will fail when :meth:`commit`-ed.
 
         Args:
-            reference (~.firestore_v1.document.DocumentReference): A
-                document reference to be created in this batch.
+            reference (:class:`~google.cloud.firestore_v1.document.DocumentReference`):
+                A document reference to be created in this batch.
             document_data (dict): Property names and values to use for
                 creating a document.
         """
@@ -66,12 +66,12 @@ class WriteBatch(object):
         """Add a "change" to replace a document.
 
         See
-        :meth:`~google.cloud.firestore_v1.document.DocumentReference.set` for
+        :meth:`google.cloud.firestore_v1.document.DocumentReference.set` for
         more information on how ``option`` determines how the change is
         applied.
 
         Args:
-            reference (~.firestore_v1.document.DocumentReference):
+            reference (:class:`~google.cloud.firestore_v1.document.DocumentReference`):
                 A document reference that will have values set in this batch.
             document_data (dict):
                 Property names and values to use for replacing a document.
@@ -94,17 +94,17 @@ class WriteBatch(object):
         """Add a "change" to update a document.
 
         See
-        :meth:`~google.cloud.firestore_v1.document.DocumentReference.update`
+        :meth:`google.cloud.firestore_v1.document.DocumentReference.update`
         for more information on ``field_updates`` and ``option``.
 
         Args:
-            reference (~.firestore_v1.document.DocumentReference): A
-               document reference that will be deleted in this batch.
-            field_updates (dict): Field names or paths to update and values
-                to update with.
-            option (Optional[~.firestore_v1.client.WriteOption]): A
-               write option to make assertions / preconditions on the server
-               state of the document before applying changes.
+            reference (:class:`~google.cloud.firestore_v1.document.DocumentReference`):
+                A document reference that will be updated in this batch.
+            field_updates (dict):
+                Field names or paths to update and values to update with.
+            option (Optional[:class:`~google.cloud.firestore_v1.client.WriteOption`]):
+                A write option to make assertions / preconditions on the server
+                state of the document before applying changes.
         """
         if option.__class__.__name__ == "ExistsOption":
             raise ValueError("you must not pass an explicit write option to " "update.")
@@ -117,16 +117,16 @@ class WriteBatch(object):
         """Add a "change" to delete a document.
 
         See
-        :meth:`~google.cloud.firestore_v1.document.DocumentReference.delete`
+        :meth:`google.cloud.firestore_v1.document.DocumentReference.delete`
         for more information on how ``option`` determines how the change is
         applied.
 
         Args:
-            reference (~.firestore_v1.document.DocumentReference): A
-               document reference that will be deleted in this batch.
-            option (Optional[~.firestore_v1.client.WriteOption]): A
-               write option to make assertions / preconditions on the server
-               state of the document before applying changes.
+            reference (:class:`~google.cloud.firestore_v1.document.DocumentReference`):
+                A document reference that will be deleted in this batch.
+            option (Optional[:class:`~google.cloud.firestore_v1.client.WriteOption`]):
+                A write option to make assertions / preconditions on the server
+                state of the document before applying changes.
         """
         write_pb = _helpers.pb_for_delete(reference._document_path, option)
         self._add_write_pbs([write_pb])
@@ -135,11 +135,10 @@ class WriteBatch(object):
         """Commit the changes accumulated in this batch.
 
         Returns:
-            List[google.cloud.proto.firestore.v1.\
-                write_pb2.WriteResult, ...]: The write results corresponding
-            to the changes committed, returned in the same order as the
-            changes were applied to this batch. A write result contains an
-            ``update_time`` field.
+            List[:class:`google.cloud.proto.firestore.v1.write_pb2.WriteResult`, ...]:
+            The write results corresponding to the changes committed, returned
+            in the same order as the changes were applied to this batch. A
+            write result contains an ``update_time`` field.
         """
         commit_response = self._client._firestore_api.commit(
             self._client._database_string,

--- a/firestore/google/cloud/firestore_v1/batch.py
+++ b/firestore/google/cloud/firestore_v1/batch.py
@@ -22,8 +22,8 @@ class WriteBatch(object):
     """Accumulate write operations to be sent in a batch.
 
     This has the same set of methods for write operations that
-    :class:`~.firestore_v1.document.DocumentReference` does,
-    e.g. :meth:`~.firestore_v1.document.DocumentReference.create`.
+    :class:`~google.cloud.firestore_v1.document.DocumentReference` does,
+    e.g. :meth:`~google.cloud.firestore_v1.document.DocumentReference.create`.
 
     Args:
         client (~.firestore_v1.client.Client): The client that
@@ -66,7 +66,7 @@ class WriteBatch(object):
         """Add a "change" to replace a document.
 
         See
-        :meth:`~.firestore_v1.document.DocumentReference.set` for
+        :meth:`~google.cloud.firestore_v1.document.DocumentReference.set` for
         more information on how ``option`` determines how the change is
         applied.
 
@@ -94,8 +94,8 @@ class WriteBatch(object):
         """Add a "change" to update a document.
 
         See
-        :meth:`~.firestore_v1.document.DocumentReference.update` for
-        more information on ``field_updates`` and ``option``.
+        :meth:`~google.cloud.firestore_v1.document.DocumentReference.update`
+        for more information on ``field_updates`` and ``option``.
 
         Args:
             reference (~.firestore_v1.document.DocumentReference): A
@@ -117,8 +117,8 @@ class WriteBatch(object):
         """Add a "change" to delete a document.
 
         See
-        :meth:`~.firestore_v1.document.DocumentReference.delete` for
-        more information on how ``option`` determines how the change is
+        :meth:`~google.cloud.firestore_v1.document.DocumentReference.delete`
+        for more information on how ``option`` determines how the change is
         applied.
 
         Args:

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -18,10 +18,10 @@ This is the base from which all interactions with the API occur.
 
 In the hierarchy of API concepts
 
-* a :class:`~.firestore_v1.client.Client` owns a
-  :class:`~.firestore_v1.collection.CollectionReference`
-* a :class:`~.firestore_v1.client.Client` owns a
-  :class:`~.firestore_v1.document.DocumentReference`
+* a :class:`~google.cloud.firestore_v1.client.Client` owns a
+  :class:`~google.cloud.firestore_v1.collection.CollectionReference`
+* a :class:`~google.cloud.firestore_v1.client.Client` owns a
+  :class:`~google.cloud.firestore_v1.document.DocumentReference`
 """
 from google.api_core.gapic_v1 import client_info
 from google.cloud.client import ClientWithProject
@@ -40,7 +40,7 @@ from google.cloud.firestore_v1.transaction import Transaction
 
 
 DEFAULT_DATABASE = "(default)"
-"""str: The default database used in a :class:`~.firestore.client.Client`."""
+"""str: The default database used in a :class:`~google.cloud.firestore.client.Client`."""
 _BAD_OPTION_ERR = (
     "Exactly one of ``last_update_time`` or ``exists`` " "must be provided."
 )
@@ -298,9 +298,9 @@ class Client(ClientWithProject):
     def write_option(**kwargs):
         """Create a write option for write operations.
 
-        Write operations include :meth:`~.DocumentReference.set`,
-        :meth:`~.DocumentReference.update` and
-        :meth:`~.DocumentReference.delete`.
+        Write operations include :meth:`~google.cloud.DocumentReference.set`,
+        :meth:`~google.cloud.DocumentReference.update` and
+        :meth:`~google.cloud.DocumentReference.delete`.
 
         One of the following keyword arguments must be provided:
 
@@ -352,7 +352,7 @@ class Client(ClientWithProject):
            If multiple ``references`` refer to the same document, the server
            will only return one result.
 
-        See :meth:`~.firestore_v1.client.Client.field_path` for
+        See :meth:`~google.cloud.firestore_v1.client.Client.field_path` for
         more information on **field paths**.
 
         If a ``transaction`` is used and it already has write operations
@@ -414,13 +414,13 @@ class Client(ClientWithProject):
     def transaction(self, **kwargs):
         """Get a transaction that uses this client.
 
-        See :class:`~.firestore_v1.transaction.Transaction` for
+        See :class:`~google.cloud.firestore_v1.transaction.Transaction` for
         more information on transactions and the constructor arguments.
 
         Args:
             kwargs (Dict[str, Any]): The keyword arguments (other than
                 ``client``) to pass along to the
-                :class:`~.firestore_v1.transaction.Transaction`
+                :class:`~google.cloud.firestore_v1.transaction.Transaction`
                 constructor.
 
         Returns:
@@ -433,7 +433,7 @@ class Client(ClientWithProject):
 def _reference_info(references):
     """Get information about document references.
 
-    Helper for :meth:`~.firestore_v1.client.Client.get_all`.
+    Helper for :meth:`~google.cloud.firestore_v1.client.Client.get_all`.
 
     Args:
         references (List[.DocumentReference, ...]): Iterable of document
@@ -461,7 +461,7 @@ def _get_reference(document_path, reference_map):
     """Get a document reference from a dictionary.
 
     This just wraps a simple dictionary look-up with a helpful error that is
-    specific to :meth:`~.firestore.client.Client.get_all`, the
+    specific to :meth:`~google.cloud.firestore.client.Client.get_all`, the
     **public** caller of this function.
 
     Args:

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -40,7 +40,7 @@ from google.cloud.firestore_v1.transaction import Transaction
 
 
 DEFAULT_DATABASE = "(default)"
-"""str: The default database used in a :class:`~google.cloud.firestore.client.Client`."""
+"""str: The default database used in a :class:`~google.cloud.firestore_v1.client.Client`."""
 _BAD_OPTION_ERR = (
     "Exactly one of ``last_update_time`` or ``exists`` " "must be provided."
 )
@@ -108,8 +108,8 @@ class Client(ClientWithProject):
         """Lazy-loading getter GAPIC Firestore API.
 
         Returns:
-            ~.gapic.firestore.v1.firestore_client.FirestoreClient: The
-            GAPIC client with the credentials of the current client.
+            :class:`~google.cloud.gapic.firestore.v1`.firestore_client.FirestoreClient:
+            <The GAPIC client with the credentials of the current client.
         """
         if self._firestore_api_internal is None:
             self._firestore_api_internal = firestore_client.FirestoreClient(
@@ -185,8 +185,8 @@ class Client(ClientWithProject):
                 * A tuple of collection path segments
 
         Returns:
-            ~.firestore_v1.collection.CollectionReference: A reference
-            to a collection in the Firestore database.
+            :class:`~google.cloud.firestore_v1.collection.CollectionReference`:
+            A reference to a collection in the Firestore database.
         """
         if len(collection_path) == 1:
             path = collection_path[0].split(_helpers.DOCUMENT_PATH_DELIMITER)
@@ -248,8 +248,8 @@ class Client(ClientWithProject):
                 * A tuple of document path segments
 
         Returns:
-            ~.firestore_v1.document.DocumentReference: A reference
-            to a document in a collection.
+            :class:`~google.cloud.firestore_v1.document.DocumentReference`:
+            A reference to a document in a collection.
         """
         if len(document_path) == 1:
             path = document_path[0].split(_helpers.DOCUMENT_PATH_DELIMITER)
@@ -326,6 +326,10 @@ class Client(ClientWithProject):
         Raises:
             TypeError: If anything other than exactly one argument is
                 provided by the caller.
+
+        Returns:
+            :class:`~google.cloud.firestore_v1.client.WriteOption`:
+            The option to be used to configure a write message.
         """
         if len(kwargs) != 1:
             raise TypeError(_BAD_OPTION_ERR)
@@ -366,9 +370,9 @@ class Client(ClientWithProject):
                 paths (``.``-delimited list of field names) to use as a
                 projection of document fields in the returned results. If
                 no value is provided, all fields will be returned.
-            transaction (Optional[~.firestore_v1.transaction.\
-                Transaction]): An existing transaction that these
-                ``references`` will be retrieved in.
+            transaction (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
+                An existing transaction that these ``references`` will be
+                retrieved in.
 
         Yields:
             .DocumentSnapshot: The next document snapshot that fulfills the
@@ -391,7 +395,7 @@ class Client(ClientWithProject):
         """List top-level collections of the client's database.
 
         Returns:
-            Sequence[~.firestore_v1.collection.CollectionReference]:
+            Sequence[:class:`~google.cloud.firestore_v1.collection.CollectionReference`]:
                 iterator of subcollections of the current document.
         """
         iterator = self._firestore_api.list_collection_ids(
@@ -405,9 +409,9 @@ class Client(ClientWithProject):
         """Get a batch instance from this client.
 
         Returns:
-            ~.firestore_v1.batch.WriteBatch: A "write" batch to be
-            used for accumulating document changes and sending the changes
-            all at once.
+            :class:`~google.cloud.firestore_v1.batch.WriteBatch`:
+            A "write" batch to be used for accumulating document changes and
+            sending the changes all at once.
         """
         return WriteBatch(self)
 
@@ -424,8 +428,8 @@ class Client(ClientWithProject):
                 constructor.
 
         Returns:
-            ~.firestore_v1.transaction.Transaction: A transaction
-            attached to this client.
+            :class:`~google.cloud.firestore_v1.transaction.Transaction`:
+            A transaction attached to this client.
         """
         return Transaction(self, **kwargs)
 
@@ -493,8 +497,8 @@ def _parse_batch_get(get_doc_response, reference_map, client):
         reference_map (Dict[str, .DocumentReference]): A mapping (produced
             by :func:`_reference_info`) of fully-qualified document paths to
             document references.
-        client (~.firestore_v1.client.Client): A client that has
-            a document factory.
+        client (:class:`~google.cloud.firestore_v1.client.Client`):
+            A client that has a document factory.
 
     Returns:
        [.DocumentSnapshot]: The retrieved snapshot.

--- a/firestore/google/cloud/firestore_v1/collection.py
+++ b/firestore/google/cloud/firestore_v1/collection.py
@@ -40,7 +40,7 @@ class CollectionReference(object):
             that contain a sub-collection.
         kwargs (dict): The keyword arguments for the constructor. The only
             supported keyword is ``client`` and it must be a
-            :class:`~.firestore_v1.client.Client` if provided. It
+            :class:`~google.cloud.firestore_v1.client.Client` if provided. It
             represents the client that created this collection reference.
 
     Raises:
@@ -210,7 +210,7 @@ class CollectionReference(object):
         """Create a "select" query with this collection as parent.
 
         See
-        :meth:`~.firestore_v1.query.Query.select` for
+        :meth:`~google.cloud.firestore_v1.query.Query.select` for
         more information on this method.
 
         Args:
@@ -228,7 +228,7 @@ class CollectionReference(object):
         """Create a "where" query with this collection as parent.
 
         See
-        :meth:`~.firestore_v1.query.Query.where` for
+        :meth:`~google.cloud.firestore_v1.query.Query.where` for
         more information on this method.
 
         Args:
@@ -251,7 +251,7 @@ class CollectionReference(object):
         """Create an "order by" query with this collection as parent.
 
         See
-        :meth:`~.firestore_v1.query.Query.order_by` for
+        :meth:`~google.cloud.firestore_v1.query.Query.order_by` for
         more information on this method.
 
         Args:
@@ -259,8 +259,8 @@ class CollectionReference(object):
                 field names) on which to order the query results.
             kwargs (Dict[str, Any]): The keyword arguments to pass along
                 to the query. The only supported keyword is ``direction``,
-                see :meth:`~.firestore_v1.query.Query.order_by` for
-                more information.
+                see :meth:`~google.cloud.firestore_v1.query.Query.order_by`
+                for more information.
 
         Returns:
             ~.firestore_v1.query.Query: An "order by" query.
@@ -272,7 +272,7 @@ class CollectionReference(object):
         """Create a limited query with this collection as parent.
 
         See
-        :meth:`~.firestore_v1.query.Query.limit` for
+        :meth:`~google.cloud.firestore_v1.query.Query.limit` for
         more information on this method.
 
         Args:
@@ -289,7 +289,7 @@ class CollectionReference(object):
         """Skip to an offset in a query with this collection as parent.
 
         See
-        :meth:`~.firestore_v1.query.Query.offset` for
+        :meth:`~google.cloud.firestore_v1.query.Query.offset` for
         more information on this method.
 
         Args:
@@ -306,7 +306,7 @@ class CollectionReference(object):
         """Start query at a cursor with this collection as parent.
 
         See
-        :meth:`~.firestore_v1.query.Query.start_at` for
+        :meth:`~google.cloud.firestore_v1.query.Query.start_at` for
         more information on this method.
 
         Args:
@@ -326,7 +326,7 @@ class CollectionReference(object):
         """Start query after a cursor with this collection as parent.
 
         See
-        :meth:`~.firestore_v1.query.Query.start_after` for
+        :meth:`~google.cloud.firestore_v1.query.Query.start_after` for
         more information on this method.
 
         Args:
@@ -346,7 +346,7 @@ class CollectionReference(object):
         """End query before a cursor with this collection as parent.
 
         See
-        :meth:`~.firestore_v1.query.Query.end_before` for
+        :meth:`~google.cloud.firestore_v1.query.Query.end_before` for
         more information on this method.
 
         Args:
@@ -366,7 +366,7 @@ class CollectionReference(object):
         """End query at a cursor with this collection as parent.
 
         See
-        :meth:`~.firestore_v1.query.Query.end_at` for
+        :meth:`~google.cloud.firestore_v1.query.Query.end_at` for
         more information on this method.
 
         Args:

--- a/firestore/google/cloud/firestore_v1/collection.py
+++ b/firestore/google/cloud/firestore_v1/collection.py
@@ -81,8 +81,8 @@ class CollectionReference(object):
         """Document that owns the current collection.
 
         Returns:
-            Optional[~.firestore_v1.document.DocumentReference]: The
-            parent document, if the current collection is not a
+            Optional[:class:`~google.cloud.firestore_v1.document.DocumentReference`]:
+            The parent document, if the current collection is not a
             top-level collection.
         """
         if len(self._path) == 1:
@@ -101,8 +101,8 @@ class CollectionReference(object):
                 uppercase and lowercase and letters.
 
         Returns:
-            ~.firestore_v1.document.DocumentReference: The child
-            document.
+            :class:`~google.cloud.firestore_v1.document.DocumentReference`:
+            The child document.
         """
         if document_id is None:
             document_id = _auto_id()
@@ -145,12 +145,12 @@ class CollectionReference(object):
                 uppercase and lowercase letters).
 
         Returns:
-            Tuple[google.protobuf.timestamp_pb2.Timestamp, \
-                ~.firestore_v1.document.DocumentReference]: Pair of
+            Tuple[:class:`google.protobuf.timestamp_pb2.Timestamp`, \
+                :class:`~google.cloud.firestore_v1.document.DocumentReference`]:
+                Pair of
 
-            * The ``update_time`` when the document was created (or
-              overwritten).
-            * A document reference for the created document.
+                * The ``update_time`` when the document was created/overwritten.
+                * A document reference for the created document.
 
         Raises:
             ~google.cloud.exceptions.Conflict: If ``document_id`` is provided
@@ -188,7 +188,7 @@ class CollectionReference(object):
             are ignored. Defaults to a sensible value set by the API.
 
         Returns:
-            Sequence[~.firestore_v1.collection.DocumentReference]:
+            Sequence[:class:`~google.cloud.firestore_v1.collection.DocumentReference`]:
                 iterator of subdocuments of the current collection. If the
                 collection does not exist at the time of `snapshot`, the
                 iterator will be empty
@@ -219,7 +219,8 @@ class CollectionReference(object):
                 of document fields in the query results.
 
         Returns:
-            ~.firestore_v1.query.Query: A "projected" query.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A "projected" query.
         """
         query = query_mod.Query(self)
         return query.select(field_paths)
@@ -242,7 +243,8 @@ class CollectionReference(object):
                 allowed operation.
 
         Returns:
-            ~.firestore_v1.query.Query: A filtered query.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A filtered query.
         """
         query = query_mod.Query(self)
         return query.where(field_path, op_string, value)
@@ -263,7 +265,8 @@ class CollectionReference(object):
                 for more information.
 
         Returns:
-            ~.firestore_v1.query.Query: An "order by" query.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            An "order by" query.
         """
         query = query_mod.Query(self)
         return query.order_by(field_path, **kwargs)
@@ -280,7 +283,8 @@ class CollectionReference(object):
                 the query.
 
         Returns:
-            ~.firestore_v1.query.Query: A limited query.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A limited query.
         """
         query = query_mod.Query(self)
         return query.limit(count)
@@ -297,7 +301,8 @@ class CollectionReference(object):
                 of query results. (Must be non-negative.)
 
         Returns:
-            ~.firestore_v1.query.Query: An offset query.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            An offset query.
         """
         query = query_mod.Query(self)
         return query.offset(num_to_skip)
@@ -310,14 +315,15 @@ class CollectionReference(object):
         more information on this method.
 
         Args:
-            document_fields (Union[~.firestore_v1.\
-                document.DocumentSnapshot, dict, list, tuple]): a document
-                snapshot or a dictionary/list/tuple of fields representing a
-                query results cursor. A cursor is a collection of values that
-                represent a position in a query result set.
+            document_fields (Union[:class:`~google.cloud.firestore_v1.\
+                document.DocumentSnapshot`, dict, list, tuple]):
+                A document snapshot or a dictionary/list/tuple of fields
+                representing a query results cursor. A cursor is a collection
+                of values that represent a position in a query result set.
 
         Returns:
-            ~.firestore_v1.query.Query: A query with cursor.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A query with cursor.
         """
         query = query_mod.Query(self)
         return query.start_at(document_fields)
@@ -330,14 +336,15 @@ class CollectionReference(object):
         more information on this method.
 
         Args:
-            document_fields (Union[~.firestore_v1.\
-                document.DocumentSnapshot, dict, list, tuple]): a document
-                snapshot or a dictionary/list/tuple of fields representing a
-                query results cursor. A cursor is a collection of values that
-                represent a position in a query result set.
+            document_fields (Union[:class:`~google.cloud.firestore_v1.\
+                document.DocumentSnapshot`, dict, list, tuple]):
+                A document snapshot or a dictionary/list/tuple of fields
+                representing a query results cursor. A cursor is a collection
+                of values that represent a position in a query result set.
 
         Returns:
-            ~.firestore_v1.query.Query: A query with cursor.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A query with cursor.
         """
         query = query_mod.Query(self)
         return query.start_after(document_fields)
@@ -350,14 +357,15 @@ class CollectionReference(object):
         more information on this method.
 
         Args:
-            document_fields (Union[~.firestore_v1.\
-                document.DocumentSnapshot, dict, list, tuple]): a document
-                snapshot or a dictionary/list/tuple of fields representing a
-                query results cursor. A cursor is a collection of values that
-                represent a position in a query result set.
+            document_fields (Union[:class:`~google.cloud.firestore_v1.\
+                document.DocumentSnapshot`, dict, list, tuple]):
+                A document snapshot or a dictionary/list/tuple of fields
+                representing a query results cursor. A cursor is a collection
+                of values that represent a position in a query result set.
 
         Returns:
-            ~.firestore_v1.query.Query: A query with cursor.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A query with cursor.
         """
         query = query_mod.Query(self)
         return query.end_before(document_fields)
@@ -370,14 +378,15 @@ class CollectionReference(object):
         more information on this method.
 
         Args:
-            document_fields (Union[~.firestore_v1.\
-                document.DocumentSnapshot, dict, list, tuple]): a document
-                snapshot or a dictionary/list/tuple of fields representing a
-                query results cursor. A cursor is a collection of values that
-                represent a position in a query result set.
+            document_fields (Union[:class:`~google.cloud.firestore_v1.\
+                document.DocumentSnapshot`, dict, list, tuple]):
+                A document snapshot or a dictionary/list/tuple of fields
+                representing a query results cursor. A cursor is a collection
+                of values that represent a position in a query result set.
 
         Returns:
-            ~.firestore_v1.query.Query: A query with cursor.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A query with cursor.
         """
         query = query_mod.Query(self)
         return query.end_at(document_fields)
@@ -410,13 +419,13 @@ class CollectionReference(object):
         allowed).
 
         Args:
-            transaction (Optional[~.firestore_v1.transaction.\
-                Transaction]): An existing transaction that the query will
-                run in.
+            transaction (Optional[:class:`~google.cloud.firestore_v1.transaction.\
+                Transaction`]):
+                An existing transaction that the query will run in.
 
         Yields:
-            ~.firestore_v1.document.DocumentSnapshot: The next
-            document that fulfills the query.
+            :class:`~google.cloud.firestore_v1.document.DocumentSnapshot`:
+            The next document that fulfills the query.
         """
         query = query_mod.Query(self)
         return query.stream(transaction=transaction)
@@ -428,8 +437,8 @@ class CollectionReference(object):
         provided callback is run on the snapshot of the documents.
 
         Args:
-            callback(~.firestore.collection.CollectionSnapshot): a callback
-                to run when a change occurs.
+            callback (Callable[[:class:`~google.cloud.firestore.collection.CollectionSnapshot`], NoneType]):
+                a callback to run when a change occurs.
 
         Example:
             from google.cloud import firestore_v1

--- a/firestore/google/cloud/firestore_v1/document.py
+++ b/firestore/google/cloud/firestore_v1/document.py
@@ -37,7 +37,7 @@ class DocumentReference(object):
             that contain a sub-collection (as well as the base document).
         kwargs (dict): The keyword arguments for the constructor. The only
             supported keyword is ``client`` and it must be a
-            :class:`~.firestore_v1.client.Client`. It represents
+            :class:`~google.cloud.firestore_v1.client.Client`. It represents
             the client that created this document reference.
 
     Raises:
@@ -242,7 +242,7 @@ class DocumentReference(object):
 
         Each key in ``field_updates`` can either be a field name or a
         **field path** (For more information on **field paths**, see
-        :meth:`~.firestore_v1.client.Client.field_path`.) To
+        :meth:`~google.cloud.firestore_v1.client.Client.field_path`.) To
         illustrate this, consider a document with
 
         .. code-block:: python
@@ -312,8 +312,8 @@ class DocumentReference(object):
            ``field_updates``.
 
         To delete / remove a field from an existing document, use the
-        :attr:`~.firestore_v1.transforms.DELETE_FIELD` sentinel. So
-        with the example above, sending
+        :attr:`~google.cloud.firestore_v1.transforms.DELETE_FIELD` sentinel.
+        So with the example above, sending
 
         .. code-block:: python
 
@@ -336,7 +336,8 @@ class DocumentReference(object):
 
         To set a field to the current time on the server when the
         update is received, use the
-        :attr:`~.firestore_v1.transforms.SERVER_TIMESTAMP` sentinel.
+        :attr:`~google.cloud.firestore_v1.transforms.SERVER_TIMESTAMP`
+        sentinel.
         Sending
 
         .. code-block:: python
@@ -408,7 +409,7 @@ class DocumentReference(object):
     def get(self, field_paths=None, transaction=None):
         """Retrieve a snapshot of the current document.
 
-        See :meth:`~.firestore_v1.client.Client.field_path` for
+        See :meth:`~google.cloud.firestore_v1.client.Client.field_path` for
         more information on **field paths**.
 
         If a ``transaction`` is used and it already has write operations
@@ -531,7 +532,7 @@ class DocumentSnapshot(object):
 
     Instances of this class are not intended to be constructed by hand,
     rather they'll be returned as responses to various methods, such as
-    :meth:`~.DocumentReference.get`.
+    :meth:`~google.cloud.DocumentReference.get`.
 
     Args:
         reference (~.firestore_v1.document.DocumentReference): A
@@ -652,7 +653,7 @@ class DocumentSnapshot(object):
            >>> snapshot.get('top1.middle2.bottom3')
            20
 
-        See :meth:`~.firestore_v1.client.Client.field_path` for
+        See :meth:`~google.cloud.firestore_v1.client.Client.field_path` for
         more information on **field paths**.
 
         A copy is returned since the data may contain mutable values,

--- a/firestore/google/cloud/firestore_v1/document.py
+++ b/firestore/google/cloud/firestore_v1/document.py
@@ -162,8 +162,8 @@ class DocumentReference(object):
         """Collection that owns the current document.
 
         Returns:
-            ~.firestore_v1.collection.CollectionReference: The
-            parent collection.
+            :class:`~google.cloud.firestore_v1.collection.CollectionReference`:
+            The parent collection.
         """
         parent_path = self._path[:-1]
         return self._client.collection(*parent_path)
@@ -176,8 +176,8 @@ class DocumentReference(object):
                 referred to as the "kind").
 
         Returns:
-            ~.firestore_v1.collection.CollectionReference: The
-            child collection.
+            :class:`~google.cloud.firestore_v1.collection.CollectionReference`:
+            The child collection.
         """
         child_path = self._path + (collection_id,)
         return self._client.collection(*child_path)
@@ -190,12 +190,13 @@ class DocumentReference(object):
                 creating a document.
 
         Returns:
-            google.cloud.firestore_v1.types.WriteResult: The
-            write result corresponding to the committed document. A write
-            result contains an ``update_time`` field.
+            :class:`~google.cloud.firestore_v1.types.WriteResult`:
+                The write result corresponding to the committed document.
+                A write result contains an ``update_time`` field.
 
         Raises:
-            ~google.cloud.exceptions.Conflict: If the document already exists.
+            :class:`~google.cloud.exceptions.Conflict`:
+                If the document already exists.
         """
         batch = self._client.batch()
         batch.create(self, document_data)
@@ -224,8 +225,8 @@ class DocumentReference(object):
                 of the document.
 
         Returns:
-            google.cloud.firestore_v1.types.WriteResult: The
-            write result corresponding to the committed document. A write
+            :class:`~google.cloud.firestore_v1.types.WriteResult`:
+            The write result corresponding to the committed document. A write
             result contains an ``update_time`` field.
         """
         batch = self._client.batch()
@@ -364,13 +365,13 @@ class DocumentReference(object):
         Args:
             field_updates (dict): Field names or paths to update and values
                 to update with.
-            option (Optional[~.firestore_v1.client.WriteOption]): A
-               write option to make assertions / preconditions on the server
-               state of the document before applying changes.
+            option (Optional[:class:`~google.cloud.firestore_v1.client.WriteOption`]):
+                A write option to make assertions / preconditions on the server
+                state of the document before applying changes.
 
         Returns:
-            google.cloud.firestore_v1.types.WriteResult: The
-            write result corresponding to the updated document. A write
+            :class:`~google.cloud.firestore_v1.types.WriteResult`:
+            The write result corresponding to the updated document. A write
             result contains an ``update_time`` field.
 
         Raises:
@@ -385,16 +386,16 @@ class DocumentReference(object):
         """Delete the current document in the Firestore database.
 
         Args:
-            option (Optional[~.firestore_v1.client.WriteOption]): A
-               write option to make assertions / preconditions on the server
-               state of the document before applying changes.
+            option (Optional[:class:`~google.cloud.firestore_v1.client.WriteOption`]):
+                A write option to make assertions / preconditions on the server
+                state of the document before applying changes.
 
         Returns:
-            google.protobuf.timestamp_pb2.Timestamp: The time that the delete
-            request was received by the server. If the document did not exist
-            when the delete was sent (i.e. nothing was deleted), this method
-            will still succeed and will still return the time that the
-            request was received by the server.
+            :class:`google.protobuf.timestamp_pb2.Timestamp`:
+            The time that the delete request was received by the server.
+            If the document did not exist when the delete was sent (i.e.
+            nothing was deleted), this method will still succeed and will
+            still return the time that the request was received by the server.
         """
         write_pb = _helpers.pb_for_delete(self._document_path, option)
         commit_response = self._client._firestore_api.commit(
@@ -421,16 +422,17 @@ class DocumentReference(object):
                 paths (``.``-delimited list of field names) to use as a
                 projection of document fields in the returned results. If
                 no value is provided, all fields will be returned.
-            transaction (Optional[~.firestore_v1.transaction.\
-                Transaction]): An existing transaction that this reference
+            transaction (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
+                An existing transaction that this reference
                 will be retrieved in.
 
         Returns:
-            ~.firestore_v1.document.DocumentSnapshot: A snapshot of
-                the current document. If the document does not exist at
-                the time of `snapshot`, the snapshot `reference`, `data`,
-                `update_time`, and `create_time` attributes will all be
-                `None` and `exists` will be `False`.
+            :class:`~google.cloud.firestore_v1.document.DocumentSnapshot`:
+                A snapshot of the current document. If the document does not
+                exist at the time of the snapshot is taken, the snapshot's
+                :attr:`reference`, :attr:`data`, :attr:`update_time`, and
+                :attr:`create_time` attributes will all be ``None`` and
+                its :attr:`exists` attribute will be ``False``.
         """
         if isinstance(field_paths, six.string_types):
             raise ValueError("'field_paths' must be a sequence of paths, not a string.")
@@ -477,7 +479,7 @@ class DocumentReference(object):
             are ignored. Defaults to a sensible value set by the API.
 
         Returns:
-            Sequence[~.firestore_v1.collection.CollectionReference]:
+            Sequence[:class:`~google.cloud.firestore_v1.collection.CollectionReference`]:
                 iterator of subcollections of the current document. If the
                 document does not exist at the time of `snapshot`, the
                 iterator will be empty
@@ -498,10 +500,13 @@ class DocumentReference(object):
         provided callback is run on the snapshot.
 
         Args:
-            callback(~.firestore.document.DocumentSnapshot):a callback to run
-                when a change occurs
+            callback(Callable[[:class:`~google.cloud.firestore.document.DocumentSnapshot`], NoneType]):
+                a callback to run when a change occurs
 
         Example:
+
+        .. code-block:: python
+
             from google.cloud import firestore_v1
 
             db = firestore_v1.Client()
@@ -535,18 +540,20 @@ class DocumentSnapshot(object):
     :meth:`~google.cloud.DocumentReference.get`.
 
     Args:
-        reference (~.firestore_v1.document.DocumentReference): A
-            document reference corresponding to the document that contains
+        reference (:class:`~google.cloud.firestore_v1.document.DocumentReference`):
+            A document reference corresponding to the document that contains
             the data in this snapshot.
-        data (Dict[str, Any]): The data retrieved in the snapshot.
-        exists (bool): Indicates if the document existed at the time the
-            snapshot was retrieved.
-        read_time (google.protobuf.timestamp_pb2.Timestamp): The time that
-            this snapshot was read from the server.
-        create_time (google.protobuf.timestamp_pb2.Timestamp): The time that
-            this document was created.
-        update_time (google.protobuf.timestamp_pb2.Timestamp): The time that
-            this document was last updated.
+        data (Dict[str, Any]):
+            The data retrieved in the snapshot.
+        exists (bool):
+            Indicates if the document existed at the time the snapshot was
+            retrieved.
+        read_time (:class:`google.protobuf.timestamp_pb2.Timestamp`):
+            The time that this snapshot was read from the server.
+        create_time (:class:`google.protobuf.timestamp_pb2.Timestamp`):
+            The time that this document was created.
+        update_time (:class:`google.protobuf.timestamp_pb2.Timestamp`):
+            The time that this document was last updated.
     """
 
     def __init__(self, reference, data, exists, read_time, create_time, update_time):
@@ -556,11 +563,8 @@ class DocumentSnapshot(object):
         self._data = copy.deepcopy(data)
         self._exists = exists
         self.read_time = read_time
-        """google.protobuf.timestamp_pb2.Timestamp: Time snapshot was read."""
         self.create_time = create_time
-        """google.protobuf.timestamp_pb2.Timestamp: Document's creation."""
         self.update_time = update_time
-        """google.protobuf.timestamp_pb2.Timestamp: Document's last update."""
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
@@ -577,8 +581,8 @@ class DocumentSnapshot(object):
         """The client that owns the document reference for this snapshot.
 
         Returns:
-            ~.firestore_v1.client.Client: The client that owns this
-            document.
+            :class:`~google.cloud.firestore_v1.client.Client`:
+            The client that owns this document.
         """
         return self._reference._client
 
@@ -608,8 +612,8 @@ class DocumentSnapshot(object):
         """Document reference corresponding to document that owns this data.
 
         Returns:
-            ~.firestore_v1.document.DocumentReference: A document
-            reference corresponding to this document.
+            :class:`~google.cloud.firestore_v1.document.DocumentReference`:
+            A document reference corresponding to this document.
         """
         return self._reference
 
@@ -702,8 +706,9 @@ def _get_document_path(client, path):
               documents/{document_path}``
 
     Args:
-        client (~.firestore_v1.client.Client): The client that holds
-            configuration details and a GAPIC client object.
+        client (:class:`~google.cloud.firestore_v1.client.Client`):
+            The client that holds configuration details and a GAPIC client
+            object.
         path (Tuple[str, ...]): The components in a document path.
 
     Returns:

--- a/firestore/google/cloud/firestore_v1/field_path.py
+++ b/firestore/google/cloud/firestore_v1/field_path.py
@@ -216,7 +216,7 @@ def get_nested_value(field_path, data):
        >>> get_nested_value('top1.middle2.bottom3', data)
        20
 
-    See :meth:`~.firestore_v1.client.Client.field_path` for
+    See :meth:`~google.cloud.firestore_v1.client.Client.field_path` for
     more information on **field paths**.
 
     Args:

--- a/firestore/google/cloud/firestore_v1/query.py
+++ b/firestore/google/cloud/firestore_v1/query.py
@@ -71,21 +71,23 @@ class Query(object):
     would modify an instance instead return a new instance.
 
     Args:
-        parent (~.firestore_v1.collection.Collection): The collection
-            that this query applies to.
-        projection (Optional[google.cloud.proto.firestore.v1.\
-            query_pb2.StructuredQuery.Projection]): A projection of document
-            fields to limit the query results to.
-        field_filters (Optional[Tuple[google.cloud.proto.firestore.v1.\
-            query_pb2.StructuredQuery.FieldFilter, ...]]): The filters to be
-            applied in the query.
-        orders (Optional[Tuple[google.cloud.proto.firestore.v1.\
-            query_pb2.StructuredQuery.Order, ...]]): The "order by" entries
-            to use in the query.
-        limit (Optional[int]): The maximum number of documents the
-            query is allowed to return.
-        offset (Optional[int]): The number of results to skip.
-        start_at (Optional[Tuple[dict, bool]]): Two-tuple of
+        parent (:class:`~google.cloud.firestore_v1.collection.CollectionReference`):
+            The collection that this query applies to.
+        projection (Optional[:class:`google.cloud.proto.firestore.v1.\
+            query_pb2.StructuredQuery.Projection`]):
+            A projection of document fields to limit the query results to.
+        field_filters (Optional[Tuple[:class:`google.cloud.proto.firestore.v1.\
+            query_pb2.StructuredQuery.FieldFilter`, ...]]):
+            The filters to be applied in the query.
+        orders (Optional[Tuple[:class:`google.cloud.proto.firestore.v1.\
+            query_pb2.StructuredQuery.Order`, ...]]):
+            The "order by" entries to use in the query.
+        limit (Optional[int]):
+            The maximum number of documents the query is allowed to return.
+        offset (Optional[int]):
+            The number of results to skip.
+        start_at (Optional[Tuple[dict, bool]]):
+            Two-tuple of :
 
             * a mapping of fields. Any field that is present in this mapping
               must also be present in ``orders``
@@ -98,7 +100,8 @@ class Query(object):
             any matching documents will be included in the result set.
             When the query is formed, the document values
             will be used in the order given by ``orders``.
-        end_at (Optional[Tuple[dict, bool]]): Two-tuple of
+        end_at (Optional[Tuple[dict, bool]]):
+            Two-tuple of:
 
             * a mapping of fields. Any field that is present in this mapping
               must also be present in ``orders``
@@ -111,10 +114,10 @@ class Query(object):
             any matching documents will be included in the result set.
             When the query is formed, the document values
             will be used in the order given by ``orders``.
-        all_descendants (Optional[bool]): When false, selects only collections
-            that are immediate children of the `parent` specified in the
-            containing `RunQueryRequest`. When true, selects all descendant
-            collections.
+        all_descendants (Optional[bool]):
+            When false, selects only collections that are immediate children
+            of the `parent` specified in the containing `RunQueryRequest`.
+            When true, selects all descendant collections.
     """
 
     ASCENDING = "ASCENDING"
@@ -164,8 +167,8 @@ class Query(object):
         """The client of the parent collection.
 
         Returns:
-            ~.firestore_v1.client.Client: The client that owns
-            this query.
+            :class:`~google.cloud.firestore_v1.client.Client`:
+            The client that owns this query.
         """
         return self._parent._client
 
@@ -185,9 +188,9 @@ class Query(object):
                 of document fields in the query results.
 
         Returns:
-            ~.firestore_v1.query.Query: A "projected" query. Acts as
-            a copy of the current query, modified with the newly added
-            projection.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A "projected" query. Acts as a copy of the current query,
+            modified with the newly added projection.
         Raises:
             ValueError: If any ``field_path`` is invalid.
         """
@@ -235,8 +238,9 @@ class Query(object):
                 allowed operation.
 
         Returns:
-            ~.firestore_v1.query.Query: A filtered query. Acts as a
-            copy of the current query, modified with the newly added filter.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A filtered query. Acts as a copy of the current query,
+            modified with the newly added filter.
 
         Raises:
             ValueError: If ``field_path`` is invalid.
@@ -307,9 +311,9 @@ class Query(object):
                 :attr:`ASCENDING`.
 
         Returns:
-            ~.firestore_v1.query.Query: An ordered query. Acts as a
-            copy of the current query, modified with the newly added
-            "order by" constraint.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            An ordered query. Acts as a copy of the current query, modified
+            with the newly added "order by" constraint.
 
         Raises:
             ValueError: If ``field_path`` is invalid.
@@ -343,9 +347,9 @@ class Query(object):
                 the query.
 
         Returns:
-            ~.firestore_v1.query.Query: A limited query. Acts as a
-            copy of the current query, modified with the newly added
-            "limit" filter.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A limited query. Acts as a copy of the current query, modified
+            with the newly added "limit" filter.
         """
         return self.__class__(
             self._parent,
@@ -370,9 +374,9 @@ class Query(object):
                 of query results. (Must be non-negative.)
 
         Returns:
-            ~.firestore_v1.query.Query: An offset query. Acts as a
-            copy of the current query, modified with the newly added
-            "offset" field.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            An offset query. Acts as a copy of the current query, modified
+            with the newly added "offset" field.
         """
         return self.__class__(
             self._parent,
@@ -396,11 +400,11 @@ class Query(object):
         :meth:`~google.cloud.firestore_v1.query.Query.order_by`.
 
         Args:
-            document_fields (Union[~.firestore_v1.\
-                document.DocumentSnapshot, dict, list, tuple]): a document
-                snapshot or a dictionary/list/tuple of fields representing a
-                query results cursor. A cursor is a collection of values that
-                represent a position in a query result set.
+            document_fields
+                (Union[:class:`~google.cloud.firestore_v1.document.DocumentSnapshot`, dict, list, tuple]):
+                a document snapshot or a dictionary/list/tuple of fields
+                representing a query results cursor. A cursor is a collection
+                of values that represent a position in a query result set.
             before (bool): Flag indicating if the document in
                 ``document_fields`` should (:data:`False`) or
                 shouldn't (:data:`True`) be included in the result set.
@@ -408,9 +412,9 @@ class Query(object):
                 cursor (:data:`True`) or an ``end_at`` cursor (:data:`False`).
 
         Returns:
-            ~.firestore_v1.query.Query: A query with cursor. Acts as
-            a copy of the current query, modified with the newly added
-            "start at" cursor.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A query with cursor. Acts as a copy of the current query, modified
+            with the newly added "start at" cursor.
         """
         if isinstance(document_fields, tuple):
             document_fields = list(document_fields)
@@ -457,14 +461,15 @@ class Query(object):
         :meth:`~google.cloud.firestore_v1.query.Query.order_by`.
 
         Args:
-            document_fields (Union[~.firestore_v1.\
-                document.DocumentSnapshot, dict, list, tuple]): a document
-                snapshot or a dictionary/list/tuple of fields representing a
-                query results cursor. A cursor is a collection of values that
-                represent a position in a query result set.
+            document_fields
+                (Union[:class:`~google.cloud.firestore_v1.document.DocumentSnapshot`, dict, list, tuple]):
+                a document snapshot or a dictionary/list/tuple of fields
+                representing a query results cursor. A cursor is a collection
+                of values that represent a position in a query result set.
 
         Returns:
-            ~.firestore_v1.query.Query: A query with cursor. Acts as
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A query with cursor. Acts as
             a copy of the current query, modified with the newly added
             "start at" cursor.
         """
@@ -486,16 +491,16 @@ class Query(object):
         :meth:`~google.cloud.firestore_v1.query.Query.order_by`.
 
         Args:
-            document_fields (Union[~.firestore_v1.\
-                document.DocumentSnapshot, dict, list, tuple]): a document
-                snapshot or a dictionary/list/tuple of fields representing a
-                query results cursor. A cursor is a collection of values that
-                represent a position in a query result set.
+            document_fields
+                (Union[:class:`~google.cloud.firestore_v1.document.DocumentSnapshot`, dict, list, tuple]):
+                a document snapshot or a dictionary/list/tuple of fields
+                representing a query results cursor. A cursor is a collection
+                of values that represent a position in a query result set.
 
         Returns:
-            ~.firestore_v1.query.Query: A query with cursor. Acts as
-            a copy of the current query, modified with the newly added
-            "start after" cursor.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A query with cursor. Acts as a copy of the current query, modified
+            with the newly added "start after" cursor.
         """
         return self._cursor_helper(document_fields, before=False, start=True)
 
@@ -515,16 +520,16 @@ class Query(object):
         :meth:`~google.cloud.firestore_v1.query.Query.order_by`.
 
         Args:
-            document_fields (Union[~.firestore_v1.\
-                document.DocumentSnapshot, dict, list, tuple]): a document
-                snapshot or a dictionary/list/tuple of fields representing a
-                query results cursor. A cursor is a collection of values that
-                represent a position in a query result set.
+            document_fields
+                (Union[:class:`~google.cloud.firestore_v1.document.DocumentSnapshot`, dict, list, tuple]):
+                a document snapshot or a dictionary/list/tuple of fields
+                representing a query results cursor. A cursor is a collection
+                of values that represent a position in a query result set.
 
         Returns:
-            ~.firestore_v1.query.Query: A query with cursor. Acts as
-            a copy of the current query, modified with the newly added
-            "end before" cursor.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A query with cursor. Acts as a copy of the current query, modified
+            with the newly added "end before" cursor.
         """
         return self._cursor_helper(document_fields, before=True, start=False)
 
@@ -544,16 +549,16 @@ class Query(object):
         :meth:`~google.cloud.firestore_v1.query.Query.order_by`.
 
         Args:
-            document_fields (Union[~.firestore_v1.\
-                document.DocumentSnapshot, dict, list, tuple]): a document
-                snapshot or a dictionary/list/tuple of fields representing a
-                query results cursor. A cursor is a collection of values that
-                represent a position in a query result set.
+            document_fields
+                (Union[:class:`~google.cloud.firestore_v1.document.DocumentSnapshot`, dict, list, tuple]):
+                a document snapshot or a dictionary/list/tuple of fields
+                representing a query results cursor. A cursor is a collection
+                of values that represent a position in a query result set.
 
         Returns:
-            ~.firestore_v1.query.Query: A query with cursor. Acts as
-            a copy of the current query, modified with the newly added
-            "end at" cursor.
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A query with cursor. Acts as a copy of the current query, modified
+            with the newly added "end at" cursor.
         """
         return self._cursor_helper(document_fields, before=False, start=False)
 
@@ -564,9 +569,8 @@ class Query(object):
         filter or may be :data:`None`.
 
         Returns:
-            google.cloud.firestore_v1.types.\
-            StructuredQuery.Filter: A "generic" filter representing the
-            current query's filters.
+            :class:`google.cloud.firestore_v1.types.StructuredQuery.Filter`:
+            A "generic" filter representing the current query's filters.
         """
         num_filters = len(self._field_filters)
         if num_filters == 0:
@@ -680,8 +684,8 @@ class Query(object):
         """Convert the current query into the equivalent protobuf.
 
         Returns:
-            google.cloud.firestore_v1.types.StructuredQuery: The
-            query protobuf.
+            :class:`google.cloud.firestore_v1.types.StructuredQuery`:
+            The query protobuf.
         """
         projection = self._normalize_projection(self._projection)
         orders = self._normalize_orders()
@@ -735,13 +739,13 @@ class Query(object):
         allowed).
 
         Args:
-            transaction (Optional[~.firestore_v1.transaction.\
-                Transaction]): An existing transaction that this query will
-                run in.
+            transaction
+                (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
+                An existing transaction that this query will run in.
 
         Yields:
-            ~.firestore_v1.document.DocumentSnapshot: The next
-            document that fulfills the query.
+            :class:`~google.cloud.firestore_v1.document.DocumentSnapshot`:
+            The next document that fulfills the query.
         """
         parent_path, expected_prefix = self._parent._parent_info()
         response_iterator = self._client._firestore_api.run_query(
@@ -770,10 +774,13 @@ class Query(object):
         provided callback is run on the snapshot of the documents.
 
         Args:
-            callback(~.firestore.query.QuerySnapshot): a callback to run when
-                a change occurs.
+            callback(Callable[[:class:`~google.cloud.firestore.query.QuerySnapshot`], NoneType]):
+                a callback to run when a change occurs.
 
         Example:
+
+        .. code-block:: python
+
             from google.cloud import firestore_v1
 
             db = firestore_v1.Client()
@@ -960,16 +967,16 @@ def _query_response_to_snapshot(response_pb, collection, expected_prefix):
     Args:
         response_pb (google.cloud.proto.firestore.v1.\
             firestore_pb2.RunQueryResponse): A
-        collection (~.firestore_v1.collection.CollectionReference): A
-            reference to the collection that initiated the query.
+        collection (:class:`~google.cloud.firestore_v1.collection.CollectionReference`):
+            A reference to the collection that initiated the query.
         expected_prefix (str): The expected prefix for fully-qualified
             document names returned in the query results. This can be computed
             directly from ``collection`` via :meth:`_parent_info`.
 
     Returns:
-        Optional[~.firestore.document.DocumentSnapshot]: A
-        snapshot of the data returned in the query. If ``response_pb.document``
-        is not set, the snapshot will be :data:`None`.
+        Optional[:class:`~google.cloud.firestore.document.DocumentSnapshot`]:
+        A snapshot of the data returned in the query. If
+        ``response_pb.document`` is not set, the snapshot will be :data:`None`.
     """
     if not response_pb.HasField("document"):
         return None
@@ -994,13 +1001,13 @@ def _collection_group_query_response_to_snapshot(response_pb, collection):
     Args:
         response_pb (google.cloud.proto.firestore.v1.\
             firestore_pb2.RunQueryResponse): A
-        collection (~.firestore_v1.collection.CollectionReference): A
-            reference to the collection that initiated the query.
+        collection (:class:`~google.cloud.firestore_v1.collection.CollectionReference`):
+            A reference to the collection that initiated the query.
 
     Returns:
-        Optional[~.firestore.document.DocumentSnapshot]: A
-        snapshot of the data returned in the query. If ``response_pb.document``
-        is not set, the snapshot will be :data:`None`.
+        Optional[:class:`~google.cloud.firestore.document.DocumentSnapshot`]:
+        A snapshot of the data returned in the query. If
+        ``response_pb.document`` is not set, the snapshot will be :data:`None`.
     """
     if not response_pb.HasField("document"):
         return None

--- a/firestore/google/cloud/firestore_v1/query.py
+++ b/firestore/google/cloud/firestore_v1/query.py
@@ -14,8 +14,8 @@
 
 """Classes for representing queries for the Google Cloud Firestore API.
 
-A :class:`~.firestore_v1.query.Query` can be created directly from
-a :class:`~.firestore_v1.collection.Collection` and that can be
+A :class:`~google.cloud.firestore_v1.query.Query` can be created directly from
+a :class:`~google.cloud.firestore_v1.collection.Collection` and that can be
 a more common way to create a query than direct usage of the constructor.
 """
 import copy
@@ -172,11 +172,11 @@ class Query(object):
     def select(self, field_paths):
         """Project documents matching query to a limited set of fields.
 
-        See :meth:`~.firestore_v1.client.Client.field_path` for
+        See :meth:`~google.cloud.firestore_v1.client.Client.field_path` for
         more information on **field paths**.
 
         If the current query already has a projection set (i.e. has already
-        called :meth:`~.firestore_v1.query.Query.select`), this
+        called :meth:`~google.cloud.firestore_v1.query.Query.select`), this
         will overwrite it.
 
         Args:
@@ -216,10 +216,10 @@ class Query(object):
     def where(self, field_path, op_string, value):
         """Filter the query on a field.
 
-        See :meth:`~.firestore_v1.client.Client.field_path` for
+        See :meth:`~google.cloud.firestore_v1.client.Client.field_path` for
         more information on **field paths**.
 
-        Returns a new :class:`~.firestore_v1.query.Query` that
+        Returns a new :class:`~google.cloud.firestore_v1.query.Query` that
         filters on a specific field path, according to an operation (e.g.
         ``==`` or "equals") and a particular value to be paired with that
         operation.
@@ -292,11 +292,11 @@ class Query(object):
     def order_by(self, field_path, direction=ASCENDING):
         """Modify the query to add an order clause on a specific field.
 
-        See :meth:`~.firestore_v1.client.Client.field_path` for
+        See :meth:`~google.cloud.firestore_v1.client.Client.field_path` for
         more information on **field paths**.
 
-        Successive :meth:`~.firestore_v1.query.Query.order_by` calls
-        will further refine the ordering of results returned by the query
+        Successive :meth:`~google.cloud.firestore_v1.query.Query.order_by`
+        calls will further refine the ordering of results returned by the query
         (i.e. the new "order by" fields will be added to existing ones).
 
         Args:
@@ -393,7 +393,7 @@ class Query(object):
 
         When the query is sent to the server, the ``document_fields`` will
         be used in the order given by fields set by
-        :meth:`~.firestore_v1.query.Query.order_by`.
+        :meth:`~google.cloud.firestore_v1.query.Query.order_by`.
 
         Args:
             document_fields (Union[~.firestore_v1.\
@@ -449,12 +449,12 @@ class Query(object):
 
         If the current query already has specified a start cursor -- either
         via this method or
-        :meth:`~.firestore_v1.query.Query.start_after` -- this will
-        overwrite it.
+        :meth:`~google.cloud.firestore_v1.query.Query.start_after` -- this
+        will overwrite it.
 
         When the query is sent to the server, the ``document_fields`` will
         be used in the order given by fields set by
-        :meth:`~.firestore_v1.query.Query.order_by`.
+        :meth:`~google.cloud.firestore_v1.query.Query.order_by`.
 
         Args:
             document_fields (Union[~.firestore_v1.\
@@ -478,12 +478,12 @@ class Query(object):
 
         If the current query already has specified a start cursor -- either
         via this method or
-        :meth:`~.firestore_v1.query.Query.start_at` -- this will
+        :meth:`~google.cloud.firestore_v1.query.Query.start_at` -- this will
         overwrite it.
 
         When the query is sent to the server, the ``document_fields`` will
         be used in the order given by fields set by
-        :meth:`~.firestore_v1.query.Query.order_by`.
+        :meth:`~google.cloud.firestore_v1.query.Query.order_by`.
 
         Args:
             document_fields (Union[~.firestore_v1.\
@@ -507,12 +507,12 @@ class Query(object):
 
         If the current query already has specified an end cursor -- either
         via this method or
-        :meth:`~.firestore_v1.query.Query.end_at` -- this will
+        :meth:`~google.cloud.firestore_v1.query.Query.end_at` -- this will
         overwrite it.
 
         When the query is sent to the server, the ``document_fields`` will
         be used in the order given by fields set by
-        :meth:`~.firestore_v1.query.Query.order_by`.
+        :meth:`~google.cloud.firestore_v1.query.Query.order_by`.
 
         Args:
             document_fields (Union[~.firestore_v1.\
@@ -536,12 +536,12 @@ class Query(object):
 
         If the current query already has specified an end cursor -- either
         via this method or
-        :meth:`~.firestore_v1.query.Query.end_before` -- this will
+        :meth:`~google.cloud.firestore_v1.query.Query.end_before` -- this will
         overwrite it.
 
         When the query is sent to the server, the ``document_fields`` will
         be used in the order given by fields set by
-        :meth:`~.firestore_v1.query.Query.order_by`.
+        :meth:`~google.cloud.firestore_v1.query.Query.order_by`.
 
         Args:
             document_fields (Union[~.firestore_v1.\
@@ -888,8 +888,8 @@ def _enum_from_direction(direction):
 
     Args:
         direction (str): A direction to order by. Must be one of
-            :attr:`~.firestore.Query.ASCENDING` or
-            :attr:`~.firestore.Query.DESCENDING`.
+            :attr:`~google.cloud.firestore.Query.ASCENDING` or
+            :attr:`~google.cloud.firestore.Query.DESCENDING`.
 
     Returns:
         int: The enum corresponding to ``direction``.

--- a/firestore/google/cloud/firestore_v1/transaction.py
+++ b/firestore/google/cloud/firestore_v1/transaction.py
@@ -46,8 +46,8 @@ class Transaction(batch.WriteBatch):
     """Accumulate read-and-write operations to be sent in a transaction.
 
     Args:
-        client (~.firestore_v1.client.Client): The client that
-            created this transaction.
+        client (:class:`~google.cloud.firestore_v1.client.Client`):
+            The client that created this transaction.
         max_attempts (Optional[int]): The maximum number of attempts for
             the transaction (i.e. allowing retries). Defaults to
             :attr:`~google.cloud.firestore_v1.transaction.MAX_ATTEMPTS`.
@@ -184,11 +184,10 @@ class Transaction(batch.WriteBatch):
         """Transactionally commit the changes accumulated.
 
         Returns:
-            List[google.cloud.proto.firestore.v1.\
-                write_pb2.WriteResult, ...]: The write results corresponding
-            to the changes committed, returned in the same order as the
-            changes were applied to this transaction. A write result contains
-            an ``update_time`` field.
+            List[:class:`google.cloud.proto.firestore.v1.write_pb2.WriteResult`, ...]:
+            The write results corresponding to the changes committed, returned
+            in the same order as the changes were applied to this transaction.
+            A write result contains an ``update_time`` field.
 
         Raises:
             ValueError: If no transaction is in progress.
@@ -209,9 +208,8 @@ class _Transactional(object):
     :func:`~google.cloud.firestore_v1.transaction.transactional`.
 
     Args:
-        to_wrap (Callable[~.firestore_v1.transaction.Transaction, \
-            Any]): A callable that should be run (and retried) in a
-            transaction.
+        to_wrap (Callable[[:class:`~google.cloud.firestore_v1.transaction.Transaction`, ...], Any]):
+            A callable that should be run (and retried) in a transaction.
     """
 
     def __init__(self, to_wrap):
@@ -234,8 +232,9 @@ class _Transactional(object):
         it will have staged writes).
 
         Args:
-            transaction (~.firestore_v1.transaction.Transaction): A
-                transaction to execute the callable within.
+            transaction
+                (:class:`~google.cloud.firestore_v1.transaction.Transaction`):
+                A transaction to execute the callable within.
             args (Tuple[Any, ...]): The extra positional arguments to pass
                 along to the wrapped callable.
             kwargs (Dict[str, Any]): The extra keyword arguments to pass
@@ -271,8 +270,9 @@ class _Transactional(object):
         not be caught.
 
         Args:
-            transaction (~.firestore_v1.transaction.Transaction): The
-                transaction to be ``Commit``-ed.
+            transaction
+                (:class:`~google.cloud.firestore_v1.transaction.Transaction`):
+                The transaction to be ``Commit``-ed.
 
         Returns:
             bool: Indicating if the commit succeeded.
@@ -294,8 +294,9 @@ class _Transactional(object):
         """Execute the wrapped callable within a transaction.
 
         Args:
-            transaction (~.firestore_v1.transaction.Transaction): A
-                transaction to execute the callable within.
+            transaction
+                (:class:`~google.cloud.firestore_v1.transaction.Transaction`):
+                A transaction to execute the callable within.
             args (Tuple[Any, ...]): The extra positional arguments to pass
                 along to the wrapped callable.
             kwargs (Dict[str, Any]): The extra keyword arguments to pass
@@ -331,13 +332,13 @@ def transactional(to_wrap):
     """Decorate a callable so that it runs in a transaction.
 
     Args:
-        to_wrap (Callable[~.firestore_v1.transaction.Transaction, \
-            Any]): A callable that should be run (and retried) in a
-            transaction.
+        to_wrap
+            (Callable[[:class:`~google.cloud.firestore_v1.transaction.Transaction`, ...], Any]):
+            A callable that should be run (and retried) in a transaction.
 
     Returns:
-        Callable[~.firestore_v1.transaction.Transaction, Any]: the
-        wrapped callable.
+        Callable[[:class:`~google.cloud.firestore_v1.transaction.Transaction`, ...], Any]:
+        the wrapped callable.
     """
     return _Transactional(to_wrap)
 
@@ -352,16 +353,15 @@ def _commit_with_retry(client, write_pbs, transaction_id):
     our own retry to special-case the ``INVALID_ARGUMENT`` error.
 
     Args:
-        client (~.firestore_v1.client.Client): A client with
-            GAPIC client and configuration details.
-        write_pbs (List[google.cloud.proto.firestore.v1.\
-            write_pb2.Write, ...]): A ``Write`` protobuf instance to
-            be committed.
-        transaction_id (bytes): ID of an existing transaction that
-            this commit will run in.
+        client (:class:`~google.cloud.firestore_v1.client.Client`):
+            A client with GAPIC client and configuration details.
+        write_pbs (List[:class:`google.cloud.proto.firestore.v1.write_pb2.Write`, ...]):
+            A ``Write`` protobuf instance to be committed.
+        transaction_id (bytes):
+            ID of an existing transaction that this commit will run in.
 
     Returns:
-        google.cloud.firestore_v1.types.CommitResponse:
+        :class:`google.cloud.firestore_v1.types.CommitResponse`:
         The protobuf response from ``Commit``.
 
     Raises:

--- a/firestore/google/cloud/firestore_v1/transaction.py
+++ b/firestore/google/cloud/firestore_v1/transaction.py
@@ -50,7 +50,7 @@ class Transaction(batch.WriteBatch):
             created this transaction.
         max_attempts (Optional[int]): The maximum number of attempts for
             the transaction (i.e. allowing retries). Defaults to
-            :attr:`~.firestore_v1.transaction.MAX_ATTEMPTS`.
+            :attr:`~google.cloud.firestore_v1.transaction.MAX_ATTEMPTS`.
         read_only (Optional[bool]): Flag indicating if the transaction
             should be read-only or should allow writes. Defaults to
             :data:`False`.
@@ -206,7 +206,7 @@ class _Transactional(object):
     """Provide a callable object to use as a transactional decorater.
 
     This is surfaced via
-    :func:`~.firestore_v1.transaction.transactional`.
+    :func:`~google.cloud.firestore_v1.transaction.transactional`.
 
     Args:
         to_wrap (Callable[~.firestore_v1.transaction.Transaction, \

--- a/firestore/google/cloud/firestore_v1beta1/_helpers.py
+++ b/firestore/google/cloud/firestore_v1beta1/_helpers.py
@@ -928,7 +928,7 @@ class LastUpdateOption(WriteOption):
     """Option used to assert a "last update" condition on a write operation.
 
     This will typically be created by
-    :meth:`~.firestore_v1beta1.client.Client.write_option`.
+    :meth:`~google.cloud.firestore_v1beta1.client.Client.write_option`.
 
     Args:
         last_update_time (google.protobuf.timestamp_pb2.Timestamp): A
@@ -968,7 +968,7 @@ class ExistsOption(WriteOption):
     """Option used to assert existence on a write operation.
 
     This will typically be created by
-    :meth:`~.firestore_v1beta1.client.Client.write_option`.
+    :meth:`~google.cloud.firestore_v1beta1.client.Client.write_option`.
 
     Args:
         exists (bool): Indicates if the document being modified

--- a/firestore/google/cloud/firestore_v1beta1/batch.py
+++ b/firestore/google/cloud/firestore_v1beta1/batch.py
@@ -22,8 +22,9 @@ class WriteBatch(object):
     """Accumulate write operations to be sent in a batch.
 
     This has the same set of methods for write operations that
-    :class:`~.firestore_v1beta1.document.DocumentReference` does,
-    e.g. :meth:`~.firestore_v1beta1.document.DocumentReference.create`.
+    :class:`~google.cloud.firestore_v1beta1.document.DocumentReference`
+    does, e.g.
+    :meth:`~google.cloud.firestore_v1beta1.document.DocumentReference.create`.
 
     Args:
         client (~.firestore_v1beta1.client.Client): The client that
@@ -66,8 +67,8 @@ class WriteBatch(object):
         """Add a "change" to replace a document.
 
         See
-        :meth:`~.firestore_v1beta1.document.DocumentReference.set` for
-        more information on how ``option`` determines how the change is
+        :meth:`~google.cloud.firestore_v1beta1.document.DocumentReference.set`
+        for more information on how ``option`` determines how the change is
         applied.
 
         Args:
@@ -94,8 +95,8 @@ class WriteBatch(object):
         """Add a "change" to update a document.
 
         See
-        :meth:`~.firestore_v1beta1.document.DocumentReference.update` for
-        more information on ``field_updates`` and ``option``.
+        :meth:`~google.cloud.firestore_v1beta1.document.DocumentReference.update`
+        for more information on ``field_updates`` and ``option``.
 
         Args:
             reference (~.firestore_v1beta1.document.DocumentReference): A
@@ -117,8 +118,8 @@ class WriteBatch(object):
         """Add a "change" to delete a document.
 
         See
-        :meth:`~.firestore_v1beta1.document.DocumentReference.delete` for
-        more information on how ``option`` determines how the change is
+        :meth:`~google.cloud.firestore_v1beta1.document.DocumentReference.delete`
+        for more information on how ``option`` determines how the change is
         applied.
 
         Args:

--- a/firestore/google/cloud/firestore_v1beta1/client.py
+++ b/firestore/google/cloud/firestore_v1beta1/client.py
@@ -18,10 +18,10 @@ This is the base from which all interactions with the API occur.
 
 In the hierarchy of API concepts
 
-* a :class:`~.firestore_v1beta1.client.Client` owns a
-  :class:`~.firestore_v1beta1.collection.CollectionReference`
-* a :class:`~.firestore_v1beta1.client.Client` owns a
-  :class:`~.firestore_v1beta1.document.DocumentReference`
+* a :class:`~google.cloud.firestore_v1beta1.client.Client` owns a
+  :class:`~google.cloud.firestore_v1beta1.collection.CollectionReference`
+* a :class:`~google.cloud.firestore_v1beta1.client.Client` owns a
+  :class:`~google.cloud.firestore_v1beta1.document.DocumentReference`
 """
 from google.cloud.client import ClientWithProject
 
@@ -37,7 +37,7 @@ from google.cloud.firestore_v1beta1.transaction import Transaction
 
 
 DEFAULT_DATABASE = "(default)"
-"""str: The default database used in a :class:`~.firestore.client.Client`."""
+"""str: The default database used in a :class:`~google.cloud.firestore.client.Client`."""
 _BAD_OPTION_ERR = (
     "Exactly one of ``last_update_time`` or ``exists`` " "must be provided."
 )
@@ -250,9 +250,9 @@ class Client(ClientWithProject):
     def write_option(**kwargs):
         """Create a write option for write operations.
 
-        Write operations include :meth:`~.DocumentReference.set`,
-        :meth:`~.DocumentReference.update` and
-        :meth:`~.DocumentReference.delete`.
+        Write operations include :meth:`~google.cloud.DocumentReference.set`,
+        :meth:`~google.cloud.DocumentReference.update` and
+        :meth:`~google.cloud.DocumentReference.delete`.
 
         One of the following keyword arguments must be provided:
 
@@ -304,8 +304,8 @@ class Client(ClientWithProject):
            If multiple ``references`` refer to the same document, the server
            will only return one result.
 
-        See :meth:`~.firestore_v1beta1.client.Client.field_path` for
-        more information on **field paths**.
+        See :meth:`~google.cloud.firestore_v1beta1.client.Client.field_path`
+        for more information on **field paths**.
 
         If a ``transaction`` is used and it already has write operations
         added, this method cannot be used (i.e. read-after-write is not
@@ -366,13 +366,13 @@ class Client(ClientWithProject):
     def transaction(self, **kwargs):
         """Get a transaction that uses this client.
 
-        See :class:`~.firestore_v1beta1.transaction.Transaction` for
-        more information on transactions and the constructor arguments.
+        See :class:`~google.cloud.firestore_v1beta1.transaction.Transaction`
+        for more information on transactions and the constructor arguments.
 
         Args:
             kwargs (Dict[str, Any]): The keyword arguments (other than
                 ``client``) to pass along to the
-                :class:`~.firestore_v1beta1.transaction.Transaction`
+                :class:`~google.cloud.firestore_v1beta1.transaction.Transaction`
                 constructor.
 
         Returns:
@@ -385,7 +385,7 @@ class Client(ClientWithProject):
 def _reference_info(references):
     """Get information about document references.
 
-    Helper for :meth:`~.firestore_v1beta1.client.Client.get_all`.
+    Helper for :meth:`~google.cloud.firestore_v1beta1.client.Client.get_all`.
 
     Args:
         references (List[.DocumentReference, ...]): Iterable of document
@@ -413,7 +413,7 @@ def _get_reference(document_path, reference_map):
     """Get a document reference from a dictionary.
 
     This just wraps a simple dictionary look-up with a helpful error that is
-    specific to :meth:`~.firestore.client.Client.get_all`, the
+    specific to :meth:`~google.cloud.firestore.client.Client.get_all`, the
     **public** caller of this function.
 
     Args:

--- a/firestore/google/cloud/firestore_v1beta1/collection.py
+++ b/firestore/google/cloud/firestore_v1beta1/collection.py
@@ -40,8 +40,9 @@ class CollectionReference(object):
             that contain a sub-collection.
         kwargs (dict): The keyword arguments for the constructor. The only
             supported keyword is ``client`` and it must be a
-            :class:`~.firestore_v1beta1.client.Client` if provided. It
-            represents the client that created this collection reference.
+            :class:`~google.cloud.firestore_v1beta1.client.Client` if
+            provided. It represents the client that created this collection
+            reference.
 
     Raises:
         ValueError: if
@@ -210,7 +211,7 @@ class CollectionReference(object):
         """Create a "select" query with this collection as parent.
 
         See
-        :meth:`~.firestore_v1beta1.query.Query.select` for
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.select` for
         more information on this method.
 
         Args:
@@ -228,7 +229,7 @@ class CollectionReference(object):
         """Create a "where" query with this collection as parent.
 
         See
-        :meth:`~.firestore_v1beta1.query.Query.where` for
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.where` for
         more information on this method.
 
         Args:
@@ -251,16 +252,16 @@ class CollectionReference(object):
         """Create an "order by" query with this collection as parent.
 
         See
-        :meth:`~.firestore_v1beta1.query.Query.order_by` for
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.order_by` for
         more information on this method.
 
         Args:
             field_path (str): A field path (``.``-delimited list of
                 field names) on which to order the query results.
             kwargs (Dict[str, Any]): The keyword arguments to pass along
-                to the query. The only supported keyword is ``direction``,
-                see :meth:`~.firestore_v1beta1.query.Query.order_by` for
-                more information.
+                to the query. The only supported keyword is ``direction``, see
+                :meth:`~google.cloud.firestore_v1beta1.query.Query.order_by`
+                for more information.
 
         Returns:
             ~.firestore_v1beta1.query.Query: An "order by" query.
@@ -272,7 +273,7 @@ class CollectionReference(object):
         """Create a limited query with this collection as parent.
 
         See
-        :meth:`~.firestore_v1beta1.query.Query.limit` for
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.limit` for
         more information on this method.
 
         Args:
@@ -289,7 +290,7 @@ class CollectionReference(object):
         """Skip to an offset in a query with this collection as parent.
 
         See
-        :meth:`~.firestore_v1beta1.query.Query.offset` for
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.offset` for
         more information on this method.
 
         Args:
@@ -306,7 +307,7 @@ class CollectionReference(object):
         """Start query at a cursor with this collection as parent.
 
         See
-        :meth:`~.firestore_v1beta1.query.Query.start_at` for
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.start_at` for
         more information on this method.
 
         Args:
@@ -326,7 +327,7 @@ class CollectionReference(object):
         """Start query after a cursor with this collection as parent.
 
         See
-        :meth:`~.firestore_v1beta1.query.Query.start_after` for
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.start_after` for
         more information on this method.
 
         Args:
@@ -346,7 +347,7 @@ class CollectionReference(object):
         """End query before a cursor with this collection as parent.
 
         See
-        :meth:`~.firestore_v1beta1.query.Query.end_before` for
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.end_before` for
         more information on this method.
 
         Args:
@@ -366,7 +367,7 @@ class CollectionReference(object):
         """End query at a cursor with this collection as parent.
 
         See
-        :meth:`~.firestore_v1beta1.query.Query.end_at` for
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.end_at` for
         more information on this method.
 
         Args:

--- a/firestore/google/cloud/firestore_v1beta1/document.py
+++ b/firestore/google/cloud/firestore_v1beta1/document.py
@@ -37,8 +37,8 @@ class DocumentReference(object):
             that contain a sub-collection (as well as the base document).
         kwargs (dict): The keyword arguments for the constructor. The only
             supported keyword is ``client`` and it must be a
-            :class:`~.firestore_v1beta1.client.Client`. It represents
-            the client that created this document reference.
+            :class:`~google.cloud.firestore_v1beta1.client.Client`.
+            It represents the client that created this document reference.
 
     Raises:
         ValueError: if
@@ -242,7 +242,7 @@ class DocumentReference(object):
 
         Each key in ``field_updates`` can either be a field name or a
         **field path** (For more information on **field paths**, see
-        :meth:`~.firestore_v1beta1.client.Client.field_path`.) To
+        :meth:`~google.cloud.firestore_v1beta1.client.Client.field_path`.) To
         illustrate this, consider a document with
 
         .. code-block:: python
@@ -312,8 +312,8 @@ class DocumentReference(object):
            ``field_updates``.
 
         To delete / remove a field from an existing document, use the
-        :attr:`~.firestore_v1beta1.transforms.DELETE_FIELD` sentinel. So
-        with the example above, sending
+        :attr:`~google.cloud.firestore_v1beta1.transforms.DELETE_FIELD`
+        sentinel. So with the example above, sending
 
         .. code-block:: python
 
@@ -336,8 +336,8 @@ class DocumentReference(object):
 
         To set a field to the current time on the server when the
         update is received, use the
-        :attr:`~.firestore_v1beta1.transforms.SERVER_TIMESTAMP` sentinel.
-        Sending
+        :attr:`~google.cloud.firestore_v1beta1.transforms.SERVER_TIMESTAMP`
+        sentinel.  Sending
 
         .. code-block:: python
 
@@ -408,8 +408,8 @@ class DocumentReference(object):
     def get(self, field_paths=None, transaction=None):
         """Retrieve a snapshot of the current document.
 
-        See :meth:`~.firestore_v1beta1.client.Client.field_path` for
-        more information on **field paths**.
+        See :meth:`~google.cloud.firestore_v1beta1.client.Client.field_path`
+        for more information on **field paths**.
 
         If a ``transaction`` is used and it already has write operations
         added, this method cannot be used (i.e. read-after-write is not
@@ -531,7 +531,7 @@ class DocumentSnapshot(object):
 
     Instances of this class are not intended to be constructed by hand,
     rather they'll be returned as responses to various methods, such as
-    :meth:`~.DocumentReference.get`.
+    :meth:`~google.cloud.DocumentReference.get`.
 
     Args:
         reference (~.firestore_v1beta1.document.DocumentReference): A
@@ -652,8 +652,8 @@ class DocumentSnapshot(object):
            >>> snapshot.get('top1.middle2.bottom3')
            20
 
-        See :meth:`~.firestore_v1beta1.client.Client.field_path` for
-        more information on **field paths**.
+        See :meth:`~google.cloud.firestore_v1beta1.client.Client.field_path`
+        for more information on **field paths**.
 
         A copy is returned since the data may contain mutable values,
         but the data stored in the snapshot must remain immutable.

--- a/firestore/google/cloud/firestore_v1beta1/field_path.py
+++ b/firestore/google/cloud/firestore_v1beta1/field_path.py
@@ -216,7 +216,7 @@ def get_nested_value(field_path, data):
        >>> get_nested_value('top1.middle2.bottom3', data)
        20
 
-    See :meth:`~.firestore_v1beta1.client.Client.field_path` for
+    See :meth:`~google.cloud.firestore_v1beta1.client.Client.field_path` for
     more information on **field paths**.
 
     Args:

--- a/firestore/google/cloud/firestore_v1beta1/query.py
+++ b/firestore/google/cloud/firestore_v1beta1/query.py
@@ -14,9 +14,10 @@
 
 """Classes for representing queries for the Google Cloud Firestore API.
 
-A :class:`~.firestore_v1beta1.query.Query` can be created directly from
-a :class:`~.firestore_v1beta1.collection.Collection` and that can be
-a more common way to create a query than direct usage of the constructor.
+A :class:`~google.cloud.firestore_v1beta1.query.Query` can be created directly
+from a :class:`~google.cloud.firestore_v1beta1.collection.Collection`,
+and that can be a more common way to create a query than direct usage of the
+constructor.
 """
 import copy
 import math
@@ -165,12 +166,12 @@ class Query(object):
     def select(self, field_paths):
         """Project documents matching query to a limited set of fields.
 
-        See :meth:`~.firestore_v1beta1.client.Client.field_path` for
-        more information on **field paths**.
+        See :meth:`~google.cloud.firestore_v1beta1.client.Client.field_path`
+        for more information on **field paths**.
 
         If the current query already has a projection set (i.e. has already
-        called :meth:`~.firestore_v1beta1.query.Query.select`), this
-        will overwrite it.
+        called :meth:`~google.cloud.firestore_v1beta1.query.Query.select`),
+        this will overwrite it.
 
         Args:
             field_paths (Iterable[str, ...]): An iterable of field paths
@@ -208,13 +209,13 @@ class Query(object):
     def where(self, field_path, op_string, value):
         """Filter the query on a field.
 
-        See :meth:`~.firestore_v1beta1.client.Client.field_path` for
-        more information on **field paths**.
+        See :meth:`~google.cloud.firestore_v1beta1.client.Client.field_path`
+        for more information on **field paths**.
 
-        Returns a new :class:`~.firestore_v1beta1.query.Query` that
-        filters on a specific field path, according to an operation (e.g.
-        ``==`` or "equals") and a particular value to be paired with that
-        operation.
+        Returns a new :class:`~google.cloud.firestore_v1beta1.query.Query`
+        that filters on a specific field path, according to an operation
+        (e.g.  ``==`` or "equals") and a particular value to be paired with
+        that operation.
 
         Args:
             field_path (str): A field path (``.``-delimited list of
@@ -283,10 +284,10 @@ class Query(object):
     def order_by(self, field_path, direction=ASCENDING):
         """Modify the query to add an order clause on a specific field.
 
-        See :meth:`~.firestore_v1beta1.client.Client.field_path` for
-        more information on **field paths**.
+        See :meth:`~google.cloud.firestore_v1beta1.client.Client.field_path`
+        for more information on **field paths**.
 
-        Successive :meth:`~.firestore_v1beta1.query.Query.order_by` calls
+        Successive :meth:`~google.cloud.firestore_v1beta1.query.Query.order_by` calls
         will further refine the ordering of results returned by the query
         (i.e. the new "order by" fields will be added to existing ones).
 
@@ -381,7 +382,7 @@ class Query(object):
 
         When the query is sent to the server, the ``document_fields`` will
         be used in the order given by fields set by
-        :meth:`~.firestore_v1beta1.query.Query.order_by`.
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.order_by`.
 
         Args:
             document_fields (Union[~.firestore_v1beta1.\
@@ -436,12 +437,12 @@ class Query(object):
 
         If the current query already has specified a start cursor -- either
         via this method or
-        :meth:`~.firestore_v1beta1.query.Query.start_after` -- this will
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.start_after` -- this will
         overwrite it.
 
         When the query is sent to the server, the ``document_fields`` will
         be used in the order given by fields set by
-        :meth:`~.firestore_v1beta1.query.Query.order_by`.
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.order_by`.
 
         Args:
             document_fields (Union[~.firestore_v1beta1.\
@@ -465,12 +466,12 @@ class Query(object):
 
         If the current query already has specified a start cursor -- either
         via this method or
-        :meth:`~.firestore_v1beta1.query.Query.start_at` -- this will
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.start_at` -- this will
         overwrite it.
 
         When the query is sent to the server, the ``document_fields`` will
         be used in the order given by fields set by
-        :meth:`~.firestore_v1beta1.query.Query.order_by`.
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.order_by`.
 
         Args:
             document_fields (Union[~.firestore_v1beta1.\
@@ -494,12 +495,12 @@ class Query(object):
 
         If the current query already has specified an end cursor -- either
         via this method or
-        :meth:`~.firestore_v1beta1.query.Query.end_at` -- this will
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.end_at` -- this will
         overwrite it.
 
         When the query is sent to the server, the ``document_fields`` will
         be used in the order given by fields set by
-        :meth:`~.firestore_v1beta1.query.Query.order_by`.
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.order_by`.
 
         Args:
             document_fields (Union[~.firestore_v1beta1.\
@@ -523,12 +524,12 @@ class Query(object):
 
         If the current query already has specified an end cursor -- either
         via this method or
-        :meth:`~.firestore_v1beta1.query.Query.end_before` -- this will
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.end_before` -- this will
         overwrite it.
 
         When the query is sent to the server, the ``document_fields`` will
         be used in the order given by fields set by
-        :meth:`~.firestore_v1beta1.query.Query.order_by`.
+        :meth:`~google.cloud.firestore_v1beta1.query.Query.order_by`.
 
         Args:
             document_fields (Union[~.firestore_v1beta1.\
@@ -870,8 +871,8 @@ def _enum_from_direction(direction):
 
     Args:
         direction (str): A direction to order by. Must be one of
-            :attr:`~.firestore.Query.ASCENDING` or
-            :attr:`~.firestore.Query.DESCENDING`.
+            :attr:`~google.cloud.firestore.Query.ASCENDING` or
+            :attr:`~google.cloud.firestore.Query.DESCENDING`.
 
     Returns:
         int: The enum corresponding to ``direction``.

--- a/firestore/google/cloud/firestore_v1beta1/transaction.py
+++ b/firestore/google/cloud/firestore_v1beta1/transaction.py
@@ -50,7 +50,7 @@ class Transaction(batch.WriteBatch):
             created this transaction.
         max_attempts (Optional[int]): The maximum number of attempts for
             the transaction (i.e. allowing retries). Defaults to
-            :attr:`~.firestore_v1beta1.transaction.MAX_ATTEMPTS`.
+            :attr:`~google.cloud.firestore_v1beta1.transaction.MAX_ATTEMPTS`.
         read_only (Optional[bool]): Flag indicating if the transaction
             should be read-only or should allow writes. Defaults to
             :data:`False`.
@@ -206,7 +206,7 @@ class _Transactional(object):
     """Provide a callable object to use as a transactional decorater.
 
     This is surfaced via
-    :func:`~.firestore_v1beta1.transaction.transactional`.
+    :func:`~google.cloud.firestore_v1beta1.transaction.transactional`.
 
     Args:
         to_wrap (Callable[~.firestore_v1beta1.transaction.Transaction, \


### PR DESCRIPTION
Expand tildes in docstring refs.

FBO Sphinx (missing ref links), static analysis, autocompletion.

Closes #8035.