### PR TITLE
BigQuery: Add list rows and --max_results option to %%bigquery magic

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1055,7 +1055,13 @@ class Client(ClientWithProject):
                 raise
 
     def _get_query_results(
-        self, job_id, retry, project=None, timeout_ms=None, location=None
+        self,
+        job_id,
+        retry,
+        project=None,
+        timeout_ms=None,
+        location=None,
+        max_results=None
     ):
         """Get the query results object for a query job.
 
@@ -1070,6 +1076,8 @@ class Client(ClientWithProject):
                 (Optional) number of milliseconds the the API call should
                 wait for the query to complete before the request times out.
             location (str): Location of the query job.
+            max_results (int): 
+                (Optional) Maximum number of results to read.
 
         Returns:
             google.cloud.bigquery.query._QueryResults:
@@ -1089,6 +1097,9 @@ class Client(ClientWithProject):
 
         if location is not None:
             extra_params["location"] = location
+        
+        if max_results is not None:
+            extra_params['maxResults'] = max_results
 
         path = "/projects/{}/queries/{}".format(project, job_id)
 
@@ -1986,6 +1997,7 @@ class Client(ClientWithProject):
                 to the client's project.
             retry (google.api_core.retry.Retry):
                 (Optional) How to retry the RPC.
+            
 
         Returns:
             google.cloud.bigquery.job.QueryJob: A new query job instance.

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1055,13 +1055,7 @@ class Client(ClientWithProject):
                 raise
 
     def _get_query_results(
-        self,
-        job_id,
-        retry,
-        project=None,
-        timeout_ms=None,
-        location=None,
-        max_results=None,
+        self, job_id, retry, project=None, timeout_ms=None, location=None
     ):
         """Get the query results object for a query job.
 
@@ -1076,9 +1070,6 @@ class Client(ClientWithProject):
                 (Optional) number of milliseconds the the API call should
                 wait for the query to complete before the request times out.
             location (str): Location of the query job.
-            max_results (int):
-                (Optional) Maximum number of results to read.
-
         Returns:
             google.cloud.bigquery.query._QueryResults:
                 A new ``_QueryResults`` instance.

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1098,9 +1098,6 @@ class Client(ClientWithProject):
         if location is not None:
             extra_params["location"] = location
 
-        if max_results is not None:
-            extra_params["maxResults"] = max_results
-
         path = "/projects/{}/queries/{}".format(project, job_id)
 
         # This call is typically made in a polling loop that checks whether the

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1061,7 +1061,7 @@ class Client(ClientWithProject):
         project=None,
         timeout_ms=None,
         location=None,
-        max_results=None
+        max_results=None,
     ):
         """Get the query results object for a query job.
 
@@ -1076,7 +1076,7 @@ class Client(ClientWithProject):
                 (Optional) number of milliseconds the the API call should
                 wait for the query to complete before the request times out.
             location (str): Location of the query job.
-            max_results (int): 
+            max_results (int):
                 (Optional) Maximum number of results to read.
 
         Returns:
@@ -1097,9 +1097,9 @@ class Client(ClientWithProject):
 
         if location is not None:
             extra_params["location"] = location
-        
+
         if max_results is not None:
-            extra_params['maxResults'] = max_results
+            extra_params["maxResults"] = max_results
 
         path = "/projects/{}/queries/{}".format(project, job_id)
 
@@ -1997,7 +1997,6 @@ class Client(ClientWithProject):
                 to the client's project.
             retry (google.api_core.retry.Retry):
                 (Optional) How to retry the RPC.
-            
 
         Returns:
             google.cloud.bigquery.job.QueryJob: A new query job instance.

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -500,7 +500,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         """Update properties from resource in body of ``api_response``
 
         Args:
-            api_response (dict): response returned from an API call.
+            api_response (Dict): response returned from an API call.
         """
         cleaned = api_response.copy()
         self._scrub_local_properties(cleaned)
@@ -2583,7 +2583,7 @@ class QueryJob(_AsyncJob):
         """Update properties from resource in body of ``api_response``
 
         Args:
