### PR TITLE
Update pin for 'grpc-google-iam-v1' to 0.12.3+.

### DIFF
--- a/asset/setup.py
+++ b/asset/setup.py
@@ -30,7 +30,7 @@ release_status = "Development Status :: 3 - Alpha"
 dependencies = [
     "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',
-    "grpc-google-iam-v1 >= 0.11.4, < 0.12dev",
+    "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
 ]
 
 # Setup boilerplate below this line.

--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -31,7 +31,7 @@ release_status = 'Development Status :: 4 - Beta'
 dependencies = [
     'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
     "google-cloud-core >= 1.0.0, < 2.0dev",
-    'grpc-google-iam-v1 >= 0.11.4, < 0.12dev',
+    "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
 ]
 extras = {
 }

--- a/container/setup.py
+++ b/container/setup.py
@@ -30,7 +30,7 @@ version = "0.2.1"
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
     "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
-    "grpc-google-iam-v1 >= 0.11.4, < 0.12dev",
+    "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
 ]
 extras = {}
 

--- a/containeranalysis/setup.py
+++ b/containeranalysis/setup.py
@@ -26,7 +26,7 @@ version = "0.1.0"
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
     "google-api-core[grpc] >= 1.4.1, < 2.0.0dev",
-    "grpc-google-iam-v1 >= 0.11.1, < 0.12dev",
+    "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
     "grafeas",
 ]

--- a/datacatalog/setup.py
+++ b/datacatalog/setup.py
@@ -29,7 +29,7 @@ version = "0.2.0"
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
     "google-api-core[grpc] >= 1.4.1, < 2.0.0dev",
-    "grpc-google-iam-v1 >= 0.11.4, < 0.12dev",
+    "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]
 

--- a/iot/setup.py
+++ b/iot/setup.py
@@ -23,7 +23,7 @@ version = "0.2.0"
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
     "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
-    "grpc-google-iam-v1 >= 0.11.4, < 0.12dev",
+    "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]
 

--- a/kms/google/cloud/kms_v1/gapic/transports/key_management_service_grpc_transport.py
+++ b/kms/google/cloud/kms_v1/gapic/transports/key_management_service_grpc_transport.py
@@ -18,7 +18,7 @@
 import google.api_core.grpc_helpers
 
 from google.cloud.kms_v1.proto import service_pb2_grpc
-from google.iam.v1 import iam_policy_pb2
+from google.iam.v1 import iam_policy_pb2_grpc as iam_policy_pb2
 
 
 class KeyManagementServiceGrpcTransport(object):

--- a/kms/setup.py
+++ b/kms/setup.py
@@ -25,7 +25,7 @@ version = "1.1.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
-    "grpc-google-iam-v1 >= 0.11.4, < 0.12dev",
+    "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]
 

--- a/kms/synth.py
+++ b/kms/synth.py
@@ -39,6 +39,13 @@ library = gapic.py_library(
 
 s.move(library, excludes=["README.rst", "setup.py", "nox*.py", "docs/**/*"])
 
+# Temporary fixup for 'grpc-google-iam-vi 0.12.4' (before generation).
+s.replace(
+    "google/cloud/kms_v1/gapic/transports/key_management_service_grpc_transport.py",
+    "from google.iam.v1 import iam_policy_pb2",
+    "from google.iam.v1 import iam_policy_pb2_grpc as iam_policy_pb2",
+)
+
 # ----------------------------------------------------------------------------
 # Add templated files
 # ----------------------------------------------------------------------------

--- a/pubsub/google/cloud/pubsub_v1/gapic/transports/publisher_grpc_transport.py
+++ b/pubsub/google/cloud/pubsub_v1/gapic/transports/publisher_grpc_transport.py
@@ -18,7 +18,7 @@
 import google.api_core.grpc_helpers
 
 from google.cloud.pubsub_v1.proto import pubsub_pb2_grpc
-from google.iam.v1 import iam_policy_pb2
+from google.iam.v1 import iam_policy_pb2_grpc as iam_policy_pb2
 
 
 class PublisherGrpcTransport(object):

--- a/pubsub/google/cloud/pubsub_v1/gapic/transports/subscriber_grpc_transport.py
+++ b/pubsub/google/cloud/pubsub_v1/gapic/transports/subscriber_grpc_transport.py
@@ -18,7 +18,7 @@
 import google.api_core.grpc_helpers
 
 from google.cloud.pubsub_v1.proto import pubsub_pb2_grpc
-from google.iam.v1 import iam_policy_pb2
+from google.iam.v1 import iam_policy_pb2_grpc as iam_policy_pb2
 
 
 class SubscriberGrpcTransport(object):

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -30,7 +30,7 @@ version = "0.42.1"
 release_status = "Development Status :: 4 - Beta"
 dependencies = [
     "google-api-core[grpc] >= 1.12.0, < 2.0.0dev",
-    "grpc-google-iam-v1 >= 0.11.4, < 0.12dev",
+    "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]
 extras = {}

--- a/pubsub/synth.py
+++ b/pubsub/synth.py
@@ -167,6 +167,13 @@ s.replace(
     """
 )
 
+# Temporary fixup for 'grpc-google-iam-vi 0.12.4' (before generation).
+s.replace(
+    "google/cloud/pubsub_v1/gapic/transports/*_grpc_transport.py",
+    "from google.iam.v1 import iam_policy_pb2",
+    "from google.iam.v1 import iam_policy_pb2_grpc as iam_policy_pb2",
+)
+
 # ----------------------------------------------------------------------------
 # Add templated files
 # ----------------------------------------------------------------------------

--- a/securitycenter/setup.py
+++ b/securitycenter/setup.py
@@ -25,7 +25,7 @@ version = '0.2.0'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
-    'grpc-google-iam-v1 >= 0.11.4, < 0.12dev',
+    'grpc-google-iam-v1 >= 0.12.3, < 0.13dev',
     'enum34; python_version < "3.4"',
 ]
 

--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -31,7 +31,7 @@ release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc, grpcgcp] >= 1.4.1, < 2.0.0dev",
     "google-cloud-core >= 1.0.0, < 2.0dev",
-    "grpc-google-iam-v1 >= 0.11.4, < 0.12dev",
+    "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
 ]
 extras = {}
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -25,7 +25,7 @@ version = "1.1.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
-    "grpc-google-iam-v1 >= 0.11.4, < 0.12dev",
+    "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]
 


### PR DESCRIPTION
For pubsub / kms, also update the import of the 'IAMPolicy' stub, which
is no longer exported from the same location.

Supersedes: #8639
Supersedes: #8640

Closes: #8574
Closes: #8576
Closes: #8577
Closes: #8585
Closes: #8587
Closes: #8591
Closes: #8594
Closes: #8595
Closes: #8598