### PR TITLE
Documentation fix in download_blob_to_file

### DIFF
--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -369,7 +369,7 @@ class Client(ClientWithProject):
             >>> blob = storage.Blob('path/to/blob', bucket)
 
             >>> with open('file-to-download-to') as file_obj:
-            >>>     client.download_blob_to_file(blob, file)  # API request.
+            >>>     client.download_blob_to_file(blob, file_obj)  # API request.
 
 
             Download a blob using a URI.


### PR DESCRIPTION
The file object name is incorrect in the method documentation.