### PR TITLE
BigQuery: Add debug logging statements to track when BQ Storage API is used.

### DIFF
--- a/bigquery/google/cloud/bigquery/_pandas_helpers.py
+++ b/bigquery/google/cloud/bigquery/_pandas_helpers.py
@@ -16,6 +16,7 @@
 
 import concurrent.futures
 import functools
+import logging
 import warnings
 
 from six.moves import queue
@@ -38,6 +39,8 @@ except ImportError:  # pragma: NO COVER
 
 from google.cloud.bigquery import schema
 
+
+_LOGGER = logging.getLogger(__name__)
 
 _NO_BQSTORAGE_ERROR = (
     "The google-cloud-bigquery-storage library is not installed, "
@@ -340,6 +343,11 @@ def _download_table_bqstorage(
         format_=bigquery_storage_v1beta1.enums.DataFormat.ARROW,
         read_options=read_options,
         requested_streams=requested_streams,
+    )
+    _LOGGER.debug(
+        "Started reading table '{}.{}.{}' with BQ Storage API session '{}'.".format(
+            table.project, table.dataset_id, table.table_id, session.name
+        )
     )
 
     # Avoid reading rows from an empty table.

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 import copy
 import datetime
 import functools
+import logging
 import operator
 import warnings
 
@@ -55,6 +56,8 @@ from google.cloud.bigquery.schema import _build_schema_resource
 from google.cloud.bigquery.schema import _parse_schema_resource
 from google.cloud.bigquery.external_config import ExternalConfig
 
+
+_LOGGER = logging.getLogger(__name__)
 
 _NO_BQSTORAGE_ERROR = (
     "The google-cloud-bigquery-storage library is not installed, "
@@ -1426,6 +1429,11 @@ class RowIterator(HTTPIterator):
                 # with the tabledata.list API.
                 pass
 
+        _LOGGER.debug(
+            "Started reading table '{}.{}.{}' with tabledata.list.".format(
+                self._table.project, self._table.dataset_id, self._table.table_id
+            )
+        )
         for item in tabledata_list_download():
             yield item
 

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -1445,8 +1445,10 @@ class TestRowIterator(unittest.TestCase):
         return RowIterator
 
     def _make_one(
-        self, client=None, api_request=None, path=None, schema=None, **kwargs
+        self, client=None, api_request=None, path=None, schema=None, table=None, **kwargs
     ):
+        from google.cloud.bigquery.table import TableReference
+
         if client is None:
             client = _mock_client()
 
@@ -1459,7 +1461,10 @@ class TestRowIterator(unittest.TestCase):
         if schema is None:
             schema = []
 
-        return self._class_under_test()(client, api_request, path, schema, **kwargs)
+        if table is None:
+            table = TableReference.from_string("my-project.my_dataset.my_table")
+
+        return self._class_under_test()(client, api_request, path, schema, table=table, **kwargs)
 
     def test_constructor(self):
         from google.cloud.bigquery.table import _item_to_row

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -14,6 +14,7 @@
 
 import itertools
 import json
+import logging
 import time
 import unittest
 import warnings
@@ -1445,7 +1446,13 @@ class TestRowIterator(unittest.TestCase):
         return RowIterator
 
     def _make_one(
-        self, client=None, api_request=None, path=None, schema=None, table=None, **kwargs
+        self,
+        client=None,
+        api_request=None,
+        path=None,
+        schema=None,
+        table=None,
+        **kwargs
     ):
         from google.cloud.bigquery.table import TableReference
 
@@ -1464,7 +1471,9 @@ class TestRowIterator(unittest.TestCase):
         if table is None:
             table = TableReference.from_string("my-project.my_dataset.my_table")
 
-        return self._class_under_test()(client, api_request, path, schema, table=table, **kwargs)
+        return self._class_under_test()(
+            client, api_request, path, schema, table=table, **kwargs
+        )
 
     def test_constructor(self):
         from google.cloud.bigquery.table import _item_to_row
@@ -2076,15 +2085,31 @@ class TestRowIterator(unittest.TestCase):
             SchemaField("name", "STRING", mode="REQUIRED"),
             SchemaField("age", "INTEGER", mode="REQUIRED"),
         ]
-        path = "/foo"
         api_request = mock.Mock(return_value={"rows": []})
-        row_iterator = self._make_one(_mock_client(), api_request, path, schema)
+        row_iterator = self._make_one(_mock_client(), api_request, schema=schema)
 
         df = row_iterator.to_dataframe()
 
         self.assertIsInstance(df, pandas.DataFrame)
         self.assertEqual(len(df), 0)  # verify the number of rows
         self.assertEqual(list(df), ["name", "age"])  # verify the column names
+
+    @unittest.skipIf(pandas is None, "Requires `pandas`")
+    def test_to_dataframe_logs_tabledata_list(self):
+        from google.cloud.bigquery.table import Table
+
+        mock_logger = mock.create_autospec(logging.Logger)
+        api_request = mock.Mock(return_value={"rows": []})
+        row_iterator = self._make_one(
+            _mock_client(), api_request, table=Table("debug-proj.debug_dset.debug_tbl")
+        )
+
+        with mock.patch("google.cloud.bigquery.table._LOGGER", mock_logger):
+            row_iterator.to_dataframe()
+
+        mock_logger.debug.assert_any_call(
+            "Started reading table 'debug-proj.debug_dset.debug_tbl' with tabledata.list."
+        )
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_w_various_types_nullable(self):
@@ -2196,23 +2221,13 @@ class TestRowIterator(unittest.TestCase):
             bigquery_storage_v1beta1.BigQueryStorageClient
         )
         session = bigquery_storage_v1beta1.types.ReadSession()
