### PR TITLE
Storage: add HMAC key support

### DIFF
--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -572,7 +572,7 @@ class Client(ClientWithProject):
             Tuple[:class:`~google.cloud.storage.hmac_key.HMACKeyMetadata`, str]
         :returns: metadata for the created key, plus the bytes of the key's secret, which is an 40-character base64-encoded string.
         """
-        path = "/projects/%s/hmacKeys".format(self.project)
+        path = "/projects/{}/hmacKeys".format(self.project)
         qs_params = {"serviceAccountEmail": service_account_email}
         api_response = self._connection.api_request(
             method="POST", path=path, query_params=qs_params
@@ -604,7 +604,7 @@ class Client(ClientWithProject):
             Tuple[:class:`~google.cloud.storage.hmac_key.HMACKeyMetadata`, str]
         :returns: metadata for the created key, plus the bytes of the key's secret, which is an 40-character base64-encoded string.
         """
-        path = "/projects/%s/hmacKeys".format(self.project)
+        path = "/projects/{}/hmacKeys".format(self.project)
         extra_params = {}
 
         if service_account_email is not None:

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -562,17 +562,24 @@ class Client(ClientWithProject):
             extra_params=extra_params,
         )
 
-    def create_hmac_key(self, service_account_email):
+    def create_hmac_key(self, service_account_email, project_id=None):
         """Create an HMAC key for a service account.
 
         :type service_account_email: str
         :param service_account_email: e-mail address of the service account
 
+        :type project_id: str
+        :param project_id: (Optional) explicit project ID for the key.
+            Defaults to the client's project.
+
         :rtype:
             Tuple[:class:`~google.cloud.storage.hmac_key.HMACKeyMetadata`, str]
         :returns: metadata for the created key, plus the bytes of the key's secret, which is an 40-character base64-encoded string.
         """
-        path = "/projects/{}/hmacKeys".format(self.project)
+        if project_id is None:
+            project_id = self.project
+
+        path = "/projects/{}/hmacKeys".format(project_id)
         qs_params = {"serviceAccountEmail": service_account_email}
         api_response = self._connection.api_request(
             method="POST", path=path, query_params=qs_params
@@ -583,7 +590,11 @@ class Client(ClientWithProject):
         return metadata, secret
 
     def list_hmac_keys(
-        self, max_results=None, service_account_email=None, show_deleted_keys=None
+        self,
+        max_results=None,
+        service_account_email=None,
+        show_deleted_keys=None,
+        project_id=None,
     ):
         """List HMAC keys for a project.
 
@@ -600,11 +611,18 @@ class Client(ClientWithProject):
             (Optional) included deleted keys in the list. Default is to
             exclude them.
 
+        :type project_id: str
+        :param project_id: (Optional) explicit project ID for the key.
+            Defaults to the client's project.
+
         :rtype:
             Tuple[:class:`~google.cloud.storage.hmac_key.HMACKeyMetadata`, str]
         :returns: metadata for the created key, plus the bytes of the key's secret, which is an 40-character base64-encoded string.
         """
-        path = "/projects/{}/hmacKeys".format(self.project)
+        if project_id is None:
+            project_id = self.project
+
+        path = "/projects/{}/hmacKeys".format(project_id)
         extra_params = {}
 
         if service_account_email is not None:

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -476,7 +476,7 @@ class Client(ClientWithProject):
             versions=versions,
             projection=projection,
             fields=fields,
-            client=self
+            client=self,
         )
 
     def list_buckets(

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -640,6 +640,20 @@ class Client(ClientWithProject):
             extra_params=extra_params,
         )
 
+    def get_hmac_key_metadata(self, access_id, project_id=None):
+        """Return a metadata instance for the given HMAC key.
+
+        :type access_id: str
+        :param access_id: Unique ID of an existing key.
+
+        :type project_id: str
+        :param project_id: (Optional) project ID of an existing key.
+            Defaults to client's project.
+        """
+        metadata = HMACKeyMetadata(self, access_id, project_id)
+        metadata.reload()  # raises NotFound for missing key
+        return metadata
+
 
 def _item_to_bucket(iterator, item):
     """Convert a JSON bucket to the native object.

--- a/storage/google/cloud/storage/hmac_key.py
+++ b/storage/google/cloud/storage/hmac_key.py
@@ -39,6 +39,18 @@ class HMACKeyMetadata(object):
         self._client = client
         self._properties = {}
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+
+        return (
+            self._client == other._client and
+            self.access_id == other.access_id
+        )
+
+    def __hash__(self):
+        return hash(self._client) + hash(self.access_id)
+
     @property
     def access_id(self):
         """ID of the key.

