### PR TITLE
[Storage] Support Uniform Bucket Level Access

### DIFF
--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -348,14 +348,18 @@ class IAMConfiguration(dict):
         :rtype: bool
         :returns: whether the bucket is configured to allow only IAM.
         """
-        bpo = self.get("uniformBucketLevelAccess", {})
-        return bpo.get("enabled", False)
+        ubla = self.get("uniformBucketLevelAccess", {})
+        return ubla.get("enabled", False)
 
     @uniform_bucket_level_access_enabled.setter
     def uniform_bucket_level_access_enabled(self, value):
         ubla = self.setdefault("uniformBucketLevelAccess", {})
         ubla["enabled"] = bool(value)
+        #### THIS IS A WORKAROUND ####
+        bpo = self.setdefault("bucketPolicyOnly", {})
+        bpo["enabled"] = bool(value)
         self.bucket._patch_property("iamConfiguration", self)
+        #### THIS IS A WORKAROUND ####
 
     @bucket_policy_only_enabled.setter
     def bucket_policy_only_enabled(self, value):
@@ -381,7 +385,7 @@ class IAMConfiguration(dict):
                    be frozen as true.
         """
         ubla = self.get("uniformBucketLevelAccess", {})
-        stamp = bpo.get("lockedTime")
+        stamp = ubla.get("lockedTime")
         if stamp is not None:
             stamp = _rfc3339_to_datetime(stamp)
         return stamp

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -301,19 +301,28 @@ class IAMConfiguration(dict):
         uniform_bucket_level_access_enabled=False,
         uniform_bucket_level_access_locked_time=None,
     ):
-        # Which one wins???
+        data = {"bucketPolicyOnly": {}, "uniformBucketLevelAccess": {}}
         if bucket_policy_only_enabled:
-          data = {"bucketPolicyOnly": {"enabled": bucket_policy_only_enabled}}
-        if bucket_policy_only_locked_time:
-            data["bucketPolicyOnly"]["lockedTime"] = _datetime_to_rfc3339(
-                bucket_policy_only_locked_time
-            )
+          data["bucketPolicyOnly"]["enabled"] = bucket_policy_only_enabled
+          data["uniformBucketLevelAccess"]["enabled"] = bucket_policy_only_enabled
+        if bucket_policy_only_locked_time is not None:
+          data["bucketPolicyOnly"]["lockedTime"] = _datetime_to_rfc3339(
+            bucket_policy_only_locked_time
+          )
+          data["uniformBucketLevelAccess"]["lockedTime"] = _datetime_to_rfc3339(
+            bucket_policy_only_locked_time
+          )
+
         if uniform_bucket_level_access_enabled:
-          data = {"uniformBucketLevelAccess": {"enabled": uniform_bucket_level_access_enabled}}
+          data["bucketPolicyOnly"]["enabled"] = uniform_bucket_level_access_enabled
+          data["uniformBucketLevelAccess"]["enabled"] = uniform_bucket_level_access_enabled
         if uniform_bucket_level_access_locked_time is not None:
-            data["uniformBucketLevelAccess"]["lockedTime"] = _datetime_to_rfc3339(
-                uniform_bucket_level_access_locked_time
-            )
+          data["bucketPolicyOnly"]["lockedTime"] = _datetime_to_rfc3339(
+              uniform_bucket_level_access_locked_time
+          )
+          data["uniformBucketLevelAccess"]["lockedTime"] = _datetime_to_rfc3339(
+            uniform_bucket_level_access_locked_time
+          )
 
         super(IAMConfiguration, self).__init__(data)
         self._bucket = bucket
