### PR TITLE
Logging: Map stdlib loglevels to Stackdriver severity enum values.

### DIFF
--- a/logging/google/cloud/logging/handlers/transports/background_thread.py
+++ b/logging/google/cloud/logging/handlers/transports/background_thread.py
@@ -28,6 +28,7 @@ import time
 
 from six.moves import queue
 
+from google.cloud.logging import _helpers
 from google.cloud.logging.handlers.transports.base import Transport
 
 _DEFAULT_GRACE_PERIOD = 5.0  # Seconds
@@ -254,17 +255,16 @@ class _Worker(object):
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
         """
-        self._queue.put_nowait(
-            {
-                "info": {"message": message, "python_logger": record.name},
-                "severity": record.levelname,
-                "resource": resource,
-                "labels": labels,
-                "trace": trace,
-                "span_id": span_id,
-                "timestamp": datetime.datetime.utcfromtimestamp(record.created),
-            }
-        )
+        queue_entry = {
+            "info": {"message": message, "python_logger": record.name},
+            "severity": _helpers._normalize_severity(record.levelno),
+            "resource": resource,
+            "labels": labels,
+            "trace": trace,
+            "span_id": span_id,
+            "timestamp": datetime.datetime.utcfromtimestamp(record.created),
+        }
+        self._queue.put_nowait(queue_entry)
 
     def flush(self):
         """Submit any pending log records."""

--- a/logging/google/cloud/logging/handlers/transports/sync.py
+++ b/logging/google/cloud/logging/handlers/transports/sync.py
@@ -17,6 +17,7 @@
 Logs directly to the the Stackdriver Logging API with a synchronous call.
 """
 
+from google.cloud.logging import _helpers
 from google.cloud.logging.handlers.transports.base import Transport
 
 
