### PR TITLE
Infrastructure: Use the Github API to compute changed files for PRs.

### DIFF
--- a/test_utils/scripts/get_target_packages_kokoro.py
+++ b/test_utils/scripts/get_target_packages_kokoro.py
@@ -46,16 +46,6 @@ def get_changed_files_from_base(base):
     ], stderr=subprocess.DEVNULL).decode('utf8').strip().split('\n')
 
 
-
-def parse_response_link(response):
-    header = response.headers.get("link")
-    if header is not None:
-        for link in header.split(","):
-            link = link.strip()
-            wrapped_url, rel = link.split(";")
-            if rel.strip() == 'rel="next"':
-                return wrapped_url[1:-1]  # strip <>
-
 _URL_TEMPLATE = (
     'https://api.github.com/repos/googleapis/google-cloud-python/pulls/'
     '{}/files'
@@ -68,7 +58,7 @@ def get_changed_files_from_pr(pr):
         response = requests.get(url)
         for info in response.json():
             yield info['filename']
-        url = parse_response_link(response)
+        url = response.links.get('next', {}).get('url')
 
 
 def determine_changed_packages(changed_files):

--- a/test_utils/scripts/get_target_packages_kokoro.py
+++ b/test_utils/scripts/get_target_packages_kokoro.py
@@ -18,6 +18,7 @@ import pathlib
 import subprocess
 
 import ci_diff_helper
+import requests
 
 
 def print_environment(environment):
@@ -39,10 +40,35 @@ def get_base(environment):
         return 'HEAD~1'
 
 
-def get_changed_files(base):
+def get_changed_files_from_base(base):
     return subprocess.check_output([
         'git', 'diff', '--name-only', f'{base}..HEAD',
     ], stderr=subprocess.DEVNULL).decode('utf8').strip().split('\n')
+
+
+
+def parse_response_link(response):
+    header = response.headers.get("link")
+    if header is not None:
+        for link in header.split(","):
+            link = link.strip()
+            wrapped_url, rel = link.split(";")
+            if rel.strip() == 'rel="next"':
+                return wrapped_url[1:-1]  # strip <>
+
+_URL_TEMPLATE = (
+    'https://api.github.com/repos/googleapis/google-cloud-python/pulls/'
+    '{}/files'
+)
+
+
+def get_changed_files_from_pr(pr):
+    url = _URL_TEMPLATE.format(pr)
+    while url is not None:
+        response = requests.get(url)
+        for info in response.json():
+            yield info['filename']
+        url = parse_response_link(response)
 
 
 def determine_changed_packages(changed_files):
@@ -64,7 +90,12 @@ def main():
     environment = ci_diff_helper.get_config()
     print_environment(environment)
     base = get_base(environment)
-    changed_files = get_changed_files(base)
+
+    if environment.in_pr:
+        changed_files = list(get_changed_files_from_pr(environment.pr))
+    else:
+        changed_files = get_changed_files_from_base(base)
+
     packages = determine_changed_packages(changed_files)
 
     print(f"Comparing against {base}.")


### PR DESCRIPTION
Rather than computing a diff from the squirrely baseref hash (as provided by `ci_diff_helper`), just use the Github API directly to query for the [list of files for a PR](https://developer.github.com/v3/pulls/#list-pull-requests-files).  We should run many fewer spurious test suites if this works as expected.  I've tested the new `get_changed_files_from_pr` function manually against both small and large PRs (which involve pagination).