### PR TITLE
Logging: Pass 'stream' argument to super in 'ContainerEngineHandler.__init__'.

### DIFF
--- a/logging/google/cloud/logging/handlers/container_engine.py
+++ b/logging/google/cloud/logging/handlers/container_engine.py
@@ -38,7 +38,7 @@ class ContainerEngineHandler(logging.StreamHandler):
     """
 
     def __init__(self, name=None, stream=None):
-        super(ContainerEngineHandler, self).__init__()
+        super(ContainerEngineHandler, self).__init__(stream=stream)
         self.name = name
 
     def format(self, record):


### PR DESCRIPTION
It looks like this was broken here: https://github.com/googleapis/google-cloud-python/commit/aee5ceca1561e7f2c92a71b7be026851c5cb5d41#diff-c49b1ce108fd52ae2640bc8afc4415d7R40