### PR TITLE
Firestore error get all removes non existing snapshot fixed

### DIFF
--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -520,8 +520,9 @@ def _parse_batch_get(get_doc_response, reference_map, client):
             update_time=get_doc_response.found.update_time,
         )
     elif result_type == "missing":
+        reference = _get_reference(get_doc_response.missing, reference_map)
         snapshot = DocumentSnapshot(
-            None,
+            reference,
             None,
             exists=False,
             read_time=get_doc_response.read_time,

--- a/firestore/google/cloud/firestore_v1/document.py
+++ b/firestore/google/cloud/firestore_v1/document.py
@@ -603,11 +603,9 @@ class DocumentSnapshot(object):
         """The document identifier (within its collection).
 
         Returns:
-            str: The last component of the path of the document if it exists.
+            str: The last component of the path of the document.
         """
-        if self._reference:
-            return self._reference.id
-        return None
+        return self._reference.id
 
     @property
     def reference(self):

--- a/firestore/google/cloud/firestore_v1/document.py
+++ b/firestore/google/cloud/firestore_v1/document.py
@@ -603,7 +603,7 @@ class DocumentSnapshot(object):
         """The document identifier (within its collection).
 
         Returns:
-            str: The last component of the path of the document if document exist..
+            str: The last component of the path of the document if it exists.
         """
         if self._reference:
             return self._reference.id

--- a/firestore/google/cloud/firestore_v1/document.py
+++ b/firestore/google/cloud/firestore_v1/document.py
@@ -603,10 +603,11 @@ class DocumentSnapshot(object):
         """The document identifier (within its collection).
 
         Returns:
-            str: The last component of the path of the document.
+            str: The last component of the path of the document if document exist..
         """
         if self._reference:
             return self._reference.id
+        return None
 
     @property
     def reference(self):

--- a/firestore/google/cloud/firestore_v1/document.py
+++ b/firestore/google/cloud/firestore_v1/document.py
@@ -605,7 +605,8 @@ class DocumentSnapshot(object):
         Returns:
             str: The last component of the path of the document.
         """
-        return self._reference.id
+        if self._reference:
+            return self._reference.id
 
     @property
     def reference(self):

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -768,7 +768,11 @@ def test_get_all(client, cleanup):
 
     assert snapshots[0].exists
     assert snapshots[1].exists
+
     assert not snapshots[2].exists
+    assert not snapshots[2]._data
+    assert snapshots[2].id == "b"
+
     snapshots = [snapshot for snapshot in snapshots if snapshot.exists]
     id_attr = operator.attrgetter("id")
     snapshots.sort(key=id_attr)

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -595,9 +595,9 @@ class Test__parse_batch_get(unittest.TestCase):
 
     def test_missing(self):
         ref_string = self._dummy_ref_string()
+        reference_map = {ref_string: mock.sentinel.reference}
         response_pb = _make_batch_response(missing=ref_string)
-
-        snapshot = self._call_fut(response_pb, {})
+        snapshot = self._call_fut(response_pb, reference_map)
         self.assertFalse(snapshot.exists)
 
     def test_unset_result_type(self):

--- a/firestore/tests/unit/v1/test_document.py
+++ b/firestore/tests/unit/v1/test_document.py
@@ -735,7 +735,7 @@ class TestDocumentSnapshot(unittest.TestCase):
         snapshot = self._make_one(None, None, False, None, None, None)
         as_dict = snapshot.to_dict()
         self.assertIsNone(as_dict)
-        self.assertIsNone(snapshot.id)
+        self.assertFalse(snapshot.exists)
 
 
 class Test__get_document_path(unittest.TestCase):

--- a/firestore/tests/unit/v1/test_document.py
+++ b/firestore/tests/unit/v1/test_document.py
@@ -735,6 +735,7 @@ class TestDocumentSnapshot(unittest.TestCase):
         snapshot = self._make_one(None, None, False, None, None, None)
         as_dict = snapshot.to_dict()
         self.assertIsNone(as_dict)
+        self.assertIsNone(snapshot.id)
 
 
 class Test__get_document_path(unittest.TestCase):


### PR DESCRIPTION
Fix #7564 