### PR TITLE
Firestore: Fix V1 'Client.collections' method.

### DIFF
--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -421,7 +421,7 @@ class Client(ClientWithProject):
                 iterator of subcollections of the current document.
         """
         iterator = self._firestore_api.list_collection_ids(
-            self._database_string, metadata=self._rpc_metadata
+            "{}/documents".format(self._database_string), metadata=self._rpc_metadata
         )
         iterator.client = self
         iterator.item_to_value = _item_to_collection_ref

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -57,6 +57,10 @@ def cleanup():
         operation()
 
 
+def test_collections(client):
+    collections = list(client.collections())
+    assert isinstance(collections, list)
+
 def test_create_document(client, cleanup):
     now = datetime.datetime.utcnow().replace(tzinfo=UTC)
     collection_id = "doc-create" + unique_resource_id("-")

--- a/firestore/tests/system.py
+++ b/firestore/tests/system.py
@@ -61,6 +61,7 @@ def test_collections(client):
     collections = list(client.collections())
     assert isinstance(collections, list)
 
+
 def test_create_document(client, cleanup):
     now = datetime.datetime.utcnow().replace(tzinfo=UTC)
     collection_id = "doc-create" + unique_resource_id("-")

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -292,8 +292,9 @@ class TestClient(unittest.TestCase):
             self.assertEqual(collection.parent, None)
             self.assertEqual(collection.id, collection_id)
 
+        base_path = client._database_string + "/documents"
         firestore_api.list_collection_ids.assert_called_once_with(
-            client._database_string, metadata=client._rpc_metadata
+            base_path, metadata=client._rpc_metadata
         )
 
     def _get_all_helper(self, client, references, document_pbs, **kwargs):


### PR DESCRIPTION
Add undocumented-but-required `/documents` to the database path.

Closes #8717.