### PR TITLE
BigQuery: Fix Pandas DataFrame load example under Python 2.7

### DIFF
--- a/bigquery/docs/snippets.py
+++ b/bigquery/docs/snippets.py
@@ -2765,15 +2765,15 @@ def test_load_table_from_dataframe(client, to_delete, parquet_engine):
     dataset_ref = client.dataset(dataset_id)
     table_ref = dataset_ref.table("monty_python")
     records = [
-        {"title": "The Meaning of Life", "release_year": 1983},
-        {"title": "Monty Python and the Holy Grail", "release_year": 1975},
-        {"title": "Life of Brian", "release_year": 1979},
-        {"title": "And Now for Something Completely Different", "release_year": 1971},
+        {"title": u"The Meaning of Life", "release_year": 1983},
+        {"title": u"Monty Python and the Holy Grail", "release_year": 1975},
+        {"title": u"Life of Brian", "release_year": 1979},
+        {"title": u"And Now for Something Completely Different", "release_year": 1971},
     ]
     # Optionally set explicit indices.
     # If indices are not specified, a column will be created for the default
     # indices created by pandas.
-    index = ["Q24980", "Q25043", "Q24953", "Q16403"]
+    index = [u"Q24980", u"Q25043", u"Q24953", u"Q16403"]
     dataframe = pandas.DataFrame(records, index=pandas.Index(index, name="wikidata_id"))
 
     job = client.load_table_from_dataframe(dataframe, table_ref, location="US")


### PR DESCRIPTION
Closes #9007.

This PR adjust am example from the docs so that it works unmodified under Python 2.7, too.

### How to test
- Create a BigQuery table with columns as in the screenshot posted in the issue description.
- Run the [load DataFrame example](https://googleapis.github.io/google-cloud-python/latest/bigquery/usage/pandas.html#load-a-pandas-dataframe-to-a-bigquery-table) from the docs using Python 2.7.

**Actual result (before the fix):**
The server responds with a 400 error (as reported in the issue).

**Expected result (after the fix):**
The adjusted example from the docs runs fine under Python 2.7, no error from the server.