### PR TITLE
IAM: Fix typo in repository metadata JSON.

### DIFF
--- a/iam/.repo-metadata.json
+++ b/iam/.repo-metadata.json
@@ -8,5 +8,5 @@
   "language": "python",
   "repo": "googleapis/google-cloud-python",
   "distribution_name": "google-cloud-iam",
-  "api_id": "iamcredentials.googleapis.com",
+  "api_id": "iamcredentials.googleapis.com"
 }


### PR DESCRIPTION
(Python's JSON support is sensitive to trailing commas)