### PR TITLE
Docs: fix the reference URL for BigQuery create_dataset()

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -343,7 +343,7 @@ class Client(ClientWithProject):
         """API call: create the dataset via a POST request.
 
         See
-        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/insert
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/insert
 
         Args:
             dataset (Union[ \


### PR DESCRIPTION
For [google.cloud.bigquery.client.Client.create_dataset](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.client.Client.html#google.cloud.bigquery.client.Client.create_dataset)

The documentation reference URL should be 
https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/insert
instead of
https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/insert