### PR TITLE
PubSub: Document different PubSub received message types

### DIFF
--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -155,6 +155,7 @@ block the current thread until a given condition obtains:
     except KeyboardInterrupt:
         future.cancel()
 
-To learn more, consult the `subscriber documentation`_.
+It is also possible to pull messages in a synchronous (blocking) fashion. To
+learn more about subscribing, consult the `subscriber documentation`_.
 
 .. _subscriber documentation: https://googleapis.github.io/google-cloud-python/latest/pubsub/subscriber/index.html


### PR DESCRIPTION
Closes #7128.

This PR documents different PubSub received message types depending on whether a synchronous or asynchronous method is used to pull messages.

> ~~**Disclaimer:** I was not able to generate the docs locally due to network timeouts when downloading intersphinx inventory files from external sources. Please double check that the generated intra-doc links work.~~

### How to test
**Steps to perform:**

- Generate the pubsub docs locally (from inside the `pubsub/` directory):
    ```
    $ nox -f noxfile.py -s docs
    ```
- Open the generated docs for subscriber:
    ```
    $ google-chrome "file://$GOOG_CLOUD_PYTHON_DIR/pubsub/docs/_build/html//subscriber/index.html"
    ```

**Expected result:**
The different received message type are clearly described, the code samples are valid, and the intra-doc links work.
