### PR TITLE
Use `job_config.schema` for data type conversion if specified in `load_table_from_dataframe`.

### DIFF
--- a/bigquery/google/cloud/bigquery/_pandas_helpers.py
+++ b/bigquery/google/cloud/bigquery/_pandas_helpers.py
@@ -19,7 +19,6 @@ try:
     import pyarrow.parquet
 except ImportError:  # pragma: NO COVER
     pyarrow = None
-import six.moves
 
 
 def pyarrow_datetime():
@@ -39,7 +38,7 @@ def pyarrow_timestamp():
 
 
 BQ_TO_ARROW_SCALARS = {}
-if pyarrow is not None:
+if pyarrow is not None:  # pragma: NO COVER
     BQ_TO_ARROW_SCALARS = {
         "BOOL": pyarrow.bool_,
         "BOOLEAN": pyarrow.bool_,
@@ -95,7 +94,6 @@ def to_parquet(dataframe, bq_schema, filepath):
         raise ValueError("pyarrow is required for BigQuery schema conversion")
 
     if len(bq_schema) != len(dataframe.columns):
-        # TODO: match names, too.
         raise ValueError(
             "Number of columns in schema must match number of columns in dataframe"
         )
@@ -110,6 +108,5 @@ def to_parquet(dataframe, bq_schema, filepath):
             )
         )
 
-    # TODO: make pyarrow table and write to parquet.
     arrow_table = pyarrow.Table.from_arrays(arrow_arrays, names=column_names)
     pyarrow.parquet.write_table(arrow_table, filepath)

