### PR TITLE
Firestore: Expand dotted keys in mappings used as cursors.

### DIFF
--- a/firestore/google/cloud/firestore_v1/query.py
+++ b/firestore/google/cloud/firestore_v1/query.py
@@ -666,7 +666,12 @@ class Query(object):
             data = document_fields
             for order_key in order_keys:
                 try:
-                    values.append(field_path_module.get_nested_value(order_key, data))
+                    if order_key in data:
+                        values.append(data[order_key])
+                    else:
+                        values.append(
+                            field_path_module.get_nested_value(order_key, data)
+                        )
                 except KeyError:
                     msg = _MISSING_ORDER_BY.format(order_key, data)
                     raise ValueError(msg)

--- a/firestore/tests/system/test_system.py
+++ b/firestore/tests/system/test_system.py
@@ -615,10 +615,9 @@ def test_query_with_order_dot_key(client, cleanup):
     db = client
     collection_id = "collek" + unique_resource_id("-")
     collection = db.collection(collection_id)
-    for index in range(10):
+    for index in range(100, -1, -1):
         doc = collection.document("test_{:09d}".format(index))
         data = {"count": 10 * index, "wordcount": {"page1": index * 10 + 100}}
-        print("Setting: {}".format(doc.path))
         doc.set(data)
         cleanup(doc)
     query = collection.order_by("wordcount.page1").limit(3)
@@ -633,15 +632,18 @@ def test_query_with_order_dot_key(client, cleanup):
         .limit(3)
         .stream()
     )
-    found_data = [{u'count': 30, u'wordcount': {u'page1': 130}},
-                  {u'count': 40, u'wordcount': {u'page1': 140}},
-                  {u'count': 50, u'wordcount': {u'page1': 150}}]
+    found_data = [
+        {u"count": 30, u"wordcount": {u"page1": 130}},
+        {u"count": 40, u"wordcount": {u"page1": 140}},
+        {u"count": 50, u"wordcount": {u"page1": 150}},
+    ]
     assert found_data == [snap.to_dict() for snap in found]
     bad_cursor = {"wordcount.page1": last_value}
     bad_cursor_data = list(
-        collection.order_by("wordcount.page1").start_after(bad_cursor).limit(
-            3).stream())
+        collection.order_by("wordcount.page1").start_after(bad_cursor).limit(3).stream()
+    )
     assert found_data == [snap.to_dict() for snap in bad_cursor_data]
+
 
 def test_query_unary(client, cleanup):
     collection_name = "unary" + UNIQUE_RESOURCE_ID

--- a/firestore/tests/system/test_system.py
+++ b/firestore/tests/system/test_system.py
@@ -625,9 +625,9 @@ def test_query_with_order_dot_key(client, cleanup):
     assert [100, 110, 120] == data
     for snapshot in collection.order_by("wordcount.page1").limit(3).stream():
         last_value = snapshot.get("wordcount.page1")
-    cursor = {"wordcount": {"page1": last_value}}
+    cursor_with_nested_keys = {"wordcount": {"page1": last_value}}
     found = list(
-        collection.order_by("wordcount.page1").start_after(cursor).limit(3).stream()
+        collection.order_by("wordcount.page1").start_after(cursor_with_nested_keys).limit(3).stream()
     )
     found_data = [
         {u"count": 30, u"wordcount": {u"page1": 130}},
@@ -635,10 +635,10 @@ def test_query_with_order_dot_key(client, cleanup):
         {u"count": 50, u"wordcount": {u"page1": 150}},
     ]
     assert found_data == [snap.to_dict() for snap in found]
-    dot_key_cursor = {"wordcount.page1": last_value}
+    cursor_with_dotted_paths = {"wordcount.page1": last_value}
     cursor_with_key_data = list(
         collection.order_by("wordcount.page1")
-        .start_after(dot_key_cursor)
+        .start_after(cursor_with_dotted_paths)
         .limit(3)
         .stream()
     )

--- a/firestore/tests/system/test_system.py
+++ b/firestore/tests/system/test_system.py
@@ -627,7 +627,10 @@ def test_query_with_order_dot_key(client, cleanup):
         last_value = snapshot.get("wordcount.page1")
     cursor_with_nested_keys = {"wordcount": {"page1": last_value}}
     found = list(
-        collection.order_by("wordcount.page1").start_after(cursor_with_nested_keys).limit(3).stream()
+        collection.order_by("wordcount.page1")
+        .start_after(cursor_with_nested_keys)
+        .limit(3)
+        .stream()
     )
     found_data = [
         {u"count": 30, u"wordcount": {u"page1": 130}},

--- a/firestore/tests/system/test_system.py
+++ b/firestore/tests/system/test_system.py
@@ -611,6 +611,29 @@ def test_query_stream(client, cleanup):
         assert value["b"] == 2
 
 
+def test_query_with_order_dot_key(client, cleanup):
+    db = client
+    collection_id = "collek" + unique_resource_id("-")
+    collection = db.collection(collection_id)
+    doc_ref1 = collection.document("page1")
+    cleanup(doc_ref1)
+    doc_ref2 = collection.document("page2")
+    cleanup(doc_ref2)
+    doc_ref3 = collection.document("page3")
+    cleanup(doc_ref3)
+    doc_ref1.set(
+        {"wordcount": {"page3": 130, "page2": 120, "page1": 100}, "count": 100}
+    )
+    doc_ref2.set(
+        {"wordcount": {"page3": 180, "page2": 120, "page1": 150}, "count": 150}
+    )
+    doc_ref3.set({"count": 200, "wordcount": {"page3": 50, "page2": 100, "page1": 200}})
+
+    query = collection.order_by("wordcount.page1").limit(3)
+    data = [doc.to_dict()["wordcount"]["page1"] for doc in query.stream()]
+    assert [100, 150, 200] == data
+
+
 def test_query_unary(client, cleanup):
     collection_name = "unary" + UNIQUE_RESOURCE_ID
     collection = client.collection(collection_name)

--- a/firestore/tests/unit/v1/test_query.py
+++ b/firestore/tests/unit/v1/test_query.py
@@ -808,6 +808,16 @@ class TestQuery(unittest.TestCase):
 
         self.assertEqual(query._normalize_cursor(cursor, query._orders), ([1], True))
 
+    def test__normalize_cursor_as_dict_with_dot_key_hit(self):
+        cursor = ({"b.a": 1}, True)
+        query = self._make_one(mock.sentinel.parent).order_by("b.a", "ASCENDING")
+        self.assertEqual(query._normalize_cursor(cursor, query._orders), ([1], True))
+
+    def test__normalize_cursor_as_dict_with_inner_data_hit(self):
+        cursor = ({"b": {"a": 1}}, True)
+        query = self._make_one(mock.sentinel.parent).order_by("b.a", "ASCENDING")
+        self.assertEqual(query._normalize_cursor(cursor, query._orders), ([1], True))
+
     def test__normalize_cursor_as_snapshot_hit(self):
         values = {"b": 1}
         docref = self._make_docref("here", "doc_id")


### PR DESCRIPTION
Fixes #7756