### PR TITLE
DNS: Change base url to dns.googleapis.com

### DIFF
--- a/dns/google/cloud/dns/_http.py
+++ b/dns/google/cloud/dns/_http.py
@@ -35,7 +35,7 @@ class Connection(_http.JSONConnection):
         self._client_info.gapic_version = __version__
         self._client_info.client_library_version = __version__
 
-    API_BASE_URL = "https://www.googleapis.com"
+    API_BASE_URL = "https://dns.googleapis.com"
     """The base of the API call URL."""
 
     API_VERSION = "v1"


### PR DESCRIPTION
Towards domain split.

The discovery document already lists the base url as dns.googleapis.com

https://www.googleapis.com/discovery/v1/apis/dns/v1/rest
https://www.googleapis.com/discovery/v1/apis/dns/v1beta2/rest
https://www.googleapis.com/discovery/v1/apis/dns/v2beta1/rest