### PR TITLE
BigQuery: Add enum with SQL type names allowed to be used in SchemaField

### DIFF
--- a/bigquery/google/cloud/bigquery/enums.py
+++ b/bigquery/google/cloud/bigquery/enums.py
@@ -67,3 +67,20 @@ def _make_sql_scalars_enum():
 
 
 StandardSqlDataTypes = _make_sql_scalars_enum()
+
+
+# see also https://cloud.google.com/bigquery/data-types#legacy_sql_data_types
+class LegacySqlDataTypes(str, enum.Enum):
+    """Enum of legacy SQL types names."""
+
+    STRING = "STRING"
+    BYTES = "BYTES"
+    INTEGER = "INTEGER"
+    FLOAT = "FLOAT"
+    NUMERIC = "NUMERIC"
+    BOOLEAN = "BOOLEAN"
+    RECORD = "RECORD"
+    TIMESTAMP = "TIMESTAMP"
+    DATE = "DATE"
+    TIME = "TIME"
+    DATETIME = "DATETIME"

--- a/bigquery/google/cloud/bigquery/enums.py
+++ b/bigquery/google/cloud/bigquery/enums.py
@@ -69,17 +69,23 @@ def _make_sql_scalars_enum():
 StandardSqlDataTypes = _make_sql_scalars_enum()
 
 
-# see also https://cloud.google.com/bigquery/data-types#legacy_sql_data_types
-class LegacySqlDataTypes(str, enum.Enum):
-    """Enum of legacy SQL types names."""
+# See also: https://cloud.google.com/bigquery/data-types#legacy_sql_data_types
+# and https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
+class SqlTypeNames(str, enum.Enum):
+    """Enum of allowed SQL type names in schema.SchemaField."""
 
     STRING = "STRING"
     BYTES = "BYTES"
     INTEGER = "INTEGER"
+    INT64 = "INTEGER"
     FLOAT = "FLOAT"
+    FLOAT64 = "FLOAT"
     NUMERIC = "NUMERIC"
     BOOLEAN = "BOOLEAN"
+    BOOL = "BOOLEAN"
+    GEOGRAPHY = "GEOGRAPHY"  # NOTE: not available in legacy types
     RECORD = "RECORD"
+    STRUCT = "RECORD"
     TIMESTAMP = "TIMESTAMP"
     DATE = "DATE"
     TIME = "TIME"


### PR DESCRIPTION
Closes #7632.

This PR adds an enum of legacy SQL type names that can be used with in schema fields.

@tswast This enum is a bit different from the existing `StandardSqlDataTypes` enum which maps type names to their gapic integer codes. Let me know if I misunderstood the ticket.

### How to test
Make sure all of the [legacy SQL type names](https://cloud.google.com/bigquery/data-types#legacy_sql_data_types) are included in the enum (and nothing else).
