### PR TITLE
Firestore: Mark tests as incompatible with emulator

### DIFF
--- a/firestore/tests/system/test_system.py
+++ b/firestore/tests/system/test_system.py
@@ -126,6 +126,10 @@ def test_create_document_w_subcollection(client, cleanup):
     assert sorted(child.id for child in children) == sorted(child_ids)
 
 
+@pytest.mark.skipif(
+    os.getenv("FIRESTORE_EMULATOR_HOST") is not None,
+    reason="Internal Issue b/137866686",
+)
 def test_cannot_use_foreign_key(client, cleanup):
     document_id = "cannot" + UNIQUE_RESOURCE_ID
     document = client.document("foreign-key", document_id)
@@ -280,6 +284,10 @@ def test_document_update_w_int_field(client, cleanup):
     assert snapshot1.to_dict() == expected
 
 
+@pytest.mark.skipif(
+    os.getenv("FIRESTORE_EMULATOR_HOST") is not None,
+    reason="Internal Issue b/137867104",
+)
 def test_update_document(client, cleanup):
     document_id = "for-update" + UNIQUE_RESOURCE_ID
     document = client.document("made", document_id)
@@ -806,6 +814,10 @@ def test_collection_group_queries_filters(client, cleanup):
     assert found == set(["cg-doc2"])
 
 
+@pytest.mark.skipif(
+    os.getenv("FIRESTORE_EMULATOR_HOST") is not None,
+    reason="Internal Issue b/137865992",
+)
 def test_get_all(client, cleanup):
     collection_name = "get-all" + UNIQUE_RESOURCE_ID
 


### PR DESCRIPTION
There are a few tests that don't currently work under the emulator. This marks them and references tracking issues to monitor to enable these.