### PR TITLE
BigQuery Storage: Add BigQuery to extra test dependencies.

### DIFF
--- a/bigquery_storage/noxfile.py
+++ b/bigquery_storage/noxfile.py
@@ -118,7 +118,7 @@ def system(session):
         session.install("-e", local_dep)
     session.install("-e", "../test_utils/")
     session.install("-e", ".[fastavro,pandas,pyarrow]")
-    session.install("-e", "../bigquery/")
+    session.install("-e", "../bigquery")
     session.install("-e", ".")
 
     # Run py.test against the system tests.

--- a/bigquery_storage/noxfile.py
+++ b/bigquery_storage/noxfile.py
@@ -118,7 +118,7 @@ def system(session):
         session.install("-e", local_dep)
     session.install("-e", "../test_utils/")
     session.install("-e", ".[fastavro,pandas,pyarrow]")
-    session.install("-e", "../bigquery")
+    session.install("-e", "../bigquery/")
     session.install("-e", ".")
 
     # Run py.test against the system tests.

--- a/bigquery_storage/synth.metadata
+++ b/bigquery_storage/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-08-21T23:15:51.548970Z",
+  "updateTime": "2019-08-21T23:20:45.275738Z",
   "sources": [
     {
       "generator": {

--- a/bigquery_storage/synth.metadata
+++ b/bigquery_storage/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-08-05T23:37:16.480074Z",
+  "updateTime": "2019-08-21T23:15:51.548970Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.32.1",
-        "dockerImage": "googleapis/artman@sha256:a684d40ba9a4e15946f5f2ca6b4bd9fe301192f522e9de4fff622118775f309b"
+        "version": "0.34.0",
+        "dockerImage": "googleapis/artman@sha256:38a27ba6245f96c3e86df7acb2ebcc33b4f186d9e475efe2d64303aec3d4e0ea"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "git@github.com:googleapis/googleapis.git",
-        "sha": "e699b0cba64ffddfae39633417180f1f65875896",
-        "internalRef": "261759677"
+        "sha": "92bebf78345af8b2d3585220527115bda8bdedf8",
+        "internalRef": "264715111"
       }
     },
     {

--- a/bigquery_storage/synth.py
+++ b/bigquery_storage/synth.py
@@ -123,7 +123,7 @@ s.replace(
 # Add templated files
 # ----------------------------------------------------------------------------
 optional_deps = [".[fastavro,pandas,pyarrow]"]
-system_test_deps = optional_deps + ["../bigquery"]
+system_test_deps = optional_deps + ["../bigquery/"]
 templated_files = common.py_library(
     unit_cov_level=79,
     cov_level=79,

--- a/bigquery_storage/synth.py
+++ b/bigquery_storage/synth.py
@@ -122,13 +122,14 @@ s.replace(
 # ----------------------------------------------------------------------------
 # Add templated files
 # ----------------------------------------------------------------------------
-extra_deps = [".[fastavro,pandas,pyarrow]", 'os.path.join("..", "bigquery")']
+optional_deps = [".[fastavro,pandas,pyarrow]"]
+system_test_deps = optional_deps + ['os.path.join("..", "bigquery")']
 templated_files = common.py_library(
     unit_cov_level=79,
     cov_level=79,
     samples_test=True,
-    system_test_dependencies=extra_deps,
-    unit_test_dependencies=extra_deps,
+    system_test_dependencies=system_test_deps,
+    unit_test_dependencies=optional_deps,
 )
 s.move(templated_files)
 

--- a/bigquery_storage/synth.py
+++ b/bigquery_storage/synth.py
@@ -123,7 +123,7 @@ s.replace(
 # Add templated files
 # ----------------------------------------------------------------------------
 optional_deps = [".[fastavro,pandas,pyarrow]"]
-system_test_deps = optional_deps + ['os.path.join("..", "bigquery")']
+system_test_deps = optional_deps + ["../bigquery"]
 templated_files = common.py_library(
     unit_cov_level=79,
     cov_level=79,

--- a/bigquery_storage/synth.py
+++ b/bigquery_storage/synth.py
@@ -122,7 +122,7 @@ s.replace(
 # ----------------------------------------------------------------------------
 # Add templated files
 # ----------------------------------------------------------------------------
-extra_deps = [".[fastavro,pandas,pyarrow]"]
+extra_deps = [".[fastavro,pandas,pyarrow]", 'os.path.join("..", "bigquery")']
 templated_files = common.py_library(
     unit_cov_level=79,
     cov_level=79,


### PR DESCRIPTION
Follow-up to: https://github.com/googleapis/google-cloud-python/pull/8992, which adds BigQuery as a system test dependency.

Replaces https://github.com/googleapis/google-cloud-python/pull/9068.