### PR TITLE
Core: Mitigate busy reopen loop in ResumableBidiRpc consuming 100% CPU

### DIFF
--- a/api_core/tests/unit/test_bidi.py
+++ b/api_core/tests/unit/test_bidi.py
@@ -514,6 +514,22 @@ class TestResumableBidiRpc(object):
         assert bidi_rpc.is_active is False
         callback.assert_called_once_with(error2)
 
+    def test_using_throttle_on_reopen_requests(self):
+        call = CallStub([])
+        start_rpc = mock.create_autospec(
+            grpc.StreamStreamMultiCallable, instance=True, return_value=call
+        )
+        should_recover = mock.Mock(spec=["__call__"], return_value=True)
+        bidi_rpc = bidi.ResumableBidiRpc(
+            start_rpc, should_recover, throttle_reopen=True
+        )
+
+        patcher = mock.patch.object(bidi_rpc._reopen_throttle.__class__, "__enter__")
+        with patcher as mock_enter:
+            bidi_rpc._reopen()
+
+        mock_enter.assert_called_once()
+
     def test_send_not_open(self):
         bidi_rpc = bidi.ResumableBidiRpc(None, lambda _: False)
 

--- a/api_core/tests/unit/test_bidi.py
+++ b/api_core/tests/unit/test_bidi.py
@@ -119,22 +119,30 @@ class Test_RequestQueueGenerator(object):
 
 class Test_Throttle(object):
     def test_repr(self):
-        instance = bidi._Throttle(time_window=4.5, entry_cap=42)
-        assert repr(instance) == "_Throttle(time_window=4.5, entry_cap=42)"
+        delta = datetime.timedelta(seconds=4.5)
+        instance = bidi._Throttle(access_limit=42, time_window=delta)
+        assert repr(instance) == \
+            "_Throttle(access_limit=42, time_window={})".format(repr(delta))
 
     def test_raises_error_on_invalid_init_arguments(self):
         with pytest.raises(ValueError) as exc_info:
-            bidi._Throttle(time_window=0.0, entry_cap=10)
+            bidi._Throttle(
+                access_limit=10, time_window=datetime.timedelta(seconds=0.0)
+            )
         assert "time_window" in str(exc_info.value)
-        assert "must be positive" in str(exc_info.value)
+        assert "must be a positive timedelta" in str(exc_info.value)
 
         with pytest.raises(ValueError) as exc_info:
-            bidi._Throttle(time_window=10, entry_cap=0)
-        assert "entry_cap" in str(exc_info.value)
+            bidi._Throttle(
+                access_limit=0, time_window=datetime.timedelta(seconds=10)
+            )
+        assert "access_limit" in str(exc_info.value)
         assert "must be positive" in str(exc_info.value)
 
     def test_does_not_delay_entry_attempts_under_threshold(self):
-        throttle = bidi._Throttle(time_window=1, entry_cap=3)
+        throttle = bidi._Throttle(
+            access_limit=3, time_window=datetime.timedelta(seconds=1)
+        )
         entries = []
 
         for _ in range(3):
@@ -155,7 +163,9 @@ class Test_Throttle(object):
         assert delta.total_seconds() < 0.1
 
     def test_delays_entry_attempts_above_threshold(self):
-        throttle = bidi._Throttle(time_window=1, entry_cap=3)
+        throttle = bidi._Throttle(
+            access_limit=3, time_window=datetime.timedelta(seconds=1)
+        )
         entries = []
 
         for _ in range(6):

--- a/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -383,6 +383,7 @@ class StreamingPullManager(object):
             start_rpc=self._client.api.streaming_pull,
             initial_request=self._get_initial_request,
             should_recover=self._should_recover,
