### PR TITLE
Bump minimum version for google-api-core to 1.14.0.

### DIFF
--- a/asset/setup.py
+++ b/asset/setup.py
@@ -28,7 +28,7 @@ version = "0.2.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
 ]

--- a/automl/setup.py
+++ b/automl/setup.py
@@ -22,7 +22,7 @@ description = "Cloud AutoML API client library"
 version = "0.3.0"
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',
 ]
 

--- a/bigquery_datatransfer/setup.py
+++ b/bigquery_datatransfer/setup.py
@@ -28,7 +28,7 @@ version = "0.4.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-api-core[grpc] >= 1.4.1, < 2.0.0dev"]
+dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 extras = {}
 
 

--- a/bigquery_storage/setup.py
+++ b/bigquery_storage/setup.py
@@ -24,7 +24,7 @@ description = "BigQuery Storage API API client library"
 version = "0.6.0"
 release_status = "Development Status :: 4 - Beta"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',
 ]
 extras = {

--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -29,7 +29,7 @@ version = '0.33.0'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 4 - Beta'
 dependencies = [
-    'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
+    'google-api-core[grpc] >= 1.14.0, < 2.0.0dev',
     "google-cloud-core >= 1.0.0, < 2.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
 ]

--- a/container/setup.py
+++ b/container/setup.py
@@ -29,7 +29,7 @@ version = "0.2.1"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
 ]
 extras = {}

--- a/containeranalysis/setup.py
+++ b/containeranalysis/setup.py
@@ -25,7 +25,7 @@ description = "Container Analysis API API client library"
 version = "0.2.0"
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.4.1, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
     "grafeas",

--- a/core/setup.py
+++ b/core/setup.py
@@ -28,7 +28,7 @@ version = "1.0.2"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 4 - Beta"
-dependencies = ["google-api-core >= 1.11.0, < 2.0.0dev"]
+dependencies = ["google-api-core >= 1.14.0, < 2.0.0dev"]
 extras = {"grpc": "grpcio >= 1.8.2, < 2.0dev"}
 
 

--- a/datacatalog/setup.py
+++ b/datacatalog/setup.py
@@ -28,7 +28,7 @@ version = "0.2.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.4.1, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]

--- a/datalabeling/setup.py
+++ b/datalabeling/setup.py
@@ -24,7 +24,7 @@ description = "Data Labeling API client library"
 version = "0.2.1"
 release_status = "Development Status :: 4 - Beta"
 dependencies = [
-    "google-api-core[grpc] >= 1.4.1, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',
 ]
 

--- a/dataproc/setup.py
+++ b/dataproc/setup.py
@@ -28,7 +28,7 @@ version = "0.4.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-api-core[grpc] >= 1.6.0, < 2.0.0dev"]
+dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 extras = {}
 
 

--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -29,7 +29,7 @@ version = "1.8.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "google-cloud-core >= 1.0.0, < 2.0dev",
 ]
 extras = {}

--- a/dlp/setup.py
+++ b/dlp/setup.py
@@ -24,7 +24,7 @@ description = "Cloud Data Loss Prevention (DLP) API API client library"
 version = "0.12.0"
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',
 ]
 

--- a/firestore/setup.py
+++ b/firestore/setup.py
@@ -29,7 +29,7 @@ version = "1.3.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 4 - Beta"
 dependencies = [
-    "google-api-core[grpc] >= 1.9.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "google-cloud-core >= 1.0.0, < 2.0dev",
     "pytz",
 ]

--- a/grafeas/setup.py
+++ b/grafeas/setup.py
@@ -24,7 +24,7 @@ description = "Grafeas API client library"
 version = "0.2.0"
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',
 ]
 

--- a/iam/setup.py
+++ b/iam/setup.py
@@ -28,7 +28,7 @@ version = "0.1.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',
 ]
 

--- a/iot/setup.py
+++ b/iot/setup.py
@@ -22,7 +22,7 @@ description = "Cloud IoT API API client library"
 version = "0.2.0"
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]

--- a/irm/setup.py
+++ b/irm/setup.py
@@ -24,7 +24,7 @@ description = "Stackdriver Incident Response & Managment API client library"
 version = "0.1.0"
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "google-cloud-monitoring >= 0.31.1, < 0.32dev",
 ]
 

--- a/kms/setup.py
+++ b/kms/setup.py
@@ -24,7 +24,7 @@ description = "Cloud Key Management Service (KMS) API API client library"
 version = "1.1.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]