-        session.avro_schema.schema = json.dumps(
-            {
-                "fields": [
-                    {"name": "colA"},
-                    # Not alphabetical to test column order.
-                    {"name": "colC"},
-                    {"name": "colB"},
-                ]
-            }
-        )
         bqstorage_client.create_read_session.return_value = session
 
         row_iterator = mut.RowIterator(
             _mock_client(),
-            None,  # api_request: ignored
-            None,  # path: ignored
-            [
+            api_request=None,
+            path=None,
+            schema=[
                 schema.SchemaField("colA", "IGNORED"),
                 schema.SchemaField("colC", "IGNORED"),
                 schema.SchemaField("colB", "IGNORED"),
@@ -2224,6 +2239,33 @@ class TestRowIterator(unittest.TestCase):
         column_names = ["colA", "colC", "colB"]
         self.assertEqual(list(got), column_names)
         self.assertTrue(got.empty)
+
+    @unittest.skipIf(
+        bigquery_storage_v1beta1 is None, "Requires `google-cloud-bigquery-storage`"
+    )
+    @unittest.skipIf(pandas is None, "Requires `pandas`")
+    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
+    def test_to_dataframe_w_bqstorage_logs_session(self):
+        from google.cloud.bigquery.table import Table
+
+        bqstorage_client = mock.create_autospec(
+            bigquery_storage_v1beta1.BigQueryStorageClient
+        )
+        session = bigquery_storage_v1beta1.types.ReadSession()
+        session.name = "projects/test-proj/locations/us/sessions/SOMESESSION"
+        bqstorage_client.create_read_session.return_value = session
+        mock_logger = mock.create_autospec(logging.Logger)
+        row_iterator = self._make_one(
+            _mock_client(), table=Table("debug-proj.debug_dset.debug_tbl")
+        )
+
+        with mock.patch("google.cloud.bigquery._pandas_helpers._LOGGER", mock_logger):
+            row_iterator.to_dataframe(bqstorage_client=bqstorage_client)
+
+        mock_logger.debug.assert_any_call(
+            "Started reading table 'debug-proj.debug_dset.debug_tbl' "
+            "with BQ Storage API session 'projects/test-proj/locations/us/sessions/SOMESESSION'."
+        )
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @unittest.skipIf(


### PR DESCRIPTION
With BQ Storage API and `logging.basicConfig(level=logging.DEBUG)`:

```python
import google.cloud.bigquery_storage_v1beta1
import google.cloud.bigquery
client = google.cloud.bigquery.Client()
bqstorage = google.cloud.bigquery_storage_v1beta1.BigQueryStorageClient()
rows = client.list_rows("schema_examples.scalar_fields")

import logging
logging.basicConfig(level=logging.DEBUG)
df = rows.to_dataframe(bqstorage_client=bqstorage)
```

Outputs:

```
DEBUG:google.auth.transport.requests:Making request: POST https://oauth2.googleapis.com/token
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): oauth2.googleapis.com:443
DEBUG:urllib3.connectionpool:https://oauth2.googleapis.com:443 "POST /token HTTP/1.1" 200 None
DEBUG:google.cloud.bigquery._pandas_helpers:Started reading table 'swast-scratch.schema_examples.scalar_fields' with BQ Storage API session 'projects/swast-scratch/locations/us/sessions/CAISCEtpQ1dKVERqGgJpchoCaXcaAmpkGgJpbhoCamMaAmpx'.
```

With tabledata.list:

```
DEBUG:google.cloud.bigquery.table:Started reading table 'swast-scratch.schema_examples.scalar_fields' with tabledata.list.
DEBUG:urllib3.connectionpool:https://www.googleapis.com:443 "GET /bigquery/v2/projects/swast-scratch/datasets/schema_examples/tables/scalar_fields/data HTTP/1.1" 200 None
```

Closes #8826.