### PR TITLE
Firestore: Allow snapshot cursors from other collections for collection group queries.

### DIFF
--- a/firestore/tests/unit/v1/test_query.py
+++ b/firestore/tests/unit/v1/test_query.py
@@ -459,6 +459,28 @@ class TestQuery(unittest.TestCase):
         with self.assertRaises(ValueError):
             query._cursor_helper(snapshot, False, False)
 
+    def test__cursor_helper_w_snapshot_other_collection_all_descendants(self):
+        values = {"a": 7, "b": "foo"}
+        docref = self._make_docref("there", "doc_id")
+        snapshot = self._make_snapshot(docref, values)
+        collection = self._make_collection("here")
+        query1 = self._make_one(collection, all_descendants=True)
+
+        query2 = query1._cursor_helper(snapshot, False, False)
+
+        self.assertIs(query2._parent, collection)
+        self.assertIsNone(query2._projection)
+        self.assertEqual(query2._field_filters, ())
+        self.assertEqual(query2._orders, ())
+        self.assertIsNone(query2._limit)
+        self.assertIsNone(query2._offset)
+        self.assertIsNone(query2._start_at)
+
+        cursor, before = query2._end_at
+
+        self.assertIs(cursor, snapshot)
+        self.assertFalse(before)
+
     def test__cursor_helper_w_snapshot(self):
         values = {"a": 7, "b": "foo"}
         docref = self._make_docref("here", "doc_id")


### PR DESCRIPTION
Closes #8633.
Supersedes #8810.