### PR TITLE
Firestore: Add gRPC keepalive to Client Init.

### DIFF
--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -116,7 +116,7 @@ class Client(ClientWithProject):
             # Use a custom channel.
             # We need this in order to set appropriate keepalive options.
             channel = firestore_grpc_transport.FirestoreGrpcTransport.create_channel(
-                target=self._target,
+                self._target,
                 credentials=self._credentials,
                 options={"grpc.keepalive_time_ms": 30000}.items(),
             )

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -23,6 +23,7 @@ In the hierarchy of API concepts
 * a :class:`~google.cloud.firestore_v1.client.Client` owns a
   :class:`~google.cloud.firestore_v1.document.DocumentReference`
 """
+from google.api_core import grpc_helpers
 from google.api_core.gapic_v1 import client_info
 from google.cloud.client import ClientWithProject
 
@@ -36,6 +37,7 @@ from google.cloud.firestore_v1.document import DocumentReference
 from google.cloud.firestore_v1.document import DocumentSnapshot
 from google.cloud.firestore_v1.field_path import render_field_path
 from google.cloud.firestore_v1.gapic import firestore_client
+from google.cloud.firestore_v1.gapic.transports import firestore_grpc_transport
 from google.cloud.firestore_v1.transaction import Transaction
 
 
@@ -112,8 +114,25 @@ class Client(ClientWithProject):
             <The GAPIC client with the credentials of the current client.
         """
         if self._firestore_api_internal is None:
-            self._firestore_api_internal = firestore_client.FirestoreClient(
-                credentials=self._credentials, client_info=self._client_info
+            SERVICE_ADDRESS = "firestore.googleapis.com:443"
+
+            # Use a custom channel.
+            # We need this in order to set appropriate keepalive options.
+            channel = grpc_helpers.create_channel(
+                target=SERVICE_ADDRESS,
+                credentials=self._credentials,
+                scopes=firestore_grpc_transport.FirestoreGrpcTransport._OAUTH_SCOPES,
+                options={
+                    "grpc.keepalive_time_ms": 30000,
+                }.items(),
+            )
+
+            transport = firestore_grpc_transport.FirestoreGrpcTransport(
+                address=SERVICE_ADDRESS, channel=channel
+            )
+      
+            self._firestore_api_internal = firestore_client.FirestoreClient(    
+                transport=transport, client_info=self._client_info
             )
 
         return self._firestore_api_internal

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -23,8 +23,6 @@ In the hierarchy of API concepts
 * a :class:`~google.cloud.firestore_v1.client.Client` owns a
   :class:`~google.cloud.firestore_v1.document.DocumentReference`
 """
-from google.api_core import grpc_helpers
-from google.api_core.gapic_v1 import client_info
 from google.cloud.client import ClientWithProject
 
 from google.cloud.firestore_v1 import _helpers

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -118,10 +118,9 @@ class Client(ClientWithProject):
 
             # Use a custom channel.
             # We need this in order to set appropriate keepalive options.
-            channel = grpc_helpers.create_channel(
+            channel = firestore_grpc_transport.FirestoreGrpcTransport.create_channel(
                 target=SERVICE_ADDRESS,
                 credentials=self._credentials,
-                scopes=firestore_grpc_transport.FirestoreGrpcTransport._OAUTH_SCOPES,
                 options={"grpc.keepalive_time_ms": 30000}.items(),
             )
 

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -114,18 +114,16 @@ class Client(ClientWithProject):
             <The GAPIC client with the credentials of the current client.
         """
         if self._firestore_api_internal is None:
-            SERVICE_ADDRESS = "firestore.googleapis.com:443"
-
             # Use a custom channel.
             # We need this in order to set appropriate keepalive options.
             channel = firestore_grpc_transport.FirestoreGrpcTransport.create_channel(
-                target=SERVICE_ADDRESS,
+                target=self._target,
                 credentials=self._credentials,
                 options={"grpc.keepalive_time_ms": 30000}.items(),
             )
 
             self._transport = firestore_grpc_transport.FirestoreGrpcTransport(
-                address=SERVICE_ADDRESS, channel=channel
+                address=self._target, channel=channel
             )
 
             self._firestore_api_internal = firestore_client.FirestoreClient(
@@ -133,6 +131,15 @@ class Client(ClientWithProject):
             )
 
         return self._firestore_api_internal
+
+    @property
+    def _target(self):
+        """Return the target (where the API is).
+
+        Returns:
+            str: The location of the API.
+        """
+        return firestore_client.FirestoreClient.SERVICE_ADDRESS
 
     @property
     def _database_string(self):

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -127,12 +127,12 @@ class Client(ClientWithProject):
                 }.items(),
             )
 
