### PR TITLE
BigQuery: Remove redundant service account key code sample.

### DIFF
--- a/bigquery/docs/snippets.py
+++ b/bigquery/docs/snippets.py
@@ -126,27 +126,6 @@ def test_create_client_default_credentials():
     assert client is not None
 
 
-def test_create_client_json_credentials():
-    """Create a BigQuery client with Application Default Credentials"""
-    with open(os.environ["GOOGLE_APPLICATION_CREDENTIALS"]) as creds_file:
-        creds_file_data = creds_file.read()
-
-    open_mock = mock.mock_open(read_data=creds_file_data)
-
-    with mock.patch("io.open", open_mock):
-        # [START bigquery_client_json_credentials]
-        from google.cloud import bigquery
-
-        # Explicitly use service account credentials by specifying the private
-        # key file. All clients in google-cloud-python have this helper.
-        client = bigquery.Client.from_service_account_json(
-            "path/to/service_account.json"
-        )
-        # [END bigquery_client_json_credentials]
-
-    assert client is not None
-
-
 def test_list_datasets_by_label(client, to_delete):
     dataset_id = "list_datasets_by_label_{}".format(_millis())
     dataset = bigquery.Dataset(client.dataset(dataset_id))

--- a/bigquery/docs/snippets.py
+++ b/bigquery/docs/snippets.py
@@ -26,7 +26,6 @@ need to be deleted during teardown.
 import os
 import time
 
-import mock
 import pytest
 import six
 


### PR DESCRIPTION
Remove this sample in favor of the sample added in https://github.com/GoogleCloudPlatform/python-docs-samples/pull/2312.