### PR TITLE
BigQuery Storage: Add more in-depth system tests 

### DIFF
--- a/bigquery_storage/noxfile.py
+++ b/bigquery_storage/noxfile.py
@@ -118,6 +118,7 @@ def system(session):
         session.install("-e", local_dep)
     session.install("-e", "../test_utils/")
     session.install("-e", ".[fastavro,pandas,pyarrow]")
+    session.install("-e", "../bigquery/")
     session.install("-e", ".")
 
     # Run py.test against the system tests.

--- a/bigquery_storage/noxfile.py
+++ b/bigquery_storage/noxfile.py
@@ -111,6 +111,8 @@ def system(session):
     # Use pre-release gRPC for system tests.
     session.install("--pre", "grpcio")
 
+    session.install("protobuf")
+
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install("mock", "pytest")

--- a/bigquery_storage/noxfile.py
+++ b/bigquery_storage/noxfile.py
@@ -111,8 +111,6 @@ def system(session):
     # Use pre-release gRPC for system tests.
     session.install("--pre", "grpcio")
 
-    session.install("protobuf")
-
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install("mock", "pytest")

--- a/bigquery_storage/tests/system/assets/people_data.csv
+++ b/bigquery_storage/tests/system/assets/people_data.csv
@@ -1,0 +1,6 @@
+first_name,last_name,age
+John,Doe,42
+Jack,Black,53
+Nick,Sleek,24
+Kevin,Powell,50
+Johnny,Young,2

--- a/bigquery_storage/tests/system/conftest.py
+++ b/bigquery_storage/tests/system/conftest.py
@@ -201,7 +201,7 @@ def all_types_table_ref(project_id, dataset, bq_client):
     bq_client.delete_table(created_table)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def client():
     return bigquery_storage_v1beta1.BigQueryStorageClient()
 

--- a/bigquery_storage/tests/system/conftest.py
+++ b/bigquery_storage/tests/system/conftest.py
@@ -32,10 +32,15 @@ def project_id():
 
 
 @pytest.fixture(scope="session")
-def dataset(project_id):
+def bq_client():
     from google.cloud import bigquery
 
-    bq_client = bigquery.Client()
+    return bigquery.Client()
+
+
+@pytest.fixture(scope="session")
+def dataset(project_id, bq_client):
+    from google.cloud import bigquery
 
     unique_suffix = str(uuid.uuid4()).replace("-", "_")
     dataset_name = "bq_storage_system_tests_" + unique_suffix
@@ -51,10 +56,8 @@ def dataset(project_id):
 
 
 @pytest.fixture(scope="session")
-def table(project_id, dataset):
+def table(project_id, dataset, bq_client):
     from google.cloud import bigquery
