### PR TITLE
Move maybe_fail_import() to top level test utils

### DIFF
--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -20,7 +20,11 @@ import shutil
 import nox
 
 
-LOCAL_DEPS = (os.path.join("..", "api_core[grpc]"), os.path.join("..", "core"))
+LOCAL_DEPS = (
+    os.path.join("..", "api_core[grpc]"),
+    os.path.join("..", "core"),
+    os.path.join("..", "test_utils"),
+)
 
 BLACK_PATHS = ("docs", "google", "samples", "tests", "noxfile.py", "setup.py")
 
@@ -40,7 +44,6 @@ def default(session):
 
     dev_install = ".[all]"
     session.install("-e", dev_install)
-    session.install("-e", os.path.join("..", "test_utils"))
 
     # IPython does not support Python 2 after version 5.x
     if session.python == "2.7":

--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -40,6 +40,7 @@ def default(session):
 
     dev_install = ".[all]"
     session.install("-e", dev_install)
+    session.install("-e", os.path.join("..", "test_utils"))
 
     # IPython does not support Python 2 after version 5.x
     if session.python == "2.7":

--- a/bigquery/tests/unit/helpers.py
+++ b/bigquery/tests/unit/helpers.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
-import six
-
 
 def make_connection(*responses):
     import google.cloud.bigquery._http
@@ -25,25 +22,3 @@ def make_connection(*responses):
     mock_conn.user_agent = "testing 1.2.3"
     mock_conn.api_request.side_effect = list(responses) + [NotFound("miss")]
     return mock_conn
-
-
-def maybe_fail_import(predicate):
-    """Create and return a patcher that conditionally makes an import fail.
-
-    Args:
-        predicate (Callable[[...], bool]): A callable that, if it returns `True`,
-            triggers an `ImportError`. It must accept the same arguments as the
-            built-in `__import__` function.
-            https://docs.python.org/3/library/functions.html#__import__
-
-    Returns:
-        A mock patcher object that can be used to enable patched import behavior.
-    """
-    orig_import = six.moves.builtins.__import__
-
-    def custom_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if predicate(name, globals, locals, fromlist, level):
-            raise ImportError
-        return orig_import(name, globals, locals, fromlist, level)
-
-    return mock.patch.object(six.moves.builtins, "__import__", new=custom_import)

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -42,7 +42,7 @@ from google.cloud.bigquery import job
 from google.cloud.bigquery import table
 from google.cloud.bigquery import magics
 from tests.unit.helpers import make_connection
-from tests.unit.helpers import maybe_fail_import
+from test_utils.imports import maybe_fail_import
 
 
 pytestmark = pytest.mark.skipif(IPython is None, reason="Requires `ipython`")

--- a/test_utils/test_utils/imports.py
+++ b/test_utils/test_utils/imports.py
@@ -1,0 +1,38 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import six
+
+
+def maybe_fail_import(predicate):
+    """Create and return a patcher that conditionally makes an import fail.
+
+    Args:
+        predicate (Callable[[...], bool]): A callable that, if it returns `True`,
+            triggers an `ImportError`. It must accept the same arguments as the
+            built-in `__import__` function.
+            https://docs.python.org/3/library/functions.html#__import__
+
+    Returns:
+        A mock patcher object that can be used to enable patched import behavior.
+    """
+    orig_import = six.moves.builtins.__import__
+
+    def custom_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if predicate(name, globals, locals, fromlist, level):
+            raise ImportError
+        return orig_import(name, globals, locals, fromlist, level)
+
+    return mock.patch.object(six.moves.builtins, "__import__", new=custom_import)


### PR DESCRIPTION
Following a [recent discussion](https://github.com/googleapis/google-cloud-python/pull/8734#discussion_r307532267), this PR moves a test utility from BigQuery to the top-level test utils, since it is considered useful outside of BigQuery, too.


### How to test
Primarily verify that the promoted utility function is general enough for the promotion.