-            api_response (dict): response returned from an API call.
+            api_response (Dict): response returned from an API call.
         """
 
         # prevent max_results value from being erased

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -499,8 +499,8 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
     def _set_properties(self, api_response):
         """Update properties from resource in body of ``api_response``
 
-        :type api_response: dict
-        :param api_response: response returned from an API call
+        Args:
+            api_response (dict): response returned from an API call.
         """
         cleaned = api_response.copy()
         self._scrub_local_properties(cleaned)
@@ -2582,8 +2582,8 @@ class QueryJob(_AsyncJob):
     def _set_properties(self, api_response):
         """Update properties from resource in body of ``api_response``
 
-        :type api_response: dict
-        :param api_response: response returned from an API call
+        Args:
+            api_response (dict): response returned from an API call.
         """
 
         # prevent max_results value from being erased

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -2154,7 +2154,7 @@ class QueryJobConfig(_JobConfig):
     @property
     def max_results(self):
         """int: Maximum number of results to read.
-        
+
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
         """
@@ -2858,7 +2858,7 @@ class QueryJob(_AsyncJob):
                 project=self.project,
                 timeout_ms=timeout_ms,
                 location=self.location,
-                max_results=self.max_results
+                max_results=self.max_results,
             )
 
             # Only reload the job once we know the query is complete.
@@ -2956,24 +2956,17 @@ class QueryJob(_AsyncJob):
                 If the job did not complete in the given timeout.
         """
 
-        if not re.search(r"[\s]", self.query):
-            table_id = self.query
-            rows = self._client.list_rows(
-                table_id, page_size=page_size, retry=retry, max_results=self.max_results
-            )
-            return rows
-
         try:
             super(QueryJob, self).result(timeout=timeout)
 
             # Return an iterator instead of returning the job.
             if not self._query_results:
                 self._query_results = self._client._get_query_results(
-                    self.job_id, 
-                    retry, 
-                    project=self.project, 
-                    location=self.location, 
-                    max_results=self.max_results
+                    self.job_id,
+                    retry,
+                    project=self.project,
+                    location=self.location,
+                    max_results=self.max_results,
                 )
         except exceptions.GoogleCloudError as exc:
             exc.message += self._format_for_exception(self.query, self.job_id)
@@ -2991,10 +2984,7 @@ class QueryJob(_AsyncJob):
         dest_table = Table(dest_table_ref, schema=schema)
         dest_table._properties["numRows"] = self._query_results.total_rows
         rows = self._client.list_rows(
-            dest_table, 
-            page_size=page_size, 
-            retry=retry, 
-            max_results=self.max_results
+            dest_table, page_size=page_size, retry=retry, max_results=self.max_results
         )
         rows._preserve_order = _contains_order_by(self.query)
         return rows

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -2158,11 +2158,11 @@ class QueryJobConfig(_JobConfig):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
         """
-        return self._properties.get("maxResults")
+        return _helpers._int_or_none(self._get_sub_prop("maxResults"))
 
     @max_results.setter
     def max_results(self, value):
-        self._properties["maxResults"] = value
+        self._set_sub_prop("maxResults", str(value))
 
     @property
     def maximum_billing_tier(self):

--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -449,12 +449,13 @@ def _cell_magic(line, query):
             if args.destination_var:
                 print(
                     "Could not save output to variable '{}'.".format(
-                        args.destination_var),
+                        args.destination_var
+                    ),
                     file=sys.stderr,
                 )
             print("\nERROR:\n", error, file=sys.stderr)
             return
-            
+
         result = rows.to_dataframe(bqstorage_client=bqstorage_client)
         if args.destination_var:
             IPython.get_ipython().push({args.destination_var: result})

--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -440,7 +440,21 @@ def _cell_magic(line, query):
 
     if not re.search(r"\s", query.rstrip()):
         table_id = query.rstrip()
-        rows = client.list_rows(table_id, max_results=max_results)
+        error = None
+        try:
+            rows = client.list_rows(table_id, max_results=max_results)
+        except Exception as ex:
+            error = str(ex)
+        if error:
+            if args.destination_var:
+                print(
+                    "Could not save output to variable '{}'.".format(
+                        args.destination_var),
+                    file=sys.stderr,
+                )
+            print("\nERROR:\n", error, file=sys.stderr)
+            return
+            
         result = rows.to_dataframe(bqstorage_client=bqstorage_client)
         if args.destination_var:
             IPython.get_ipython().push({args.destination_var: result})

--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -438,7 +438,7 @@ def _cell_magic(line, query):
     else:
         max_results = None
 
-    if not re.search(r"\b\s+\b", query):
+    if not re.search(r"\s", query.rstrip()):
         table_id = query.rstrip()
         rows = client.list_rows(table_id, max_results=max_results)
         result = rows.to_dataframe(bqstorage_client=bqstorage_client)

--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -404,6 +404,7 @@ def _cell_magic(line, query):
     Returns:
         pandas.DataFrame: the query results.
     """