--- a/bigquery/google/cloud/bigquery/_pandas_helpers.py
+++ b/bigquery/google/cloud/bigquery/_pandas_helpers.py
@@ -1,0 +1,115 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helper functions for connecting BigQuery and pandas."""
+
+try:
+    import pyarrow
+    import pyarrow.parquet
+except ImportError:  # pragma: NO COVER
+    pyarrow = None
+import six.moves
+
+
+def pyarrow_datetime():
+    return pyarrow.timestamp("us", tz=None)
+
+
+def pyarrow_numeric():
+    return pyarrow.decimal128(38, 9)
+
+
+def pyarrow_time():
+    return pyarrow.time64("us")
+
+
+def pyarrow_timestamp():
+    return pyarrow.timestamp("us", tz="UTC")
+
+
+BQ_TO_ARROW_SCALARS = {}
+if pyarrow is not None:
+    BQ_TO_ARROW_SCALARS = {
+        "BOOL": pyarrow.bool_,
+        "BOOLEAN": pyarrow.bool_,
+        "BYTES": pyarrow.binary,
+        "DATE": pyarrow.date32,
+        "DATETIME": pyarrow_datetime,
+        "FLOAT": pyarrow.float64,
+        "FLOAT64": pyarrow.float64,
+        "GEOGRAPHY": pyarrow.string,
+        "INT64": pyarrow.int64,
+        "INTEGER": pyarrow.int64,
+        "NUMERIC": pyarrow_numeric,
+        "STRING": pyarrow.string,
+        "TIME": pyarrow_time,
+        "TIMESTAMP": pyarrow_timestamp,
+    }
+
+
+def bq_to_arrow_data_type(field):
+    """Return the Arrow data type, corresponding to a given BigQuery column.
+
+    Returns None if default Arrow type inspection should be used.
+    """
+    # TODO: Use pyarrow.list_(item_type) for repeated (array) fields.
+    if field.mode is not None and field.mode.upper() == "REPEATED":
+        return None
+    # TODO: Use pyarrow.struct(fields) for record (struct) fields.
+    if field.field_type.upper() in ("RECORD", "STRUCT"):
+        return None
+
+    data_type_constructor = BQ_TO_ARROW_SCALARS.get(field.field_type.upper())
+    if data_type_constructor is None:
+        return None
+    return data_type_constructor()
+
+
+def to_parquet(dataframe, bq_schema, filepath):
+    """Write dataframe as a Parquet file, according to the desired BQ schema.
+
+    This function requires the :mod:`pyarrow` package. Arrow is used as an
+    intermediate format.
+
+    Args:
+        dataframe (pandas.DataFrame):
+            DataFrame to convert to convert to Parquet file.
+        bq_schema (Sequence[google.cloud.bigquery.schema.SchemaField]):
+            Desired BigQuery schema. Number of columns must match number of
+            columns in the DataFrame.
+        filepath (str):
+            Path to write Parquet file to.
+    """
+    if pyarrow is None:
+        raise ValueError("pyarrow is required for BigQuery schema conversion")
+
+    if len(bq_schema) != len(dataframe.columns):
+        # TODO: match names, too.
+        raise ValueError(
+            "Number of columns in schema must match number of columns in dataframe"
+        )
+
+    arrow_arrays = []
+    column_names = []
+    for bq_field in bq_schema:
+        column_names.append(bq_field.name)
+        arrow_arrays.append(
+            pyarrow.array(
+                dataframe[bq_field.name], type=bq_to_arrow_data_type(bq_field)
+            )
+        )
+
+    # TODO: make pyarrow table and write to parquet.
+    arrow_table = pyarrow.Table.from_arrays(arrow_arrays, names=column_names)
+    pyarrow.parquet.write_table(arrow_table, filepath)

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -44,6 +44,7 @@ from google.cloud.client import ClientWithProject
 from google.cloud.bigquery._helpers import _record_field_to_json
 from google.cloud.bigquery._helpers import _str_or_none
 from google.cloud.bigquery._http import Connection
+from google.cloud.bigquery import _pandas_helpers
 from google.cloud.bigquery.dataset import Dataset
 from google.cloud.bigquery.dataset import DatasetListItem
 from google.cloud.bigquery.dataset import DatasetReference
@@ -1274,6 +1275,12 @@ class Client(ClientWithProject):
             job_config (google.cloud.bigquery.job.LoadJobConfig, optional):
                 Extra configuration options for the job.
 
+                To override the default pandas data type conversions, supply
+                a BigQuery schema in the job configuration. If a schema is
+                supplied, the BigQuery schema will be used to determine the
+                correct pandas to parquet type conversion. Indexes are not
+                loaded. Requires the :mod:`pyarrow` library.
+
         Returns:
             google.cloud.bigquery.job.LoadJob: A new load job.
 
@@ -1296,7 +1303,10 @@ class Client(ClientWithProject):
         os.close(tmpfd)
 
         try:
-            dataframe.to_parquet(tmppath)
+            if job_config.schema:
+                _pandas_helpers.to_parquet(dataframe, job_config.schema, tmppath)
+            else:
+                dataframe.to_parquet(tmppath)
 
             with open(tmppath, "rb") as parquet_file:
                 return self.load_table_from_file(

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1272,14 +1272,15 @@ class Client(ClientWithProject):
             project (str, optional):
                 Project ID of the project of where to run the job. Defaults
                 to the client's project.
-            job_config (google.cloud.bigquery.job.LoadJobConfig, optional):
+            job_config (~google.cloud.bigquery.job.LoadJobConfig, optional):
                 Extra configuration options for the job.
 
                 To override the default pandas data type conversions, supply
-                a BigQuery schema in the job configuration. If a schema is
-                supplied, the BigQuery schema will be used to determine the
-                correct pandas to parquet type conversion. Indexes are not
-                loaded. Requires the :mod:`pyarrow` library.
+                a value for
+                :attr:`~google.cloud.bigquery.job.LoadJobConfig.schema` with
+                column names matching those of the dataframe. The BigQuery
+                schema is used to determine the correct data type conversion.
+                Indexes are not loaded. Requires the :mod:`pyarrow` library.
 
         Returns:
             google.cloud.bigquery.job.LoadJob: A new load job.

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -635,7 +635,7 @@ class TestBigQuery(unittest.TestCase):
         See: https://github.com/googleapis/google-cloud-python/issues/7370
         """
         # Schema with all scalar types.
