### PR TITLE
BigQuery: Complete the to_arrow() method feature request

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -2896,6 +2896,8 @@ class QueryJob(_AsyncJob):
         rows._preserve_order = _contains_order_by(self.query)
         return rows
 
+    # If changing the signature of this method, make sure to apply the same
+    # changes to table.RowIterator.to_arrow()
     def to_arrow(self, progress_bar_type=None):
         """[Beta] Create a class:`pyarrow.Table` by loading all pages of a
         table or query.
@@ -2934,6 +2936,8 @@ class QueryJob(_AsyncJob):
         """
         return self.result().to_arrow(progress_bar_type=progress_bar_type)
 
+    # If changing the signature of this method, make sure to apply the same
+    # changes to table.RowIterator.to_dataframe()
     def to_dataframe(self, bqstorage_client=None, dtypes=None, progress_bar_type=None):
         """Return a pandas DataFrame from a QueryJob
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -2898,7 +2898,7 @@ class QueryJob(_AsyncJob):
 
     # If changing the signature of this method, make sure to apply the same
     # changes to table.RowIterator.to_arrow()
-    def to_arrow(self, progress_bar_type=None):
+    def to_arrow(self, progress_bar_type=None, bqstorage_client=None):
         """[Beta] Create a class:`pyarrow.Table` by loading all pages of a
         table or query.
 
@@ -2921,6 +2921,18 @@ class QueryJob(_AsyncJob):
                 ``'tqdm_gui'``
                   Use the :func:`tqdm.tqdm_gui` function to display a
                   progress bar as a graphical dialog box.
+            bqstorage_client ( \
+                google.cloud.bigquery_storage_v1beta1.BigQueryStorageClient \
+            ):
+                **Beta Feature** Optional. A BigQuery Storage API client. If
+                supplied, use the faster BigQuery Storage API to fetch rows
+                from BigQuery. This API is a billable API.
+
+                This method requires the ``pyarrow`` and
+                ``google-cloud-bigquery-storage`` libraries.
+
+                Reading from a specific partition or snapshot is not
+                currently supported by this method.
 
         Returns:
             pyarrow.Table
@@ -2934,7 +2946,9 @@ class QueryJob(_AsyncJob):
 
         ..versionadded:: 1.17.0
         """
-        return self.result().to_arrow(progress_bar_type=progress_bar_type)
+        return self.result().to_arrow(
+            progress_bar_type=progress_bar_type, bqstorage_client=bqstorage_client
+        )
 
     # If changing the signature of this method, make sure to apply the same
     # changes to table.RowIterator.to_dataframe()

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1449,6 +1449,8 @@ class RowIterator(HTTPIterator):
             bqstorage_client=bqstorage_client,
         )
 
+    # If changing the signature of this method, make sure to apply the same
+    # changes to job.QueryJob.to_arrow()
     def to_arrow(self, progress_bar_type=None, bqstorage_client=None):
         """[Beta] Create a class:`pyarrow.Table` by loading all pages of a
         table or query.
@@ -1552,6 +1554,8 @@ class RowIterator(HTTPIterator):
             bqstorage_client=bqstorage_client,
         )
 
+    # If changing the signature of this method, make sure to apply the same
+    # changes to job.QueryJob.to_dataframe()
     def to_dataframe(self, bqstorage_client=None, dtypes=None, progress_bar_type=None):
         """Create a pandas DataFrame by loading all pages of a query.
 

--- a/bigquery/tests/unit/test_signature_compatibility.py
+++ b/bigquery/tests/unit/test_signature_compatibility.py
@@ -1,0 +1,43 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+
+import pytest
+
+
+@pytest.fixture
+def query_job_class():
+    from google.cloud.bigquery.job import QueryJob
+
+    return QueryJob
+
+
+@pytest.fixture
+def row_iterator_class():
+    from google.cloud.bigquery.table import RowIterator
+
+    return RowIterator
+
+
+def test_to_arrow_method_signatures_match(query_job_class, row_iterator_class):
+    sig = inspect.signature(query_job_class.to_arrow)
+    sig2 = inspect.signature(row_iterator_class.to_arrow)
+    assert sig == sig2
+
+
+def test_to_dataframe_method_signatures_match(query_job_class, row_iterator_class):
+    sig = inspect.signature(query_job_class.to_dataframe)
+    sig2 = inspect.signature(row_iterator_class.to_dataframe)
+    assert sig == sig2

--- a/bigquery/tests/unit/test_signature_compatibility.py
+++ b/bigquery/tests/unit/test_signature_compatibility.py
@@ -31,12 +31,20 @@ def row_iterator_class():
     return RowIterator
 
 
+@pytest.mark.skipif(
+    not hasattr(inspect, "signature"),
+    reason="inspect.signature() is not availalbe in older Python versions",
+)
 def test_to_arrow_method_signatures_match(query_job_class, row_iterator_class):
     sig = inspect.signature(query_job_class.to_arrow)
     sig2 = inspect.signature(row_iterator_class.to_arrow)
     assert sig == sig2
 
 
+@pytest.mark.skipif(
+    not hasattr(inspect, "signature"),
+    reason="inspect.signature() is not availalbe in older Python versions",
+)
 def test_to_dataframe_method_signatures_match(query_job_class, row_iterator_class):
     sig = inspect.signature(query_job_class.to_dataframe)
     sig2 = inspect.signature(row_iterator_class.to_dataframe)


### PR DESCRIPTION
Closes #5204.

This PR adds the [last missing piece](https://github.com/googleapis/google-cloud-python/issues/5204#issuecomment-511906029) of the feature, i.e. the `bqstorage_client` parameter that was still missing from one of the methods.

### How to test
Check that the signatures for various `to_arrow()` methods match (and the same for the `to_dataframe()` methods).