+            throttle_reopen=True,
         )
         self._rpc.add_done_callback(self._on_rpc_done)
 

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -428,6 +428,7 @@ def test_open(heartbeater, dispatcher, leaser, background_consumer, resumable_bi
         start_rpc=manager._client.api.streaming_pull,
         initial_request=manager._get_initial_request,
         should_recover=manager._should_recover,
+        throttle_reopen=True,
     )
     resumable_bidi_rpc.return_value.add_done_callback.assert_called_once_with(
         manager._on_rpc_done


### PR DESCRIPTION
Closes #7910.

This PR fixes the issue with `ResumableBidiRpc` that can enter a busy re-open loop consuming lots of CPU in the process . The [comment](https://github.com/googleapis/google-cloud-python/issues/7910#issuecomment-494987224) on the issue explains this in more detail.

### How to test
**Steps to reproduce:**
- (optional) Configure more verbose logging in the subscriber script:
```py
import logging 
log_format = (
    "%(levelname)-8s [%(asctime)s] %(threadName)-33s "
    "[%(name)s] [%(filename)s:%(lineno)d][%(funcName)s] %(message)s"
)
logging.basicConfig(
    level=logging.DEBUG,
    format=log_format,
)
```
- Disable your internet connection
- Start the streaming pull using a susbscriber client instance:
```py
subscriber.subscribe(SUBSCRIPTION_PATH, callback=my_callback)

while True:
    try:
        time.sleep(60)
    except KeyboardInterrupt:
        break
 ```


**Actual result (before the fix):**
The `ResumableBidiRpc` class tries to re-establish the stream many times in rapid succession, resulting in a 100% CPU spike and a ton of log output:
```
...
DEBUG    [2019-05-15 10:06:01,440] Thread-ConsumeBidirectionalStream [_recoverable] Call to retryable <bound method ResumableBidiRpc._recv of <google.api_core.bidi.ResumableBidiRpc object at 0x7fb5eb91d630>> caused 503 DNS resolution failed.
INFO     [2019-05-15 10:06:01,440] Thread-ConsumeBidirectionalStream [_should_recover] Observed recoverable stream error 503 DNS resolution failed
DEBUG    [2019-05-15 10:06:01,440] Thread-ConsumeBidirectionalStream [_recoverable] Re-opening stream from retryable <bound method ResumableBidiRpc._recv of <google.api_core.bidi.ResumableBidiRpc object at 0x7fb5eb91d630>>.
INFO     [2019-05-15 10:06:01,441] Thread-ConsumeBidirectionalStream [_reopen] Re-established stream
INFO     [2019-05-15 10:06:01,441] Thread-1                          [_should_recover] Observed recoverable stream error 503 DNS resolution failed
DEBUG    [2019-05-15 10:06:01,441] Thread-1                          [_on_call_done] Re-opening stream from gRPC callback.
DEBUG    [2019-05-15 10:06:01,441] Thread-1                          [_reopen] Stream was already re-established.
INFO     [2019-05-15 10:06:01,441] Thread-1                          [_should_recover] Observed recoverable stream error 503 DNS resolution failed
DEBUG    [2019-05-15 10:06:01,441] Thread-1                          [_on_call_done] Re-opening stream from gRPC callback.
INFO     [2019-05-15 10:06:01,441] Thread-1                          [_reopen] Re-established stream
DEBUG    [2019-05-15 10:06:01,441] Thread-ConsumeBidirectionalStream [_recoverable] Call to retryable <bound method ResumableBidiRpc._recv of <google.api_core.bidi.ResumableBidiRpc object at 0x7fb5eb91d630>> caused 503 DNS resolution failed.
INFO     [2019-05-15 10:06:01,442] Thread-ConsumeBidirectionalStream [_should_recover] Observed recoverable stream error 503 DNS resolution failed
DEBUG    [2019-05-15 10:06:01,442] Thread-ConsumeBidirectionalStream [_recoverable] Re-opening stream from retryable <bound method ResumableBidiRpc._recv of <google.api_core.bidi.ResumableBidiRpc object at 0x7fb5eb91d630>>.
INFO     [2019-05-15 10:06:01,442] Thread-ConsumeBidirectionalStream [_reopen] Re-established stream
INFO     [2019-05-15 10:06:01,442] Thread-1                          [_should_recover] Observed recoverable stream error 503 DNS resolution failed
DEBUG    [2019-05-15 10:06:01,442] Thread-1                          [_on_call_done] Re-opening stream from gRPC callback.
DEBUG    [2019-05-15 10:06:01,442] Thread-1                          [_reopen] Stream was already re-established.
INFO     [2019-05-15 10:06:01,442] Thread-1                          [_should_recover] Observed recoverable stream error 503 DNS resolution failed
DEBUG    [2019-05-15 10:06:01,442] Thread-1                          [_on_call_done] Re-opening stream from gRPC callback.
INFO     [2019-05-15 10:06:01,443] Thread-1                          [_reopen] Re-established stream
...
```

This also happens if the streaming pull is running normally, and the internet connection is shut down in the middle of it - eventually the busy re-open loop starts. What's worse, this happens more than a single thread - both the gRPC channel thread (?)  and the consumer helper thread try to re-establish the stream.

**Expected result (after the fix):**
The re-open calls are throttled, and the CPU consumption is "normal".


### Things to do/discuss:
- [x] Fix test coverage (one branch appears to be missing).
- [ ] What should the default throttle params be set to? 
- [x] `ResumalbeBidiRpc` is also used in the Firestore client, does this PR (negatively) affect it in any way?
ANSWER: No, because this PR does not change the former's default behavior.
- [ ] Tests rely on timing, and even with a sizeable safety buffer, this is not ideal. Would there be any objections to adding [freezegun](https://pypi.org/project/freezegun/) as an API core dependency?