### PR TITLE
PubSub: Document FlowControl settings

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/types.py
+++ b/pubsub/google/cloud/pubsub_v1/types.py
@@ -71,6 +71,38 @@ FlowControl.__new__.__defaults__ = (
     2 * 60 * 60,  # max_lease_duration: 2 hours.
 )
 
+if sys.version_info >= (3, 5):
+    FlowControl.__doc__ = (
+        "The settings for controlling the rate at which messages are pulled "
+        "with an asynchronous subscription."
+    )
+    FlowControl.max_bytes.__doc__ = (
+        "The maximum total size of received - but not yet processed - messages "
+        "before pausing the message stream."
+    )
+    FlowControl.max_messages.__doc__ = (
+        "The maximum number of received - but not yet processed - messages before "
+        "pausing the message stream."
+    )
+    FlowControl.resume_threshold.__doc__ = (
+        "The relative threshold of the ``max_bytes`` and ``max_messages`` limits "
+        "below which to resume the message stream. Must be a positive number not "
+        "greater than ``1.0``."
+    )
+    FlowControl.max_requests.__doc__ = "Currently not in use."
+    FlowControl.max_request_batch_size.__doc__ = (
+        "The maximum number of requests scheduled by callbacks to process and "
+        "dispatch at a time."
+    )
+    FlowControl.max_request_batch_latency.__doc__ = (
+        "The maximum amount of time in seconds to wait for additional request "
+        "items before processing the next batch of requests."
+    )
+    FlowControl.max_lease_duration.__doc__ = (
+        "The maximum amount of time in seconds to hold a lease on a message "
+        "before dropping it from the lease management."
+    )
+
 
 _shared_modules = [
     http_pb2,

--- a/pubsub/synth.metadata
+++ b/pubsub/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-06T00:31:04.007153Z",
+  "updateTime": "2019-06-12T13:55:40.520528Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.23.1",
-        "dockerImage": "googleapis/artman@sha256:9d5cae1454da64ac3a87028f8ef486b04889e351c83bb95e83b8fab3959faed0"
+        "version": "0.24.1",
+        "dockerImage": "googleapis/artman@sha256:6018498e15310260dc9b03c9d576608908ed9fbabe42e1494ff3d827fea27b19"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "5487c78983f6bd5bbafa69166593826a90778a2f",
-        "internalRef": "251716150"
+        "sha": "f117dac435e96ebe58d85280a3faf2350c4d4219",
+        "internalRef": "252714985"
       }
     },
     {

--- a/pubsub/synth.py
+++ b/pubsub/synth.py
@@ -15,6 +15,7 @@
 """This script is used to synthesize generated parts of this library."""
 
 import re
+import textwrap
 
 import synthtool as s
 from synthtool import gcp
@@ -164,6 +165,48 @@ s.replace(
         else:
             client_config = _merge_dict(default_client_config, client_config)
     """
+)
+
+# document FlowControl settings in Python 3.5+
+s.replace(
+    "google/cloud/pubsub_v1/types.py",
+    "FlowControl.__new__.__defaults__ = \(.*?\)",
+    textwrap.dedent("""\
+    \g<0>
+
+    if sys.version_info >= (3, 5):
+        FlowControl.__doc__ = (
+            "The settings for controlling the rate at which messages are pulled "
+            "with an asynchronous subscription."
+        )
+        FlowControl.max_bytes.__doc__ = (
+            "The maximum total size of received - but not yet processed - messages "
+            "before pausing the message stream."
+        )
+        FlowControl.max_messages.__doc__ = (
+            "The maximum number of received - but not yet processed - messages before "
+            "pausing the message stream."
+        )
+        FlowControl.resume_threshold.__doc__ = (
+            "The relative threshold of the ``max_bytes`` and ``max_messages`` limits "
+            "below which to resume the message stream. Must be a positive number not "
+            "greater than ``1.0``."
+        )
+        FlowControl.max_requests.__doc__ = "Currently not in use."
+        FlowControl.max_request_batch_size.__doc__ = (
+            "The maximum number of requests scheduled by callbacks to process and "
+            "dispatch at a time."
+        )
+        FlowControl.max_request_batch_latency.__doc__ = (
+            "The maximum amount of time in seconds to wait for additional request "
+            "items before processing the next batch of requests."
+        )
+        FlowControl.max_lease_duration.__doc__ = (
+            "The maximum amount of time in seconds to hold a lease on a message "
+            "before dropping it from the lease management."
+        )
+    """),
+    flags=re.DOTALL,
 )
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #7043.

This PR makes sure that FlowControl settings are properly documented in the generated documentation.

### How to test
**Steps to perform:**

(from inside the `pubsub/` directory)
- Install the [synthtool](https://github.com/googleapis/synthtool) and run it,
- Generate the pubsub docs locally:
    ```
    $ nox -f noxfile.py -s docs
    ```
- Open the generated docs for `FlowControl`:
    ```
    $ chromium-browser "file://$GOOG_CLOUD_PYTHON_DIR/pubsub/docs/_build/html/types.html#google.cloud.pubsub_v1.types.FlowControl"
    ```

**Expected result:**
`FlowControl` settings have nice descriptions (as opposed to the [current docs](https://googleapis.github.io/google-cloud-python/latest/pubsub/types.html?highlight=flowcontrol#google.cloud.pubsub_v1.types.FlowControl)).