--- a/storage/google/cloud/storage/hmac_key.py
+++ b/storage/google/cloud/storage/hmac_key.py
@@ -1,0 +1,126 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.cloud._helpers import _rfc3339_to_datetime
+
+
+class HMACKeyMetadata(object):
+    """Metadata about an HMAC service account key withn Cloud Storage.
+
+    :type client: :class:`~google.cloud.stoage.client.Client`
+    :param client: client associated with the key metadata.
+    """
+
+    ACTIVE_STATE = "ACTIVE"
+    """Key is active, and may be used to sign requests."""
+    INACTIVE_STATE = "INACTIVE"
+    """Key is inactive, and may not be used to sign requests.
+
+    It can be re-activated via :meth:`update`.
+    """
+    DELETED_STATE = "DELETED"
+    """Key is deleted.  It cannot be re-activated."""
+
+    _SETTABLE_STATES = (ACTIVE_STATE, INACTIVE_STATE)
+
+    def __init__(self, client):
+        self._client = client
+        self._properties = {}
+
+    @property
+    def access_id(self):
+        """ID of the key.
+
+        :rtype: str or None
+        :returns: unique identifier of the key within a project.
+        """
+        return self._properties.get("accessId")
+
+    @property
+    def etag(self):
+        """ETag identifying the version of the key metadata.
+
+        :rtype: str or None
+        :returns: ETag for the version of the key's metadata.
+        """
+        return self._properties.get("etag")
+
+    @property
+    def project(self):
+        """Project ID associated with the key.
+
+        :rtype: str or None
+        :returns: project identfier for the key.
+        """
+        return self._properties.get("projectId")
+
+    @property
+    def service_account_email(self):
+        """Service account e-mail address associated with the key.
+
+        :rtype: str or None
+        :returns: e-mail address for the service account which created the key.
+        """
+        return self._properties.get("serviceAccountEmail")
+
+    @property
+    def state(self):
+        """Get / set key's state.
+
+        One of:
+            - ``ACTIVE``
+            - ``INACTIVE``
+            - ``DELETED``
+
+        :rtype: str or None
+        :returns: key's current state.
+        """
+        return self._properties.get("state")
+
+    @state.setter
+    def state(self, value):
+        if value not in self._SETTABLE_STATES:
+            raise ValueError(
+                "State may only be set to one of: {}".format(
+                    ", ".join(self._SETTABLE_STATES)
+                )
+            )
+
+        self._properties["state"] = value
+
+    @property
+    def time_created(self):
+        """Retrieve the timestamp at which the HMAC key was created.
+
+        :rtype: :class:`datetime.datetime` or ``NoneType``
+        :returns: Datetime object parsed from RFC3339 valid timestamp, or
+                  ``None`` if the bucket's resource has not been loaded
+                  from the server.
+        """
+        value = self._properties.get("timeCreated")
+        if value is not None:
+            return _rfc3339_to_datetime(value)
+
+    @property
+    def updated(self):
+        """Retrieve the timestamp at which the HMAC key was created.
+
+        :rtype: :class:`datetime.datetime` or ``NoneType``
+        :returns: Datetime object parsed from RFC3339 valid timestamp, or
+                  ``None`` if the bucket's resource has not been loaded
+                  from the server.
+        """
+        value = self._properties.get("updated")
+        if value is not None:
+            return _rfc3339_to_datetime(value)

--- a/storage/google/cloud/storage/hmac_key.py
+++ b/storage/google/cloud/storage/hmac_key.py
@@ -170,7 +170,7 @@ class HMACKeyMetadata(object):
         """
         payload = {"state": self.state}
         self._properties = self._client._connection.api_request(
-            method="POST", path=self.path, data=payload
+            method="PUT", path=self.path, data=payload
         )
 
     def delete(self):

--- a/storage/google/cloud/storage/hmac_key.py
+++ b/storage/google/cloud/storage/hmac_key.py
@@ -44,8 +44,8 @@ class HMACKeyMetadata(object):
             return NotImplemented
 
         return (
-            self._client == other._client and
-            self.access_id == other.access_id
+            self._client == other._client
+            and self.access_id == other.access_id
         )
 
     def __hash__(self):

--- a/storage/google/cloud/storage/hmac_key.py
+++ b/storage/google/cloud/storage/hmac_key.py
@@ -21,6 +21,13 @@ class HMACKeyMetadata(object):
 
     :type client: :class:`~google.cloud.stoage.client.Client`
     :param client: client associated with the key metadata.
+
+    :type access_id: str
+    :param access_id: (Optional) unique ID of an existing key.
+
+    :type project_id: str
+    :param project_id: (Optional) project ID of an existing key.
+        Defaults to client's project.
     """
 
     ACTIVE_STATE = "ACTIVE"
