### PR TITLE
Datastore: Add `client_options` to constructors for manual clients.

### DIFF
--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -15,6 +15,7 @@
 
 import os
 
+import google.api_core.client_options
 from google.cloud._helpers import _LocalStack
 from google.cloud._helpers import _determine_default_project as _base_default_project
 from google.cloud.client import ClientWithProject
@@ -201,6 +202,11 @@ class Client(ClientWithProject):
                         you only need to set this if you're developing your
                         own library or partner tool.
 
+    :type client_options: :class:`~google.api_core.client_options.ClientOptions`
+                          or :class:`dict`
+    :param client_options: (Optional) Client options used to set user options on the
+                           client. API Endpoint should be set through client_options.
+
     :type _http: :class:`~requests.Session`
     :param _http: (Optional) HTTP object to make requests. Can be any object
                   that defines ``request()`` with the same interface as
@@ -228,6 +234,7 @@ class Client(ClientWithProject):
         namespace=None,
         credentials=None,
         client_info=_CLIENT_INFO,
+        client_options=None,
         _http=None,
         _use_grpc=None,
     ):
@@ -236,6 +243,7 @@ class Client(ClientWithProject):
         )
         self.namespace = namespace
         self._client_info = client_info
+        self._client_options = client_options
         self._batch_stack = _LocalStack()
         self._datastore_api_internal = None
         if _use_grpc is None:
@@ -246,7 +254,16 @@ class Client(ClientWithProject):
             host = os.environ[GCD_HOST]
             self._base_url = "http://" + host
         except KeyError:
-            self._base_url = _DATASTORE_BASE_URL
+            api_endpoint = _DATASTORE_BASE_URL
+            client_options = self._client_options
+            if client_options:
+                if type(client_options) == dict:
+                    client_options = google.api_core.client_options.from_dict(
+                        client_options
+                    )
+                if client_options.api_endpoint:
+                    api_endpoint = client_options.api_endpoint
+            self._base_url = api_endpoint
 
     @staticmethod
     def _determine_default(project):

--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -255,7 +255,6 @@ class Client(ClientWithProject):
             self._base_url = "http://" + host
         except KeyError:
             api_endpoint = _DATASTORE_BASE_URL
-            client_options = self._client_options
             if client_options:
                 if type(client_options) == dict:
                     client_options = google.api_core.client_options.from_dict(

--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -30,7 +30,7 @@ version = "1.9.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
-    "google-cloud-core >= 1.0.0, < 2.0dev",
+    "google-cloud-core >= 1.0.3, < 2.0dev",
 ]
 extras = {}
 


### PR DESCRIPTION
Toward #8475