### PR TITLE
BigQuery Snippets: Use autodetected location

### DIFF
--- a/bigquery/docs/snippets.py
+++ b/bigquery/docs/snippets.py
@@ -987,11 +987,7 @@ def test_load_table_from_file(client, to_delete):
     job_config.autodetect = True
 
     with open(filename, "rb") as source_file:
-        job = client.load_table_from_file(
-            source_file,
-            table_ref,
-            job_config=job_config,
-        )  # API request
+        job = client.load_table_from_file(source_file, table_ref, job_config=job_config)
 
     job.result()  # Waits for table load to complete.
 

--- a/bigquery/docs/snippets.py
+++ b/bigquery/docs/snippets.py
@@ -990,7 +990,6 @@ def test_load_table_from_file(client, to_delete):
         job = client.load_table_from_file(
             source_file,
             table_ref,
-            location="US",  # Must match the destination dataset location.
             job_config=job_config,
         )  # API request
 


### PR DESCRIPTION
This change update a BigQuery sample to show that the location field can be autodetected .

We can remove the location since it is now auto-detected.
See b/116968956.