### PR TITLE
docs(bigquery): document how to load data as JSON string

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1644,6 +1644,22 @@ class Client(ClientWithProject):
             json_rows (Iterable[Dict[str, Any]]):
                 Row data to be inserted. Keys must match the table schema fields
                 and values must be JSON-compatible representations.
+
+                .. note::
+
+                    If your data is already a newline-delimited JSON string,
+                    it is best to wrap it into a file-like object and pass it
+                    to :meth:`~google.cloud.bigquery.client.Client.load_table_from_file`::
+
+                        import io
+                        from google.cloud import bigquery
+
+                        data = u'{"foo": "bar"}'
+                        data_as_file = io.StringIO(data)
+
+                        client = bigquery.Client()
+                        client.load_table_from_file(data_as_file, ...)
+
             destination (Union[ \
                 :class:`~google.cloud.bigquery.table.Table`, \
                 :class:`~google.cloud.bigquery.table.TableReference`, \


### PR DESCRIPTION
Closes #9203.

This PR documents how to load table data from a JSON string. This will make it less likely for the users to try loading JSON string data with the `load_table_from_json()` method (the latter expects an iterable of dicts.

We opted not to add a yet another load method `load_table_from_string`, as that will more or less just repeat the logic from `load_table_from_file()`, and because wrapping string data into a file-like object is straightforward.