### PR TITLE
Core: Make build_api_url an instance method.

### DIFF
--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -159,8 +159,6 @@ class JSONConnection(Connection):
     This defines :meth:`api_request` for making a generic JSON
     API request and API requests are created elsewhere.
 
-    The class constants
-
     * :attr:`API_BASE_URL`
     * :attr:`API_VERSION`
     * :attr:`API_URL_TEMPLATE`
@@ -177,9 +175,8 @@ class JSONConnection(Connection):
     API_URL_TEMPLATE = None
     """A template for the URL of a particular API call."""
 
-    @classmethod
     def build_api_url(
-        cls, path, query_params=None, api_base_url=None, api_version=None
+        self, path, query_params=None, api_base_url=None, api_version=None
     ):
         """Construct an API url given a few components, some optional.
 
@@ -205,9 +202,9 @@ class JSONConnection(Connection):
         :rtype: str
         :returns: The URL assembled from the pieces provided.
         """
-        url = cls.API_URL_TEMPLATE.format(
-            api_base_url=(api_base_url or cls.API_BASE_URL),
-            api_version=(api_version or cls.API_VERSION),
+        url = self.API_URL_TEMPLATE.format(
+            api_base_url=(api_base_url or self.API_BASE_URL),
+            api_version=(api_version or self.API_VERSION),
             path=path,
         )
 


### PR DESCRIPTION
See #8737.

> Hmm, that `@classmethod` looks a little bogus to me. All actual uses of it are via instances:
> 
> ```shell
> $ git grep "\.build_api_url"
> bigquery/tests/unit/test__http.py:        self.assertEqual(conn.build_api_url("/foo"), URI)
> bigquery/tests/unit/test__http.py:        uri = conn.build_api_url("/foo", {"bar": "baz"})
> bigquery/tests/unit/test__http.py:        expected_uri = conn.build_api_url("/rainbow")
> bigquery/tests/unit/test__http.py:        expected_uri = conn.build_api_url("/rainbow")
> core/google/cloud/_http.py:        url = self.build_api_url(
> core/tests/unit/test__http.py:        self.assertEqual(conn.build_api_url("/foo"), URI)
> core/tests/unit/test__http.py:        uri = conn.build_api_url("/foo", {"bar": "baz", "qux": ["quux", "corge"]})
> dns/tests/unit/test__http.py:        self.assertEqual(conn.build_api_url("/foo"), URI)
> dns/tests/unit/test__http.py:        uri = conn.build_api_url("/foo", {"bar": "baz"})
> dns/tests/unit/test__http.py:        expected_uri = conn.build_api_url("/rainbow")
> logging/tests/unit/test__http.py:        expected_uri = conn.build_api_url("/rainbow")
> resource_manager/tests/unit/test__http.py:        self.assertEqual(conn.build_api_url("/foo"), URI)
> resource_manager/tests/unit/test__http.py:        uri = conn.build_api_url("/foo", {"bar": "baz"})
> resource_manager/tests/unit/test__http.py:        expected_uri = conn.build_api_url("/rainbow")
> runtimeconfig/tests/unit/test__http.py:        expected_uri = conn.build_api_url("/rainbow")
> storage/tests/unit/test__http.py:        expected_uri = conn.build_api_url("/rainbow")
> storage/tests/unit/test__http.py:        self.assertEqual(conn.build_api_url("/foo"), URI)
> storage/tests/unit/test__http.py:        uri = conn.build_api_url("/foo", {"bar": "baz"})
> translate/tests/unit/test__http.py:        self.assertEqual(conn.build_api_url("/foo"), URI)
> translate/tests/unit/test__http.py:        uri = conn.build_api_url("/foo", query_params=query_params)
> translate/tests/unit/test__http.py:        expected_uri = conn.build_api_url("/rainbow")
> ```