### PR TITLE
Text-to-Speech: Repair top-level API reference page.

### DIFF
--- a/texttospeech/docs/api.rst
+++ b/texttospeech/docs/api.rst
@@ -1,31 +1,30 @@
-API Reference
-=============
+Text-to-Speech Client API Reference
+===================================
 
-APIs
-----
+This package includes clients for multiple versions of the Text-to-Speech
+API. By default, you will get ``v1``, the latest GA version.
 
-.. autosummary::
+.. toctree::
+  :maxdepth: 2
 
-.. :toctree::
+  gapic/v1/api
+  gapic/v1/types
 
-   google.cloud.texttospeech_v1.trace_service_client
+If you are interested in beta features ahead of the latest GA, you may
+opt-in to the v1.1 beta, which is spelled ``v1beta1``. In order to do this,
+you will want to import from ``google.cloud.texttospeech_v1beta1`` in lieu of
+``google.cloud.texttospeech``.
 
+An API and type reference is provided for the v1.1 beta also:
 
-API types
-~~~~~~~~~
+.. toctree::
+  :maxdepth: 2
 
-.. autosummary::
-.. :toctree::
+  gapic/v1beta1/api
+  gapic/v1beta1/types
 
-   google.cloud.trace_v1
+.. note::
 
-
-API types
-~~~~~~~~~
-
-.. autosummary::
-.. :toctree::
-
-   google.cloud.trace_v1.gapic.enums
-   google.cloud.trace_v1.gapic.types
-
+  The client for the beta API is provided on a provisional basis. The API
+  surface is subject to change, and it is possible that this client will be
+  deprecated or removed after its features become GA.


### PR DESCRIPTION
Supersedes #7645.

Fixes #7629.