--- a/language/setup.py
+++ b/language/setup.py
@@ -29,7 +29,7 @@ version = "1.2.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34;python_version<"3.4"',
 ]
 extras = {}

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -29,7 +29,7 @@ version = '1.11.0'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
-    'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
+    'google-api-core[grpc] >= 1.14.0, < 2.0.0dev',
     "google-cloud-core >= 1.0.0, < 2.0dev",
 ]
 extras = {

--- a/monitoring/setup.py
+++ b/monitoring/setup.py
@@ -29,7 +29,7 @@ version = '0.31.1'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
+    'google-api-core[grpc] >= 1.14.0, < 2.0.0dev',
 ]
 extras = {
     'pandas': 'pandas >= 0.17.1',

--- a/oslogin/setup.py
+++ b/oslogin/setup.py
@@ -28,7 +28,7 @@ version = "0.1.2"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-api-core[grpc] >= 1.6.0, < 2.0.0dev"]
+dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 extras = {}
 
 

--- a/phishingprotection/setup.py
+++ b/phishingprotection/setup.py
@@ -24,7 +24,7 @@ description = "Phishing Protection API API client library"
 version = "0.1.0"
 release_status = "3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.4.1, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',
 ]
 

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -29,7 +29,7 @@ version = "0.42.1"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 4 - Beta"
 dependencies = [
-    "google-api-core[grpc] >= 1.12.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]

--- a/redis/setup.py
+++ b/redis/setup.py
@@ -29,7 +29,7 @@ version = "0.2.1"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',
 ]
 extras = {}

--- a/scheduler/setup.py
+++ b/scheduler/setup.py
@@ -28,7 +28,7 @@ version = "1.1.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',
 ]
 

--- a/securitycenter/setup.py
+++ b/securitycenter/setup.py
@@ -24,7 +24,7 @@ description = 'Cloud Security Command Center API API client library'
 version = '0.2.0'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
+    'google-api-core[grpc] >= 1.14.0, < 2.0.0dev',
     'grpc-google-iam-v1 >= 0.12.3, < 0.13dev',
     'enum34; python_version < "3.4"',
 ]

--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -29,7 +29,7 @@ version = "1.9.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc, grpcgcp] >= 1.4.1, < 2.0.0dev",
+    "google-api-core[grpc, grpcgcp] >= 1.14.0, < 2.0.0dev",
     "google-cloud-core >= 1.0.0, < 2.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
 ]

--- a/speech/setup.py
+++ b/speech/setup.py
@@ -28,7 +28,7 @@ version = "1.1.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
-dependencies = ["google-api-core[grpc] >= 1.6.0, < 2.0.0dev"]
+dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 extras = {}
 
 

--- a/talent/setup.py
+++ b/talent/setup.py
@@ -28,7 +28,7 @@ version = "0.2.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-api-core[grpc] >= 1.6.0, < 2.0.0dev"]
+dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 extras = {}
 
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -24,7 +24,7 @@ description = "Cloud Tasks API API client library"
 version = "1.1.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]

--- a/texttospeech/setup.py
+++ b/texttospeech/setup.py
@@ -41,7 +41,7 @@ version = "0.4.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-api-core[grpc] >= 1.6.0, < 2.0.0dev"]
+dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 extras = {}
 
 

--- a/trace/setup.py
+++ b/trace/setup.py
@@ -29,7 +29,7 @@ version = '0.21.0'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
+    'google-api-core[grpc] >= 1.14.0, < 2.0.0dev',
     "google-cloud-core >= 1.0.0, < 2.0dev",
 ]
 extras = {

--- a/translate/setup.py
+++ b/translate/setup.py
@@ -29,7 +29,7 @@ version = "1.6.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "google-cloud-core >= 1.0.0, < 2.0dev",
 ]
 extras = {}

--- a/videointelligence/setup.py
+++ b/videointelligence/setup.py
@@ -28,7 +28,7 @@ version = "1.9.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
-dependencies = ["google-api-core[grpc] >= 1.6.0, < 2.0.0dev"]
+dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 extras = {}
 
 

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -22,7 +22,7 @@ description = "Cloud Vision API API client library"
 version = "0.38.0"
 release_status = "Development Status :: 4 - Beta"
 dependencies = [
-    "google-api-core[grpc] >= 1.6.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     'enum34; python_version < "3.4"',
 ]
 

--- a/webrisk/setup.py
+++ b/webrisk/setup.py
@@ -29,7 +29,7 @@ version = '0.1.0'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    'google-api-core[grpc] >= 1.6.0, < 2.0.0dev',
+    'google-api-core[grpc] >= 1.14.0, < 2.0.0dev',
 ]
 extras = {
 }

--- a/websecurityscanner/setup.py
+++ b/websecurityscanner/setup.py
@@ -28,7 +28,7 @@ version = "0.2.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-api-core[grpc] >= 1.6.0, < 2.0.0dev"]
+dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 
 extras = {}
 


### PR DESCRIPTION
Toward #8686.