### PR TITLE
Storage: Fix example in 'Client.download_blob_to_file' docstring.

### DIFF
--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -389,7 +389,7 @@ class Client(ClientWithProject):
 
             >>> with open('file-to-download-to') as file_obj:
             >>>     client.download_blob_to_file(
-            >>>         'gs://bucket_name/path/to/blob', file)
+            >>>         'gs://bucket_name/path/to/blob', file_obj)
 
 
         """


### PR DESCRIPTION
The argument passed to `download_blob_to_file` is `file` although it was defined as `file_obj`.