### PR TITLE
Coverage tests noise

### DIFF
--- a/automl/.coveragerc
+++ b/automl/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -57,7 +57,7 @@ def default(session):
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
-        "--cov-fail-under=97",
+        "--cov-fail-under=0",
         os.path.join("tests", "unit"),
         *session.posargs
     )

--- a/bigquery_datatransfer/.coveragerc
+++ b/bigquery_datatransfer/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/bigquery_datatransfer/noxfile.py
+++ b/bigquery_datatransfer/noxfile.py
@@ -78,7 +78,7 @@ def default(session):
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
-        "--cov-fail-under=79",
+        "--cov-fail-under=0",
         os.path.join("tests", "unit"),
         *session.posargs,
     )

--- a/bigtable/.coveragerc
+++ b/bigtable/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/bigtable/noxfile.py
+++ b/bigtable/noxfile.py
@@ -22,6 +22,7 @@ import nox
 
 LOCAL_DEPS = (os.path.join("..", "api_core"), os.path.join("..", "core"))
 
+
 @nox.session(python="3.7")
 def lint(session):
     """Run linters.
@@ -78,7 +79,7 @@ def default(session):
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
-        "--cov-fail-under=97",
+        "--cov-fail-under=0",
         os.path.join("tests", "unit"),
         *session.posargs,
     )

--- a/container/.coveragerc
+++ b/container/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/container/noxfile.py
+++ b/container/noxfile.py
@@ -46,7 +46,7 @@ def blacken(session):
     """Run black.
 
     Format code to uniform standard.
-    
+
     This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
     That run uses an image that doesn't have 3.6 installed. Before updating this
     check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
@@ -83,7 +83,7 @@ def default(session):
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
-        "--cov-fail-under=75",
+        "--cov-fail-under=0",
         os.path.join("tests", "unit"),
         *session.posargs,
     )

--- a/datacatalog/.coveragerc
+++ b/datacatalog/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/datalabeling/.coveragerc
+++ b/datalabeling/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/dataproc/.coveragerc
+++ b/dataproc/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/datastore/.coveragerc
+++ b/datastore/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/dlp/.coveragerc
+++ b/dlp/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/dlp/noxfile.py
+++ b/dlp/noxfile.py
@@ -46,7 +46,7 @@ def blacken(session):
     """Run black.
 
     Format code to uniform standard.
-    
+
     This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
     That run uses an image that doesn't have 3.6 installed. Before updating this
     check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
@@ -78,7 +78,7 @@ def default(session):
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
-        "--cov-fail-under=97",
+        "--cov-fail-under=0",
         os.path.join("tests", "unit"),
         *session.posargs,
     )

--- a/firestore/.coveragerc
+++ b/firestore/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/iam/.coveragerc
+++ b/iam/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/irm/.coveragerc
+++ b/irm/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/language/.coveragerc
+++ b/language/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/logging/.coveragerc
+++ b/logging/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/logging/noxfile.py
+++ b/logging/noxfile.py
@@ -96,7 +96,7 @@ def default(session, django_dep=('django',)):
         '--cov-append',
         '--cov-config=.coveragerc',
         '--cov-report=',
-        '--cov-fail-under=97',
+        "--cov-fail-under=0",
         'tests/unit',
         *session.posargs
     )

--- a/monitoring/.coveragerc
+++ b/monitoring/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/monitoring/noxfile.py
+++ b/monitoring/noxfile.py
@@ -46,7 +46,7 @@ def blacken(session):
     """Run black.
 
     Format code to uniform standard.
-    
+
     This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
     That run uses an image that doesn't have 3.6 installed. Before updating this
     check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
@@ -83,7 +83,7 @@ def default(session):
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
-        "--cov-fail-under=97",
+        "--cov-fail-under=0",
         os.path.join("tests", "unit"),
         *session.posargs,
     )