+
     args = magic_arguments.parse_argstring(_cell_magic, line)
 
     params = []
@@ -437,10 +438,15 @@ def _cell_magic(line, query):
     else:
         max_results = None
 
-    if not re.search(r"[\s]", query):
-        table_id = query
+    if not re.search(r"\b\s+\b", query):
+        table_id = query.rstrip()
         rows = client.list_rows(table_id, max_results=max_results)
-        return rows.to_dataframe(bqstorage_client=bqstorage_client)
+        result = rows.to_dataframe(bqstorage_client=bqstorage_client)
+        if args.destination_var:
+            IPython.get_ipython().push({args.destination_var: result})
+            return
+        else:
+            return result
 
     job_config = bigquery.job.QueryJobConfig()
     job_config.query_parameters = params

--- a/bigquery/google/cloud/bigquery/magics.py
+++ b/bigquery/google/cloud/bigquery/magics.py
@@ -278,6 +278,7 @@ def _run_query(client, query, job_config=None):
         job_config (google.cloud.bigquery.job.QueryJobConfig, optional):
             Extra configuration options for the job.
 
+
     Returns:
         google.cloud.bigquery.job.QueryJob: the query job created
 
@@ -319,6 +320,14 @@ def _run_query(client, query, job_config=None):
     type=str,
     default=None,
     help=("Project to use for executing this query. Defaults to the context project."),
+)
+@magic_arguments.argument(
+    "--max_results",
+    default=None,
+    help=(
+        "Maximum number of rows in dataframe returned from executing the query."
+        "Defaults to returning all rows."
+    ),
 )
 @magic_arguments.argument(
     "--maximum_bytes_billed",
@@ -409,6 +418,7 @@ def _cell_magic(line, query):
             )
 
     project = args.project or context.project
