### PR TITLE
Storage: Make signurl work with objects containing tildes.

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -298,7 +298,7 @@ class Blob(_PropertyMixin):
         return "{storage_base_url}/{bucket_name}/{quoted_name}".format(
             storage_base_url=_API_ACCESS_ENDPOINT,
             bucket_name=self.bucket.name,
-            quoted_name=quote(self.name.encode("utf-8")),
+            quoted_name=_quote(self.name),
         )
 
     def generate_signed_url(
@@ -417,7 +417,7 @@ class Blob(_PropertyMixin):
             raise ValueError("'version' must be either 'v2' or 'v4'")
 
         resource = "/{bucket_name}/{quoted_name}".format(
-            bucket_name=self.bucket.name, quoted_name=quote(self.name.encode("utf-8"))
+            bucket_name=self.bucket.name, quoted_name=_quote(self.name)
         )
 
         if credentials is None:
@@ -1998,7 +1998,7 @@ def _quote(value):
     :returns: The encoded value (bytes in Python 2, unicode in Python 3).
     """
     value = _to_bytes(value, encoding="utf-8")
-    return quote(value, safe="")
+    return quote(value, safe=b"/~")
 
 
 def _maybe_rewind(stream, rewind=False):


### PR DESCRIPTION
Fixes https://issuetracker.google.com/issues/133359302

Similar to this one: https://github.com/GoogleCloudPlatform/gsutil/pull/783