@@ -50,7 +51,7 @@ class SyncTransport(Transport):
         info = {"message": message, "python_logger": record.name}
         self.logger.log_struct(
             info,
-            severity=record.levelname,
+            severity=_helpers._normalize_severity(record.levelno),
             resource=resource,
             labels=labels,
             trace=trace,

--- a/logging/tests/system/test_system.py
+++ b/logging/tests/system/test_system.py
@@ -112,7 +112,7 @@ class TestLogging(unittest.TestCase):
                 retry_not_found(retry_other(doomed.delete))()
             except AttributeError:
                 client, dataset = doomed
-                retry(client.delete_dataset)(dataset)
+                retry_not_found(retry_other(client.delete_dataset))(dataset)
             except NotFound:
                 pass
         logging.getLogger().handlers = self._handlers_cache[:]

--- a/logging/tests/system/test_system.py
+++ b/logging/tests/system/test_system.py
@@ -105,10 +105,11 @@ class TestLogging(unittest.TestCase):
         self._handlers_cache = logging.getLogger().handlers[:]
 
     def tearDown(self):
-        retry = RetryErrors((NotFound, TooManyRequests, RetryError), max_tries=9)
+        retry_not_found = RetryErrors((NotFound), max_tries=4)
+        retry_other = RetryErrors((TooManyRequests, RetryError))
         for doomed in self.to_delete:
             try:
-                retry(doomed.delete)()
+                retry_not_found(retry_other(doomed.delete))()
             except AttributeError:
                 client, dataset = doomed
                 retry(client.delete_dataset)(dataset)

--- a/logging/tests/system/test_system.py
+++ b/logging/tests/system/test_system.py
@@ -112,6 +112,8 @@ class TestLogging(unittest.TestCase):
             except AttributeError:
                 client, dataset = doomed
                 retry(client.delete_dataset)(dataset)
+            except NotFound:
+                pass
         logging.getLogger().handlers = self._handlers_cache[:]
 
     @staticmethod

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -264,13 +264,65 @@ class Test_Worker(unittest.TestCase):
         self.assertFalse(worker.is_alive)
 
     @staticmethod
-    def _enqueue_record(worker, message):
-        record = logging.LogRecord(
-            "python_logger", logging.INFO, None, None, message, None, None
+    def _enqueue_record(worker, message, levelno=logging.INFO, **kw):
+        record = logging.LogRecord("testing", levelno, None, None, message, None, None)
+        worker.enqueue(record, message, **kw)
+
+    def test_enqueue_defaults(self):
+        import datetime
+        from google.cloud.logging._helpers import LogSeverity
+
+        worker = self._make_one(_Logger(self.NAME))
+        self.assertTrue(worker._queue.empty())
+        message = "TEST SEVERITY"
+
+        self._enqueue_record(worker, message)
+
+        entry = worker._queue.get_nowait()
+        expected_info = {"message": message, "python_logger": "testing"}
+        self.assertEqual(entry["info"], expected_info)
+        self.assertEqual(entry["severity"], LogSeverity.INFO)
+        self.assertIsNone(entry["resource"])
+        self.assertIsNone(entry["labels"])
+        self.assertIsNone(entry["trace"])
+        self.assertIsNone(entry["span_id"])
+        self.assertIsInstance(entry["timestamp"], datetime.datetime)
+
+    def test_enqueue_explicit(self):
+        import datetime
+        from google.cloud.logging._helpers import LogSeverity
+
+        worker = self._make_one(_Logger(self.NAME))
+        self.assertTrue(worker._queue.empty())
+        message = "TEST SEVERITY"
+        resource = object()
+        labels = {"foo": "bar"}
+        trace = "TRACE"
+        span_id = "SPAN_ID"
+
+        self._enqueue_record(
+            worker,
+            message,
+            levelno=logging.ERROR,
+            resource=resource,
+            labels=labels,
+            trace=trace,
+            span_id=span_id,
         )
-        worker.enqueue(record, message)
+
+        entry = worker._queue.get_nowait()
+
+        expected_info = {"message": message, "python_logger": "testing"}
+        self.assertEqual(entry["info"], expected_info)
+        self.assertEqual(entry["severity"], LogSeverity.ERROR)
+        self.assertIs(entry["resource"], resource)
+        self.assertIs(entry["labels"], labels)
+        self.assertIs(entry["trace"], trace)
+        self.assertIs(entry["span_id"], span_id)
+        self.assertIsInstance(entry["timestamp"], datetime.datetime)
 
     def test__thread_main(self):
+        import datetime
         from google.cloud.logging.handlers.transports import background_thread
 
         worker = self._make_one(_Logger(self.NAME))

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -322,7 +322,6 @@ class Test_Worker(unittest.TestCase):
         self.assertIsInstance(entry["timestamp"], datetime.datetime)
 
     def test__thread_main(self):
-        import datetime
         from google.cloud.logging.handlers.transports import background_thread
 
         worker = self._make_one(_Logger(self.NAME))

--- a/logging/tests/unit/handlers/transports/test_sync.py
+++ b/logging/tests/unit/handlers/transports/test_sync.py
@@ -37,6 +37,7 @@ class TestSyncHandler(unittest.TestCase):
 
     def test_send(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
+        from google.cloud.logging._helpers import LogSeverity
 
         client = _Client(self.PROJECT)
 
@@ -50,7 +51,14 @@ class TestSyncHandler(unittest.TestCase):
 
         transport.send(record, message, _GLOBAL_RESOURCE)
         EXPECTED_STRUCT = {"message": message, "python_logger": python_logger_name}
-        EXPECTED_SENT = (EXPECTED_STRUCT, "INFO", _GLOBAL_RESOURCE, None, None, None)
+        EXPECTED_SENT = (
+            EXPECTED_STRUCT,
+            LogSeverity.INFO,
+            _GLOBAL_RESOURCE,
+            None,
+            None,
+            None,
+        )
         self.assertEqual(transport.logger.log_struct_called_with, EXPECTED_SENT)
 
 

--- a/logging/tests/unit/test__helpers.py
+++ b/logging/tests/unit/test__helpers.py
@@ -18,8 +18,6 @@ import unittest
 
 import mock
 
-from google.cloud.logging_v2.gapic.enums import LogSeverity
-
 
 class Test_entry_from_resource(unittest.TestCase):
     @staticmethod

--- a/logging/tests/unit/test__helpers.py
+++ b/logging/tests/unit/test__helpers.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 
+import logging
 import unittest
 
 import mock
+
+from google.cloud.logging_v2.gapic.enums import LogSeverity
 
 
 class Test_entry_from_resource(unittest.TestCase):
@@ -119,6 +122,47 @@ class Test_retrieve_metadata_server(unittest.TestCase):
                 metadata = self._call_fut(metadata_key)
 
         self.assertIsNone(metadata)
+
+
+class Test__normalize_severity(unittest.TestCase):
+    @staticmethod
+    def _stackdriver_severity():
+        from google.cloud.logging._helpers import LogSeverity
+
+        return LogSeverity
+
+    def _normalize_severity_helper(self, stdlib_level, enum_level):
+        from google.cloud.logging._helpers import _normalize_severity
+
+        self.assertEqual(_normalize_severity(stdlib_level), enum_level)
+
+    def test__normalize_severity_critical(self):
+        severity = self._stackdriver_severity()
+        self._normalize_severity_helper(logging.CRITICAL, severity.CRITICAL)
+
+    def test__normalize_severity_error(self):
+        severity = self._stackdriver_severity()
+        self._normalize_severity_helper(logging.ERROR, severity.ERROR)
+
+    def test__normalize_severity_warning(self):
+        severity = self._stackdriver_severity()
+        self._normalize_severity_helper(logging.WARNING, severity.WARNING)
+
+    def test__normalize_severity_info(self):
+        severity = self._stackdriver_severity()
+        self._normalize_severity_helper(logging.INFO, severity.INFO)
+
+    def test__normalize_severity_debug(self):
+        severity = self._stackdriver_severity()
+        self._normalize_severity_helper(logging.DEBUG, severity.DEBUG)
+
+    def test__normalize_severity_notset(self):
+        severity = self._stackdriver_severity()
+        self._normalize_severity_helper(logging.NOTSET, severity.DEFAULT)
+
+    def test__normalize_severity_non_standard(self):
+        unknown_level = 35
+        self._normalize_severity_helper(unknown_level, unknown_level)
 
 
 class EntryMock(object):


### PR DESCRIPTION
Rather than relying on `logging.LogRecord.levelname`, which can be changed to arbitrary values, map `logging.LogRecord.levelno` to the corresponding enum value.

Closes #7213.