### PR TITLE
Speech: Increase speech max received msg size to 256 MiB

### DIFF
--- a/speech/google/cloud/speech_v1/gapic/transports/speech_grpc_transport.py
+++ b/speech/google/cloud/speech_v1/gapic/transports/speech_grpc_transport.py
@@ -90,7 +90,10 @@ class SpeechGrpcTransport(object):
             grpc.Channel: A gRPC channel object.
         """
         return google.api_core.grpc_helpers.create_channel(
-            address, credentials=credentials, scopes=cls._OAUTH_SCOPES
+            address,
+            credentials=credentials,
+            scopes=cls._OAUTH_SCOPES,
+            options={"grpc.max_receive_message_length": 256 * 1024 * 1024}.items(),
         )
 
     @property

--- a/speech/synth.metadata
+++ b/speech/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-14T12:31:03.692038Z",
+  "updateTime": "2019-06-17T08:38:08.782762Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.25.0",
-        "dockerImage": "googleapis/artman@sha256:ef1a98ab1e2b8f05f4d9a56f27d63347aefe14020e5f2d585172b14ca76f1d90"
+        "version": "0.26.0",
+        "dockerImage": "googleapis/artman@sha256:6db0735b0d3beec5b887153a2a7c7411fc7bb53f73f6f389a822096bd14a3a15"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "c23b68eecb00c4d285a730a49b1d7d943cd56183",
-        "internalRef": "253113405"
+        "sha": "7b58b37559f6a5337c4c564518e9573d742df225",
+        "internalRef": "253322136"
       }
     },
     {

--- a/speech/synth.py
+++ b/speech/synth.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ versions = ["v1p1beta1", "v1"]
 # Generate speech GAPIC layer
 # ----------------------------------------------------------------------------
 for version in versions:
-    library = gapic.py_library("speech", version, include_protos=True,)
+    library = gapic.py_library("speech", version, include_protos=True)
 
     # Don't move over __init__.py, as we modify it to make the generated client
     # use helpers.py.
@@ -53,6 +53,16 @@ s.replace(
     "tests/unit/**/test*client*.py",
     r"from google\.cloud import speech_(.+?)$",
     r"from google.cloud.speech_\1.gapic import speech_client as speech_\1",
+)
+
+# Set the maximum received message size to 256 MiB, the default of 4 MiB is
+# often insufficient in practice.
+s.replace(
+    "google/cloud/speech_v1/gapic/transports/speech_grpc_transport.py",
+    r".*scopes=cls\._OAUTH_SCOPES.*",
+    """\g<0>
+    options={"grpc.max_receive_message_length": 256 * 1024 * 1024}.items()
+    """,
 )
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #5819

This PR increases the default max received message size for speech messages to 256 MiB.

Hardcoded, indeed, but that setting was already not directly available to end users (a full `SpeechGrpcTransport` needs to be passed instead). This PR does not address this aspect.

### How to test
- Install the [synthtool](https://github.com/googleapis/synthtool),
- Revert the changes in `transports/speech_grpc_transport.py`,
- Got to the `speech` library directory and run the synthtool.

**Expected result:**
- The generated code changes in `transports/speech_grpc_transport.py` are the same as those submitted with this PR.
- The problem described in the [issue description](https://github.com/googleapis/google-cloud-python/issues/5819#issue-351776995) is also resolved, because the old 4 MiB max message size is now much higher.