### PR TITLE
Update Cloud Memorystore service link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@
   Natural Language <language/index>
   OSLogin <oslogin/index>
   PubSub <pubsub/index>
-  Redis <redis/index>
+  Memorystore <redis/index>
   Resource Manager <resource-manager/index>
   Runtime Configuration <runtimeconfig/index>
   Scheduler <scheduler/index>


### PR DESCRIPTION
Hello,

It is recommended to use the official name of the service.

This PR is similar to:
https://github.com/googleapis/google-cloud-python/pull/7624

Regards,
Kamil