### PR TITLE
BigQuery, BigQuery Storage: Fix list_rows() max results with BQ storage client

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1630,6 +1630,14 @@ class RowIterator(HTTPIterator):
         if dtypes is None:
             dtypes = {}
 
+        if bqstorage_client and self.max_results is not None:
+            warnings.warn(
+                "Cannot use bqstorage_client if max_results is set, "
+                "reverting to fetching data with the tabledata.list endpoint.",
+                stacklevel=2,
+            )
+            bqstorage_client = None
+
         progress_bar = self._get_progress_bar(progress_bar_type)
 
         frames = []


### PR DESCRIPTION
Closes #9174.

This PR fixes the issue with `max_results` if BQ storage API is used by falling back to the `tabledata.list` API endpoint, and issuing a user warning.

### How to test
Run the code sample from the issue description, and verify that indeed only 100 rows is returned regardless of which client (BQ or BQ storage) is used.