### PR TITLE
BigQuery: Revert "Disable failing snippets test"

### DIFF
--- a/bigquery/docs/snippets.py
+++ b/bigquery/docs/snippets.py
@@ -1393,7 +1393,6 @@ def test_copy_table_multiple_source(client, to_delete):
     assert dest_table.num_rows == 2
 
 
-@pytest.mark.skip(reason="Backend responds with a 500 internal error.")
 def test_copy_table_cmek(client, to_delete):
     dataset_id = "copy_table_cmek_{}".format(_millis())
     dest_dataset = bigquery.Dataset(client.dataset(dataset_id))


### PR DESCRIPTION
Reverts googleapis/google-cloud-python#9156

Per internal issue 140294699:

> The bug affects table copy non-cmek into CMEK for tables created a long time ago. Does not affect new tables.

The engineering team has applied a fix for the problematic table `bigquery-public-data:samples.shakespeare`, so the test in question should now pass.