### PR TITLE
Docs: Fix broken links for Core, DNS, Language, RuntimeConfig and WebRisk

### DIFF
--- a/api_core/docs/auth.rst
+++ b/api_core/docs/auth.rst
@@ -188,7 +188,7 @@ and stored in a file and then and deserialized with
 to use ``oauth2client``'s credentials with this library, you'll need to
 `convert them`_.
 
-.. _oauth2client: https://github.com/Google/oauth2client.
+.. _oauth2client: https://github.com/Google/oauth2client
 .. _client secrets: https://developers.google.com/api-client-library/python/guide/aaa_oauth#flow_from_clientsecrets
 .. _webserver flow: https://developers.google.com/api-client-library/python/guide/aaa_oauth#OAuth2WebServerFlow
 .. _convert them: http://google-auth.readthedocs.io/en/stable/user-guide.html#user-credentials

--- a/dns/README.rst
+++ b/dns/README.rst
@@ -15,7 +15,6 @@ manage DNS for your applications.
    :target: https://pypi.org/project/google-cloud-dns/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dns.svg
 .. _Google Cloud DNS: https://cloud.google.com/dns/
-   :target: https://pypi.org/project/google-cloud-dns/
 .. _Client Library Documentation: https://googleapis.dev/python/dns/latest
 .. _Product Documentation: https://cloud.google.com/dns/docs/
 

--- a/language/README.rst
+++ b/language/README.rst
@@ -23,7 +23,7 @@ with your document storage on Google Cloud Storage.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-language.svg
    :target: https://pypi.org/project/google-cloud-language/
 .. _Google Cloud Natural Language: https://cloud.google.com/natural-language/
-.. _Product Documentation:  https://cloud.google.com/language/docs
+.. _Product Documentation:  https://cloud.google.com/natural-language/docs
 .. _Client Library Documentation: https://googleapis.dev/python/language/latest
 
 .. note::

--- a/runtimeconfig/README.rst
+++ b/runtimeconfig/README.rst
@@ -35,7 +35,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud RuntimeConfig API.:  https://cloud.google.com/runtimeconfig
+.. _Enable the Google Cloud RuntimeConfig API.:  https://cloud.google.com/deployment-manager/
 .. _Setup Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation

--- a/webrisk/README.rst
+++ b/webrisk/README.rst
@@ -13,9 +13,9 @@ Python Client for Web Risk API (`Alpha`_)
 - `Product Documentation`_
 
 .. _Alpha: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
-.. _Web Risk API: https://cloud.google.com/webrisk
+.. _Web Risk API: https://cloud.google.com/web-risk
 .. _Client Library Documentation: https://googleapis.dev/python/webrisk/latest
-.. _Product Documentation:  https://cloud.google.com/webrisk
+.. _Product Documentation:  https://cloud.google.com/web-risk
 
 Quick Start
 -----------
@@ -29,7 +29,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Web Risk API.:  https://cloud.google.com/webrisk
+.. _Enable the Web Risk API.:  https://cloud.google.com/web-risk
 .. _Setup Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -77,5 +77,5 @@ Next Steps
 -  View this `repository’s main README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Web Risk API Product documentation:  https://cloud.google.com/webrisk
+.. _Web Risk API Product documentation:  https://cloud.google.com/web-risk
 .. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst


### PR DESCRIPTION
Fix following broken links:

- 'Google Cloud DNS ' on https://googleapis.github.io/google-cloud-python/latest/dns/index.html
- 'Product Documentation' on https://googleapis.github.io/google-cloud-python/latest/language/index.html
- 'Enable the Google Cloud RuntimeConfig API.' on https://googleapis.github.io/google-cloud-python/latest/runtimeconfig/index.html
- 'Product Documentation', 'Enable the Web Risk API.' and 'Web Risk API' on https://googleapis.github.io/google-cloud-python/latest/webrisk/index.html
- 'oauth2client' on https://googleapis.github.io/google-cloud-python/latest/core/auth.html