### PR TITLE
BigQuery: Set IPython user agent when running queries with IPython cell magic

### DIFF
--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -144,6 +144,7 @@ try:
 except ImportError:  # pragma: NO COVER
     bigquery_storage_v1beta1 = None
 
+from google.api_core import client_info
 import google.auth
 from google.cloud import bigquery
 from google.cloud.bigquery.dbapi import _helpers
@@ -398,6 +399,9 @@ def _cell_magic(line, query):
         project=project,
         credentials=context.credentials,
         default_query_job_config=context.default_query_job_config,
+        client_info=client_info.ClientInfo(
+            user_agent="ipython-{}".format(IPython.__version__)
+        ),
     )
     if context._connection:
         client._connection = context._connection

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -5353,10 +5353,11 @@ class TestClientUpload(object):
                 dataframe, self.TABLE_REF, job_config=job_config, location=self.LOCATION
             )
 
-        assert len(warned) == 1
-        warning = warned[0]
-        assert warning.category is PendingDeprecationWarning
-        assert "pyarrow" in str(warning)
+        # there might be other warnings unrelated to the expected pyarrow warning,
+        # thus some filtering is necessary
+        pyarrow_warning = next((w for w in warned if "pyarrow" in str(w)), None)
+        assert pyarrow_warning is not None
+        assert pyarrow_warning.category is PendingDeprecationWarning
 
         load_table_from_file.assert_called_once_with(
             client,

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -5353,11 +5353,10 @@ class TestClientUpload(object):
                 dataframe, self.TABLE_REF, job_config=job_config, location=self.LOCATION
             )
 
-        # there might be other warnings unrelated to the expected pyarrow warning,
-        # thus some filtering is necessary
-        pyarrow_warning = next((w for w in warned if "pyarrow" in str(w)), None)
-        assert pyarrow_warning is not None
-        assert pyarrow_warning.category is PendingDeprecationWarning
+        assert warned  # there should be at least one warning
+        for warning in warned:
+            assert "pyarrow" in str(warning)
+            assert warning.category in (DeprecationWarning, PendingDeprecationWarning)
 
         load_table_from_file.assert_called_once_with(
             client,

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -318,6 +318,31 @@ def test_bigquery_magic_without_optional_arguments(monkeypatch):
     assert isinstance(return_value, pandas.DataFrame)
     assert len(return_value) == len(result)  # verify row count
     assert list(return_value) == list(result)  # verify column names
+
+
+@pytest.mark.usefixtures("ipython_interactive")
+def test_bigquery_magic_default_connection_user_agent():
+    ip = IPython.get_ipython()
+    ip.extension_manager.load_extension("google.cloud.bigquery")
+    magics.context._connection = None
+
+    credentials_mock = mock.create_autospec(
+        google.auth.credentials.Credentials, instance=True
+    )
+    default_patch = mock.patch(
+        "google.auth.default", return_value=(credentials_mock, "general-project")
+    )
+    run_query_patch = mock.patch(
+        "google.cloud.bigquery.magics._run_query", autospec=True
+    )
+    conn_patch = mock.patch("google.cloud.bigquery.client.Connection", autospec=True)
+
+    with conn_patch as conn, run_query_patch, default_patch:
+        ip.run_cell_magic("bigquery", "", "SELECT 17 as num")
+
+    client_info_arg = conn.call_args.kwargs.get("client_info")
+    assert client_info_arg is not None
+    assert client_info_arg.user_agent == "ipython-" + IPython.__version__
 
 
 @pytest.mark.usefixtures("ipython_interactive")


### PR DESCRIPTION
Closes #8696.

### How to test

See issue description - the Client should be instantiated with a custom user agent string when used from an IPython cell.

### Things to discuss
- [x] ~~A connection from the context could override this custom user agent string - is that expected behavior, or should the cell magic actually override the user agent string in context connections, too?~~
No, this is primarily used with Kaggle datasets, thus the overridden user agent string should take precedence.