### PR TITLE
Logging: Set the 'timestamp' on log records created by handler.

### DIFF
--- a/logging/google/cloud/logging/handlers/transports/background_thread.py
+++ b/logging/google/cloud/logging/handlers/transports/background_thread.py
@@ -267,6 +267,7 @@ class _Worker(object):
                 "labels": labels,
                 "trace": trace,
                 "span_id": span_id,
+                "timestamp": datetime.utcfromtimestamp(record.created),
             }
         )
 


### PR DESCRIPTION
There's no easy way to inject your own Worker thread that I can see, but I don't know why you wouldn't want to know the original time of the log entry.

Closes #8222