@@ -331,6 +340,7 @@ class IAMConfiguration(dict):
         :rtype: :class:`IAMConfiguration`
         :returns: Instance created from resource.
         """
+
         instance = cls(bucket)
         instance.update(resource)
         return instance
@@ -366,8 +376,8 @@ class IAMConfiguration(dict):
         #### THIS IS A WORKAROUND ####
         bpo = self.setdefault("bucketPolicyOnly", {})
         bpo["enabled"] = bool(value)
-        self.bucket._patch_property("iamConfiguration", self)
         #### THIS IS A WORKAROUND ####
+        self.bucket._patch_property("iamConfiguration", self)
 
     @bucket_policy_only_enabled.setter
     def bucket_policy_only_enabled(self, value):

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -302,11 +302,19 @@ class IAMConfiguration(dict):
         uniform_bucket_level_access_locked_time=None,
     ):
         # Which one wins???
-        data = {"uniformBucketLevelAccess": {"enabled": bucket_policy_only_enabled}}
-        if uniform_bucket_level_access_locked_time is not None:
-            data["uniformBucketLevelAccess"]["lockedTime"] = _datetime_to_rfc3339(
+        if bucket_policy_only_enabled:
+          data = {"bucketPolicyOnly": {"enabled": bucket_policy_only_enabled}}
+        if bucket_policy_only_locked_time:
+            data["bucketPolicyOnly"]["lockedTime"] = _datetime_to_rfc3339(
                 bucket_policy_only_locked_time
             )
+        if uniform_bucket_level_access_enabled:
+          data = {"uniformBucketLevelAccess": {"enabled": uniform_bucket_level_access_enabled}}
+        if uniform_bucket_level_access_locked_time is not None:
+            data["uniformBucketLevelAccess"]["lockedTime"] = _datetime_to_rfc3339(
+                uniform_bucket_level_access_locked_time
+            )
+
         super(IAMConfiguration, self).__init__(data)
         self._bucket = bucket
 

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -1647,13 +1647,13 @@ class TestIAMConfiguration(unittest.TestCase):
             bucket = Config.CLIENT.bucket(bucket_name)
             retry_429_harder(bucket.delete)(force=True)
 
-    def test_new_bucket_w_bpo(self):
-        new_bucket_name = "new-w-bpo" + unique_resource_id("-")
+    def test_new_bucket_w_ubla(self):
+        new_bucket_name = "new-w-ubla" + unique_resource_id("-")
         self.assertRaises(
             exceptions.NotFound, Config.CLIENT.get_bucket, new_bucket_name
         )
         bucket = Config.CLIENT.bucket(new_bucket_name)
-        bucket.iam_configuration.bucket_policy_only_enabled = True
+        bucket.iam_configuration.uniform_bucket_level_access_enabled = True
         retry_429(bucket.create)()
         self.case_buckets_to_delete.append(new_bucket_name)
 
@@ -1702,17 +1702,17 @@ class TestIAMConfiguration(unittest.TestCase):
         blob_acl_before = list(bucket.acl)
 
         # Set BPO
-        bucket.iam_configuration.bucket_policy_only_enabled = True
+        bucket.iam_configuration.uniform_bucket_level_access_enabled = True
         bucket.patch()
 
-        self.assertTrue(bucket.iam_configuration.bucket_policy_only_enabled)
+        self.assertTrue(bucket.iam_configuration.uniform_bucket_level_access_enabled)
 
         # While BPO is set, cannot get / set ACLs
         with self.assertRaises(exceptions.BadRequest):
             bucket.acl.reload()
 
         # Clear BPO
-        bucket.iam_configuration.bucket_policy_only_enabled = False
+        bucket.iam_configuration.uniform_bucket_level_access_enabled = False
         bucket.patch()
 
         # Query ACLs after clearing BPO
@@ -1723,3 +1723,4 @@ class TestIAMConfiguration(unittest.TestCase):
 
         self.assertEqual(bucket_acl_before, bucket_acl_after)
         self.assertEqual(blob_acl_before, blob_acl_after)
+

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -1683,9 +1683,8 @@ class TestIAMConfiguration(unittest.TestCase):
         with self.assertRaises(exceptions.BadRequest):
             blob_acl.save()
 
-    @unittest.skipUnless(False, "Back-end fix for BPO/UBLA expected 2019-07-12")
     def test_bpo_set_unset_preserves_acls(self):
-        new_bucket_name = "bpo-acls" + unique_resource_id("-")
+        new_bucket_name = "ubla-acls" + unique_resource_id("-")
         self.assertRaises(
             exceptions.NotFound, Config.CLIENT.get_bucket, new_bucket_name
         )
@@ -1697,25 +1696,25 @@ class TestIAMConfiguration(unittest.TestCase):
         payload = b"DEADBEEF"
         blob.upload_from_string(payload)
 
-        # Preserve ACLs before setting BPO
+        # Preserve ACLs before setting UBLA
         bucket_acl_before = list(bucket.acl)
         blob_acl_before = list(bucket.acl)
 
-        # Set BPO
+        # Set UBLA
         bucket.iam_configuration.uniform_bucket_level_access_enabled = True
         bucket.patch()
 
         self.assertTrue(bucket.iam_configuration.uniform_bucket_level_access_enabled)
 
-        # While BPO is set, cannot get / set ACLs
+        # While UBLA is set, cannot get / set ACLs
         with self.assertRaises(exceptions.BadRequest):
             bucket.acl.reload()
 
-        # Clear BPO
+        # Clear UBLA
         bucket.iam_configuration.uniform_bucket_level_access_enabled = False
         bucket.patch()
 
-        # Query ACLs after clearing BPO
+        # Query ACLs after clearing UBLA
         bucket.acl.reload()
         bucket_acl_after = list(bucket.acl)
         blob.acl.reload()

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -197,8 +197,8 @@ class Test_IAMConfiguration(unittest.TestCase):
         config = self._make_one(bucket)
 
         self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only_enabled)
-        self.assertIsNone(config.bucket_policy_only_locked_time)
+        self.assertFalse(config.uniform_bucket_level_access_enabled)
+        self.assertIsNone(config.uniform_bucket_level_access_locked_time)
 
     def test_ctor_explicit(self):
         import datetime
@@ -208,12 +208,12 @@ class Test_IAMConfiguration(unittest.TestCase):
         now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
 
         config = self._make_one(
-            bucket, bucket_policy_only_enabled=True, bucket_policy_only_locked_time=now
+            bucket, uniform_bucket_level_access_enabled=True, uniform_bucket_level_access_locked_time=now
         )
 
         self.assertIs(config.bucket, bucket)
-        self.assertTrue(config.bucket_policy_only_enabled)
-        self.assertEqual(config.bucket_policy_only_locked_time, now)
+        self.assertTrue(config.uniform_bucket_level_access_enabled)
+        self.assertEqual(config.uniform_bucket_level_access_locked_time, now)
 
     def test_from_api_repr_w_empty_resource(self):
         klass = self._get_target_class()
@@ -223,30 +223,30 @@ class Test_IAMConfiguration(unittest.TestCase):
         config = klass.from_api_repr(resource, bucket)
 
         self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only_enabled)
-        self.assertIsNone(config.bucket_policy_only_locked_time)
+        self.assertFalse(config.uniform_bucket_level_access_enabled)
+        self.assertIsNone(config.uniform_bucket_level_access_locked_time)
 
-    def test_from_api_repr_w_empty_bpo(self):
+    def test_from_api_repr_w_empty_ubla(self):
         klass = self._get_target_class()
         bucket = self._make_bucket()
-        resource = {"bucketPolicyOnly": {}}
+        resource = {"uniformBucketLevelAccess": {}}
 
         config = klass.from_api_repr(resource, bucket)
 
         self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only_enabled)
-        self.assertIsNone(config.bucket_policy_only_locked_time)
+        self.assertFalse(config.uniform_bucket_level_access_enabled)
+        self.assertIsNone(config.uniform_bucket_level_access_locked_time)
 
     def test_from_api_repr_w_disabled(self):
         klass = self._get_target_class()
         bucket = self._make_bucket()
-        resource = {"bucketPolicyOnly": {"enabled": False}}
+        resource = {"uniformBucketLevelAccess": {"enabled": False}}
 
         config = klass.from_api_repr(resource, bucket)
 
         self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only_enabled)
-        self.assertIsNone(config.bucket_policy_only_locked_time)
+        self.assertFalse(config.uniform_bucket_level_access_enabled)
+        self.assertIsNone(config.uniform_bucket_level_access_locked_time)
 
     def test_from_api_repr_w_enabled(self):
         import datetime
@@ -257,7 +257,7 @@ class Test_IAMConfiguration(unittest.TestCase):
         bucket = self._make_bucket()
         now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
         resource = {
-            "bucketPolicyOnly": {
+            "uniformBucketLevelAccess": {
                 "enabled": True,
                 "lockedTime": _datetime_to_rfc3339(now),
             }
@@ -266,16 +266,16 @@ class Test_IAMConfiguration(unittest.TestCase):
         config = klass.from_api_repr(resource, bucket)
 
         self.assertIs(config.bucket, bucket)
-        self.assertTrue(config.bucket_policy_only_enabled)
-        self.assertEqual(config.bucket_policy_only_locked_time, now)
+        self.assertTrue(config.uniform_bucket_level_access_enabled)
+        self.assertEqual(config.uniform_bucket_level_access_locked_time, now)
 
-    def test_bucket_policy_only_enabled_setter(self):
+    def test_uniform_bucket_level_access_enabled_setter(self):
         bucket = self._make_bucket()
         config = self._make_one(bucket)
 
-        config.bucket_policy_only_enabled = True
+        config.uniform_bucket_level_access_enabled = True
 
-        self.assertTrue(config["bucketPolicyOnly"]["enabled"])
+        self.assertTrue(config["uniformBucketLevelAccess"]["enabled"])
         bucket._patch_property.assert_called_once_with("iamConfiguration", config)
 
 
@@ -1249,8 +1249,8 @@ class Test_Bucket(unittest.TestCase):
 
         self.assertIsInstance(config, IAMConfiguration)
         self.assertIs(config.bucket, bucket)
-        self.assertFalse(config.bucket_policy_only_enabled)
-        self.assertIsNone(config.bucket_policy_only_locked_time)
+        self.assertFalse(config.uniform_bucket_level_access_enabled)
+        self.assertIsNone(config.uniform_bucket_level_access_locked_time)
 
     def test_iam_configuration_policy_w_entry(self):
         import datetime
@@ -1262,7 +1262,7 @@ class Test_Bucket(unittest.TestCase):
         NAME = "name"
         properties = {
             "iamConfiguration": {
-                "bucketPolicyOnly": {
+                "uniformBucketLevelAccess": {
                     "enabled": True,
                     "lockedTime": _datetime_to_rfc3339(now),
                 }
@@ -1274,8 +1274,8 @@ class Test_Bucket(unittest.TestCase):
 
         self.assertIsInstance(config, IAMConfiguration)
         self.assertIs(config.bucket, bucket)
-        self.assertTrue(config.bucket_policy_only_enabled)
-        self.assertEqual(config.bucket_policy_only_locked_time, now)
+        self.assertTrue(config.uniform_bucket_level_access_enabled)
+        self.assertEqual(config.uniform_bucket_level_access_locked_time, now)
 
     def test_lifecycle_rules_getter_unknown_action_type(self):
         NAME = "name"


### PR DESCRIPTION
Storage feature request to support the rename of Bucket Policy Only to Uniform Bucket Level Access.

- [x] Update integration tests to use uniform bucket-level access instead.
- [x] Update documentation.
- [x] Review from GCS eng team(@thanhld94).
- [ ] Fix pending for backend bug: 134695162. Remove workaround.