### PR TITLE
Dataproc: Update version number to 0.4.0

### DIFF
--- a/dataproc/setup.py
+++ b/dataproc/setup.py
@@ -22,7 +22,7 @@ import setuptools
 
 name = "google-cloud-dataproc"
 description = "Google Cloud Dataproc API client library"
-version = "0.3.1"
+version = "0.4.0"
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
Not sure why releasetool missed this, but I didn't notice the version hadn't been updated until the release build failed. 

Follow up to #8195 