### PR TITLE
BigQuery Data Transfer: Adjust indentation on scheduled query sample.

### DIFF
--- a/bigquery_datatransfer/samples/create_scheduled_query.py
+++ b/bigquery_datatransfer/samples/create_scheduled_query.py
@@ -46,12 +46,12 @@ def sample_create_transfer_config(project_id, dataset_id, authorization_code="")
 
     # Use standard SQL syntax for the query.
     query_string = """
-SELECT
-  CURRENT_TIMESTAMP() as current_time,
-  @run_time as intended_run_time,
-  @run_date as intended_run_date,
-  17 as some_integer
-"""
+    SELECT
+      CURRENT_TIMESTAMP() as current_time,
+      @run_time as intended_run_time,
+      @run_date as intended_run_date,
+      17 as some_integer
+    """
 
     parent = client.project_path(project_id)
 


### PR DESCRIPTION
This allows imports to render at the same indentation as the rest of the code. Whitespace doesn't matter for the actual SQL.