### PR TITLE
Firestore: Enabling system tests to run on emulator

### DIFF
--- a/firestore/noxfile.py
+++ b/firestore/noxfile.py
@@ -98,9 +98,8 @@ def system(session):
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
     # Sanity check: Only run tests if the environment variable is set.
-    if not os.getenv("FIRESTORE_EMULATOR_HOST"):
-        if not os.environ.get("FIRESTORE_APPLICATION_CREDENTIALS", ""):
-            session.skip("Credentials must be set via environment variable")
+    if not os.environ.get("FIRESTORE_APPLICATION_CREDENTIALS", ""):
+        session.skip("Credentials must be set via environment variable")
 
     system_test_exists = os.path.exists(system_test_path)
     system_test_folder_exists = os.path.exists(system_test_folder_path)

--- a/firestore/noxfile.py
+++ b/firestore/noxfile.py
@@ -98,8 +98,9 @@ def system(session):
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
     # Sanity check: Only run tests if the environment variable is set.
-    if not os.environ.get("FIRESTORE_APPLICATION_CREDENTIALS", ""):
-        session.skip("Credentials must be set via environment variable")
+    if not os.getenv("FIRESTORE_EMULATOR_HOST"):
+        if not os.environ.get("FIRESTORE_APPLICATION_CREDENTIALS", ""):
+            session.skip("Credentials must be set via environment variable")
 
     system_test_exists = os.path.exists(system_test_path)
     system_test_folder_exists = os.path.exists(system_test_folder_path)

--- a/firestore/tests/system/test_system.py
+++ b/firestore/tests/system/test_system.py
@@ -43,6 +43,7 @@ DOCUMENT_EXISTS = "Document already exists: "
 UNIQUE_RESOURCE_ID = unique_resource_id("-")
 FIRESTORE_EMULATOR_HOST = "FIRESTORE_EMULATOR_HOST"
 
+
 @pytest.fixture(scope=u"module")
 def client():
     firestore_emulator = os.getenv(FIRESTORE_EMULATOR_HOST)
@@ -50,7 +51,9 @@ def client():
         credentials = EmulatorCreds()
         project = "emulatorproject"
     else:
-        credentials = service_account.Credentials.from_service_account_file(FIRESTORE_CREDS)
+        credentials = service_account.Credentials.from_service_account_file(
+            FIRESTORE_CREDS
+        )
         project = FIRESTORE_PROJECT or credentials.project_id
     yield firestore.Client(project=project, credentials=credentials)
 

--- a/firestore/tests/system/test_system.py
+++ b/firestore/tests/system/test_system.py
@@ -136,7 +136,7 @@ def test_create_document_w_subcollection(client, cleanup):
     assert sorted(child.id for child in children) == sorted(child_ids)
 
 
-@pytest.mark.skipif(IN_EMULATOR, reason="Not supported in emulator.")
+@pytest.mark.skipif(IN_EMULATOR, reason="Internal Issue b/137866686")
 def test_cannot_use_foreign_key(client, cleanup):
     document_id = "cannot" + UNIQUE_RESOURCE_ID
     document = client.document("foreign-key", document_id)
@@ -291,7 +291,7 @@ def test_document_update_w_int_field(client, cleanup):
     assert snapshot1.to_dict() == expected
 
 
-@pytest.mark.skipif(IN_EMULATOR, reason="Not supported in emulator.")
+@pytest.mark.skipif(IN_EMULATOR, reason="Internal Issue b/137867104")
 def test_update_document(client, cleanup):
     document_id = "for-update" + UNIQUE_RESOURCE_ID
     document = client.document("made", document_id)
@@ -504,7 +504,6 @@ def test_collection_add(client, cleanup):
     assert set(collection3.list_documents()) == {document_ref5}
 
 
-@pytest.mark.skipif(IN_EMULATOR, reason="Not supported in emulator.")
 def test_query_stream(client, cleanup):
     collection_id = "qs" + UNIQUE_RESOURCE_ID
     sub_collection = "child" + UNIQUE_RESOURCE_ID
@@ -819,7 +818,7 @@ def test_collection_group_queries_filters(client, cleanup):
     assert found == set(["cg-doc2"])
 
 
-@pytest.mark.skipif(IN_EMULATOR, reason="Not supported in emulator.")
+@pytest.mark.skipif(IN_EMULATOR, reason="Internal Issue b/137865992")
 def test_get_all(client, cleanup):
     collection_name = "get-all" + UNIQUE_RESOURCE_ID
 
@@ -871,7 +870,6 @@ def test_get_all(client, cleanup):
     check_snapshot(snapshot3, document3, restricted3, write_result3)
 
 
