### PR TITLE
BigQuery: Disable failing snippets test

### DIFF
--- a/bigquery/docs/snippets.py
+++ b/bigquery/docs/snippets.py
@@ -1393,6 +1393,7 @@ def test_copy_table_multiple_source(client, to_delete):
     assert dest_table.num_rows == 2
 
 
+@pytest.mark.skip(reason="Backend responds with a 500 internal error.")
 def test_copy_table_cmek(client, to_delete):
     dataset_id = "copy_table_cmek_{}".format(_millis())
     dest_dataset = bigquery.Dataset(client.dataset(dataset_id))


### PR DESCRIPTION
`test_copy_table_cmek()` snippets test results in internal error on the backend and fails, blocking the PRs, and this PR marks the test as skipped.

Currently awaiting more information from the backend team. If the issue is not fixed soon, we will temporarily disable the test, but until then please do not merge this PR just yet.