### PR TITLE
Storage: Harden 'test_access_to_public_bucket' against 429 / 503 errors.

### DIFF
--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -1335,9 +1335,9 @@ class TestAnonymousClient(unittest.TestCase):
     def test_access_to_public_bucket(self):
         anonymous = storage.Client.create_anonymous_client()
         bucket = anonymous.bucket(self.PUBLIC_BUCKET)
-        blob, = bucket.list_blobs(max_results=1)
+        blob, = retry_429_503(bucket.list_blobs)(max_results=1)
         with tempfile.TemporaryFile() as stream:
-            blob.download_to_file(stream)
+            retry_429_503(blob.download_to_file)(stream)
 
 
 class TestKMSIntegration(TestStorageFiles):


### PR DESCRIPTION
Closes #8996.