### PR TITLE
BigQuery: Fix unit tests for new versions of fastparquet and pytest

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -51,6 +51,11 @@ extras = {
 all_extras = []
 
 for extra in extras:
+    if extra == "fastparquet":
+        # Skip fastparquet from "all" because it is redundant with pyarrow and
+        # creates a dependency on pre-release versions of numpy. See:
+        # https://github.com/googleapis/google-cloud-python/issues/8549
+        continue
     all_extras.extend(extras[extra])
 
 extras["all"] = all_extras

--- a/bigquery/tests/unit/test__pandas_helpers.py
+++ b/bigquery/tests/unit/test__pandas_helpers.py
@@ -533,16 +533,16 @@ def test_dataframe_to_arrow_w_unknown_type(module_under_test):
 @pytest.mark.skipIf(pandas is None, "Requires `pandas`")
 def test_dataframe_to_parquet_without_pyarrow(module_under_test, monkeypatch):
     monkeypatch.setattr(module_under_test, "pyarrow", None)
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError) as exc_context:
         module_under_test.dataframe_to_parquet(pandas.DataFrame(), (), None)
-    assert "pyarrow is required" in str(exc)
+    assert "pyarrow is required" in str(exc_context.value)
 
 
 @pytest.mark.skipIf(pandas is None, "Requires `pandas`")
 @pytest.mark.skipIf(pyarrow is None, "Requires `pyarrow`")
 def test_dataframe_to_parquet_w_missing_columns(module_under_test, monkeypatch):
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError) as exc_context:
         module_under_test.dataframe_to_parquet(
             pandas.DataFrame(), (schema.SchemaField("not_found", "STRING"),), None
         )
-    assert "columns in schema must match" in str(exc)
+    assert "columns in schema must match" in str(exc_context.value)

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -273,10 +273,10 @@ def test__make_bqstorage_client_true_raises_import_error(monkeypatch):
         google.auth.credentials.Credentials, instance=True
     )
 
-    with pytest.raises(ImportError) as exc:
+    with pytest.raises(ImportError) as exc_context:
         magics._make_bqstorage_client(True, credentials_mock)
 
-    assert "google-cloud-bigquery-storage" in str(exc)
+    assert "google-cloud-bigquery-storage" in str(exc_context.value)
 
 
 @pytest.mark.usefixtures("ipython_interactive")

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -2226,9 +2226,9 @@ class TestRowIterator(unittest.TestCase):
 
         with mock.patch.object(mut, "bigquery_storage_v1beta1", None), pytest.raises(
             ValueError
-        ) as exc:
+        ) as exc_context:
             row_iterator.to_dataframe(bqstorage_client=bqstorage_client)
-        assert mut._NO_BQSTORAGE_ERROR in str(exc)
+        assert mut._NO_BQSTORAGE_ERROR in str(exc_context.value)
 
     @unittest.skipIf(
         bigquery_storage_v1beta1 is None, "Requires `google-cloud-bigquery-storage`"
@@ -2514,6 +2514,6 @@ def test_table_reference_to_bqstorage_raises_import_error():
     for cls in classes:
         with mock.patch.object(mut, "bigquery_storage_v1beta1", None), pytest.raises(
             ValueError
-        ) as exc:
+        ) as exc_context:
             cls.from_string("my-project.my_dataset.my_table").to_bqstorage()
-        assert mut._NO_BQSTORAGE_ERROR in str(exc)
+        assert mut._NO_BQSTORAGE_ERROR in str(exc_context.value)


### PR DESCRIPTION
`fastparquet` is an optional dependency, and is redundant with `pyarrow`. It is not necessary to include in in the `[all]` extras. This avoids an issue where the `fastparquet` dependency pulls in a pre-release version of numpy.

Closes https://github.com/googleapis/google-cloud-python/issues/8549

Version 5.0.0 of pytest modifies the behavior of `str` on the `pytest.raises()` context manager. Update the tests to call `str` on the actual exception (`context.value`), instead.