### PR TITLE
Bigtable: Add 'PartialRowsData.cancel'.

### DIFF
--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -377,7 +377,7 @@ class PartialRowsData(object):
         self._state = self.STATE_NEW_ROW
 
         # Flag to stop iteration, for any reason not related to self.retry()
-        self._stop = False
+        self._cancelled = False
 
     @property
     def state(self):
@@ -391,7 +391,7 @@ class PartialRowsData(object):
 
     def cancel(self):
         """Cancels the iterator, closing the stream."""
-        self._stop = True
+        self._cancelled = True
         self.response_iterator.cancel()
 
     def consume_all(self, max_loops=None):
@@ -440,7 +440,7 @@ class PartialRowsData(object):
         Parse the response and its chunks into a new/existing row in
         :attr:`_rows`. Rows are returned in order by row key.
         """
-        while not self._stop:
+        while not self._cancelled:
             try:
                 response = self._read_next_response()
             except StopIteration:
@@ -449,7 +449,7 @@ class PartialRowsData(object):
                 break
 
             for chunk in response.chunks:
-                if self._stop:
+                if self._cancelled:
                     break
                 self._process_chunk(chunk)
                 if chunk.commit_row:

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -443,6 +443,8 @@ class PartialRowsData(object):
             try:
                 response = self._read_next_response()
                 for chunk in response.chunks:
+                    if self.stop:
+                        raise StopIteration
                     self._process_chunk(chunk)
                     if chunk.commit_row:
                         self.last_scanned_row_key = self._previous_row.row_key
@@ -458,8 +460,6 @@ class PartialRowsData(object):
                 self.last_scanned_row_key = resp_last_key
 
     def _process_chunk(self, chunk):
-        if self.stop:
-            raise StopIteration
         if chunk.reset_row:
             self._validate_chunk_reset_row(chunk)
             self._row = None

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -376,6 +376,9 @@ class PartialRowsData(object):
         self.rows = {}
         self._state = self.STATE_NEW_ROW
 
+        # Flag to stop iteration, for any reason not related to self.retry()
+        self.stop = False
+
     @property
     def state(self):
         """State machine state.
@@ -427,6 +430,8 @@ class PartialRowsData(object):
 
     def _read_next_response(self):
         """Helper for :meth:`__iter__`."""
+        if self.stop:
+            raise StopIteration
         return self.retry(self._read_next, on_error=self._on_error)()
 
     def __iter__(self):

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -529,6 +529,7 @@ class TestPartialRowsData(unittest.TestCase):
         self.assertEqual(response_iterator.cancel_calls, 0)
         yield_rows_data.cancel()
         self.assertEqual(response_iterator.cancel_calls, 1)
+        self.assertRaises(StopIteration, iter(yield_rows_data).next())
 
     # 'consume_next' tested via 'TestPartialRowsData_JSON_acceptance_tests'
 

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -529,7 +529,7 @@ class TestPartialRowsData(unittest.TestCase):
         self.assertEqual(response_iterator.cancel_calls, 0)
         yield_rows_data.cancel()
         self.assertEqual(response_iterator.cancel_calls, 1)
-        self.assertRaises(StopIteration, iter(yield_rows_data).next())
+        self.assertEqual(list(yield_rows_data), [])
 
     # 'consume_next' tested via 'TestPartialRowsData_JSON_acceptance_tests'
 

--- a/spanner/README.rst
+++ b/spanner/README.rst
@@ -71,7 +71,7 @@ Mac/Linux
     pip install virtualenv
     virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install google-cloud-datastore
+    <your-env>/bin/pip install google-cloud-spanner
 
 
 Windows
@@ -82,7 +82,7 @@ Windows
     pip install virtualenv
     virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install google-cloud-datastore
+    <your-env>\Scripts\pip.exe install google-cloud-spanner
 
 
 Example Usage


### PR DESCRIPTION
Fixes #7760.

Introducing a "stop" flag into the iterable PartialRowsData() class. Setting this flag to True results in cancelling of the iteration the next time the iterator is called.