### PR TITLE
PubSub: Release the state lock before calling the publish api

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -188,10 +188,11 @@ class Batch(base.Batch):
                 return
 
         # Once in the IN_PROGRESS state, no other thread can publish additional
-        # messages or initiate a commit (those operations becme a no-op), thus
+        # messages or initiate a commit (those operations become a no-op), thus
         # it is safe to release the state lock here. Releasing the lock avoids
         # blocking other threads in case api.publish() below takes a long time
         # to complete.
+        # https://github.com/googleapis/google-cloud-python/issues/8036
 
         # Sanity check: If there are no messages, no-op.
         if not self._messages:
@@ -264,7 +265,8 @@ class Batch(base.Batch):
 
         Add the given message to this object; this will cause it to be
         published once the batch either has enough messages or a sufficient
-        period of time has elapsed.
+        period of time has elapsed. If the batch is full or the commit is
+        already in progress, the method does not do anything.
 
         This method is called by :meth:`~.PublisherClient.publish`.
 

--- a/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -187,56 +187,62 @@ class Batch(base.Batch):
                 _LOGGER.debug("Batch is already in progress, exiting commit")
                 return
 
-            # Sanity check: If there are no messages, no-op.
-            if not self._messages:
-                _LOGGER.debug("No messages to publish, exiting commit")
-                self._status = base.BatchStatus.SUCCESS
-                return
+        # Once in the IN_PROGRESS state, no other thread can publish additional
+        # messages or initiate a commit (those operations becme a no-op), thus
+        # it is safe to release the state lock here. Releasing the lock avoids
+        # blocking other threads in case api.publish() below takes a long time
+        # to complete.
 
-            # Begin the request to publish these messages.
-            # Log how long the underlying request takes.
-            start = time.time()
+        # Sanity check: If there are no messages, no-op.
+        if not self._messages:
+            _LOGGER.debug("No messages to publish, exiting commit")
+            self._status = base.BatchStatus.SUCCESS
+            return
 
-            try:
-                response = self._client.api.publish(self._topic, self._messages)
-            except google.api_core.exceptions.GoogleAPIError as exc:
-                # We failed to publish, set the exception on all futures and
-                # exit.
-                self._status = base.BatchStatus.ERROR
+        # Begin the request to publish these messages.
+        # Log how long the underlying request takes.
+        start = time.time()
 
-                for future in self._futures:
-                    future.set_exception(exc)
+        try:
+            response = self._client.api.publish(self._topic, self._messages)
+        except google.api_core.exceptions.GoogleAPIError as exc:
+            # We failed to publish, set the exception on all futures and
+            # exit.
+            self._status = base.BatchStatus.ERROR
 
-                _LOGGER.exception("Failed to publish %s messages.", len(self._futures))
-                return
+            for future in self._futures:
+                future.set_exception(exc)
 
-            end = time.time()
-            _LOGGER.debug("gRPC Publish took %s seconds.", end - start)
+            _LOGGER.exception("Failed to publish %s messages.", len(self._futures))
+            return
 
-            if len(response.message_ids) == len(self._futures):
-                # Iterate over the futures on the queue and return the response
-                # IDs. We are trusting that there is a 1:1 mapping, and raise
-                # an exception if not.
-                self._status = base.BatchStatus.SUCCESS
-                zip_iter = six.moves.zip(response.message_ids, self._futures)
-                for message_id, future in zip_iter:
-                    future.set_result(message_id)
-            else:
-                # Sanity check: If the number of message IDs is not equal to
-                # the number of futures I have, then something went wrong.
-                self._status = base.BatchStatus.ERROR
-                exception = exceptions.PublishError(
-                    "Some messages were not successfully published."
-                )
+        end = time.time()
+        _LOGGER.debug("gRPC Publish took %s seconds.", end - start)
 
-                for future in self._futures:
-                    future.set_exception(exception)
+        if len(response.message_ids) == len(self._futures):
+            # Iterate over the futures on the queue and return the response
+            # IDs. We are trusting that there is a 1:1 mapping, and raise
+            # an exception if not.
+            self._status = base.BatchStatus.SUCCESS
+            zip_iter = six.moves.zip(response.message_ids, self._futures)
+            for message_id, future in zip_iter:
+                future.set_result(message_id)
+        else:
+            # Sanity check: If the number of message IDs is not equal to
+            # the number of futures I have, then something went wrong.
+            self._status = base.BatchStatus.ERROR
+            exception = exceptions.PublishError(
+                "Some messages were not successfully published."
+            )
 
-                _LOGGER.error(
-                    "Only %s of %s messages were published.",
-                    len(response.message_ids),
-                    len(self._futures),
-                )
+            for future in self._futures:
+                future.set_exception(exception)
+
+            _LOGGER.error(
+                "Only %s of %s messages were published.",
+                len(response.message_ids),
+                len(self._futures),
+            )
 
     def monitor(self):
         """Commit this batch after sufficient time has elapsed.


### PR DESCRIPTION
Closes #8036.

Supersedes #7686 (the fix here is essentially the same, but also adds tests and a few minor things).

### Summary
This PR makes sure that calls to `publisher.publish()` are not unnecessarily blocked while the underlying API publish call is in progress - the latter can take a substantial amount of time, especially on network errors when retries kick in.

### Description
The fix makes sure that the lock in the `_commit()` method is held for no longer than necessary. The details on why releasing the lock earlier is fine are listed in the [comment](https://github.com/googleapis/google-cloud-python/pull/7686#discussion_r284314182) on the original PR.

### How to test
**Steps to reproduce:**
- Set the total publish timeout [setting](https://github.com/googleapis/google-cloud-python/blob/master/pubsub/google/cloud/pubsub_v1/gapic/publisher_client_config.py#L35) to 60,000 milliseconds (in order to not wait for too long),
- Disable the internet connection on your machine,
- Run the test publisher script:
```py
import logging

from google.cloud import pubsub_v1


log_format = (
    "%(levelname)-8s [%(asctime)s] %(threadName)-33s "
    "[%(name)s] [%(filename)s:%(lineno)d][%(funcName)s] %(message)s"
)
logging.basicConfig(
    level=logging.DEBUG,
    format=log_format,
)
logger = logging.getLogger(__name__)

PROJECT_NAME = "some-pubsub-project"
TOPIC_NAME = "my-topic"


def main():
    publisher = pubsub_v1.PublisherClient()
    topic_path = publisher.topic_path(PROJECT_NAME, TOPIC_NAME)

    message_future = publisher.publish(topic_path, b"I'm going to timeout")

    try:
        message_future.exception(timeout=3)
    except Exception as exc:
        logger.info("\x1b[1mException raised:\x1b[0m {}".format(exc))

    logger.info("\x1b[1mAbout to publish the second message\x1b[0m")
    publisher.publish(topic_path, b"I'm going to take quite some time to return")
    logger.info("\x1b[1mReturned from second call to publish()\x1b[0m")


if __name__ == "__main__":
    main()
```

**Actual result (before the fix):**
The message _"Returned from second call to publish"_ appears in the logs only after a minute or so after the _"About to publish the second message"_.

**Expected result (after the fix):**
The second message is logged shortly after the first one. The second call to `publisher.publish()` is not blocked while publishing the first message is in progress and hitting the automatic retry because of the network error.