### PR TITLE
BigQuery: Fix deserializing None QueryParameters

### DIFF
--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -126,8 +126,15 @@ class ScalarQueryParameter(_AbstractQueryParameter):
         """
         name = resource.get("name")
         type_ = resource["parameterType"]["type"]
-        value = resource["parameterValue"]["value"]
-        converted = _QUERY_PARAMS_FROM_JSON[type_](value, None)
+
+        # parameterValue might not be present if JSON resource originates
+        # from the back-end - the latter omits it for None values.
+        value = resource.get("parameterValue", {}).get("value")
+        if value is not None:
+            converted = _QUERY_PARAMS_FROM_JSON[type_](value, None)
+        else:
+            converted = None
+
         return cls(name, type_, converted)
 
     def to_api_repr(self):

--- a/bigquery/tests/unit/test_query.py
+++ b/bigquery/tests/unit/test_query.py
@@ -121,6 +121,15 @@ class Test_ScalarQueryParameter(unittest.TestCase):
         self.assertEqual(param.type_, "INT64")
         self.assertEqual(param.value, 123)
 
+    def test_from_api_repr_wo_value(self):
+        # Back-end may not send back values for None params. See #9027
+        RESOURCE = {"name": "foo", "parameterType": {"type": "INT64"}}
+        klass = self._get_target_class()
+        param = klass.from_api_repr(RESOURCE)
+        self.assertEqual(param.name, "foo")
+        self.assertEqual(param.type_, "INT64")
+        self.assertIs(param.value, None)
+
     def test_to_api_repr_w_name(self):
         EXPECTED = {
             "name": "foo",


### PR DESCRIPTION
Closes #9027.

For `None` parameters, the back-end does not return the parameter value in response, causing an error when deserializing ScalarQueryParameter from JSON.


### How to test
Run the example from the issue description. With the fix applied, the error should not occur anymore, and the resulting `query_parameters` object is correct.