@@ -35,9 +42,15 @@ class HMACKeyMetadata(object):
 
     _SETTABLE_STATES = (ACTIVE_STATE, INACTIVE_STATE)
 
-    def __init__(self, client):
+    def __init__(self, client, access_id=None, project_id=None):
         self._client = client
         self._properties = {}
+
+        if access_id is not None:
+            self._properties["accessId"] = access_id
+
+        if project_id is not None:
+            self._properties["projectId"] = project_id
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/storage/google/cloud/storage/hmac_key.py
+++ b/storage/google/cloud/storage/hmac_key.py
@@ -43,10 +43,7 @@ class HMACKeyMetadata(object):
         if not isinstance(other, self.__class__):
             return NotImplemented
 
-        return (
-            self._client == other._client
-            and self.access_id == other.access_id
-        )
+        return self._client == other._client and self.access_id == other.access_id
 
     def __hash__(self):
         return hash(self._client) + hash(self.access_id)
@@ -194,6 +191,4 @@ class HMACKeyMetadata(object):
         if self.state != self.INACTIVE_STATE:
             raise ValueError("Cannot delete key if not in 'INACTIVE' state.")
 
-        self._client._connection.api_request(
-            method="DELETE", path=self.path
-        )
+        self._client._connection.api_request(method="DELETE", path=self.path)

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -94,6 +94,8 @@ class TestClient(unittest.TestCase):
         self.case_hmac_keys_to_delete = []
 
     def tearDown(self):
+        from google.cloud.storage.hmac_key import HMACKeyMetadata
+
         for hmac_key in self.case_hmac_keys_to_delete:
             if hmac_key.state == HMACKeyMetadata.ACTIVE_STATE:
                 hmac_key.state = HMACKeyMetadata.INACTIVE_STATE
@@ -115,8 +117,6 @@ class TestClient(unittest.TestCase):
 
     def test_hmac_key_crud(self):
         from google.cloud.storage.hmac_key import HMACKeyMetadata
-
-        #email = Config.CLIENT.get_service_account_email()
 
         credentials = Config.CLIENT._credentials
         email = credentials.service_account_email

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -348,9 +348,7 @@ class Test_Blob(unittest.TestCase):
         BLOB_NAME = "foo~bar"
         bucket = _Bucket()
         blob = self._make_one(BLOB_NAME, bucket=bucket)
-        self.assertEqual(
-            blob.public_url, "https://storage.googleapis.com/name/foo~bar"
-        )
+        self.assertEqual(blob.public_url, "https://storage.googleapis.com/name/foo~bar")
 
     def test_public_url_with_non_ascii(self):
         blob_name = u"winter \N{snowman}"

--- a/storage/tests/unit/test_client.py
+++ b/storage/tests/unit/test_client.py
@@ -651,6 +651,7 @@ class TestClient(unittest.TestCase):
 
     def test_list_blobs(self):
         from google.cloud.storage.bucket import Bucket
+
         BUCKET_NAME = "bucket-name"
 
         credentials = _make_credentials()
@@ -658,8 +659,8 @@ class TestClient(unittest.TestCase):
         connection = _make_connection({"items": []})
 
         with mock.patch(
-            'google.cloud.storage.client.Client._connection',
-            new_callable=mock.PropertyMock
+            "google.cloud.storage.client.Client._connection",
+            new_callable=mock.PropertyMock,
         ) as client_mock:
             client_mock.return_value = connection
 
@@ -671,11 +672,12 @@ class TestClient(unittest.TestCase):
             connection.api_request.assert_called_once_with(
                 method="GET",
                 path="/b/%s/o" % BUCKET_NAME,
-                query_params={"projection": "noAcl"}
+                query_params={"projection": "noAcl"},
             )
 
     def test_list_blobs_w_all_arguments_and_user_project(self):
         from google.cloud.storage.bucket import Bucket
+
         BUCKET_NAME = "name"
         USER_PROJECT = "user-project-123"
         MAX_RESULTS = 10
@@ -701,8 +703,8 @@ class TestClient(unittest.TestCase):
         connection = _make_connection({"items": []})
 
         with mock.patch(
-            'google.cloud.storage.client.Client._connection',
-            new_callable=mock.PropertyMock
+            "google.cloud.storage.client.Client._connection",
+            new_callable=mock.PropertyMock,
         ) as client_mock:
             client_mock.return_value = connection
 
