### PR TITLE
BigQuery Storage: Add 'client_options' support (via synth).

### DIFF
--- a/bigquery_storage/google/cloud/bigquery_storage_v1beta1/gapic/big_query_storage_client.py
+++ b/bigquery_storage/google/cloud/bigquery_storage_v1beta1/gapic/big_query_storage_client.py
@@ -20,6 +20,7 @@ import pkg_resources
 import warnings
 
 from google.oauth2 import service_account
+import google.api_core.client_options
 import google.api_core.gapic_v1.client_info
 import google.api_core.gapic_v1.config
 import google.api_core.gapic_v1.method
@@ -86,6 +87,7 @@ class BigQueryStorageClient(object):
         credentials=None,
         client_config=None,
         client_info=None,
+        client_options=None,
     ):
         """Constructor.
 
@@ -116,6 +118,9 @@ class BigQueryStorageClient(object):
                 API requests. If ``None``, then default info will be used.
                 Generally, you only need to set this if you're developing
                 your own client library.
+            client_options (Union[dict, google.api_core.client_options.ClientOptions]):
+                Client options used to set user options on the client. API Endpoint
+                should be set through client_options.
         """
         # Raise deprecation warnings for things we want to go away.
         if client_config is not None:
@@ -134,6 +139,15 @@ class BigQueryStorageClient(object):
                 stacklevel=2,
             )
 
+        api_endpoint = self.SERVICE_ADDRESS
+        if client_options:
+            if type(client_options) == dict:
+                client_options = google.api_core.client_options.from_dict(
+                    client_options
+                )
+            if client_options.api_endpoint:
+                api_endpoint = client_options.api_endpoint
+
         # Instantiate the transport.
         # The transport is responsible for handling serialization and
         # deserialization and actually sending data to the service.
@@ -142,6 +156,7 @@ class BigQueryStorageClient(object):
                 self.transport = transport(
                     credentials=credentials,
                     default_class=big_query_storage_grpc_transport.BigQueryStorageGrpcTransport,
+                    address=api_endpoint,
                 )
             else:
                 if credentials:
@@ -152,7 +167,7 @@ class BigQueryStorageClient(object):
                 self.transport = transport
         else:
             self.transport = big_query_storage_grpc_transport.BigQueryStorageGrpcTransport(
-                address=self.SERVICE_ADDRESS, channel=channel, credentials=credentials
+                address=api_endpoint, channel=channel, credentials=credentials
             )
 
         if client_info is None:

--- a/bigquery_storage/synth.metadata
+++ b/bigquery_storage/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-26T12:12:55.594550Z",
+  "updateTime": "2019-06-28T17:48:47.667101Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.29.0",
-        "dockerImage": "googleapis/artman@sha256:b79c8c20ee51e5302686c9d1294672d59290df1489be93749ef17d0172cc508d"
+        "version": "0.29.2",
+        "dockerImage": "googleapis/artman@sha256:45263333b058a4b3c26a8b7680a2710f43eae3d250f791a6cb66423991dcb2df"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "3a152bcdb544743be7bfc79ebb88b2397a3c4020",
-        "internalRef": "255067043"
+        "sha": "84c8ad4e52f8eec8f08a60636cfa597b86969b5c",
+        "internalRef": "255474859"
       }
     }
   ],

--- a/bigquery_storage/tests/unit/test_client.py
+++ b/bigquery_storage/tests/unit/test_client.py
@@ -41,7 +41,7 @@ def client_under_test(mock_transport):
 
     # The mock is detected as a callable. By creating a real callable here, the
     # mock can still be used to verify RPCs.
-    def transport_callable(credentials=None, default_class=None):
+    def transport_callable(credentials=None, default_class=None, address=None):
         return mock_transport
 
     return client.BigQueryStorageClient(transport=transport_callable)
@@ -50,7 +50,7 @@ def client_under_test(mock_transport):
 def test_constructor_w_client_info(mock_transport):
     from google.cloud.bigquery_storage_v1beta1 import client
 
-    def transport_callable(credentials=None, default_class=None):
+    def transport_callable(credentials=None, default_class=None, address=None):
         return mock_transport
 
     client_under_test = client.BigQueryStorageClient(


### PR DESCRIPTION
Supersedes #8499.