### PR TITLE
Firestore: Fix sorting 'delete_changes' in 'Watch._compute_snapshot'.

### DIFF
--- a/firestore/google/cloud/firestore_v1/watch.py
+++ b/firestore/google/cloud/firestore_v1/watch.py
@@ -667,7 +667,7 @@ class Watch(object):
         key = functools.cmp_to_key(self._comparator)
 
         # Deletes are sorted based on the order of the existing document.
-        delete_changes = sorted(delete_changes, key=key)
+        delete_changes = sorted(delete_changes)
         for name in delete_changes:
             change, updated_tree, updated_map = delete_doc(
                 name, updated_tree, updated_map

--- a/firestore/tests/unit/v1/test_watch.py
+++ b/firestore/tests/unit/v1/test_watch.py
@@ -735,7 +735,7 @@ class TestWatch(unittest.TestCase):
             doc_tree, doc_map, delete_changes, add_changes, update_changes
         )
         self.assertEqual(updated_map, doc_map)  # no change
-        
+
     def test__compute_snapshot_deletes_w_real_comparator(self):
         from google.cloud.firestore_v1.watch import WatchDocTree
 

--- a/firestore/tests/unit/v1/test_watch.py
+++ b/firestore/tests/unit/v1/test_watch.py
@@ -735,6 +735,38 @@ class TestWatch(unittest.TestCase):
             doc_tree, doc_map, delete_changes, add_changes, update_changes
         )
         self.assertEqual(updated_map, doc_map)  # no change
+        
+    def test__compute_snapshot_deletes_w_real_comparator(self):
+        from google.cloud.firestore_v1.watch import WatchDocTree
+
+        doc_tree = WatchDocTree()
+
+        class DummyDoc(object):
+            update_time = mock.sentinel
+
+        def _comparator(doc1, doc2):
+            if doc1.field > doc2.field:
+                return 1
+            if doc1.field < doc2.field:
+                return -1
+            return 0
+
+        deleted_doc_1 = DummyDoc()
+        deleted_doc_2 = DummyDoc()
+        doc_tree = doc_tree.insert(deleted_doc_1, None)
+        doc_tree = doc_tree.insert(deleted_doc_2, None)
+        doc_map = {
+            "/deleted_1": deleted_doc_1,
+            "/deleted_2": deleted_doc_2,
+        }
+        delete_changes = ["/deleted_1", "/deleted_2"]
+        add_changes = []
+        update_changes = []
+        inst = self._makeOne(comparator=_comparator)
+        updated_tree, updated_map, applied_changes = inst._compute_snapshot(
+            doc_tree, doc_map, delete_changes, add_changes, update_changes
+        )
+        self.assertEqual(updated_map, {})
 
     def test__reset_docs(self):
         from google.cloud.firestore_v1.watch import ChangeType

--- a/firestore/tests/unit/v1/test_watch.py
+++ b/firestore/tests/unit/v1/test_watch.py
@@ -744,25 +744,15 @@ class TestWatch(unittest.TestCase):
         class DummyDoc(object):
             update_time = mock.sentinel
 
-        def _comparator(doc1, doc2):
-            if doc1.field > doc2.field:
-                return 1
-            if doc1.field < doc2.field:
-                return -1
-            return 0
-
         deleted_doc_1 = DummyDoc()
         deleted_doc_2 = DummyDoc()
         doc_tree = doc_tree.insert(deleted_doc_1, None)
         doc_tree = doc_tree.insert(deleted_doc_2, None)
-        doc_map = {
-            "/deleted_1": deleted_doc_1,
-            "/deleted_2": deleted_doc_2,
-        }
+        doc_map = {"/deleted_1": deleted_doc_1, "/deleted_2": deleted_doc_2}
         delete_changes = ["/deleted_1", "/deleted_2"]
         add_changes = []
         update_changes = []
-        inst = self._makeOne(comparator=_comparator)
+        inst = self._makeOne(comparator=object())
         updated_tree, updated_map, applied_changes = inst._compute_snapshot(
             doc_tree, doc_map, delete_changes, add_changes, update_changes
         )


### PR DESCRIPTION
`delete_changes` on the changed line is a list of string, not a list of DocumentSnapshots, so it should not be sorted with the query comparator function (see https://github.com/googleapis/google-cloud-python/blob/master/firestore/google/cloud/firestore_v1/watch.py#L575)

For context, I'm getting this error in one of my snapshot listeners in google-cloud-firestore==1.3.0
```
Thread-ConsumeBidirectionalStream caught unexpected exception 'str' object has no attribute 'reference' and will exit.
Traceback (most recent call last):
  File ".../venv/lib/python3.5/site-packages/google/api_core/bidi.py", line 635, in _thread_main
    self._on_response(response)
  File ".../venv/lib/python3.5/site-packages/google/cloud/firestore_v1/watch.py", line 443, in on
_snapshot
    meth(proto)
  File ".../venv/lib/python3.5/site-packages/google/cloud/firestore_v1/watch.py", line 378, in _o
n_snapshot_target_change_no_change
    self.push(change.read_time, change.resume_token)
  File ".../venv/lib/python3.5/site-packages/google/cloud/firestore_v1/watch.py", line 540, in pu
sh
    self.doc_tree, self.doc_map, deletes, adds, updates
  File ".../venv/lib/python3.5/site-packages/google/cloud/firestore_v1/watch.py", line 669, in _c
ompute_snapshot
    delete_changes = sorted(delete_changes, key=key)
  File ".../venv/lib/python3.5/site-packages/google/cloud/firestore_v1/query.py", line 819, in _c
omparator
    comp = Order()._compare_to(doc1.reference._path, doc2.reference._path)
AttributeError: 'str' object has no attribute 'reference'
```