### PR TITLE
API Core: Forward 'timeout' arg from 'exception' to '_blocking_poll'.

### DIFF
--- a/api_core/google/api_core/future/polling.py
+++ b/api_core/google/api_core/future/polling.py
@@ -139,7 +139,7 @@ class PollingFuture(base.Future):
             Optional[google.api_core.GoogleAPICallError]: The operation's
                 error.
         """
-        self._blocking_poll()
+        self._blocking_poll(timeout=timeout)
         return self._exception
 
     def add_done_callback(self, fn):

--- a/api_core/tests/unit/future/test_polling.py
+++ b/api_core/tests/unit/future/test_polling.py
@@ -119,6 +119,12 @@ def test_result_timeout():
         future.result(timeout=1)
 
 
+def test_exception_timeout():
+    future = PollingFutureImplTimeout()
+    with pytest.raises(concurrent.futures.TimeoutError):
+        future.exception(timeout=1)
+
+
 class PollingFutureImplTransient(PollingFutureImplWithPoll):
     def __init__(self, errors):
         super(PollingFutureImplTransient, self).__init__()


### PR DESCRIPTION
Closes #8733.