### PR TITLE
BigQuery: Raise helpful error when loading table from dataframe with STRUCT columns

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1558,13 +1558,6 @@ class Client(ClientWithProject):
                         PendingDeprecationWarning,
                         stacklevel=2,
                     )
-                else:
-                    warnings.warn(
-                        "Loading from a dataframe without a schema will be "
-                        "deprecated in the future, please provide a schema.",
-                        PendingDeprecationWarning,
-                        stacklevel=2,
-                    )
 
                 dataframe.to_parquet(tmppath, compression=parquet_compression)
 

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -60,6 +60,7 @@ from google.cloud.bigquery.query import _QueryResults
 from google.cloud.bigquery.retry import DEFAULT_RETRY
 from google.cloud.bigquery.routine import Routine
 from google.cloud.bigquery.routine import RoutineReference
+from google.cloud.bigquery.schema import _STRUCT_TYPES
 from google.cloud.bigquery.schema import SchemaField
 from google.cloud.bigquery.table import _table_arg_to_table
 from google.cloud.bigquery.table import _table_arg_to_table_ref
@@ -1529,6 +1530,14 @@ class Client(ClientWithProject):
         os.close(tmpfd)
 
         try:
+            if job_config.schema:
+                for field in job_config.schema:
+                    if field.field_type in _STRUCT_TYPES:
+                        raise ValueError(
+                            "Pyarrow does not support serializing dataframes with "
+                            "struct (record) column types."
+                        )
+
             if pyarrow and job_config.schema:
                 if parquet_compression == "snappy":  # adjust the default value
                     parquet_compression = parquet_compression.upper()

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1534,8 +1534,9 @@ class Client(ClientWithProject):
                 for field in job_config.schema:
                     if field.field_type in _STRUCT_TYPES:
                         raise ValueError(
-                            "Pyarrow does not support serializing dataframes with "
-                            "struct (record) column types."
+                            "Uploading dataframes with struct (record) column types "
+                            "is not supported. See: "
+                            "https://github.com/googleapis/google-cloud-python/issues/8191"
                         )
 
             if pyarrow and job_config.schema:

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1548,6 +1548,14 @@ class Client(ClientWithProject):
                         PendingDeprecationWarning,
                         stacklevel=2,
                     )
+                else:
+                    warnings.warn(
+                        "Loading from a dataframe without a schema will be "
+                        "deprecated in the future, please provide a schema.",
+                        PendingDeprecationWarning,
+                        stacklevel=2,
+                    )
+
                 dataframe.to_parquet(tmppath, compression=parquet_compression)
 
             with open(tmppath, "rb") as parquet_file:

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -5379,14 +5379,13 @@ class TestClientUpload(object):
                 dataframe, self.TABLE_REF, location=self.LOCATION
             )
 
-        for warning in warned:
-            if warning.category in (
-                DeprecationWarning,
-                PendingDeprecationWarning,
-            ) and "please provide a schema" in str(warning):
-                break
-        else:
-            pytest.fail("A missing schema deprecation warning was not raised.")
+        matches = [
+            warning
+            for warning in warned
+            if warning.category in (DeprecationWarning, PendingDeprecationWarning)
+            and "please provide a schema" in str(warning)
+        ]
+        assert matches, "A missing schema deprecation warning was not raised."
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -5364,31 +5364,6 @@ class TestClientUpload(object):
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
-    def test_load_table_from_dataframe_wo_schema_warning(self):
-        client = self._make_client()
-        records = [{"name": "Monty", "age": 100}, {"name": "Python", "age": 60}]
-        dataframe = pandas.DataFrame(records)
-
-        load_patch = mock.patch(
-            "google.cloud.bigquery.client.Client.load_table_from_file", autospec=True
-        )
-        pyarrow_patch = mock.patch("google.cloud.bigquery.client.pyarrow", None)
-
-        with load_patch, pyarrow_patch, warnings.catch_warnings(record=True) as warned:
-            client.load_table_from_dataframe(
-                dataframe, self.TABLE_REF, location=self.LOCATION
-            )
-
-        matches = [
-            warning
-            for warning in warned
-            if warning.category in (DeprecationWarning, PendingDeprecationWarning)
-            and "please provide a schema" in str(warning)
-        ]
-        assert matches, "A missing schema deprecation warning was not raised."
-
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
-    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_schema_wo_pyarrow(self):
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -5330,6 +5330,40 @@ class TestClientUpload(object):
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
+    def test_load_table_from_dataframe_struct_fields_error(self):
+        from google.cloud.bigquery import job
+        from google.cloud.bigquery.schema import SchemaField
+
+        client = self._make_client()
+
+        records = [{"float_column": 3.14, "struct_column": [{"foo": 1}, {"bar": -1}]}]
+        dataframe = pandas.DataFrame(data=records)
+
+        schema = [
+            SchemaField("float_column", "FLOAT"),
+            SchemaField(
+                "agg_col",
+                "RECORD",
+                fields=[SchemaField("foo", "INTEGER"), SchemaField("bar", "INTEGER")],
+            ),
+        ]
+        job_config = job.LoadJobConfig(schema=schema)
+
+        load_patch = mock.patch(
+            "google.cloud.bigquery.client.Client.load_table_from_file", autospec=True
+        )
+
+        with pytest.raises(ValueError) as exc_info, load_patch:
+            client.load_table_from_dataframe(
+                dataframe, self.TABLE_REF, job_config=job_config, location=self.LOCATION
+            )
+
+        err_msg = str(exc_info.value)
+        assert "struct" in err_msg
+        assert "not support" in err_msg
+
+    @unittest.skipIf(pandas is None, "Requires `pandas`")
+    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_wo_schema_warning(self):
         client = self._make_client()
         records = [{"name": "Monty", "age": 100}, {"name": "Python", "age": 60}]

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -5330,6 +5330,32 @@ class TestClientUpload(object):
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
+    def test_load_table_from_dataframe_wo_schema_warning(self):
+        client = self._make_client()
+        records = [{"name": "Monty", "age": 100}, {"name": "Python", "age": 60}]
+        dataframe = pandas.DataFrame(records)
+
+        load_patch = mock.patch(
+            "google.cloud.bigquery.client.Client.load_table_from_file", autospec=True
+        )
+        pyarrow_patch = mock.patch("google.cloud.bigquery.client.pyarrow", None)
+
+        with load_patch, pyarrow_patch, warnings.catch_warnings(record=True) as warned:
+            client.load_table_from_dataframe(
+                dataframe, self.TABLE_REF, location=self.LOCATION
+            )
+
+        for warning in warned:
+            if warning.category in (
+                DeprecationWarning,
+                PendingDeprecationWarning,
+            ) and "please provide a schema" in str(warning):
+                break
+        else:
+            pytest.fail("A missing schema deprecation warning was not raised.")
+
+    @unittest.skipIf(pandas is None, "Requires `pandas`")
+    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_load_table_from_dataframe_w_schema_wo_pyarrow(self):
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
         from google.cloud.bigquery import job


### PR DESCRIPTION
Closes #9024.

This PR detects if loading table data from a dataframe with STRUCT columns, and raises a helpful error before doing any more work.

It also issues a pending deprecation warning if schema is not provided as discussed separately.

**Edit:** Now seeing the specs for no-schema deprecation in #9042, this PR can be viewed as a step towards it (the additional logic for when to issue a warning will be added separately). If the warning should be removed altogether in this PR, please let me know.

### How to test
- Create a table matching the schema from the issue description.
- Run the example from the issue description.

**Expected result (after the fix):**
Instead of an uninformative `FileNotFoundError`, a `ValueError` with a clear message is raised.