### PR TITLE
Monitoring: Update noxfile.py

### DIFF
--- a/monitoring/noxfile.py
+++ b/monitoring/noxfile.py
@@ -122,12 +122,12 @@ def system(session):
     session.install("-e", ".")
 
     # Additional setup for VPCSC system tests
-    env = {
-        "PROJECT_ID": "secure-gcp-test-project-4",
-        "GOOGLE_CLOUD_TESTS_VPCSC_OUTSIDE_PERIMETER_PROJECT": os.environ.get(
-            "PROJECT_ID"
-        ),
-    }
+    # env = {
+    #     "PROJECT_ID": "secure-gcp-test-project-4",
+    #     "GOOGLE_CLOUD_TESTS_VPCSC_OUTSIDE_PERIMETER_PROJECT": os.environ.get(
+    #         "PROJECT_ID"
+    #     ),
+    # }
 
     # Run py.test against the system tests.
     if system_test_exists:

--- a/monitoring/noxfile.py
+++ b/monitoring/noxfile.py
@@ -131,9 +131,9 @@ def system(session):
 
     # Run py.test against the system tests.
     if system_test_exists:
-        session.run("py.test", "--quiet", system_test_path, env=env, *session.posargs)
+        session.run("py.test", "--quiet", system_test_path, *session.posargs)
     if system_test_folder_exists:
-        session.run("py.test", "--quiet", system_test_folder_path, env=env, *session.posargs)
+        session.run("py.test", "--quiet", system_test_folder_path, *session.posargs)
 
 
 @nox.session(python="3.7")


### PR DESCRIPTION
The `GOOGLE_CLOUD_TESTS_VPCSC_OUTSIDE_PERIMETER_PROJECT` should be a project outside of the VPCSC perimeter. `PROJECT_ID` is a project inside the perimeter. Do not uncomment until we have a project for the second environment variable. Otherwise this wrong value is breaking the system tests of the VPCSC team.