### PR TITLE
Pub/Sub docs: double back-ticks for ReST correctness.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/publisher/client.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/client.py
@@ -58,9 +58,9 @@ class Client(object):
             Before being passed along to the GAPIC constructor, a channel may
             be added if ``credentials`` are passed explicitly or if the
             Pub / Sub emulator is detected as running.
-            Regional endpoints can be set via `client_options` that takes a
+            Regional endpoints can be set via ``client_options`` that takes a
             single key-value pair that defines the endpoint, i.e.
-            `client_options={"api_endpoint": REGIONAL_ENDPOINT}`
+            ``client_options={"api_endpoint": REGIONAL_ENDPOINT}``.
     """
 
     _batch_class = thread.Batch

--- a/pubsub/google/cloud/pubsub_v1/subscriber/client.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/client.py
@@ -53,9 +53,9 @@ class Client(object):
             :class:`~.gapic.pubsub.v1.subscriber_client.SubscriberClient`.
             Generally, you should not need to set additional keyword
             arguments.
-            Regional endpoints can be set via `client_options` that takes a
+            Regional endpoints can be set via ``client_options`` that takes a
             single key-value pair that defines the endpoint, i.e.
-            `client_options={"api_endpoint": REGIONAL_ENDPOINT}`.
+            ``client_options={"api_endpoint": REGIONAL_ENDPOINT}``.
     """
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Fix formatting. 