### PR TITLE
PubSub: Document how to choose the PubSub auth method

### DIFF
--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -164,8 +164,8 @@ Authentication
 ^^^^^^^^^^^^^^
 
 It is possible to specify the authentication method to use with the Pub/Sub
-clients. This can be done by providing an explicit `Credentials`_ instance from
-the `google-auth`_ library.
+clients. This can be done by providing an explicit `Credentials`_ instance. Support
+for various authentication methods is available from the `google-auth`_ library.
 
 For example, to use JSON Web Tokens, provide a `jwt.Credentials`_ instance:
 
@@ -183,9 +183,6 @@ For example, to use JSON Web Tokens, provide a `jwt.Credentials`_ instance:
 
     publisher = pubsub_v1.PublisherClient(credentials=credentials)
     subscriber = pubsub_v1.SubscriberClient(credentials=credentials)
-
-Check the `google-auth`_ library documentation for the list of supported
-authentication methods.
 
 .. _Credentials: https://google-auth.readthedocs.io/en/latest/reference/google.auth.credentials.html#google.auth.credentials.Credentials
 .. _google-auth: https://google-auth.readthedocs.io/en/latest/index.html

--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -167,7 +167,7 @@ It is possible to specify the authentication method to use with the Pub/Sub
 clients. This can be done by providing an explicit `Credentials`_ instance. Support
 for various authentication methods is available from the `google-auth`_ library.
 
-For example, to use JSON Web Tokens, provide a `jwt.Credentials`_ instance:
+For example, to use JSON Web Tokens, provide a `google.auth.jwt.Credentials`_ instance:
 
 .. code-block:: python
 
@@ -181,9 +181,13 @@ For example, to use JSON Web Tokens, provide a `jwt.Credentials`_ instance:
         service_account_info, audience=audience
     )
 
-    publisher = pubsub_v1.PublisherClient(credentials=credentials)
     subscriber = pubsub_v1.SubscriberClient(credentials=credentials)
+
+    # The same for the publisher, except that the "audience" claim needs to be adjusted
+    publisher_audience = "https://pubsub.googleapis.com/google.pubsub.v1.Publisher"
+    credentials_pub = credentials.with_claims(audience=publisher_audience) 
+    publisher = pubsub_v1.PublisherClient(credentials=credentials_pub)
 
 .. _Credentials: https://google-auth.readthedocs.io/en/latest/reference/google.auth.credentials.html#google.auth.credentials.Credentials
 .. _google-auth: https://google-auth.readthedocs.io/en/latest/index.html
-.. _jwt.Credentials: https://google-auth.readthedocs.io/en/latest/reference/google.auth.jwt.html#google.auth.jwt.Credentials
+.. _google.auth.jwt.Credentials: https://google-auth.readthedocs.io/en/latest/reference/google.auth.jwt.html#google.auth.jwt.Credentials

--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -158,3 +158,35 @@ block the current thread until a given condition obtains:
 To learn more, consult the `subscriber documentation`_.
 
 .. _subscriber documentation: https://googleapis.github.io/google-cloud-python/latest/pubsub/subscriber/index.html
+
+
+Authentication
+^^^^^^^^^^^^^^
+
+It is possible to specify the authentication method to use with the Pub/Sub
+clients. This can be done by providing an explicit `Credentials`_ instance from
+the `google-auth`_ library.
+
+For example, to use JSON Web Tokens, provide a `jwt.Credentials`_ instance:
+
+.. code-block:: python
+
+    import json
+    from google.auth import jwt
+
+    service_account_info = json.load(open("service-account-info.json"))
+    audience = "https://pubsub.googleapis.com/google.pubsub.v1.Subscriber"
+
+    credentials = jwt.Credentials.from_service_account_info(
+        service_account_info, audience=audience
+    )
+
+    publisher = pubsub_v1.PublisherClient(credentials=credentials)
+    subscriber = pubsub_v1.SubscriberClient(credentials=credentials)
+
+Check the `google-auth`_ library documentation for the list of supported
+authentication methods.
+
+.. _Credentials: https://google-auth.readthedocs.io/en/latest/reference/google.auth.credentials.html#google.auth.credentials.Credentials
+.. _google-auth: https://google-auth.readthedocs.io/en/latest/index.html
+.. _jwt.Credentials: https://google-auth.readthedocs.io/en/latest/reference/google.auth.jwt.html#google.auth.jwt.Credentials


### PR DESCRIPTION
Closes #8137.

Describes a possible workaround for #7387, however, it does not close it, the PR just fulfills a GA  requirement (documenting a possible workaround).

### How to test
**Steps to perform:**

- Generate the pubsub docs locally (from inside the `pubsub/` directory):
    ```
    $ nox -f noxfile.py -s docs
    ```
- Open the generated docs for authentication:
    ```
    $ google-chrome "file://$GOOG_CLOUD_PYTHON_DIR/pubsub/docs/_build/html/index.html#authentication"
    ```

**Expected result:**
The example is understandable and correct, the links point to correct locations.

### Background
The issue itself is hard to reproduce in practice, but it was discovered in other PubSub clients that using JWT-based authentication avoids the issue. The goal of this PR is to document how different auth methods can be used with the Python client.