### PR TITLE
BigQuery: Add performance note to fetchall() docs

### DIFF
--- a/bigquery/google/cloud/bigquery/dbapi/cursor.py
+++ b/bigquery/google/cloud/bigquery/dbapi/cursor.py
@@ -264,6 +264,10 @@ class Cursor(object):
     def fetchall(self):
         """Fetch all remaining results from the last ``execute*()`` call.
 
+        .. note::
+            The ``arraysize`` attribute can affect the performance of this
+            operation. Make sure to set it to appropriate batch size beforehand.
+
         :rtype: List[tuple]
         :returns: A list of all the rows in the results.
         :raises: :class:`~google.cloud.bigquery.dbapi.InterfaceError`


### PR DESCRIPTION
Closes #9185.

This PR adds a note on `arraysize` parameter, and its impact on the `fetchall()` method performance.

### How to test
Run the code sample from the issue description, and verify that by setting `cursor.arraysize` to appropriate value avoids the reported performance issue, which what the updated docs point out.