### PR TITLE
Firestore: Preserve reference to missing documents in 'Client.get_all'.

### DIFF
--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -520,8 +520,9 @@ def _parse_batch_get(get_doc_response, reference_map, client):
             update_time=get_doc_response.found.update_time,
         )
     elif result_type == "missing":
+        reference = _get_reference(get_doc_response.missing, reference_map)
         snapshot = DocumentSnapshot(
-            None,
+            reference,
             None,
             exists=False,
             read_time=get_doc_response.read_time,

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -768,11 +768,7 @@ def test_get_all(client, cleanup):
 
     assert snapshots[0].exists
     assert snapshots[1].exists
-
-    # missing document attribute
     assert not snapshots[2].exists
-    assert snapshots[2].id == "b"
-    assert not snapshots[2]._data
 
     snapshots = [snapshot for snapshot in snapshots if snapshot.exists]
     id_attr = operator.attrgetter("id")

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -768,7 +768,12 @@ def test_get_all(client, cleanup):
 
     assert snapshots[0].exists
     assert snapshots[1].exists
+
+    # missing document attribute
     assert not snapshots[2].exists
+    assert snapshots[2].id == "b"
+    assert not snapshots[2]._data
+
     snapshots = [snapshot for snapshot in snapshots if snapshot.exists]
     id_attr = operator.attrgetter("id")
     snapshots.sort(key=id_attr)

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -594,12 +594,16 @@ class Test__parse_batch_get(unittest.TestCase):
         self.assertEqual(snapshot.update_time, update_time)
 
     def test_missing(self):
+        from google.cloud.firestore_v1.document import DocumentReference
+
         ref_string = self._dummy_ref_string()
         response_pb = _make_batch_response(missing=ref_string)
-        reference_map = {ref_string: mock.sentinel.reference}
-
+        document = DocumentReference("fizz", "bazz", client=mock.sentinel.client)
+        reference_map = {ref_string: document}
         snapshot = self._call_fut(response_pb, reference_map)
         self.assertFalse(snapshot.exists)
+        self.assertEqual(snapshot.id, "bazz")
+        self.assertIsNone(snapshot._data)
 
     def test_unset_result_type(self):
         response_pb = _make_batch_response()

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -596,8 +596,9 @@ class Test__parse_batch_get(unittest.TestCase):
     def test_missing(self):
         ref_string = self._dummy_ref_string()
         response_pb = _make_batch_response(missing=ref_string)
+        reference_map = {ref_string: mock.sentinel.reference}
 
-        snapshot = self._call_fut(response_pb, {})
+        snapshot = self._call_fut(response_pb, reference_map)
         self.assertFalse(snapshot.exists)
 
     def test_unset_result_type(self):


### PR DESCRIPTION
Fix #7564 