-
-    bq_client = bigquery.Client()
 
     schema = [
         bigquery.SchemaField("first_name", "STRING", mode="REQUIRED"),
@@ -72,10 +75,8 @@ def table(project_id, dataset):
 
 
 @pytest.fixture
-def table_with_data_ref(dataset, table):
+def table_with_data_ref(dataset, table, bq_client):
     from google.cloud import bigquery
-
-    bq_client = bigquery.Client()
 
     job_config = bigquery.LoadJobConfig()
     job_config.source_format = bigquery.SourceFormat.CSV
@@ -102,10 +103,8 @@ def table_with_data_ref(dataset, table):
 
 
 @pytest.fixture
-def col_partition_table_ref(project_id, dataset):
+def col_partition_table_ref(project_id, dataset, bq_client):
     from google.cloud import bigquery
-
-    bq_client = bigquery.Client()
 
     schema = [
         bigquery.SchemaField("occurred", "DATE", mode="REQUIRED"),
@@ -132,10 +131,8 @@ def col_partition_table_ref(project_id, dataset):
 
 
 @pytest.fixture
-def ingest_partition_table_ref(project_id, dataset):
+def ingest_partition_table_ref(project_id, dataset, bq_client):
     from google.cloud import bigquery
-
-    bq_client = bigquery.Client()
 
     schema = [
         bigquery.SchemaField("shape", "STRING", mode="REQUIRED"),
@@ -163,10 +160,8 @@ def ingest_partition_table_ref(project_id, dataset):
 
 
 @pytest.fixture
-def all_types_table_ref(project_id, dataset):
+def all_types_table_ref(project_id, dataset, bq_client):
     from google.cloud import bigquery
-
-    bq_client = bigquery.Client()
 
     schema = [
         bigquery.SchemaField("string_field", "STRING"),

--- a/bigquery_storage/tests/system/conftest.py
+++ b/bigquery_storage/tests/system/conftest.py
@@ -131,6 +131,50 @@ def col_partition_table_ref(project_id, dataset):
     bq_client.delete_table(created_table)
 
 
+@pytest.fixture
+def all_types_table_ref(project_id, dataset):
+    from google.cloud import bigquery
+
+    bq_client = bigquery.Client()
+
+    schema = [
+        bigquery.SchemaField("string_field", "STRING"),
+        bigquery.SchemaField("bytes_field", "BYTES"),
+        bigquery.SchemaField("int64_field", "INT64"),
+        bigquery.SchemaField("float64_field", "FLOAT64"),
+        bigquery.SchemaField("numeric_field", "NUMERIC"),
+        bigquery.SchemaField("bool_field", "BOOL"),
+        bigquery.SchemaField("geography_field", "GEOGRAPHY"),
+        bigquery.SchemaField(
+            "person_struct_field",
+            "STRUCT",
+            fields=(
+                bigquery.SchemaField("name", "STRING"),
+                bigquery.SchemaField("age", "INT64"),
+            ),
+        ),
+        bigquery.SchemaField("timestamp_field", "TIMESTAMP"),
+        bigquery.SchemaField("date_field", "DATE"),
+        bigquery.SchemaField("time_field", "TIME"),
+        bigquery.SchemaField("datetime_field", "DATETIME"),
+        bigquery.SchemaField("string_array_field", "STRING", mode="REPEATED"),
+    ]
+    bq_table = bigquery.table.Table(
+        table_ref="{}.{}.complex_records".format(project_id, dataset.dataset_id),
+        schema=schema,
+    )
+
+    created_table = bq_client.create_table(bq_table)
+
+    table_ref = bigquery_storage_v1beta1.types.TableReference()
+    table_ref.project_id = created_table.project
+    table_ref.dataset_id = created_table.dataset_id
+    table_ref.table_id = created_table.table_id
+    yield table_ref
+
+    bq_client.delete_table(created_table)
+
+
 @pytest.fixture()
 def client():
     return bigquery_storage_v1beta1.BigQueryStorageClient()

--- a/bigquery_storage/tests/system/conftest.py
+++ b/bigquery_storage/tests/system/conftest.py
@@ -32,10 +32,19 @@ def project_id():
 
 
 @pytest.fixture(scope="session")
-def bq_client():
+def credentials():
+    from google.oauth2 import service_account
+
+    # NOTE: the test config in noxfile checks that the env variable is indeed set
+    filename = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+    return service_account.Credentials.from_service_account_file(filename)
+
+
+@pytest.fixture(scope="session")
+def bq_client(credentials):
     from google.cloud import bigquery
 
-    return bigquery.Client()
+    return bigquery.Client(credentials=credentials)
 
 
 @pytest.fixture(scope="session")
@@ -202,8 +211,8 @@ def all_types_table_ref(project_id, dataset, bq_client):
 
 
 @pytest.fixture(scope="session")
-def client():
-    return bigquery_storage_v1beta1.BigQueryStorageClient()
+def client(credentials):
+    return bigquery_storage_v1beta1.BigQueryStorageClient(credentials=credentials)
 
 
 @pytest.fixture()

--- a/bigquery_storage/tests/system/test_reader.py
+++ b/bigquery_storage/tests/system/test_reader.py
@@ -73,3 +73,27 @@ def test_read_rows_as_rows_full_table(
     rows = list(client.read_rows(stream_pos).rows(session))
 
     assert len(rows) > 0
+
+
+@pytest.mark.parametrize(
+    "data_format",
+    (
+        (bigquery_storage_v1beta1.enums.DataFormat.AVRO),
+        (bigquery_storage_v1beta1.enums.DataFormat.ARROW),
+    ),
+)
+def test_basic_nonfiltered_read(client, project_id, table_with_data_ref, data_format):
+    session = client.create_read_session(
+        table_with_data_ref,
+        "projects/{}".format(project_id),
+        format_=data_format,
+        requested_streams=1,
+    )
+    stream_pos = bigquery_storage_v1beta1.types.StreamPosition(
+        stream=session.streams[0]
+    )
+
+    rows = list(client.read_rows(stream_pos).rows(session))
+
+    assert len(rows) == 5  # all table rows
+

--- a/bigquery_storage/tests/system/test_reader.py
+++ b/bigquery_storage/tests/system/test_reader.py
@@ -30,6 +30,8 @@ from google.cloud import bigquery_storage_v1beta1
 from google.protobuf import timestamp_pb2
 
 
+# TODO: remove once a similar method is implemented in the library itself
+# https://github.com/googleapis/google-cloud-python/issues/4553
 def _add_rows(table_ref, new_data, partition_suffix=""):
     """Insert additional rows into an existing table.
 

--- a/bigquery_storage/tests/system/test_reader.py
+++ b/bigquery_storage/tests/system/test_reader.py
@@ -97,3 +97,22 @@ def test_basic_nonfiltered_read(client, project_id, table_with_data_ref, data_fo
 
     assert len(rows) == 5  # all table rows
 
+
+def test_filtered_rows_read(client, project_id, table_with_data_ref):
+    read_options = bigquery_storage_v1beta1.types.TableReadOptions()
+    read_options.row_restriction = "age >= 50"
+
+    session = client.create_read_session(
+        table_with_data_ref,
+        "projects/{}".format(project_id),
+        format_=bigquery_storage_v1beta1.enums.DataFormat.AVRO,
+        requested_streams=1,
+        read_options=read_options,
+    )
+    stream_pos = bigquery_storage_v1beta1.types.StreamPosition(
+        stream=session.streams[0]
+    )
+
+    rows = list(client.read_rows(stream_pos).rows(session))
+
+    assert len(rows) == 2


### PR DESCRIPTION
Closes #8983.

This PR adds additional system tests for BigQuery Storage. It _does not_ include the last item from the issue description, i.e. the long-running test, at least not until decided otherwise.

### Things to mind
- [x] One of the tests depends on the fix in #9001 to pass. Tests need to be re-run once that is merged.
- [x] ~~(see the comment below) There is currently an inconsistent type returned for datetime columns (string instead of a `datetime` instance), affecting the same test.~~
Created #9066 for that.