### PR TITLE
Bigtable: New 'retry' parameter for 'Table.read_row()'

### DIFF
--- a/bigtable/google/cloud/bigtable/batcher.py
+++ b/bigtable/google/cloud/bigtable/batcher.py
@@ -128,15 +128,15 @@ class MutationsBatcher(object):
             self.mutate(row)
 
     def flush(self):
-        """ Sends the current. batch to Cloud Bigtable.
-        For example:
+        """ Sends the current batch to Cloud Bigtable.
 
+        For example:
         .. literalinclude:: snippets.py
             :start-after: [START bigtable_batcher_flush]
             :end-before: [END bigtable_batcher_flush]
 
         """
-        if len(self.rows) != 0:
+        if self.rows:
             self.table.mutate_rows(self.rows)
             self.total_mutation_count = 0
             self.total_size = 0

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -334,7 +334,7 @@ class Table(object):
             for cluster_id, value_pb in table_pb.cluster_states.items()
         }
 
-    def read_row(self, row_key, filter_=None):
+    def read_row(self, row_key, filter_=None, retry=DEFAULT_RETRY_READ_ROWS):
         """Read a single row from this table.
 
         For example:
@@ -350,6 +350,12 @@ class Table(object):
         :param filter_: (Optional) The filter to apply to the contents of the
                         row. If unset, returns the entire row.
 
+        :type retry: :class:`~google.api_core.retry.Retry`
+        :param retry: (Optional) Retry delay or deadline argument. Override
+            the default via, e.g.:
+            ``DEFAULT_RETRY_READ_ROWS.with_deadline(new_value)`` or
+            ``DEFAULT_RETRY_READ_ROWS.with_delay(new_value)``.
+
         :rtype: :class:`.PartialRowData`, :data:`NoneType <types.NoneType>`
         :returns: The contents of the row if any chunks were returned in
                   the response, otherwise :data:`None`.
@@ -358,7 +364,9 @@ class Table(object):
         """
         row_set = RowSet()
         row_set.add_row_key(row_key)
-        result_iter = iter(self.read_rows(filter_=filter_, row_set=row_set))
+        result_iter = iter(
+            self.read_rows(filter_=filter_, row_set=row_set, retry=retry)
+        )
         row = next(result_iter, None)
         if next(result_iter, None) is not None:
             raise ValueError("More than one row was returned.")

--- a/bigtable/noxfile.py
+++ b/bigtable/noxfile.py
@@ -23,6 +23,7 @@ import nox
 
 LOCAL_DEPS = (os.path.join("..", "api_core"), os.path.join("..", "core"))
 
+
 @nox.session(python="3.7")
 def lint(session):
     """Run linters.
@@ -136,6 +137,7 @@ def cover(session):
 
     session.run("coverage", "erase")
 
+
 @nox.session(python="3.7")
 def docs(session):
     """Build the docs for this library."""
@@ -156,6 +158,7 @@ def docs(session):
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
     )
+
 
 @nox.session(python=['2.7', '3.7'])
 def snippets(session):

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -627,10 +627,22 @@ class TestTable(unittest.TestCase):
 
         self.assertEqual(result, expected_result)
 
+    def test_read_row_default_retry(self):
+        from google.cloud.bigtable import row_data
+
+        credentials = _make_credentials()
+        client = self._make_client(project="project-id", credentials=credentials)
+        instance = client.instance(instance_id=self.INSTANCE_ID)
+        table = self._make_one(self.TABLE_ID, instance)
+        table.read_rows = mock.Mock(return_value=[])
+
+        table.read_row(self.ROW_KEY)
+        args, kwargs = table.read_rows.call_args
+        self.assertEqual(kwargs["retry"], row_data.DEFAULT_RETRY_READ_ROWS)
+
     def test_read_row_custom_retry(self):
         from google.api_core import retry
         from google.api_core.retry import if_exception_type
-        from google.cloud.bigtable import row_data
         from google.cloud.bigtable.table import _BigtableRetryableError
 
         credentials = _make_credentials()
@@ -649,10 +661,6 @@ class TestTable(unittest.TestCase):
         table.read_row(self.ROW_KEY, retry=custom_retry)
         args, kwargs = table.read_rows.call_args
         self.assertEqual(kwargs["retry"], custom_retry)
-
-        table.read_row(self.ROW_KEY)
-        args, kwargs = table.read_rows.call_args
-        self.assertEqual(kwargs["retry"], row_data.DEFAULT_RETRY_READ_ROWS)
 
     def test_read_rows(self):
         from google.cloud._testing import _Monkey


### PR DESCRIPTION
Fixes #7955 . Reformatted.