### PR TITLE
Data Catalog: Fix client documentation links

### DIFF
--- a/datacatalog/.repo-metadata.json
+++ b/datacatalog/.repo-metadata.json
@@ -2,7 +2,7 @@
   "name": "datacatalog ",
   "name_pretty": "Google Cloud Data Catalog",
   "product_documentation": "https://cloud.google.com/data-catalog",
-  "client_documentation": "https://cloud.google.com/nodejs/docs/reference/datacatalog/latest/",
+  "client_documentation": "https://googleapis.dev/python/datacatalog/latest",
   "issue_tracker": "",
   "release_level": "alpha",
   "language": "python",

--- a/datacatalog/README.rst
+++ b/datacatalog/README.rst
@@ -16,7 +16,7 @@ include: Entries (Data Catalog representation of a cloud resource).
    :target: https://python-compatibility-tools.appspot.com/one_badge_target?package=git%2Bgit%3A//github.com/googleapis/google-cloud-python.git%23subdirectory%3Ddatacatalog
 .. _Alpha: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
 .. _Google Cloud Data Catalog API: https://cloud.google.com/data-catalog
-.. _Client Library Documentation: https://cloud.google.com/nodejs/docs/reference/datacatalog/latest/
+.. _Client Library Documentation: https://googleapis.dev/python/datacatalog/latest
 .. _Product Documentation:  https://cloud.google.com/data-catalog
 
 Quick Start


### PR DESCRIPTION
Data Catalog: Fix client documentation links from nodejs version to python version