### PR TITLE
Firestore: Add 'FieldPath.documentId()'.

### DIFF
--- a/firestore/google/cloud/firestore_v1/field_path.py
+++ b/firestore/google/cloud/firestore_v1/field_path.py
@@ -384,3 +384,12 @@ class FieldPath(object):
         """
         indexes = six.moves.range(1, len(self.parts))
         return {FieldPath(*self.parts[:index]) for index in indexes}
+
+    @staticmethod
+    def document_id():
+        """A special FieldPath value to refer to the ID of a document. It can be used
+           in queries to sort or filter by the document ID.
+
+        Returns: A special sentinel value to refer to the ID of a document.
+        """
+        return "__name__"

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -729,8 +729,12 @@ def test_collection_group_queries_filters(client, cleanup):
 
     query = (
         client.collection_group(collection_group)
-        .where("__name__", ">=", client.document("a/b"))
-        .where("__name__", "<=", client.document("a/b0"))
+        .where(
+            firestore.field_path.FieldPath.document_id(), ">=", client.document("a/b")
+        )
+        .where(
+            firestore.field_path.FieldPath.document_id(), "<=", client.document("a/b0")
+        )
     )
     snapshots = list(query.stream())
     found = set(snapshot.id for snapshot in snapshots)
@@ -738,9 +742,13 @@ def test_collection_group_queries_filters(client, cleanup):
 
     query = (
         client.collection_group(collection_group)
-        .where("__name__", ">", client.document("a/b"))
         .where(
-            "__name__", "<", client.document("a/b/{}/cg-doc3".format(collection_group))
+            firestore.field_path.FieldPath.document_id(), ">", client.document("a/b")
+        )
+        .where(
+            firestore.field_path.FieldPath.document_id(),
+            "<",
+            client.document("a/b/{}/cg-doc3".format(collection_group)),
         )
     )
     snapshots = list(query.stream())

--- a/firestore/tests/unit/v1/test_field_path.py
+++ b/firestore/tests/unit/v1/test_field_path.py
@@ -493,3 +493,8 @@ class TestFieldPath(unittest.TestCase):
         field_path = self._make_one("a", "b", "c")
         expected = set([self._make_one("a"), self._make_one("a", "b")])
         self.assertEqual(field_path.lineage(), expected)
+
+    def test_document_id(self):
+        parts = "__name__"
+        field_path = self._make_one(parts)
+        self.assertEqual(field_path.document_id(), "__name__")

--- a/firestore/tests/unit/v1/test_field_path.py
+++ b/firestore/tests/unit/v1/test_field_path.py
@@ -497,4 +497,4 @@ class TestFieldPath(unittest.TestCase):
     def test_document_id(self):
         parts = "__name__"
         field_path = self._make_one(parts)
-        self.assertEqual(field_path.document_id(), "__name__")
+        self.assertEqual(field_path.document_id(), parts)


### PR DESCRIPTION
Fixes:  #8437 