### PR TITLE
Firestore: support emulator in client.

### DIFF
--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -193,7 +193,7 @@ class Client(ClientWithProject):
 
             if self._emulator_host is not None:
                 # The emulator requires additional metadata to be set.
-                self._rpc_metadata_internal.append(("authorization", "bearer owner"))
+                self._rpc_metadata_internal.append(("authorization", "Bearer owner"))
 
         return self._rpc_metadata_internal
 

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -192,7 +192,7 @@ class Client(ClientWithProject):
             )
 
             if self._emulator_host is not None:
-                # The emulator requires additioanl metadata to be set.
+                # The emulator requires additional metadata to be set.
                 self._rpc_metadata_internal.append(("authorization", "bearer owner"))
 
         return self._rpc_metadata_internal

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -127,7 +127,7 @@ class Client(ClientWithProject):
 
             if self._emulator_host is not None:
                 channel = firestore_grpc_transport.firestore_pb2_grpc.grpc.insecure_channel(
-                    self._emulator_host,
+                    self._emulator_host
                 )
 
             self._transport = firestore_grpc_transport.FirestoreGrpcTransport(
@@ -190,6 +190,10 @@ class Client(ClientWithProject):
             self._rpc_metadata_internal = _helpers.metadata_with_prefix(
                 self._database_string
             )
+
+            if self._emulator_host is not None:
+                # The emulator requires additioanl metadata to be set.
+                self._rpc_metadata_internal.append(("authorization", "bearer owner"))
 
         return self._rpc_metadata_internal
 

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -120,15 +120,15 @@ class Client(ClientWithProject):
             # Use a custom channel.
             # We need this in order to set appropriate keepalive options.
 
-            channel = firestore_grpc_transport.FirestoreGrpcTransport.create_channel(
-                self._target,
-                credentials=self._credentials,
-                options={"grpc.keepalive_time_ms": 30000}.items(),
-            )
-
             if self._emulator_host is not None:
                 channel = firestore_grpc_transport.firestore_pb2_grpc.grpc.insecure_channel(
                     self._emulator_host
+                )
+            else:
+                channel = firestore_grpc_transport.FirestoreGrpcTransport.create_channel(
+                    self._target,
+                    credentials=self._credentials,
+                    options={"grpc.keepalive_time_ms": 30000}.items(),
                 )
 
             self._transport = firestore_grpc_transport.FirestoreGrpcTransport(

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -53,7 +53,7 @@ _BAD_DOC_TEMPLATE = (
 _ACTIVE_TXN = "There is already an active transaction."
 _INACTIVE_TXN = "There is no active transaction."
 _CLIENT_INFO = client_info.ClientInfo(client_library_version=__version__)
-
+_FIRESTORE_EMULATOR_HOST = "FIRESTORE_EMULATOR_HOST"
 
 class Client(ClientWithProject):
     """Client for interacting with Google Cloud Firestore API.
@@ -105,7 +105,7 @@ class Client(ClientWithProject):
         )
         self._client_info = client_info
         self._database = database
-        self._emulator_host = os.getenv("FIRESTORE_EMULATOR_HOST")
+        self._emulator_host = os.getenv(_FIRESTORE_EMULATOR_HOST)
 
     @property
     def _firestore_api(self):

--- a/firestore/google/cloud/firestore_v1/client.py
+++ b/firestore/google/cloud/firestore_v1/client.py
@@ -55,6 +55,7 @@ _INACTIVE_TXN = "There is no active transaction."
 _CLIENT_INFO = client_info.ClientInfo(client_library_version=__version__)
 _FIRESTORE_EMULATOR_HOST = "FIRESTORE_EMULATOR_HOST"
 
+
 class Client(ClientWithProject):
     """Client for interacting with Google Cloud Firestore API.
 

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -143,6 +143,23 @@ class TestClient(unittest.TestCase):
             [("google-cloud-resource-prefix", client._database_string)],
         )
 
+    def test__rpc_metadata_property_with_emulator(self):
+        emulator_host = "localhost:8081"
+        with mock.patch("os.getenv") as getenv:
+            getenv.return_value = emulator_host
+
+            credentials = _make_credentials()
+            database = "quanta"
+            client = self._make_one(
+                project=self.PROJECT, credentials=credentials, database=database
+            )
+
+        self.assertEqual(
+            client._rpc_metadata,
+            [("google-cloud-resource-prefix", client._database_string),
+            ("authorization", "Bearer owner")],
+        )
+
     def test_collection_factory(self):
         from google.cloud.firestore_v1.collection import CollectionReference
 

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -118,8 +118,8 @@ class TestClient(unittest.TestCase):
         self.assertIs(firestore_api, mock_client.return_value)
         self.assertIs(firestore_api, client._firestore_api_internal)
 
-        self.assertEqual(mock_insecure_channel.call_count, 1)
-        self.assertEqual(mock_insecure_channel.call_args.args[0], emulator_host)
+        mock_insecure_channel.assert_called_once_with(emulator_host)
+
 
         # Call again to show that it is cached, but call count is still 1.
         self.assertIs(client._firestore_api, mock_client.return_value)

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -120,7 +120,6 @@ class TestClient(unittest.TestCase):
 
         mock_insecure_channel.assert_called_once_with(emulator_host)
 
-
         # Call again to show that it is cached, but call count is still 1.
         self.assertIs(client._firestore_api, mock_client.return_value)
         self.assertEqual(mock_client.call_count, 1)

--- a/firestore/tests/unit/v1/test_client.py
+++ b/firestore/tests/unit/v1/test_client.py
@@ -156,8 +156,10 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(
             client._rpc_metadata,
-            [("google-cloud-resource-prefix", client._database_string),
-            ("authorization", "Bearer owner")],
+            [
+                ("google-cloud-resource-prefix", client._database_string),
+                ("authorization", "Bearer owner"),
+            ],
         )
 
     def test_collection_factory(self):


### PR DESCRIPTION
Adds support for using the firestore emulator with the client library. 

Fixes #7500