+
     client = bigquery.Client(
         project=project,
         credentials=context.credentials,
@@ -424,6 +434,11 @@ def _cell_magic(line, query):
     job_config.query_parameters = params
     job_config.use_legacy_sql = args.use_legacy_sql
     job_config.dry_run = args.dry_run
+
+    if args.max_results:
+        job_config.max_results = int(args.max_results)
+    else:
+        job_config.max_results = None
 
     if args.maximum_bytes_billed == "None":
         job_config.maximum_bytes_billed = 0

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -3455,6 +3455,11 @@ class TestQueryJob(unittest.TestCase, _Base):
             self.assertIsInstance(job.maximum_bytes_billed, int)
         else:
             self.assertIsNone(job.maximum_bytes_billed)
+        if "maxResults" in config:
+            self.assertEqual(str(job.max_results), config["maxResults"])
+            self.assertIsInstance(job.max_results, int)
+        else:
+            self.assertIsNone(job.max_results)
 
     def _verify_udf_resources(self, job, config):
         udf_resources = config.get("userDefinedFunctionResources", ())

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -3455,11 +3455,6 @@ class TestQueryJob(unittest.TestCase, _Base):
             self.assertIsInstance(job.maximum_bytes_billed, int)
         else:
             self.assertIsNone(job.maximum_bytes_billed)
-        if "maxResults" in config:
-            self.assertEqual(str(job.max_results), config["maxResults"])
-            self.assertIsInstance(job.max_results, int)
-        else:
-            self.assertIsNone(job.max_results)
 
     def _verify_udf_resources(self, job, config):
         udf_resources = config.get("userDefinedFunctionResources", ())

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -832,7 +832,6 @@ def test_bigquery_magic_w_table_id_invalid():
     table_id = "not-a-real-table"
 
     with list_rows_patch, io.capture_output() as captured_io:
-
         ip.run_cell_magic("bigquery", "df", table_id)
 
     output = captured_io.stderr

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -817,24 +817,22 @@ def test_bigquery_magic_w_table_id_and_max_results():
 
     assert isinstance(return_value, pandas.DataFrame)
 
+
 def test_bigquery_magic_w_table_id_invalid():
     ip = IPython.get_ipython()
     ip.extension_manager.load_extension("google.cloud.bigquery")
     magics.context._project = None
 
-    
-
     list_rows_patch = mock.patch(
-        "google.cloud.bigquery.magics.bigquery.Client.list_rows", 
+        "google.cloud.bigquery.magics.bigquery.Client.list_rows",
         autospec=True,
-        side_effect=exceptions.BadRequest("Not a valid table ID")
+        side_effect=exceptions.BadRequest("Not a valid table ID"),
     )
 
     table_id = "not-a-real-table"
 
-
     with list_rows_patch, io.capture_output() as captured_io:
-        
+
         ip.run_cell_magic("bigquery", "", table_id)
 
     output = captured_io.stderr

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -817,6 +817,30 @@ def test_bigquery_magic_w_table_id_and_max_results():
 
     assert isinstance(return_value, pandas.DataFrame)
 
+def test_bigquery_magic_w_table_id_invalid():
+    ip = IPython.get_ipython()
+    ip.extension_manager.load_extension("google.cloud.bigquery")
+    magics.context._project = None
+
+    
+
+    list_rows_patch = mock.patch(
+        "google.cloud.bigquery.magics.bigquery.Client.list_rows", 
+        autospec=True,
+        side_effect=exceptions.BadRequest("Not a valid table ID")
+    )
+
+    table_id = "not-a-real-table"
+
+
+    with list_rows_patch, io.capture_output() as captured_io:
+        
+        ip.run_cell_magic("bigquery", "", table_id)
+
+    output = captured_io.stderr
+    assert "400 Not a valid table ID" in output
+    assert "Traceback (most recent call last)" not in output
+
 
 @pytest.mark.usefixtures("ipython_interactive")
 def test_bigquery_magic_w_table_id_and_destination_var():

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -758,9 +758,6 @@ def test_bigquery_magic_w_max_results_invalid():
     client_query_patch = mock.patch(
         "google.cloud.bigquery.client.Client.query", autospec=True
     )
-    query_job_mock = mock.create_autospec(
-        google.cloud.bigquery.job.QueryJob, instance=True
-    )
 
     sql = "SELECT 17 AS num"
 
@@ -774,12 +771,6 @@ def test_bigquery_magic_w_max_results_valid_sets_job_config():
     ip.extension_manager.load_extension("google.cloud.bigquery")
     magics.context._project = None
 
-    credentials_mock = mock.create_autospec(
-        google.auth.credentials.Credentials, instance=True
-    )
-    default_patch = mock.patch(
-        "google.auth.default", return_value=(credentials_mock, "general-project")
-    )
     run_query_patch = mock.patch(
         "google.cloud.bigquery.magics._run_query", autospec=True
     )
@@ -799,19 +790,8 @@ def test_bigquery_magic_w_table_id_instead_of_sql():
     ip.extension_manager.load_extension("google.cloud.bigquery")
     magics.context._project = None
 
-    credentials_mock = mock.create_autospec(
-        google.auth.credentials.Credentials, instance=True
-    )
-    default_patch = mock.patch(
-        "google.auth.default", return_value=(credentials_mock, "general-project")
-    )
-
     row_iterator_mock = mock.create_autospec(
         google.cloud.bigquery.table.RowIterator, instance=True
-    )
-
-    query_job_mock = mock.create_autospec(
-        google.cloud.bigquery.job.QueryJob, instance=True
     )
 
     client_patch = mock.patch(
@@ -822,7 +802,7 @@ def test_bigquery_magic_w_table_id_instead_of_sql():
         "google.cloud.bigquery.magics._run_query", autospec=True
     )
 
-    table_id = "12345"
+    table_id = "bigquery-public-data.samples.shakespeare"
     result = pandas.DataFrame([17], columns=["num"])
 
     with client_patch as client_mock, run_query_patch as run_query_mock:

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -833,9 +833,10 @@ def test_bigquery_magic_w_table_id_invalid():
 
     with list_rows_patch, io.capture_output() as captured_io:
 
-        ip.run_cell_magic("bigquery", "", table_id)
+        ip.run_cell_magic("bigquery", "df", table_id)
 
     output = captured_io.stderr
+    assert "Could not save output to variable" in output
     assert "400 Not a valid table ID" in output
     assert "Traceback (most recent call last)" not in output
 

--- a/bigquery/tests/unit/test_magics.py
+++ b/bigquery/tests/unit/test_magics.py
@@ -817,6 +817,7 @@ def test_bigquery_magic_w_table_id_and_max_results():
 
     assert isinstance(return_value, pandas.DataFrame)
 
+
 @pytest.mark.usefixtures("ipython_interactive")
 def test_bigquery_magic_w_table_id_and_destination_var():
     ip = IPython.get_ipython()
@@ -838,12 +839,13 @@ def test_bigquery_magic_w_table_id_and_destination_var():
         client_mock().list_rows.return_value = row_iterator_mock
         row_iterator_mock.to_dataframe.return_value = result
 
-        return_value = ip.run_cell_magic("bigquery", "df --max_results=5", table_id)
+        ip.run_cell_magic("bigquery", "df --max_results=5", table_id)
 
     assert "df" in ip.user_ns
-    df = ip.user_ns['df']
+    df = ip.user_ns["df"]
 
     assert isinstance(df, pandas.DataFrame)
+
 
 @pytest.mark.usefixtures("ipython_interactive")
 def test_bigquery_magic_w_table_id_and_bqstorage_client():
@@ -858,7 +860,6 @@ def test_bigquery_magic_w_table_id_and_bqstorage_client():
     client_patch = mock.patch(
         "google.cloud.bigquery.magics.bigquery.Client", autospec=True
     )
-
 
     bqstorage_mock = mock.create_autospec(
         bigquery_storage_v1beta1.BigQueryStorageClient
@@ -875,10 +876,11 @@ def test_bigquery_magic_w_table_id_and_bqstorage_client():
 
     with client_patch as client_mock, bqstorage_client_patch:
         client_mock().list_rows.return_value = row_iterator_mock
-    
-        return_value = ip.run_cell_magic("bigquery", "--use_bqstorage_api --max_results=5", table_id)
+
+        ip.run_cell_magic("bigquery", "--use_bqstorage_api --max_results=5", table_id)
         row_iterator_mock.to_dataframe.assert_called_once_with(
-            bqstorage_client=bqstorage_instance_mock)
+            bqstorage_client=bqstorage_instance_mock
+        )
 
 
 @pytest.mark.usefixtures("ipython_interactive")


### PR DESCRIPTION
See #9105. Creating draft for visibility.

Adds option to pass a table id instead of a SQL query to `%%bigquery` cell magic as a cost-saving alternative to `SELECT *` queries. `--max_results` option limits the number of rows read. The returned `pandas.DataFrame` can be saved to a variable by passing a `destination_var` argument.

![image](https://user-images.githubusercontent.com/19631367/63981298-5bb2b900-ca73-11e9-9f50-78b6324f421f.png)


TODO:

- [x] Fix coverage failures

- [x] Test that running cell magic with table ID instead of query works with `bqstorage_client` set

- [x] Add tests for failure cases- handles failure cases when table IDs are passed instead of queries:
![image](https://user-images.githubusercontent.com/19631367/64050102-e0f9a480-cb2b-11e9-8267-e90c9c65c3c9.png)


- [x] ~~`max_results` is currently not working with regular SQL queries~~ - fixed! See screenshot below
![image](https://user-images.githubusercontent.com/19631367/64031440-45513f80-cafd-11e9-890a-f11b4c289ab2.png)

To get this working, I ended up adding `max_results` as a property of `QueryJobConfig`, but if that wasn't the right call, I can refactor to pass `max_results` as a separate parameter.