### PR TITLE
Release pubsub 0.44.0

### DIFF
--- a/pubsub/CHANGELOG.md
+++ b/pubsub/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 [1]: https://pypi.org/project/google-cloud-pubsub/#history
 
+## 0.44.0
+
+07-29-2019 04:28 PDT
+
+
+### Implementation Changes
+
+- PubSub: Deprecate several FlowControl settings and things in Message class ([#8796](https://github.com/googleapis/google-cloud-python/pull/8796))
+
+### Documentation
+
+- Pub/Sub: document regional endpoint ([#8789](https://github.com/googleapis/google-cloud-python/pull/8789))
+
 ## 0.43.0
 
 07-24-2019 17:13 PDT

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -22,7 +22,7 @@ import setuptools
 
 name = "google-cloud-pubsub"
 description = "Google Cloud Pub/Sub API client library"
-version = "0.43.0"
+version = "0.44.0"
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
This pull request was generated using releasetool.

**Comment:** It is primarily meant to mark several things in the PubSub client as deprecated.