@@ -721,9 +723,7 @@ class TestClient(unittest.TestCase):
 
             self.assertEqual(blobs, [])
             connection.api_request.assert_called_once_with(
-                method="GET",
-                path="/b/%s/o" % BUCKET_NAME,
-                query_params=EXPECTED
+                method="GET", path="/b/%s/o" % BUCKET_NAME, query_params=EXPECTED
             )
 
     def test_list_buckets_wo_project(self):

--- a/storage/tests/unit/test_client.py
+++ b/storage/tests/unit/test_client.py
@@ -953,7 +953,9 @@ class TestClient(unittest.TestCase):
                 client._connection.API_BASE_URL,
                 "storage",
                 client._connection.API_VERSION,
-                "projects/%s/hmacKeys",
+                "projects",
+                PROJECT,
+                "hmacKeys",
             ]
         )
         QS_PARAMS = {"serviceAccountEmail": EMAIL}
@@ -979,7 +981,9 @@ class TestClient(unittest.TestCase):
                 client._connection.API_BASE_URL,
                 "storage",
                 client._connection.API_VERSION,
-                "projects/%s/hmacKeys",
+                "projects",
+                PROJECT,
+               "hmacKeys",
             ]
         )
         http.request.assert_called_once_with(
@@ -1031,7 +1035,9 @@ class TestClient(unittest.TestCase):
                 client._connection.API_BASE_URL,
                 "storage",
                 client._connection.API_VERSION,
-                "projects/%s/hmacKeys",
+                "projects",
+                PROJECT,
+                "hmacKeys",
             ]
         )
         QS_PARAMS = {

--- a/storage/tests/unit/test_client.py
+++ b/storage/tests/unit/test_client.py
@@ -983,7 +983,7 @@ class TestClient(unittest.TestCase):
                 client._connection.API_VERSION,
                 "projects",
                 PROJECT,
-               "hmacKeys",
+                "hmacKeys",
             ]
         )
         http.request.assert_called_once_with(

--- a/storage/tests/unit/test_client.py
+++ b/storage/tests/unit/test_client.py
@@ -1007,7 +1007,7 @@ class TestClient(unittest.TestCase):
         )
 
     def test_list_hmac_keys_explicit_non_empty(self):
-        from six.moves.urllib.parse import urlencode
+        from six.moves.urllib.parse import parse_qsl
         from google.cloud.storage.hmac_key import HMACKeyMetadata
 
         PROJECT = "PROJECT"
@@ -1058,12 +1058,17 @@ class TestClient(unittest.TestCase):
                 "hmacKeys",
             ]
         )
