### PR TITLE
BigQuery: Mock external calls in one of BigQuery unit tests

### DIFF
--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -584,9 +584,17 @@ def test_bigquery_magic_w_maximum_bytes_billed_invalid():
     ip.extension_manager.load_extension("google.cloud.bigquery")
     magics.context._project = None
 
+    credentials_mock = mock.create_autospec(
+        google.auth.credentials.Credentials, instance=True
+    )
+    default_patch = mock.patch(
+        "google.auth.default", return_value=(credentials_mock, "general-project")
+    )
+    client_query_patch = mock.patch("google.cloud.bigquery.client.Client.query")
+
     sql = "SELECT 17 AS num"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError), default_patch, client_query_patch:
         ip.run_cell_magic("bigquery", "--maximum_bytes_billed=abc", sql)
 
 


### PR DESCRIPTION
Closes #8719 

This PR properly mocks external calls in one of the tests.

### How to test
1. Clear environment credentials config:
    ```sh
    $ unset GOOGLE_APPLICATION_CREDENTIALS
    ```
1. Run bigquery unit tests, check the result of `test_bigquery_magic_w_maximum_bytes_billed_invalid`.

**Actual result (before the fix):**
The test fails with `DefaultCredentialsError`.

**Expected result (after the fix):**
The code under tests raises `ValueError` as expected, and the test passes.
