### PR TITLE
Pub/Sub: hide a method in docs

### DIFF
--- a/pubsub/docs/subscriber/api/futures.rst
+++ b/pubsub/docs/subscriber/api/futures.rst
@@ -4,3 +4,4 @@ Futures
 .. automodule:: google.cloud.pubsub_v1.subscriber.futures
   :members:
   :inherited-members:
+  :exclude-members: add_done_callback


### PR DESCRIPTION
Removed `StreamingPullFuture.add_done_callback()` from docs. 