-            transport = firestore_grpc_transport.FirestoreGrpcTransport(
+            self._transport = firestore_grpc_transport.FirestoreGrpcTransport(
                 address=SERVICE_ADDRESS, channel=channel
             )
       
             self._firestore_api_internal = firestore_client.FirestoreClient(    
-                transport=transport, client_info=self._client_info
+                transport=self._transport, client_info=self._client_info
             )
 
         return self._firestore_api_internal

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -122,16 +122,14 @@ class Client(ClientWithProject):
                 target=SERVICE_ADDRESS,
                 credentials=self._credentials,
                 scopes=firestore_grpc_transport.FirestoreGrpcTransport._OAUTH_SCOPES,
-                options={
-                    "grpc.keepalive_time_ms": 30000,
-                }.items(),
+                options={"grpc.keepalive_time_ms": 30000}.items(),
             )
 
             self._transport = firestore_grpc_transport.FirestoreGrpcTransport(
                 address=SERVICE_ADDRESS, channel=channel
             )
-      
-            self._firestore_api_internal = firestore_client.FirestoreClient(    
+
+            self._firestore_api_internal = firestore_client.FirestoreClient(
                 transport=self._transport, client_info=self._client_info
             )
 

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -23,6 +23,7 @@ In the hierarchy of API concepts
 * a :class:`~google.cloud.firestore_v1.client.Client` owns a
   :class:`~google.cloud.firestore_v1.document.DocumentReference`
 """
+from google.api_core.gapic_v1 import client_info
 from google.cloud.client import ClientWithProject
 
 from google.cloud.firestore_v1 import _helpers

--- a/firestore/google/cloud/firestore_v1beta1/client.py
+++ b/firestore/google/cloud/firestore_v1beta1/client.py
@@ -23,7 +23,6 @@ In the hierarchy of API concepts
 * a :class:`~google.cloud.firestore_v1beta1.client.Client` owns a
   :class:`~google.cloud.firestore_v1beta1.document.DocumentReference`
 """
-from google.api_core import grpc_helpers
 from google.cloud.client import ClientWithProject
 
 from google.cloud.firestore_v1beta1 import _helpers
@@ -98,19 +97,16 @@ class Client(ClientWithProject):
             GAPIC client with the credentials of the current client.
         """
         if self._firestore_api_internal is None:
-            SERVICE_ADDRESS = "firestore.googleapis.com:443"
-
             # Use a custom channel.
             # We need this in order to set appropriate keepalive options.
-            channel = grpc_helpers.create_channel(
-                target=SERVICE_ADDRESS,
+            channel = firestore_grpc_transport.FirestoreGrpcTransport.create_channel(
+                target=self._target,
                 credentials=self._credentials,
-                scopes=firestore_grpc_transport.FirestoreGrpcTransport._OAUTH_SCOPES,
                 options={"grpc.keepalive_time_ms": 30000}.items(),
             )
 
             self._transport = firestore_grpc_transport.FirestoreGrpcTransport(
-                address=SERVICE_ADDRESS, channel=channel
+                address=self._target, channel=channel
             )
 
             self._firestore_api_internal = firestore_client.FirestoreClient(
@@ -118,6 +114,15 @@ class Client(ClientWithProject):
             )
 
         return self._firestore_api_internal
+
+    @property
+    def _target(self):
+        """Return the target (where the API is).
+
+        Returns:
+            str: The location of the API.
+        """
+        return firestore_client.FirestoreClient.SERVICE_ADDRESS
 
     @property
     def _database_string(self):

--- a/firestore/google/cloud/firestore_v1beta1/client.py
+++ b/firestore/google/cloud/firestore_v1beta1/client.py
@@ -98,8 +98,23 @@ class Client(ClientWithProject):
             GAPIC client with the credentials of the current client.
         """
         if self._firestore_api_internal is None:
+            SERVICE_ADDRESS = "firestore.googleapis.com:443"
+
+            # Use a custom channel.
+            # We need this in order to set appropriate keepalive options.
+            channel = grpc_helpers.create_channel(
+                target=SERVICE_ADDRESS,
+                credentials=self._credentials,
+                scopes=firestore_grpc_transport.FirestoreGrpcTransport._OAUTH_SCOPES,
+                options={"grpc.keepalive_time_ms": 30000}.items(),
+            )
+
+            self._transport = firestore_grpc_transport.FirestoreGrpcTransport(
+                address=SERVICE_ADDRESS, channel=channel
+            )
+
             self._firestore_api_internal = firestore_client.FirestoreClient(
-                credentials=self._credentials
+                transport=self._transport
             )
 
         return self._firestore_api_internal

--- a/firestore/google/cloud/firestore_v1beta1/client.py
+++ b/firestore/google/cloud/firestore_v1beta1/client.py
@@ -100,7 +100,7 @@ class Client(ClientWithProject):
             # Use a custom channel.
             # We need this in order to set appropriate keepalive options.
             channel = firestore_grpc_transport.FirestoreGrpcTransport.create_channel(
-                target=self._target,
+                self._target,
                 credentials=self._credentials,
                 options={"grpc.keepalive_time_ms": 30000}.items(),
             )

--- a/firestore/google/cloud/firestore_v1beta1/client.py
+++ b/firestore/google/cloud/firestore_v1beta1/client.py
@@ -23,6 +23,7 @@ In the hierarchy of API concepts
 * a :class:`~google.cloud.firestore_v1beta1.client.Client` owns a
   :class:`~google.cloud.firestore_v1beta1.document.DocumentReference`
 """
+from google.api_core import grpc_helpers
 from google.cloud.client import ClientWithProject
 
 from google.cloud.firestore_v1beta1 import _helpers
@@ -33,6 +34,7 @@ from google.cloud.firestore_v1beta1.document import DocumentReference
 from google.cloud.firestore_v1beta1.document import DocumentSnapshot
 from google.cloud.firestore_v1beta1.field_path import render_field_path
 from google.cloud.firestore_v1beta1.gapic import firestore_client
+from google.cloud.firestore_v1beta1.gapic.transports import firestore_grpc_transport
 from google.cloud.firestore_v1beta1.transaction import Transaction
 
 

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -76,7 +76,7 @@ class TestClient(unittest.TestCase):
         self.assertIs(firestore_api, mock_client.return_value)
         self.assertIs(firestore_api, client._firestore_api_internal)
         mock_client.assert_called_once_with(
-            credentials=client._credentials, client_info=client_info
+            transport=client._transport, client_info=client_info
         )
 
         # Call again to show that it is cached, but call count is still 1.

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -69,6 +69,7 @@ class TestClient(unittest.TestCase):
         return_value=mock.sentinel.firestore_api,
     )
     def test__firestore_api_property(self, mock_client):
+        mock_client.SERVICE_ADDRESS = "endpoint"
         client = self._make_default_one()
         client_info = client._client_info = mock.Mock()
         self.assertIsNone(client._firestore_api_internal)

--- a/firestore/tests/unit/v1beta1/test_client.py
+++ b/firestore/tests/unit/v1beta1/test_client.py
@@ -62,6 +62,7 @@ class TestClient(unittest.TestCase):
         return_value=mock.sentinel.firestore_api,
     )
     def test__firestore_api_property(self, mock_client):
+        mock_client.SERVICE_ADDRESS = "endpoint"
         client = self._make_default_one()
         self.assertIsNone(client._firestore_api_internal)
         firestore_api = client._firestore_api

--- a/firestore/tests/unit/v1beta1/test_client.py
+++ b/firestore/tests/unit/v1beta1/test_client.py
@@ -67,7 +67,7 @@ class TestClient(unittest.TestCase):
         firestore_api = client._firestore_api
         self.assertIs(firestore_api, mock_client.return_value)
         self.assertIs(firestore_api, client._firestore_api_internal)
-        mock_client.assert_called_once_with(credentials=client._credentials)
+        mock_client.assert_called_once_with(transport=client._transport)
 
         # Call again to show that it is cached, but call count is still 1.
         self.assertIs(client._firestore_api, mock_client.return_value)


### PR DESCRIPTION
In order to run a listen for longer than one our, gRPC needs to be configured to keep the connection alive. These changes are in generated code here though and shouldn't be merged.

b/130522486