### PR TITLE
Logging: Remove gRPC size restrictions (4MB default)

### DIFF
--- a/logging/google/cloud/logging_v2/gapic/transports/config_service_v2_grpc_transport.py
+++ b/logging/google/cloud/logging_v2/gapic/transports/config_service_v2_grpc_transport.py
@@ -64,7 +64,14 @@ class ConfigServiceV2GrpcTransport(object):
 
         # Create the channel.
         if channel is None:
-            channel = self.create_channel(address=address, credentials=credentials)
+            channel = self.create_channel(
+                address=address,
+                credentials=credentials,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                }.items(),
+            )
 
         self._channel = channel
 

--- a/logging/google/cloud/logging_v2/gapic/transports/logging_service_v2_grpc_transport.py
+++ b/logging/google/cloud/logging_v2/gapic/transports/logging_service_v2_grpc_transport.py
@@ -64,7 +64,14 @@ class LoggingServiceV2GrpcTransport(object):
 
         # Create the channel.
         if channel is None:
-            channel = self.create_channel(address=address, credentials=credentials)
+            channel = self.create_channel(
+                address=address,
+                credentials=credentials,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                }.items(),
+            )
 
         self._channel = channel
 

--- a/logging/google/cloud/logging_v2/gapic/transports/metrics_service_v2_grpc_transport.py
+++ b/logging/google/cloud/logging_v2/gapic/transports/metrics_service_v2_grpc_transport.py
@@ -64,7 +64,14 @@ class MetricsServiceV2GrpcTransport(object):
 
         # Create the channel.
         if channel is None:
-            channel = self.create_channel(address=address, credentials=credentials)
+            channel = self.create_channel(
+                address=address,
+                credentials=credentials,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                }.items(),
+            )
 
         self._channel = channel
 

--- a/logging/synth.metadata
+++ b/logging/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-07-10T12:23:32.614992Z",
+  "updateTime": "2019-08-01T00:00:23.364082Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.29.4",
-        "dockerImage": "googleapis/artman@sha256:63f21e83cb92680b7001dc381069e962c9e6dee314fd8365ac554c07c89221fb"
+        "version": "0.31.0",
+        "dockerImage": "googleapis/artman@sha256:9aed6bbde54e26d2fcde7aa86d9f64c0278f741e58808c46573e488cbf6098f0"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "16c0ea3cde17a897ba04b7b94d9bf4dd57e3227e",
-        "internalRef": "257239177"
+        "sha": "e3b51e761db720974bc153a380a2f7ae5baee43d",
+        "internalRef": "260992170"
       }
     },
     {

--- a/logging/synth.py
+++ b/logging/synth.py
@@ -38,7 +38,7 @@ s.move(library / "tests/unit/gapic/v2")
 # https://github.com/googleapis/gapic-generator/issues/2097
 s.replace("google/**/proto/*_pb2.py", r"(^.*$\n)*", r"# -*- coding: utf-8 -*-\n\g<0>")
 
-# the metric service grpc transport channel shouldn't limit the size of a grpc message at the default 4mb
+# the logging service grpc transport channel shouldn't limit the size of a grpc message at the default 4mb
 s.replace("google/cloud/logging_v2/gapic/transports/*_service_v2_grpc_transport.py",
     "channel =.*\n(\s+)address=.*\n\s+credentials=.*,\n",
     "\g<0>\g<1>options={\n"

--- a/logging/synth.py
+++ b/logging/synth.py
@@ -38,6 +38,14 @@ s.move(library / "tests/unit/gapic/v2")
 # https://github.com/googleapis/gapic-generator/issues/2097
 s.replace("google/**/proto/*_pb2.py", r"(^.*$\n)*", r"# -*- coding: utf-8 -*-\n\g<0>")
 
+# the metric service grpc transport channel shouldn't limit the size of a grpc message at the default 4mb
+s.replace("google/cloud/logging_v2/gapic/transports/*_service_v2_grpc_transport.py",
+    "channel =.*\n(\s+)address=.*\n\s+credentials=.*,\n",
+    "\g<0>\g<1>options={\n"
+    "\g<1>    'grpc.max_send_message_length': -1,\n"
+    "\g<1>    'grpc.max_receive_message_length': -1,\n"
+    "\g<1>}.items(),\n")
+
 # ----------------------------------------------------------------------------
 # Add templated files
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Applies fix from #5594 (in response to #5574) to Logging.

Also opened PR https://github.com/grpc/grpc/pull/19810 to see if the defaults can be changed for grpcio.