--- a/oslogin/.coveragerc
+++ b/oslogin/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/phishingprotection/.coveragerc
+++ b/phishingprotection/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/phishingprotection/noxfile.py
+++ b/phishingprotection/noxfile.py
@@ -46,7 +46,7 @@ def blacken(session):
     """Run black.
 
     Format code to uniform standard.
-    
+
     This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
     That run uses an image that doesn't have 3.6 installed. Before updating this
     check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
@@ -83,7 +83,7 @@ def default(session):
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
-        "--cov-fail-under=97",
+        "--cov-fail-under=0",
         os.path.join("tests", "unit"),
         *session.posargs,
     )

--- a/pubsub/.coveragerc
+++ b/pubsub/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/redis/.coveragerc
+++ b/redis/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/scheduler/.coveragerc
+++ b/scheduler/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/securitycenter/.coveragerc
+++ b/securitycenter/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/securitycenter/noxfile.py
+++ b/securitycenter/noxfile.py
@@ -16,7 +16,7 @@
 
 from __future__ import absolute_import
 import os
-import shutil 
+import shutil
 
 import nox
 
@@ -46,7 +46,7 @@ def blacken(session):
     """Run black.
 
     Format code to uniform standard.
-    
+
     This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
     That run uses an image that doesn't have 3.6 installed. Before updating this
     check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
@@ -83,7 +83,7 @@ def default(session):
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
-        "--cov-fail-under=97",
+        "--cov-fail-under=0",
         os.path.join("tests", "unit"),
         *session.posargs,
     )

--- a/spanner/.coveragerc
+++ b/spanner/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/speech/.coveragerc
+++ b/speech/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/storage/.coveragerc
+++ b/storage/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -14,3 +15,4 @@ exclude_lines =
 omit =
   */gapic/*.py
   */proto/*.py
+  google/cloud/__init__.py

--- a/storage/noxfile.py
+++ b/storage/noxfile.py
@@ -49,7 +49,7 @@ def default(session):
         '--cov-append',
         '--cov-config=.coveragerc',
         '--cov-report=',
-        '--cov-fail-under=97',
+        "--cov-fail-under=0",
         'tests/unit',
         *session.posargs
     )

--- a/talent/.coveragerc
+++ b/talent/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/texttospeech/.coveragerc
+++ b/texttospeech/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/texttospeech/noxfile.py
+++ b/texttospeech/noxfile.py
@@ -46,7 +46,7 @@ def blacken(session):
     """Run black.
 
     Format code to uniform standard.
-    
+
     This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
     That run uses an image that doesn't have 3.6 installed. Before updating this
     check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
@@ -83,7 +83,7 @@ def default(session):
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
-        "--cov-fail-under=97",
+        "--cov-fail-under=0",
         os.path.join("tests", "unit"),
         *session.posargs,
     )

--- a/translate/.coveragerc
+++ b/translate/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/translate/noxfile.py
+++ b/translate/noxfile.py
@@ -46,7 +46,7 @@ def blacken(session):
     """Run black.
 
     Format code to uniform standard.
-    
+
     This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
     That run uses an image that doesn't have 3.6 installed. Before updating this
     check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
@@ -83,7 +83,7 @@ def default(session):
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
-        "--cov-fail-under=100",
+        "--cov-fail-under=0",
         os.path.join("tests", "unit"),
         *session.posargs,
     )

--- a/videointelligence/.coveragerc
+++ b/videointelligence/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/vision/.coveragerc
+++ b/vision/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/webrisk/.coveragerc
+++ b/webrisk/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py

--- a/webrisk/noxfile.py
+++ b/webrisk/noxfile.py
@@ -46,7 +46,7 @@ def blacken(session):
     """Run black.
 
     Format code to uniform standard.
-    
+
     This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
     That run uses an image that doesn't have 3.6 installed. Before updating this
     check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
@@ -83,7 +83,7 @@ def default(session):
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
-        "--cov-fail-under=97",
+        "--cov-fail-under=0",
         os.path.join("tests", "unit"),
         *session.posargs,
     )

--- a/websecurityscanner/.coveragerc
+++ b/websecurityscanner/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+disable_warnings = module-not-measured
 
 [report]
 fail_under = 100
@@ -16,3 +17,4 @@ omit =
   */proto/*.py
   */core/*.py
   */site-packages/*.py
+  google/cloud/__init__.py


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-python/issues/8174
Dropped --cov-fail-under param to zero (saw such changes by Yoshi Automation Bot) and tweaked coveragerc-files to ignore path-extender-files