### PR TITLE
BigQuery Storage: Remove send/recv msg size limit (via synth).

### DIFF
--- a/bigquery_storage/google/cloud/bigquery_storage_v1beta1/gapic/big_query_storage_client.py
+++ b/bigquery_storage/google/cloud/bigquery_storage_v1beta1/gapic/big_query_storage_client.py
@@ -260,8 +260,8 @@ class BigQueryStorageClient(object):
             sharding_strategy (~google.cloud.bigquery_storage_v1beta1.types.ShardingStrategy): The strategy to use for distributing data among multiple streams. Currently
                 defaults to liquid sharding.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
-                to retry requests. If ``None`` is specified, requests will not
-                be retried.
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
             timeout (Optional[float]): The amount of time, in seconds, to wait
                 for the request to complete. Note that if ``retry`` is
                 specified, the timeout applies to each individual attempt.
@@ -356,8 +356,8 @@ class BigQueryStorageClient(object):
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.bigquery_storage_v1beta1.types.StreamPosition`
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
-                to retry requests. If ``None`` is specified, requests will not
-                be retried.
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
             timeout (Optional[float]): The amount of time, in seconds, to wait
                 for the request to complete. Note that if ``retry`` is
                 specified, the timeout applies to each individual attempt.
@@ -439,8 +439,8 @@ class BigQueryStorageClient(object):
                 Number of added streams may be less than this, see CreateReadSessionRequest
                 for more information.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
-                to retry requests. If ``None`` is specified, requests will not
-                be retried.
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
             timeout (Optional[float]): The amount of time, in seconds, to wait
                 for the request to complete. Note that if ``retry`` is
                 specified, the timeout applies to each individual attempt.
@@ -531,8 +531,8 @@ class BigQueryStorageClient(object):
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.bigquery_storage_v1beta1.types.Stream`
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
-                to retry requests. If ``None`` is specified, requests will not
-                be retried.
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
             timeout (Optional[float]): The amount of time, in seconds, to wait
                 for the request to complete. Note that if ``retry`` is
                 specified, the timeout applies to each individual attempt.
@@ -621,8 +621,8 @@ class BigQueryStorageClient(object):
                 server-side unit for assigning data is collections of rows, this fraction
                 will always map to to a data storage boundary on the server side.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
-                to retry requests. If ``None`` is specified, requests will not
-                be retried.
+                to retry requests. If ``None`` is specified, requests will
+                be retried using a default configuration.
             timeout (Optional[float]): The amount of time, in seconds, to wait
                 for the request to complete. Note that if ``retry`` is
                 specified, the timeout applies to each individual attempt.

--- a/bigquery_storage/google/cloud/bigquery_storage_v1beta1/gapic/transports/big_query_storage_grpc_transport.py
+++ b/bigquery_storage/google/cloud/bigquery_storage_v1beta1/gapic/transports/big_query_storage_grpc_transport.py
@@ -64,7 +64,14 @@ class BigQueryStorageGrpcTransport(object):
 
         # Create the channel.
         if channel is None:  # pragma: no cover
-            channel = self.create_channel(address=address, credentials=credentials)
+            channel = self.create_channel(
+                address=address,
+                credentials=credentials,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                }.items(),
+            )
 
         self._channel = channel
 
@@ -94,14 +101,7 @@ class BigQueryStorageGrpcTransport(object):
             grpc.Channel: A gRPC channel object.
         """
         return google.api_core.grpc_helpers.create_channel(  # pragma: no cover
-            address,
-            credentials=credentials,
-            scopes=cls._OAUTH_SCOPES,
-            options={
-                "grpc.max_send_message_length": -1,
-                "grpc.max_receive_message_length": -1,
-            }.items(),
-            **kwargs
+            address, credentials=credentials, scopes=cls._OAUTH_SCOPES, **kwargs
         )
 
     @property

--- a/bigquery_storage/synth.metadata
+++ b/bigquery_storage/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-07-13T12:13:02.277005Z",
+  "updateTime": "2019-08-05T23:37:16.480074Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.29.4",
-        "dockerImage": "googleapis/artman@sha256:63f21e83cb92680b7001dc381069e962c9e6dee314fd8365ac554c07c89221fb"
+        "version": "0.32.1",
+        "dockerImage": "googleapis/artman@sha256:a684d40ba9a4e15946f5f2ca6b4bd9fe301192f522e9de4fff622118775f309b"
       }
     },
     {
       "git": {
         "name": "googleapis",
-        "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "47bd0c2ba33c28dd624a65dad382e02bb61d1618",
-        "internalRef": "257690259"
+        "remote": "git@github.com:googleapis/googleapis.git",
+        "sha": "e699b0cba64ffddfae39633417180f1f65875896",
+        "internalRef": "261759677"
       }
     },
     {

--- a/bigquery_storage/synth.py
+++ b/bigquery_storage/synth.py
@@ -75,18 +75,6 @@ s.replace(
     "big_query_storage_client.BigQueryStorageClient",
 )
 
-# The grpc transport channel shouldn't limit the size of a grpc message at the
-# default 4mb.
-s.replace(
-    "google/cloud/bigquery_storage_v1beta1/gapic/transports/*_grpc_transport.py",
-    "return google.api_core.grpc_helpers.create_channel\(\n(\s+)address,\n"
-    "\s+credentials=.*,\n\s+scopes=.*,\n",
-    "\g<0>\g<1>options={\n"
-    "\g<1>    'grpc.max_send_message_length': -1,\n"
-    "\g<1>    'grpc.max_receive_message_length': -1,\n"
-    "\g<1>}.items(),\n",
-)
-
 # START: Ignore lint and coverage
 s.replace(
     ["google/cloud/bigquery_storage_v1beta1/gapic/big_query_storage_client.py"],


### PR DESCRIPTION
Supersedes #8935.