### PR TITLE
Enable Sample Generator Tool for Data Catalog

### DIFF
--- a/datacatalog/synth.py
+++ b/datacatalog/synth.py
@@ -30,6 +30,7 @@ library = gapic.py_library(
     config_path='/google/cloud/datacatalog/artman_datacatalog_v1beta1.yaml',
     artman_output_name='datacatalog-v1beta1',
     include_protos=True,
+    generator_args=["--dev_samples"],
 )
 
 s.move(


### PR DESCRIPTION
Enable Sample Generator Tool for Data Catalog. See https://github.com/googleapis/google-cloud-python/issues/8702 for details.