### PR TITLE
BigQuery: Add support for unsetting LoadJobConfig schema

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1160,6 +1160,10 @@ class LoadJobConfig(_JobConfig):
 
     @schema.setter
     def schema(self, value):
+        if value is None:
+            self._del_sub_prop("schema")
+            return
+
         if not all(hasattr(field, "to_api_repr") for field in value):
             raise ValueError("Schema items must be fields")
         _helpers._set_sub_prop(

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1504,6 +1504,19 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
             config._properties["load"]["schema"], {"fields": [full_name_repr, age_repr]}
         )
 
+    def test_schema_setter_unsetting_schema(self):
+        from google.cloud.bigquery.schema import SchemaField
+
+        config = self._get_target_class()()
+        config._properties["load"]["schema"] = [
+            SchemaField("full_name", "STRING", mode="REQUIRED"),
+            SchemaField("age", "INTEGER", mode="REQUIRED"),
+        ]
+
+        config.schema = None
+        self.assertNotIn("schema", config._properties["load"])
+        config.schema = None  # no error, idempotent operation
+
     def test_schema_update_options_missing(self):
         config = self._get_target_class()()
         self.assertIsNone(config.schema_update_options)


### PR DESCRIPTION
Closes #9074.

This PR adds a public way of unsetting a schema from a `LoadJobConfig`.

### How to test
Create a `LoadJobConfig` with a `schema` attribute, then set `schema` to `None` --> the schema should be cleared.