-        QS_PARAMS = {
-            "maxResults": MAX_RESULTS,
+        EXPECTED_QPARAMS = {
+            "maxResults": str(MAX_RESULTS),
             "serviceAccountEmail": EMAIL,
-            "showDeletedKeys": True,
+            "showDeletedKeys": "True",
         }
-        FULL_URI = "{}?{}".format(URI, urlencode(QS_PARAMS))
         http.request.assert_called_once_with(
-            method="GET", url=FULL_URI, data=None, headers=mock.ANY
+            method="GET", url=mock.ANY, data=None, headers=mock.ANY
         )
+        kwargs = http.request.mock_calls[0].kwargs
+        uri = kwargs["url"]
+        base, qparam_str = uri.split("?")
+        qparams = dict(parse_qsl(qparam_str))
+        self.assertEqual(base, URI)
+        self.assertEqual(qparams, EXPECTED_QPARAMS)

--- a/storage/tests/unit/test_hmac_key.py
+++ b/storage/tests/unit/test_hmac_key.py
@@ -245,7 +245,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
             client.DEFAULT_PROJECT, access_id
         )
         expected_kwargs = {
-            "method": "POST",
+            "method": "PUT",
             "path": expected_path,
             "data": {
                 "state": "INACTIVE",
@@ -277,7 +277,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
 
         expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
         expected_kwargs = {
-            "method": "POST",
+            "method": "PUT",
             "path": expected_path,
             "data": {
                 "state": "ACTIVE",

--- a/storage/tests/unit/test_hmac_key.py
+++ b/storage/tests/unit/test_hmac_key.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestHMACKeyMetadata(unittest.TestCase):
     @staticmethod
@@ -24,7 +26,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
 
     def _make_one(self, client=None, *args, **kw):
         if client is None:
-            client = object()
+            client = _Client()
         return self._get_target_class()(client, *args, **kw)
 
     def test_ctor_defaults(self):
@@ -114,3 +116,230 @@ class TestHMACKeyMetadata(unittest.TestCase):
         now_stamp = "{}Z".format(now.isoformat())
         metadata._properties["updated"] = now_stamp
         self.assertEqual(metadata.updated, now.replace(tzinfo=UTC))
+
+    def test_path_wo_access_id(self):
+        metadata = self._make_one()
+
+        with self.assertRaises(ValueError):
+            metadata.path
+
+    def test_path_w_access_id_wo_project(self):
+        access_id = "ACCESS-ID"
+        client = _Client()
+        metadata = self._make_one()
+        metadata._properties["accessId"] = access_id
+
+        expected_path = "/projects/{}/hmacKeys/{}".format(
+            client.DEFAULT_PROJECT, access_id
+        )
+        self.assertEqual(metadata.path, expected_path)
+
+    def test_path_w_access_id_w_explicit_project(self):
+        access_id = "ACCESS-ID"
+        project = "OTHER-PROJECT"
+        metadata = self._make_one()
+        metadata._properties["accessId"] = access_id
+        metadata._properties["projectId"] = project
+
+        expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
+        self.assertEqual(metadata.path, expected_path)
+
+    def test_exists_miss_no_project_set(self):
+        from google.cloud.exceptions import NotFound
+
+        access_id = "ACCESS-ID"
+        connection = mock.Mock(spec=["api_request"])
+        connection.api_request.side_effect = NotFound("testing")
+        client = _Client(connection)
+        metadata = self._make_one(client)
+        metadata._properties["accessId"] = access_id
+
+        self.assertFalse(metadata.exists())
+
+        expected_path = "/projects/{}/hmacKeys/{}".format(
+            client.DEFAULT_PROJECT, access_id
+        )
+        expected_kwargs = {"method": "GET", "path": expected_path}
+        connection.api_request.assert_called_once_with(**expected_kwargs)
+
+    def test_exists_hit_w_project_set(self):
+        project = "PROJECT-ID"
+        access_id = "ACCESS-ID"
+        email = "service-account@example.com"
+        resource = {
+            "kind": "storage#hmacKeyMetadata",
+            "accessId": access_id,
+            "serviceAccountEmail": email,
+        }
+        connection = mock.Mock(spec=["api_request"])
+        connection.api_request.return_value = resource
+        client = _Client(connection)
+        metadata = self._make_one(client)
+        metadata._properties["accessId"] = access_id
+        metadata._properties["projectId"] = project
+
+        self.assertTrue(metadata.exists())
+
+        expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
+        expected_kwargs = {"method": "GET", "path": expected_path}
+        connection.api_request.assert_called_once_with(**expected_kwargs)
+
+    def test_reload_miss_no_project_set(self):
+        from google.cloud.exceptions import NotFound
+
+        access_id = "ACCESS-ID"
+        connection = mock.Mock(spec=["api_request"])
+        connection.api_request.side_effect = NotFound("testing")
+        client = _Client(connection)
+        metadata = self._make_one(client)
+        metadata._properties["accessId"] = access_id
+
+        with self.assertRaises(NotFound):
+            metadata.reload()
+
+        expected_path = "/projects/{}/hmacKeys/{}".format(
+            client.DEFAULT_PROJECT, access_id
+        )
+        expected_kwargs = {"method": "GET", "path": expected_path}
+        connection.api_request.assert_called_once_with(**expected_kwargs)
+
+    def test_reload_hit_w_project_set(self):
+        project = "PROJECT-ID"
+        access_id = "ACCESS-ID"
+        email = "service-account@example.com"
+        resource = {
+            "kind": "storage#hmacKeyMetadata",
+            "accessId": access_id,
+            "serviceAccountEmail": email,
+        }
+        connection = mock.Mock(spec=["api_request"])
+        connection.api_request.return_value = resource
+        client = _Client(connection)
+        metadata = self._make_one(client)
+        metadata._properties["accessId"] = access_id
+        metadata._properties["projectId"] = project
+
+        metadata.reload()
+
+        self.assertEqual(metadata._properties, resource)
+
+        expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
+        expected_kwargs = {"method": "GET", "path": expected_path}
+        connection.api_request.assert_called_once_with(**expected_kwargs)
+
+    def test_update_miss_no_project_set(self):
+        from google.cloud.exceptions import NotFound
+
+        access_id = "ACCESS-ID"
+        connection = mock.Mock(spec=["api_request"])
+        connection.api_request.side_effect = NotFound("testing")
+        client = _Client(connection)
+        metadata = self._make_one(client)
+        metadata._properties["accessId"] = access_id
+        metadata.state = "INACTIVE"
+
+        with self.assertRaises(NotFound):
+            metadata.update()
+
+        expected_path = "/projects/{}/hmacKeys/{}".format(
+            client.DEFAULT_PROJECT, access_id
+        )
+        expected_kwargs = {
+            "method": "POST",
+            "path": expected_path,
+            "data": {
+                "state": "INACTIVE",
+            },
+        }
+        connection.api_request.assert_called_once_with(**expected_kwargs)
+
+    def test_update_hit_w_project_set(self):
+        project = "PROJECT-ID"
+        access_id = "ACCESS-ID"
+        email = "service-account@example.com"
+        resource = {
+            "kind": "storage#hmacKeyMetadata",
+            "accessId": access_id,
+            "serviceAccountEmail": email,
+            "state": "ACTIVE"
+        }
+        connection = mock.Mock(spec=["api_request"])
+        connection.api_request.return_value = resource
+        client = _Client(connection)
+        metadata = self._make_one(client)
+        metadata._properties["accessId"] = access_id
+        metadata._properties["projectId"] = project
+        metadata.state = "ACTIVE"
+
+        metadata.update()
+
+        self.assertEqual(metadata._properties, resource)
+
+        expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
+        expected_kwargs = {
+            "method": "POST",
+            "path": expected_path,
+            "data": {
+                "state": "ACTIVE",
+            },
+        }
+        connection.api_request.assert_called_once_with(**expected_kwargs)
+
+    def test_delete_not_inactive(self):
+        metadata = self._make_one()
+        for state in ("ACTIVE", "DELETED"):
+            metadata._properties["state"] = state
+
+            with self.assertRaises(ValueError):
+                metadata.delete()
+
+    def test_delete_miss_no_project_set(self):
+        from google.cloud.exceptions import NotFound
+
+        access_id = "ACCESS-ID"
+        connection = mock.Mock(spec=["api_request"])
+        connection.api_request.side_effect = NotFound("testing")
+        client = _Client(connection)
+        metadata = self._make_one(client)
+        metadata._properties["accessId"] = access_id
+        metadata.state = "INACTIVE"
+
+        with self.assertRaises(NotFound):
+            metadata.delete()
+
+        expected_path = "/projects/{}/hmacKeys/{}".format(
+            client.DEFAULT_PROJECT, access_id
+        )
+        expected_kwargs = {
+            "method": "DELETE",
+            "path": expected_path,
+        }
+        connection.api_request.assert_called_once_with(**expected_kwargs)
+
+    def test_delete_hit_w_project_set(self):
+        project = "PROJECT-ID"
+        access_id = "ACCESS-ID"
+        connection = mock.Mock(spec=["api_request"])
+        connection.api_request.return_value = {}
+        client = _Client(connection)
+        metadata = self._make_one(client)
+        metadata._properties["accessId"] = access_id
+        metadata._properties["projectId"] = project
+        metadata.state = "INACTIVE"
+
+        metadata.delete()
+
+        expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
+        expected_kwargs = {
+            "method": "DELETE",
+            "path": expected_path,
+        }
+        connection.api_request.assert_called_once_with(**expected_kwargs)
+
+
+class _Client(object):
+    DEFAULT_PROJECT = "project-123"
+
+    def __init__(self, connection=None, project=DEFAULT_PROJECT):
+        self._connection = connection
+        self.project = project

--- a/storage/tests/unit/test_hmac_key.py
+++ b/storage/tests/unit/test_hmac_key.py
@@ -1,0 +1,116 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+
+class TestHMACKeyMetadata(unittest.TestCase):
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.storage.hmac_key import HMACKeyMetadata
+
+        return HMACKeyMetadata
+
+    def _make_one(self, client=None, *args, **kw):
+        if client is None:
+            client = object()
+        return self._get_target_class()(client, *args, **kw)
+
+    def test_ctor_defaults(self):
+        client = object()
+        metadata = self._make_one(client)
+        self.assertIs(metadata._client, client)
+        self.assertEqual(metadata._properties, {})
+        self.assertIsNone(metadata.access_id)
+        self.assertIsNone(metadata.etag)
+        self.assertIsNone(metadata.project)
+        self.assertIsNone(metadata.service_account_email)
+        self.assertIsNone(metadata.state)
+        self.assertIsNone(metadata.time_created)
+        self.assertIsNone(metadata.updated)
+
+    def test_access_id_getter(self):
+        metadata = self._make_one()
+        expected = "ACCESS-ID"
+        metadata._properties["accessId"] = expected
+        self.assertEqual(metadata.access_id, expected)
+
+    def test_etag_getter(self):
+        metadata = self._make_one()
+        expected = "ETAG"
+        metadata._properties["etag"] = expected
+        self.assertEqual(metadata.etag, expected)
+
+    def test_project_getter(self):
+        metadata = self._make_one()
+        expected = "PROJECT-ID"
+        metadata._properties["projectId"] = expected
+        self.assertEqual(metadata.project, expected)
+
+    def test_service_account_email_getter(self):
+        metadata = self._make_one()
+        expected = "service_account@example.com"
+        metadata._properties["serviceAccountEmail"] = expected
+        self.assertEqual(metadata.service_account_email, expected)
+
+    def test_state_getter(self):
+        metadata = self._make_one()
+        expected = "STATE"
+        metadata._properties["state"] = expected
+        self.assertEqual(metadata.state, expected)
+
+    def test_state_setter_invalid_state(self):
+        metadata = self._make_one()
+        expected = "INVALID"
+
+        with self.assertRaises(ValueError):
+            metadata.state = expected
+
+        self.assertIsNone(metadata.state)
+
+    def test_state_setter_inactive(self):
+        metadata = self._make_one()
+        metadata._properties["state"] = "ACTIVE"
+        expected = "INACTIVE"
+        metadata.state = expected
+        self.assertEqual(metadata.state, expected)
+        self.assertEqual(metadata._properties["state"], expected)
+
+    def test_state_setter_active(self):
+        metadata = self._make_one()
+        metadata._properties["state"] = "INACTIVE"
+        expected = "ACTIVE"
+        metadata.state = expected
+        self.assertEqual(metadata.state, expected)
+        self.assertEqual(metadata._properties["state"], expected)
+
+    def test_time_created_getter(self):
+        import datetime
+        from pytz import UTC
+
+        metadata = self._make_one()
+        now = datetime.datetime.utcnow()
+        now_stamp = "{}Z".format(now.isoformat())
+        metadata._properties["timeCreated"] = now_stamp
+        self.assertEqual(metadata.time_created, now.replace(tzinfo=UTC))
+
+    def test_updated_getter(self):
+        import datetime
+        from pytz import UTC
+
+        metadata = self._make_one()
+        now = datetime.datetime.utcnow()
+        now_stamp = "{}Z".format(now.isoformat())
+        metadata._properties["updated"] = now_stamp
+        self.assertEqual(metadata.updated, now.replace(tzinfo=UTC))

--- a/storage/tests/unit/test_hmac_key.py
+++ b/storage/tests/unit/test_hmac_key.py
@@ -71,7 +71,10 @@ class TestHMACKeyMetadata(unittest.TestCase):
         client = _Client()
         metadata = self._make_one(client)
         metadata._properties['accessId'] = 'ABC123'
-        self.assertEqual(hash(metadata), hash(client) + hash('ABC123'))
+        self.assertIsInstance(hash(metadata), int)
+        other = self._make_one(client)
+        metadata._properties['accessId'] = 'DEF456'
+        self.assertNotEqual(hash(metadata), hash(other))
 
     def test_access_id_getter(self):
         metadata = self._make_one()

--- a/storage/tests/unit/test_hmac_key.py
+++ b/storage/tests/unit/test_hmac_key.py
@@ -379,7 +379,7 @@ class _Client(object):
         self.project = project
 
     def __eq__(self, other):
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, self.__class__):  # pragma: NO COVER
             return NotImplemented
         return (
             self._connection == other._connection and

--- a/storage/tests/unit/test_hmac_key.py
+++ b/storage/tests/unit/test_hmac_key.py
@@ -382,8 +382,8 @@ class _Client(object):
         if not isinstance(other, self.__class__):  # pragma: NO COVER
             return NotImplemented
         return (
-            self._connection == other._connection and
-            self.project == other.project
+            self._connection == other._connection
+            and self.project == other.project
         )
 
     def __hash__(self):

--- a/storage/tests/unit/test_hmac_key.py
+++ b/storage/tests/unit/test_hmac_key.py
@@ -49,31 +49,31 @@ class TestHMACKeyMetadata(unittest.TestCase):
 
     def test___eq___mismatched_client(self):
         metadata = self._make_one()
-        other_client = _Client(project='other-project-456')
+        other_client = _Client(project="other-project-456")
         other = self._make_one(other_client)
         self.assertNotEqual(metadata, other)
 
     def test___eq___mismatched_access_id(self):
         metadata = self._make_one()
-        metadata._properties['accessId'] = 'ABC123'
+        metadata._properties["accessId"] = "ABC123"
         other = self._make_one(metadata._client)
-        metadata._properties['accessId'] = 'DEF456'
+        metadata._properties["accessId"] = "DEF456"
         self.assertNotEqual(metadata, other)
 
     def test___eq___hit(self):
         metadata = self._make_one()
-        metadata._properties['accessId'] = 'ABC123'
+        metadata._properties["accessId"] = "ABC123"
         other = self._make_one(metadata._client)
-        other._properties['accessId'] = metadata.access_id
+        other._properties["accessId"] = metadata.access_id
         self.assertEqual(metadata, other)
 
     def test___hash__(self):
         client = _Client()
         metadata = self._make_one(client)
-        metadata._properties['accessId'] = 'ABC123'
+        metadata._properties["accessId"] = "ABC123"
         self.assertIsInstance(hash(metadata), int)
         other = self._make_one(client)
-        metadata._properties['accessId'] = 'DEF456'
+        metadata._properties["accessId"] = "DEF456"
         self.assertNotEqual(hash(metadata), hash(other))
 
     def test_access_id_getter(self):
@@ -281,9 +281,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
         expected_kwargs = {
             "method": "PUT",
             "path": expected_path,
-            "data": {
-                "state": "INACTIVE",
-            },
+            "data": {"state": "INACTIVE"},
         }
         connection.api_request.assert_called_once_with(**expected_kwargs)
 
@@ -295,7 +293,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
             "kind": "storage#hmacKeyMetadata",
             "accessId": access_id,
             "serviceAccountEmail": email,
-            "state": "ACTIVE"
+            "state": "ACTIVE",
         }
         connection = mock.Mock(spec=["api_request"])
         connection.api_request.return_value = resource
@@ -313,9 +311,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
         expected_kwargs = {
             "method": "PUT",
             "path": expected_path,
-            "data": {
-                "state": "ACTIVE",
-            },
+            "data": {"state": "ACTIVE"},
         }
         connection.api_request.assert_called_once_with(**expected_kwargs)
 
@@ -344,10 +340,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
         expected_path = "/projects/{}/hmacKeys/{}".format(
             client.DEFAULT_PROJECT, access_id
         )
-        expected_kwargs = {
-            "method": "DELETE",
-            "path": expected_path,
-        }
+        expected_kwargs = {"method": "DELETE", "path": expected_path}
         connection.api_request.assert_called_once_with(**expected_kwargs)
 
     def test_delete_hit_w_project_set(self):
@@ -364,10 +357,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
         metadata.delete()
 
         expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
-        expected_kwargs = {
-            "method": "DELETE",
-            "path": expected_path,
-        }
+        expected_kwargs = {"method": "DELETE", "path": expected_path}
         connection.api_request.assert_called_once_with(**expected_kwargs)
 
 
@@ -381,10 +371,7 @@ class _Client(object):
     def __eq__(self, other):
         if not isinstance(other, self.__class__):  # pragma: NO COVER
             return NotImplemented
-        return (
-            self._connection == other._connection
-            and self.project == other.project
-        )
+        return self._connection == other._connection and self.project == other.project
 
     def __hash__(self):
         return hash(self._connection) + hash(self.project)

--- a/storage/tests/unit/test_hmac_key.py
+++ b/storage/tests/unit/test_hmac_key.py
@@ -42,6 +42,22 @@ class TestHMACKeyMetadata(unittest.TestCase):
         self.assertIsNone(metadata.time_created)
         self.assertIsNone(metadata.updated)
 
+    def test_ctor_explicit(self):
+        OTHER_PROJECT = "other-project-456"
+        ACCESS_ID = "access-id-123456789"
+        client = _Client()
+        metadata = self._make_one(client, access_id=ACCESS_ID, project_id=OTHER_PROJECT)
+        self.assertIs(metadata._client, client)
+        expected = {"accessId": ACCESS_ID, "projectId": OTHER_PROJECT}
+        self.assertEqual(metadata._properties, expected)
+        self.assertEqual(metadata.access_id, ACCESS_ID)
+        self.assertIsNone(metadata.etag)
+        self.assertEqual(metadata.project, OTHER_PROJECT)
+        self.assertIsNone(metadata.service_account_email)
+        self.assertIsNone(metadata.state)
+        self.assertIsNone(metadata.time_created)
+        self.assertIsNone(metadata.updated)
+
     def test___eq___other_type(self):
         metadata = self._make_one()
         for bogus in (None, "bogus", 123, 456.78, [], (), {}, set()):


### PR DESCRIPTION
@jkwlui This PR is for merging the HMAC keys feature branch to `master`:  you have already-reviewed the changes in PRs #8041, #8043, and #8045.

I still need to:

- [x] Add system tests exercising the CRUD cycle for `HMACKeyMetadata` resources.

Closes #7851.