-        table_schema = (
+        scalars_schema = (
             bigquery.SchemaField("bool_col", "BOOLEAN"),
             bigquery.SchemaField("bytes_col", "BYTES"),
             bigquery.SchemaField("date_col", "DATE"),
@@ -647,6 +647,15 @@ class TestBigQuery(unittest.TestCase):
             bigquery.SchemaField("str_col", "STRING"),
             bigquery.SchemaField("time_col", "TIME"),
             bigquery.SchemaField("ts_col", "TIMESTAMP"),
+        )
+        table_schema = scalars_schema + (
+            # TODO: Array columns can't be read due to NULLABLE versus REPEATED
+            #       mode mismatch. See:
+            #       https://issuetracker.google.com/133415569#comment3
+            # bigquery.SchemaField("array_col", "INTEGER", mode="REPEATED"),
+            # TODO: Support writing StructArrays to Parquet. See:
+            #       https://jira.apache.org/jira/browse/ARROW-2587
+            # bigquery.SchemaField("struct_col", "RECORD", fields=scalars_schema),
         )
         num_rows = 100
         nulls = [None] * num_rows

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -27,6 +27,7 @@ import re
 
 import six
 import pytest
+import pytz
 
 try:
     from google.cloud import bigquery_storage_v1beta1
@@ -680,6 +681,9 @@ class TestBigQuery(unittest.TestCase):
         table_id = "{}.{}.load_table_from_dataframe_w_nulls".format(
             Config.CLIENT.project, dataset_id
         )
+
+        # Create the table before loading so that schema mismatch errors are
+        # identified.
         table = retry_403(Config.CLIENT.create_table)(
             Table(table_id, schema=table_schema)
         )
@@ -694,6 +698,87 @@ class TestBigQuery(unittest.TestCase):
         table = Config.CLIENT.get_table(table)
         self.assertEqual(tuple(table.schema), table_schema)
         self.assertEqual(table.num_rows, num_rows)
+
+    @unittest.skipIf(pandas is None, "Requires `pandas`")
+    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
+    def test_load_table_from_dataframe_w_explicit_schema(self):
+        # Schema with all scalar types.
+        scalars_schema = (
+            bigquery.SchemaField("bool_col", "BOOLEAN"),
+            bigquery.SchemaField("bytes_col", "BYTES"),
+            bigquery.SchemaField("date_col", "DATE"),
+            bigquery.SchemaField("dt_col", "DATETIME"),
+            bigquery.SchemaField("float_col", "FLOAT"),
+            bigquery.SchemaField("geo_col", "GEOGRAPHY"),
+            bigquery.SchemaField("int_col", "INTEGER"),
+            bigquery.SchemaField("num_col", "NUMERIC"),
+            bigquery.SchemaField("str_col", "STRING"),
+            bigquery.SchemaField("time_col", "TIME"),
+            bigquery.SchemaField("ts_col", "TIMESTAMP"),
+        )
+        table_schema = scalars_schema + (
+            # TODO: Array columns can't be read due to NULLABLE versus REPEATED
+            #       mode mismatch. See:
+            #       https://issuetracker.google.com/133415569#comment3
+            # bigquery.SchemaField("array_col", "INTEGER", mode="REPEATED"),
+            # TODO: Support writing StructArrays to Parquet. See:
+            #       https://jira.apache.org/jira/browse/ARROW-2587
+            # bigquery.SchemaField("struct_col", "RECORD", fields=scalars_schema),
+        )
+        dataframe = pandas.DataFrame(
+            {
+                "bool_col": [True, None, False],
+                "bytes_col": [b"abc", None, b"def"],
+                "date_col": [datetime.date(1, 1, 1), None, datetime.date(9999, 12, 31)],
+                "dt_col": [
+                    datetime.datetime(1, 1, 1, 0, 0, 0),
+                    None,
+                    datetime.datetime(9999, 12, 31, 23, 59, 59, 999999),
+                ],
+                "float_col": [float("-inf"), float("nan"), float("inf")],
+                "geo_col": [
+                    "POINT(30 10)",
+                    None,
+                    "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))",
+                ],
+                "int_col": [-9223372036854775808, None, 9223372036854775807],
+                "num_col": [
+                    decimal.Decimal("-99999999999999999999999999999.999999999"),
+                    None,
+                    decimal.Decimal("99999999999999999999999999999.999999999"),
+                ],
+                "str_col": ["abc", None, "def"],
+                "time_col": [
+                    datetime.time(0, 0, 0),
+                    None,
+                    datetime.time(23, 59, 59, 999999),
+                ],
+                "ts_col": [
+                    datetime.datetime(1, 1, 1, 0, 0, 0, tzinfo=pytz.utc),
+                    None,
+                    datetime.datetime(
+                        9999, 12, 31, 23, 59, 59, 999999, tzinfo=pytz.utc
+                    ),
+                ],
+            },
+            dtype="object",
+        )
+
+        dataset_id = _make_dataset_id("bq_load_test")
+        self.temp_dataset(dataset_id)
+        table_id = "{}.{}.load_table_from_dataframe_w_explicit_schema".format(
+            Config.CLIENT.project, dataset_id
+        )
+
+        job_config = bigquery.LoadJobConfig(schema=table_schema)
+        load_job = Config.CLIENT.load_table_from_dataframe(
+            dataframe, table_id, job_config=job_config
+        )
+        load_job.result()
+
+        table = Config.CLIENT.get_table(table_id)
+        self.assertEqual(tuple(table.schema), table_schema)
+        self.assertEqual(table.num_rows, 3)
 
     def test_load_avro_from_uri_then_dump_table(self):
         from google.cloud.bigquery.job import CreateDisposition

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -634,7 +634,6 @@ class TestBigQuery(unittest.TestCase):
 
         See: https://github.com/googleapis/google-cloud-python/issues/7370
         """
-        # TODO: make table with certain schema. Try to load / append to that table with a bunch of null columns.
         # Schema with all scalar types.
         table_schema = (
             bigquery.SchemaField("bool_col", "BOOLEAN"),

--- a/bigquery/tests/unit/test__pandas_helpers.py
+++ b/bigquery/tests/unit/test__pandas_helpers.py
@@ -1,0 +1,112 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pyarrow.types
+import pytest
+
+from google.cloud.bigquery import schema
+
+
+@pytest.fixture
+def module_under_test():
+    from google.cloud.bigquery import _pandas_helpers
+
+    return _pandas_helpers
+
+
+def is_none(value):
+    return value is None
+
+
+def is_numeric(type_):
+    # See: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric-type
+    return all_(
+        pyarrow.types.is_decimal,
+        lambda type_: type_.precision == 38,
+        lambda type_: type_.scale == 9,
+    )
+
+
+def is_timestamp(type_):
+    # See: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp-type
+    return all_(
+        pyarrow.types.is_timestamp,
+        lambda type_: type_.unit == "us",
+        lambda type_: type_.tz == "UTC",
+    )
+
+
+def is_datetime(type_):
+    # See: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#datetime-type
+    return all_(
+        pyarrow.types.is_timestamp,
+        lambda type_: type_.unit == "us",
+        lambda type_: type_.tz is None,
+    )
+
+
+def all_(*functions):
+    def do_all(value):
+        return all((func(value) for func in functions))
+
+    return do_all
+
+
+@pytest.mark.parametrize(
+    "bq_type,bq_mode,is_correct_type",
+    [
+        ("STRING", "NULLABLE", pyarrow.types.is_string),
+        ("STRING", None, pyarrow.types.is_string),
+        ("string", "NULLABLE", pyarrow.types.is_string),
+        ("StRiNg", "NULLABLE", pyarrow.types.is_string),
+        ("BYTES", "NULLABLE", pyarrow.types.is_binary),
+        ("INTEGER", "NULLABLE", pyarrow.types.is_int64),
+        ("INT64", "NULLABLE", pyarrow.types.is_int64),
+        ("FLOAT", "NULLABLE", pyarrow.types.is_float64),
+        ("FLOAT64", "NULLABLE", pyarrow.types.is_float64),
+        ("NUMERIC", "NULLABLE", is_numeric),
+        ("BOOLEAN", "NULLABLE", pyarrow.types.is_boolean),
+        ("BOOL", "NULLABLE", pyarrow.types.is_boolean),
+        ("TIMESTAMP", "NULLABLE", is_timestamp),
+        ("DATE", "NULLABLE", pyarrow.types.is_date32),
+        ("TIME", "NULLABLE", pyarrow.types.is_time64),
+        ("DATETIME", "NULLABLE", is_datetime),
+        ("GEOGRAPHY", "NULLABLE", pyarrow.types.is_string),
+        # TODO: Use pyarrow.struct(fields) for record (struct) fields.
+        ("RECORD", "NULLABLE", is_none),
+        ("STRUCT", "NULLABLE", is_none),
+        # TODO: Use pyarrow.list_(item_type) for repeated (array) fields.
+        ("STRING", "REPEATED", is_none),
+        ("STRING", "repeated", is_none),
+        ("STRING", "RePeAtEd", is_none),
+        ("BYTES", "REPEATED", is_none),
+        ("INTEGER", "REPEATED", is_none),
+        ("INT64", "REPEATED", is_none),
+        ("FLOAT", "REPEATED", is_none),
+        ("FLOAT64", "REPEATED", is_none),
+        ("NUMERIC", "REPEATED", is_none),
+        ("BOOLEAN", "REPEATED", is_none),
+        ("BOOL", "REPEATED", is_none),
+        ("TIMESTAMP", "REPEATED", is_none),
+        ("DATE", "REPEATED", is_none),
+        ("TIME", "REPEATED", is_none),
+        ("DATETIME", "REPEATED", is_none),
+        ("GEOGRAPHY", "REPEATED", is_none),
+        ("RECORD", "REPEATED", is_none),
+    ],
+)
+def test_bq_to_arrow_data_type(module_under_test, bq_type, bq_mode, is_correct_type):
+    field = schema.SchemaField("ignored_name", bq_type, mode=bq_mode)
+    got = module_under_test.bq_to_arrow_data_type(field)
+    assert is_correct_type(got)


### PR DESCRIPTION
Use the BigQuery schema to inform encoding of file used in load job.
This fixes an issue where a dataframe with ambiguous types (such as an
`object` column containing all `None` values) could not be appended to
an existing table, since the schemas wouldn't match in most cases.

Closes #7370.