### PR TITLE
Omnibus: don't pin 'google-api-core' in libs using 'google-cloud-core'.

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -30,7 +30,6 @@ version = "1.13.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     'enum34; python_version < "3.4"',
-    "google-api-core >= 1.6.0, < 2.0.0dev",
     "google-cloud-core >= 1.0.0, < 2.0dev",
     "google-resumable-media >= 0.3.1",
     "protobuf >= 3.6.0",

--- a/dns/setup.py
+++ b/dns/setup.py
@@ -29,7 +29,6 @@ version = '0.30.0'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    'google-api-core >= 1.0.0, < 2.0.0dev',
     "google-cloud-core >= 1.0.0, < 2.0dev",
 ]
 extras = {

--- a/resource_manager/setup.py
+++ b/resource_manager/setup.py
@@ -29,7 +29,6 @@ version = '0.29.0'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    'google-api-core >= 1.6.0, < 2.0.0dev',
     "google-cloud-core >= 1.0.0, < 2.0dev",
 ]
 extras = {

--- a/runtimeconfig/setup.py
+++ b/runtimeconfig/setup.py
@@ -29,7 +29,6 @@ version = '0.29.0'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    'google-api-core >= 1.6.0, < 2.0.0dev',
     "google-cloud-core >= 1.0.0, < 2.0dev",
 ]
 extras = {

--- a/storage/setup.py
+++ b/storage/setup.py
@@ -30,7 +30,6 @@ version = '1.16.0'
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
     'google-auth >= 1.2.0',
-    'google-api-core >= 1.6.0, < 2.0.0dev',
     "google-cloud-core >= 1.0.0, < 2.0dev",
     'google-resumable-media >= 0.3.1',
 ]


### PR DESCRIPTION
Apparently, at least some versions of pip treat the more relaxed version of the `google-api-core` pin in these packages as license to ignore the transitive, stricter pin in `google-cloud-core 1.0.0`.

Closes #8085.