### PR TITLE
Prevent requests from hanging on SSL handshake issue by adding a max t.o.

### DIFF
--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -34,7 +34,7 @@ _GOOGLE_AUTH_CREDENTIALS_HELP = (
 )
 
 # Default timeout for auth requests.
-_REFRESH_TIMEOUT = 300
+_CREDENTIALS_REFRESH_TIMEOUT = 300
 
 
 class _ClientFactoryMixin(object):
@@ -157,7 +157,7 @@ class Client(_ClientFactoryMixin):
         if self._http_internal is None:
             self._http_internal = google.auth.transport.requests.AuthorizedSession(
                 self._credentials,
-                _REFRESH_TIMEOUT,
+                _CREDENTIALS_REFRESH_TIMEOUT,
             )
         return self._http_internal
 

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -157,7 +157,7 @@ class Client(_ClientFactoryMixin):
         if self._http_internal is None:
             self._http_internal = google.auth.transport.requests.AuthorizedSession(
                 self._credentials,
-                _CREDENTIALS_REFRESH_TIMEOUT,
+                refresh_timeout=_CREDENTIALS_REFRESH_TIMEOUT,
             )
         return self._http_internal
 

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -33,6 +33,9 @@ _GOOGLE_AUTH_CREDENTIALS_HELP = (
     "for help on authentication with this library."
 )
 
+# Default timeout for auth requests.
+_REFRESH_TIMEOUT = 300
+
 
 class _ClientFactoryMixin(object):
     """Mixin to allow factories that create credentials.
@@ -153,7 +156,8 @@ class Client(_ClientFactoryMixin):
         """
         if self._http_internal is None:
             self._http_internal = google.auth.transport.requests.AuthorizedSession(
-                self._credentials
+                self._credentials,
+                _REFRESH_TIMEOUT,
             )
         return self._http_internal
 

--- a/core/tests/unit/test_client.py
+++ b/core/tests/unit/test_client.py
@@ -133,7 +133,7 @@ class TestClient(unittest.TestCase):
         with authorized_session_patch as AuthorizedSession:
             self.assertIs(client._http, mock.sentinel.http)
             # Check the mock.
-            AuthorizedSession.assert_called_once_with(credentials)
+            AuthorizedSession.assert_called_once_with(credentials, 300)
             # Make sure the cached value is used on subsequent access.
             self.assertIs(client._http_internal, mock.sentinel.http)
             self.assertIs(client._http, mock.sentinel.http)

--- a/core/tests/unit/test_client.py
+++ b/core/tests/unit/test_client.py
@@ -134,7 +134,7 @@ class TestClient(unittest.TestCase):
         with authorized_session_patch as AuthorizedSession:
             self.assertIs(client._http, mock.sentinel.http)
             # Check the mock.
-            AuthorizedSession.assert_called_once_with(credentials, _CREDENTIALS_REFRESH_TIMEOUT)
+            AuthorizedSession.assert_called_once_with(credentials, refresh_timeout=_CREDENTIALS_REFRESH_TIMEOUT)
             # Make sure the cached value is used on subsequent access.
             self.assertIs(client._http_internal, mock.sentinel.http)
             self.assertIs(client._http, mock.sentinel.http)

--- a/core/tests/unit/test_client.py
+++ b/core/tests/unit/test_client.py
@@ -122,6 +122,7 @@ class TestClient(unittest.TestCase):
         self.assertIs(client._http, http)
 
     def test__http_property_new(self):
+        from google.cloud.client import _CREDENTIALS_REFRESH_TIMEOUT
         credentials = _make_credentials()
         client = self._make_one(credentials=credentials)
         self.assertIsNone(client._http_internal)
@@ -133,7 +134,7 @@ class TestClient(unittest.TestCase):
         with authorized_session_patch as AuthorizedSession:
             self.assertIs(client._http, mock.sentinel.http)
             # Check the mock.
-            AuthorizedSession.assert_called_once_with(credentials, 300)
+            AuthorizedSession.assert_called_once_with(credentials, _CREDENTIALS_REFRESH_TIMEOUT)
             # Make sure the cached value is used on subsequent access.
             self.assertIs(client._http_internal, mock.sentinel.http)
             self.assertIs(client._http, mock.sentinel.http)


### PR DESCRIPTION
The auth library defaults to timeout of None, effectively having no timeout. This adds a default timeout of 5 minutes for all users of the core._http implementation

b/132819217