### PR TITLE
Fix reference to library name

### DIFF
--- a/firestore/docs/index.rst
+++ b/firestore/docs/index.rst
@@ -21,7 +21,7 @@ API Reference
 Changelog
 ---------
 
-For a list of all ``google-cloud-datastore`` releases:
+For a list of all ``google-cloud-firestore`` releases:
 
 .. toctree::
   :maxdepth: 2


### PR DESCRIPTION
Seems like it should be google-cloud-firestore instead of google-cloud-datastore