-@pytest.mark.skipif(IN_EMULATOR, reason="Not supported in emulator.")
 def test_batch(client, cleanup):
     collection_name = "batch" + UNIQUE_RESOURCE_ID
 

--- a/firestore/tests/system/test_system.py
+++ b/firestore/tests/system/test_system.py
@@ -43,11 +43,12 @@ DOCUMENT_EXISTS = "Document already exists: "
 UNIQUE_RESOURCE_ID = unique_resource_id("-")
 FIRESTORE_EMULATOR_HOST = "FIRESTORE_EMULATOR_HOST"
 
+IN_EMULATOR = os.getenv(FIRESTORE_EMULATOR_HOST) is not None
+
 
 @pytest.fixture(scope=u"module")
 def client():
-    firestore_emulator = os.getenv(FIRESTORE_EMULATOR_HOST)
-    if firestore_emulator is not None:
+    if IN_EMULATOR:
         credentials = EmulatorCreds()
         project = "emulatorproject"
     else:
@@ -135,6 +136,7 @@ def test_create_document_w_subcollection(client, cleanup):
     assert sorted(child.id for child in children) == sorted(child_ids)
 
 
+@pytest.mark.skipif(IN_EMULATOR, reason="Not supported in emulator.")
 def test_cannot_use_foreign_key(client, cleanup):
     document_id = "cannot" + UNIQUE_RESOURCE_ID
     document = client.document("foreign-key", document_id)
@@ -289,6 +291,7 @@ def test_document_update_w_int_field(client, cleanup):
     assert snapshot1.to_dict() == expected
 
 
+@pytest.mark.skipif(IN_EMULATOR, reason="Not supported in emulator.")
 def test_update_document(client, cleanup):
     document_id = "for-update" + UNIQUE_RESOURCE_ID
     document = client.document("made", document_id)
@@ -501,6 +504,7 @@ def test_collection_add(client, cleanup):
     assert set(collection3.list_documents()) == {document_ref5}
 
 
+@pytest.mark.skipif(IN_EMULATOR, reason="Not supported in emulator.")
 def test_query_stream(client, cleanup):
     collection_id = "qs" + UNIQUE_RESOURCE_ID
     sub_collection = "child" + UNIQUE_RESOURCE_ID
@@ -815,6 +819,7 @@ def test_collection_group_queries_filters(client, cleanup):
     assert found == set(["cg-doc2"])
 
 
+@pytest.mark.skipif(IN_EMULATOR, reason="Not supported in emulator.")
 def test_get_all(client, cleanup):
     collection_name = "get-all" + UNIQUE_RESOURCE_ID
 
@@ -866,6 +871,7 @@ def test_get_all(client, cleanup):
     check_snapshot(snapshot3, document3, restricted3, write_result3)
 
 
+@pytest.mark.skipif(IN_EMULATOR, reason="Not supported in emulator.")
 def test_batch(client, cleanup):
     collection_name = "batch" + UNIQUE_RESOURCE_ID
 

--- a/firestore/tests/system/test_system.py
+++ b/firestore/tests/system/test_system.py
@@ -31,6 +31,7 @@ from google.cloud._helpers import _pb_timestamp_to_datetime
 from google.cloud._helpers import UTC
 from google.cloud import firestore_v1 as firestore
 from test_utils.system import unique_resource_id
+from test_utils.system import EmulatorCreds
 
 from time import sleep
 
@@ -40,12 +41,17 @@ RANDOM_ID_REGEX = re.compile("^[a-zA-Z0-9]{20}$")
 MISSING_DOCUMENT = "No document to update: "
 DOCUMENT_EXISTS = "Document already exists: "
 UNIQUE_RESOURCE_ID = unique_resource_id("-")
-
+FIRESTORE_EMULATOR_HOST = "FIRESTORE_EMULATOR_HOST"
 
 @pytest.fixture(scope=u"module")
 def client():
-    credentials = service_account.Credentials.from_service_account_file(FIRESTORE_CREDS)
-    project = FIRESTORE_PROJECT or credentials.project_id
+    firestore_emulator = os.getenv(FIRESTORE_EMULATOR_HOST)
+    if firestore_emulator is not None:
+        credentials = EmulatorCreds()
+        project = "emulatorproject"
+    else:
+        credentials = service_account.Credentials.from_service_account_file(FIRESTORE_CREDS)
+        project = FIRESTORE_PROJECT or credentials.project_id
     yield firestore.Client(project=project, credentials=credentials)
 
 


### PR DESCRIPTION
Towards #8722 

- Updated sys tests to make them run on emulator. 

- Marked some tests as skipped as those functionalities still not supported on emulator.