### PR TITLE
New 'retry' parameter for 'Table.read_row()'

### DIFF
--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -330,7 +330,7 @@ class Table(object):
             for cluster_id, value_pb in table_pb.cluster_states.items()
         }
 
-    def read_row(self, row_key, filter_=None):
+    def read_row(self, row_key, filter_=None, retry=DEFAULT_RETRY_READ_ROWS):
         """Read a single row from this table.
 
         For example:
@@ -346,6 +346,14 @@ class Table(object):
         :param filter_: (Optional) The filter to apply to the contents of the
                         row. If unset, returns the entire row.
 
+        :type retry: :class:`~google.api_core.retry.Retry`
+        :param retry:
+            (Optional) Retry delay and deadline arguments. To override, the
+            default value :attr:`DEFAULT_RETRY_READ_ROWS` can be used and
+            modified with the :meth:`~google.api_core.retry.Retry.with_delay`
+            method or the :meth:`~google.api_core.retry.Retry.with_deadline`
+            method.
+
         :rtype: :class:`.PartialRowData`, :data:`NoneType <types.NoneType>`
         :returns: The contents of the row if any chunks were returned in
                   the response, otherwise :data:`None`.
@@ -354,7 +362,7 @@ class Table(object):
         """
         row_set = RowSet()
         row_set.add_row_key(row_key)
-        result_iter = iter(self.read_rows(filter_=filter_, row_set=row_set))
+        result_iter = iter(self.read_rows(filter_=filter_, row_set=row_set, retry=retry))
         row = next(result_iter, None)
         if next(result_iter, None) is not None:
             raise ValueError("More than one row was returned.")


### PR DESCRIPTION
Fixes [#7955](https://github.com/googleapis/google-cloud-python/issues/7955).
[largely replicating a previous [PR](https://github.com/googleapis/google-cloud-python/pull/8088) by @elisheva-qlogic] 