### PR TITLE
BigQuery: Fix schema recognition of struct field types

### DIFF
--- a/bigquery/google/cloud/bigquery/_pandas_helpers.py
+++ b/bigquery/google/cloud/bigquery/_pandas_helpers.py
@@ -47,7 +47,6 @@ _NO_BQSTORAGE_ERROR = (
     "please install google-cloud-bigquery-storage to use bqstorage features."
 )
 
-STRUCT_TYPES = ("RECORD", "STRUCT")
 _PROGRESS_INTERVAL = 0.2  # Maximum time between download status checks, in seconds.
 
 
@@ -126,7 +125,7 @@ def bq_to_arrow_data_type(field):
             return pyarrow.list_(inner_type)
         return None
 
-    if field.field_type.upper() in STRUCT_TYPES:
+    if field.field_type.upper() in schema.STRUCT_TYPES:
         return bq_to_arrow_struct_data_type(field)
 
     data_type_constructor = BQ_TO_ARROW_SCALARS.get(field.field_type.upper())
@@ -168,7 +167,7 @@ def bq_to_arrow_array(series, bq_field):
     arrow_type = bq_to_arrow_data_type(bq_field)
     if bq_field.mode.upper() == "REPEATED":
         return pyarrow.ListArray.from_pandas(series, type=arrow_type)
-    if bq_field.field_type.upper() in STRUCT_TYPES:
+    if bq_field.field_type.upper() in schema.STRUCT_TYPES:
         return pyarrow.StructArray.from_pandas(series, type=arrow_type)
     return pyarrow.array(series, type=arrow_type)
 

--- a/bigquery/google/cloud/bigquery/_pandas_helpers.py
+++ b/bigquery/google/cloud/bigquery/_pandas_helpers.py
@@ -125,7 +125,7 @@ def bq_to_arrow_data_type(field):
             return pyarrow.list_(inner_type)
         return None
 
-    if field.field_type.upper() in schema.STRUCT_TYPES:
+    if field.field_type.upper() in schema._STRUCT_TYPES:
         return bq_to_arrow_struct_data_type(field)
 
     data_type_constructor = BQ_TO_ARROW_SCALARS.get(field.field_type.upper())
@@ -167,7 +167,7 @@ def bq_to_arrow_array(series, bq_field):
     arrow_type = bq_to_arrow_data_type(bq_field)
     if bq_field.mode.upper() == "REPEATED":
         return pyarrow.ListArray.from_pandas(series, type=arrow_type)
-    if bq_field.field_type.upper() in schema.STRUCT_TYPES:
+    if bq_field.field_type.upper() in schema._STRUCT_TYPES:
         return pyarrow.StructArray.from_pandas(series, type=arrow_type)
     return pyarrow.array(series, type=arrow_type)
 

--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -17,7 +17,7 @@
 from google.cloud.bigquery_v2 import types
 
 
-STRUCT_TYPES = ("RECORD", "STRUCT")
+_STRUCT_TYPES = ("RECORD", "STRUCT")
 
 # SQL types reference:
 # https://cloud.google.com/bigquery/data-types#legacy_sql_data_types
@@ -152,7 +152,7 @@ class SchemaField(object):
 
         # If this is a RECORD type, then sub-fields are also included,
         # add this to the serialized representation.
-        if self.field_type.upper() in STRUCT_TYPES:
+        if self.field_type.upper() in _STRUCT_TYPES:
             answer["fields"] = [f.to_api_repr() for f in self.fields]
 
         # Done; return the serialized dictionary.

--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -17,6 +17,8 @@
 from google.cloud.bigquery_v2 import types
 
 
+STRUCT_TYPES = ("RECORD", "STRUCT")
+
 # SQL types reference:
 # https://cloud.google.com/bigquery/data-types#legacy_sql_data_types
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
@@ -150,7 +152,7 @@ class SchemaField(object):
 
         # If this is a RECORD type, then sub-fields are also included,
         # add this to the serialized representation.
-        if self.field_type.upper() == "RECORD":
+        if self.field_type.upper() in STRUCT_TYPES:
             answer["fields"] = [f.to_api_repr() for f in self.fields]
 
         # Done; return the serialized dictionary.

--- a/bigquery/tests/unit/test_schema.py
+++ b/bigquery/tests/unit/test_schema.py
@@ -71,25 +71,26 @@ class TestSchemaField(unittest.TestCase):
         )
 
     def test_to_api_repr_with_subfield(self):
-        subfield = self._make_one("bar", "INTEGER", "NULLABLE")
-        field = self._make_one("foo", "RECORD", "REQUIRED", fields=(subfield,))
-        self.assertEqual(
-            field.to_api_repr(),
-            {
-                "fields": [
-                    {
-                        "mode": "NULLABLE",
-                        "name": "bar",
-                        "type": "INTEGER",
-                        "description": None,
-                    }
-                ],
-                "mode": "REQUIRED",
-                "name": "foo",
-                "type": "RECORD",
-                "description": None,
-            },
-        )
+        for record_type in ("RECORD", "STRUCT"):
+            subfield = self._make_one("bar", "INTEGER", "NULLABLE")
+            field = self._make_one("foo", record_type, "REQUIRED", fields=(subfield,))
+            self.assertEqual(
+                field.to_api_repr(),
+                {
+                    "fields": [
+                        {
+                            "mode": "NULLABLE",
+                            "name": "bar",
+                            "type": "INTEGER",
+                            "description": None,
+                        }
+                    ],
+                    "mode": "REQUIRED",
+                    "name": "foo",
+                    "type": record_type,
+                    "description": None,
+                },
+            )
 
     def test_from_api_repr(self):
         field = self._get_target_class().from_api_repr(


### PR DESCRIPTION
A struct field can be referred to as "RECORD" or "STRUCT", and this commit assures that the `to_api_repr()` logic is correct. It also moves `STRUCT_TYPES` from `_pandas_helpers` to `schema` where it belongs more naturally IMO.

Discovered this while writing the "all types" system test, and tried to create a STRUCT field using the  standard SQL type name `"STRUCT"`.

### How to test
 - Using the BigQuery client, try to create a table with a "STRUCT" column (using that particular type name):
    ```py
    from google.cloud import bigquery

    bq_client = bigquery.Client()

    schema = [
        bigquery.SchemaField(
            "person_struct_field",
            "STRUCT",
            fields=(
                bigquery.SchemaField("name", "STRING"),
                bigquery.SchemaField("age", "INT64"),
            )
        ),
    ]
    bq_table = bigquery.table.Table(
        table_ref="{}.{}.active_users".format(PROJECT_ID, DATASET_ID),
        schema=schema,
    )

    bq_client.create_table(bq_table)
    ```

**Actual result (before the fix):**
The server responds with an error:
> Field <field_name> is type RECORD but has no schema

**Expected result (after the fix):**
The table is successfully created.