### PR TITLE
Error reporting: fixed mistake in documentation

### DIFF
--- a/error_reporting/docs/usage.rst
+++ b/error_reporting/docs/usage.rst
@@ -97,7 +97,7 @@ line number of the location where the error was reported.
    from google.cloud import error_reporting
 
    client = error_reporting.Client()
-   error_reporting.report("Found an error!")
+   client.report("Found an error!")
 
 As with reporting an exception, the user and HTTP context can be provided:
 
@@ -111,5 +111,5 @@ As with reporting an exception, the user and HTTP context can be provided:
        method='GET', url='/', user_agent='test agent',
        referrer='example.com', response_status_code=500,
        remote_ip='1.2.3.4')
-   error_reporting.report(
+   client.report(
        "Found an error!", http_context=http_context, user=user))


### PR DESCRIPTION
Fixing mistake in documentation regarding issue: https://github.com/googleapis/google-cloud-python/issues/8270. 

Changed code examples on chapter:[Reporting an error without an exception]( https://googleapis.github.io/google-cloud-python/latest/error-reporting/usage.html#reporting-an-error-without-an-exception) to call `report()` method of the instance of Client-class, instead of method within error_reporting module.