### PR TITLE
BigQuery: Hide error traceback in BigQuery cell magic

### DIFF
--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -130,6 +130,7 @@
 from __future__ import print_function
 
 import ast
+import sys
 import time
 from concurrent import futures
 
@@ -428,7 +429,7 @@ def _cell_magic(line, query):
         display.clear_output()
 
     if error:
-        print("\nERROR:\n", error)
+        print("\nERROR:\n", error, file=sys.stderr)
         return
 
     result = query_job.to_dataframe(bqstorage_client=bqstorage_client)

--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -417,10 +417,19 @@ def _cell_magic(line, query):
     elif args.maximum_bytes_billed is not None:
         value = int(args.maximum_bytes_billed)
         job_config.maximum_bytes_billed = value
-    query_job = _run_query(client, query, job_config)
+
+    error = None
+    try:
+        query_job = _run_query(client, query, job_config)
+    except Exception as ex:
+        error = str(ex)
 
     if not args.verbose:
         display.clear_output()
+
+    if error:
+        print("\nERROR:\n", error)
+        return
 
     result = query_job.to_dataframe(bqstorage_client=bqstorage_client)
     if args.destination_var:

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -839,6 +839,7 @@ def test_bigquery_magic_omits_tracebacks_from_error_message():
     with run_query_patch, default_patch, io.capture_output() as captured_io:
         ip.run_cell_magic("bigquery", "", "SELECT foo FROM WHERE LIMIT bar")
 
-    output = captured_io.stdout
+    output = captured_io.stderr
     assert "400 Syntax error in SQL query" in output
     assert "Traceback (most recent call last)" not in output
+    assert "Syntax error" not in captured_io.stdout

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -32,6 +32,7 @@ try:
 except ImportError:  # pragma: NO COVER
     IPython = None
 
+from google.api_core import exceptions
 import google.auth.credentials
 
 try:
@@ -815,3 +816,29 @@ def test_bigquery_magic_with_improperly_formatted_params():
 
     with pytest.raises(SyntaxError):
         ip.run_cell_magic("bigquery", "--params {17}", sql)
+
+
+@pytest.mark.usefixtures("ipython_interactive")
+def test_bigquery_magic_omits_tracebacks_from_error_message():
+    ip = IPython.get_ipython()
+    ip.extension_manager.load_extension("google.cloud.bigquery")
+
+    credentials_mock = mock.create_autospec(
+        google.auth.credentials.Credentials, instance=True
+    )
+    default_patch = mock.patch(
+        "google.auth.default", return_value=(credentials_mock, "general-project")
+    )
+
+    run_query_patch = mock.patch(
+        "google.cloud.bigquery.magics._run_query",
+        autospec=True,
+        side_effect=exceptions.BadRequest("Syntax error in SQL query"),
+    )
+
+    with run_query_patch, default_patch, io.capture_output() as captured_io:
+        ip.run_cell_magic("bigquery", "", "SELECT foo FROM WHERE LIMIT bar")
+
+    output = captured_io.stdout
+    assert "400 Syntax error in SQL query" in output
+    assert "Traceback (most recent call last)" not in output


### PR DESCRIPTION
Closes #6848.

This PR makes sure that long tracebacks are hidden on exceptions when using `%%bigquery` cell magic, and only the relevant info is printed out.

### How to test
- Run IPython from the virtualenv and load the `%%bigquery` cell magic:
    ```
    %load_ext google.cloud.bigquery
    ```
- Run a query that triggers an error, e.g. a syntax error, unknown dataset, etc. Example:
    ```
    %%bigquery 
    SELECT 1 SELECT
    ```

**Actual result (before the fix):**
An error is printed out, including the full traceback of internal calls.

**Expected result (after the fix):**
Only the relevant error info is printed out, i.e. _without_ the traceback, as the latter can be considered an internal detail of the cell magic.

### Things to discuss
- [x] ~~It might not be desirable for the exception to be swallowed and replaced with a simple output to _stdout_. Should not make any difference for users, unless some of them use `%%bigquery` cell magic programmatically?~~
No, as no one should be using the `%%bigquery` magic outside of a Jupyter environment