### PR TITLE
Revert "Monitoring: Allow recursive group deletion, deprecate internal checkers, add SSL validation and content match options to uptime check (via synth)."

### DIFF
--- a/monitoring/google/cloud/monitoring_v3/gapic/enums.py
+++ b/monitoring/google/cloud/monitoring_v3/gapic/enums.py
@@ -397,28 +397,6 @@ class AlertPolicy(object):
         AND_WITH_MATCHING_RESOURCE = 3
 
 
-class InternalChecker(object):
-    class State(enum.IntEnum):
-        """
-        Operational states for an internal checker.
-
-        Attributes:
-          UNSPECIFIED (int): An internal checker should never be in the unspecified state.
-          CREATING (int): The checker is being created, provisioned, and configured. A checker in
-          this state can be returned by ListInternalCheckers or GetInternalChecker,
-          as well as by examining the longrunning.Operation that created it.
-          RUNNING (int): The checker is running and available for use. A checker in this state
-          can be returned by ListInternalCheckers or GetInternalChecker as well
-          as by examining the longrunning.Operation that created it.
-          If a checker is being torn down, it is neither visible nor usable, so
-          there is no "deleting" or "down" state.
-        """
-
-        UNSPECIFIED = 0
-        CREATING = 1
-        RUNNING = 2
-
-
 class LabelDescriptor(object):
     class ValueType(enum.IntEnum):
         """
@@ -520,26 +498,3 @@ class NotificationChannel(object):
         VERIFICATION_STATUS_UNSPECIFIED = 0
         UNVERIFIED = 1
         VERIFIED = 2
-
-
-class UptimeCheckConfig(object):
-    class ContentMatcher(object):
-        class ContentMatcherOption(enum.IntEnum):
-            """
-            Options to perform content matching.
-
-            Attributes:
-              CONTENT_MATCHER_OPTION_UNSPECIFIED (int): No content macher option specified. Treated as CONTAINS\_STRING.
-              CONTAINS_STRING (int): Allows checking substring matching.
-              Default value for previous versions without option.
-              NOT_CONTAINS_STRING (int): Allows checking negation of substring matching (doesn't contain the
-              substring).
-              MATCHES_REGEX (int): Allows checking regular expression matching.
-              NOT_MATCHES_REGEX (int): Allows checking negation of regular expression matching.
-            """
-
-            CONTENT_MATCHER_OPTION_UNSPECIFIED = 0
-            CONTAINS_STRING = 1
-            NOT_CONTAINS_STRING = 2
-            MATCHES_REGEX = 3
-            NOT_MATCHES_REGEX = 4

--- a/monitoring/google/cloud/monitoring_v3/gapic/group_service_client.py
+++ b/monitoring/google/cloud/monitoring_v3/gapic/group_service_client.py
@@ -599,7 +599,6 @@ class GroupServiceClient(object):
     def delete_group(
         self,
         name,
-        recursive=None,
         retry=google.api_core.gapic_v1.method.DEFAULT,
         timeout=google.api_core.gapic_v1.method.DEFAULT,
         metadata=None,
@@ -619,9 +618,6 @@ class GroupServiceClient(object):
         Args:
             name (str): The group to delete. The format is
                 ``"projects/{project_id_or_number}/groups/{group_id}"``.
-            recursive (bool): If this field is true, then the request means to delete a group with all
-                its descendants. Otherwise, the request means to delete a group only when
-                it has no descendants. The default value is false.
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will
                 be retried using a default configuration.
@@ -652,7 +648,7 @@ class GroupServiceClient(object):
                 client_info=self._client_info,
             )
 
-        request = group_service_pb2.DeleteGroupRequest(name=name, recursive=recursive)
+        request = group_service_pb2.DeleteGroupRequest(name=name)
         if metadata is None:
             metadata = []
         metadata = list(metadata)

--- a/monitoring/google/cloud/monitoring_v3/gapic/metric_service_client.py
+++ b/monitoring/google/cloud/monitoring_v3/gapic/metric_service_client.py
@@ -236,7 +236,8 @@ class MetricServiceClient(object):
         metadata=None,
     ):
         """
-        Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
+        Lists monitored resource descriptors that match a filter. This method does
+        not require a Stackdriver account.
 
         Example:
             >>> from google.cloud import monitoring_v3
@@ -355,7 +356,8 @@ class MetricServiceClient(object):
         metadata=None,
     ):
         """
-        Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
+        Gets a single monitored resource descriptor. This method does not require a
+        Stackdriver account.
 
         Example:
             >>> from google.cloud import monitoring_v3
@@ -436,7 +438,8 @@ class MetricServiceClient(object):
         metadata=None,
     ):
         """
-        Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
+        Lists metric descriptors that match a filter. This method does not require
+        a Stackdriver account.
 
         Example:
             >>> from google.cloud import monitoring_v3
@@ -552,7 +555,8 @@ class MetricServiceClient(object):
         metadata=None,
     ):
         """
-        Gets a single metric descriptor. This method does not require a Stackdriver account.
+        Gets a single metric descriptor. This method does not require a Stackdriver
+        account.
 
         Example:
             >>> from google.cloud import monitoring_v3
@@ -793,7 +797,8 @@ class MetricServiceClient(object):
         metadata=None,
     ):
         """
-        Lists time series that match a filter. This method does not require a Stackdriver account.
+        Lists time series that match a filter. This method does not require a
+        Stackdriver account.
 
         Example:
             >>> from google.cloud import monitoring_v3
@@ -838,7 +843,7 @@ class MetricServiceClient(object):
                 ::
 
                      metric.type = "compute.googleapis.com/instance/cpu/usage_time" AND
-                         metric.labels.instance_name = "my-instance-name"
+                         metric.label.instance_name = "my-instance-name"
             interval (Union[dict, ~google.cloud.monitoring_v3.types.TimeInterval]): The time interval for which results should be returned. Only time series
                 that contain data points in the specified interval are included
                 in the response.
@@ -966,9 +971,6 @@ class MetricServiceClient(object):
                 recent than any other point in its time series. Each ``TimeSeries``
                 value must fully specify a unique time series by supplying all label
                 values for the metric and the monitored resource.
-
-                The maximum number of ``TimeSeries`` objects per ``Create`` request is
-                200.
 
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.monitoring_v3.types.TimeSeries`

--- a/monitoring/google/cloud/monitoring_v3/gapic/transports/metric_service_grpc_transport.py
+++ b/monitoring/google/cloud/monitoring_v3/gapic/transports/metric_service_grpc_transport.py
@@ -116,7 +116,8 @@ class MetricServiceGrpcTransport(object):
     def list_monitored_resource_descriptors(self):
         """Return the gRPC stub for :meth:`MetricServiceClient.list_monitored_resource_descriptors`.
 
-        Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
+        Lists monitored resource descriptors that match a filter. This method does
+        not require a Stackdriver account.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -129,7 +130,8 @@ class MetricServiceGrpcTransport(object):
     def get_monitored_resource_descriptor(self):
         """Return the gRPC stub for :meth:`MetricServiceClient.get_monitored_resource_descriptor`.
 
-        Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
+        Gets a single monitored resource descriptor. This method does not require a
+        Stackdriver account.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -142,7 +144,8 @@ class MetricServiceGrpcTransport(object):
     def list_metric_descriptors(self):
         """Return the gRPC stub for :meth:`MetricServiceClient.list_metric_descriptors`.
 
-        Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
+        Lists metric descriptors that match a filter. This method does not require
+        a Stackdriver account.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -155,7 +158,8 @@ class MetricServiceGrpcTransport(object):
     def get_metric_descriptor(self):
         """Return the gRPC stub for :meth:`MetricServiceClient.get_metric_descriptor`.
 
-        Gets a single metric descriptor. This method does not require a Stackdriver account.
+        Gets a single metric descriptor. This method does not require a Stackdriver
+        account.
 
         Returns:
             Callable: A callable which accepts the appropriate
@@ -197,7 +201,8 @@ class MetricServiceGrpcTransport(object):
     def list_time_series(self):
         """Return the gRPC stub for :meth:`MetricServiceClient.list_time_series`.
 
-        Lists time series that match a filter. This method does not require a Stackdriver account.
+        Lists time series that match a filter. This method does not require a
+        Stackdriver account.
 
         Returns:
             Callable: A callable which accepts the appropriate

--- a/monitoring/google/cloud/monitoring_v3/proto/alert.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/alert.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@ syntax = "proto3";
 
 package google.monitoring.v3;
 
+import "google/api/annotations.proto";
 import "google/monitoring/v3/common.proto";
 import "google/monitoring/v3/mutation_record.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
-import "google/rpc/status.proto";
 
 option csharp_namespace = "Google.Cloud.Monitoring.V3";
 option go_package = "google.golang.org/genproto/googleapis/monitoring/v3;monitoring";
@@ -324,10 +324,6 @@ message AlertPolicy {
   // field should always be populated on List and Get operations, unless
   // a field projection has been specified that strips it out.
   google.protobuf.BoolValue enabled = 17;
-
-  // Read-only description of how the alert policy is invalid. OK if the alert
-  // policy is valid. If not OK, the alert policy will not generate incidents.
-  google.rpc.Status validity = 18;
 
   // Identifies the notification channels to which notifications should be sent
   // when incidents are opened or closed or when new violations occur on

--- a/monitoring/google/cloud/monitoring_v3/proto/alert_pb2.py
+++ b/monitoring/google/cloud/monitoring_v3/proto/alert_pb2.py
@@ -15,6 +15,7 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
+from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 from google.cloud.monitoring_v3.proto import (
     common_pb2 as google_dot_cloud_dot_monitoring__v3_dot_proto_dot_common__pb2,
 )
@@ -23,7 +24,6 @@ from google.cloud.monitoring_v3.proto import (
 )
 from google.protobuf import duration_pb2 as google_dot_protobuf_dot_duration__pb2
 from google.protobuf import wrappers_pb2 as google_dot_protobuf_dot_wrappers__pb2
-from google.rpc import status_pb2 as google_dot_rpc_dot_status__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -34,14 +34,14 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         "\n\030com.google.monitoring.v3B\nAlertProtoP\001Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\252\002\032Google.Cloud.Monitoring.V3\312\002\032Google\\Cloud\\Monitoring\\V3"
     ),
     serialized_pb=_b(
-        '\n,google/cloud/monitoring_v3/proto/alert.proto\x12\x14google.monitoring.v3\x1a-google/cloud/monitoring_v3/proto/common.proto\x1a\x36google/cloud/monitoring_v3/proto/mutation_record.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x17google/rpc/status.proto"\x83\r\n\x0b\x41lertPolicy\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x02 \x01(\t\x12\x46\n\rdocumentation\x18\r \x01(\x0b\x32/.google.monitoring.v3.AlertPolicy.Documentation\x12\x46\n\x0buser_labels\x18\x10 \x03(\x0b\x32\x31.google.monitoring.v3.AlertPolicy.UserLabelsEntry\x12?\n\nconditions\x18\x0c \x03(\x0b\x32+.google.monitoring.v3.AlertPolicy.Condition\x12I\n\x08\x63ombiner\x18\x06 \x01(\x0e\x32\x37.google.monitoring.v3.AlertPolicy.ConditionCombinerType\x12+\n\x07\x65nabled\x18\x11 \x01(\x0b\x32\x1a.google.protobuf.BoolValue\x12$\n\x08validity\x18\x12 \x01(\x0b\x32\x12.google.rpc.Status\x12\x1d\n\x15notification_channels\x18\x0e \x03(\t\x12=\n\x0f\x63reation_record\x18\n \x01(\x0b\x32$.google.monitoring.v3.MutationRecord\x12=\n\x0fmutation_record\x18\x0b \x01(\x0b\x32$.google.monitoring.v3.MutationRecord\x1a\x33\n\rDocumentation\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\x12\x11\n\tmime_type\x18\x02 \x01(\t\x1a\xf8\x06\n\tCondition\x12\x0c\n\x04name\x18\x0c \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x06 \x01(\t\x12Z\n\x13\x63ondition_threshold\x18\x01 \x01(\x0b\x32;.google.monitoring.v3.AlertPolicy.Condition.MetricThresholdH\x00\x12U\n\x10\x63ondition_absent\x18\x02 \x01(\x0b\x32\x39.google.monitoring.v3.AlertPolicy.Condition.MetricAbsenceH\x00\x1a\x35\n\x07Trigger\x12\x0f\n\x05\x63ount\x18\x01 \x01(\x05H\x00\x12\x11\n\x07percent\x18\x02 \x01(\x01H\x00\x42\x06\n\x04type\x1a\x81\x03\n\x0fMetricThreshold\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x37\n\x0c\x61ggregations\x18\x08 \x03(\x0b\x32!.google.monitoring.v3.Aggregation\x12\x1a\n\x12\x64\x65nominator_filter\x18\t \x01(\t\x12\x43\n\x18\x64\x65nominator_aggregations\x18\n \x03(\x0b\x32!.google.monitoring.v3.Aggregation\x12\x38\n\ncomparison\x18\x04 \x01(\x0e\x32$.google.monitoring.v3.ComparisonType\x12\x17\n\x0fthreshold_value\x18\x05 \x01(\x01\x12+\n\x08\x64uration\x18\x06 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x44\n\x07trigger\x18\x07 \x01(\x0b\x32\x33.google.monitoring.v3.AlertPolicy.Condition.Trigger\x1a\xcb\x01\n\rMetricAbsence\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x37\n\x0c\x61ggregations\x18\x05 \x03(\x0b\x32!.google.monitoring.v3.Aggregation\x12+\n\x08\x64uration\x18\x02 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x44\n\x07trigger\x18\x03 \x01(\x0b\x32\x33.google.monitoring.v3.AlertPolicy.Condition.TriggerB\x0b\n\tcondition\x1a\x31\n\x0fUserLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"a\n\x15\x43onditionCombinerType\x12\x17\n\x13\x43OMBINE_UNSPECIFIED\x10\x00\x12\x07\n\x03\x41ND\x10\x01\x12\x06\n\x02OR\x10\x02\x12\x1e\n\x1a\x41ND_WITH_MATCHING_RESOURCE\x10\x03\x42\xa2\x01\n\x18\x63om.google.monitoring.v3B\nAlertProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
+        '\n,google/cloud/monitoring_v3/proto/alert.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a-google/cloud/monitoring_v3/proto/common.proto\x1a\x36google/cloud/monitoring_v3/proto/mutation_record.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto"\xdd\x0c\n\x0b\x41lertPolicy\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x02 \x01(\t\x12\x46\n\rdocumentation\x18\r \x01(\x0b\x32/.google.monitoring.v3.AlertPolicy.Documentation\x12\x46\n\x0buser_labels\x18\x10 \x03(\x0b\x32\x31.google.monitoring.v3.AlertPolicy.UserLabelsEntry\x12?\n\nconditions\x18\x0c \x03(\x0b\x32+.google.monitoring.v3.AlertPolicy.Condition\x12I\n\x08\x63ombiner\x18\x06 \x01(\x0e\x32\x37.google.monitoring.v3.AlertPolicy.ConditionCombinerType\x12+\n\x07\x65nabled\x18\x11 \x01(\x0b\x32\x1a.google.protobuf.BoolValue\x12\x1d\n\x15notification_channels\x18\x0e \x03(\t\x12=\n\x0f\x63reation_record\x18\n \x01(\x0b\x32$.google.monitoring.v3.MutationRecord\x12=\n\x0fmutation_record\x18\x0b \x01(\x0b\x32$.google.monitoring.v3.MutationRecord\x1a\x33\n\rDocumentation\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\x12\x11\n\tmime_type\x18\x02 \x01(\t\x1a\xf8\x06\n\tCondition\x12\x0c\n\x04name\x18\x0c \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x06 \x01(\t\x12Z\n\x13\x63ondition_threshold\x18\x01 \x01(\x0b\x32;.google.monitoring.v3.AlertPolicy.Condition.MetricThresholdH\x00\x12U\n\x10\x63ondition_absent\x18\x02 \x01(\x0b\x32\x39.google.monitoring.v3.AlertPolicy.Condition.MetricAbsenceH\x00\x1a\x35\n\x07Trigger\x12\x0f\n\x05\x63ount\x18\x01 \x01(\x05H\x00\x12\x11\n\x07percent\x18\x02 \x01(\x01H\x00\x42\x06\n\x04type\x1a\x81\x03\n\x0fMetricThreshold\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x37\n\x0c\x61ggregations\x18\x08 \x03(\x0b\x32!.google.monitoring.v3.Aggregation\x12\x1a\n\x12\x64\x65nominator_filter\x18\t \x01(\t\x12\x43\n\x18\x64\x65nominator_aggregations\x18\n \x03(\x0b\x32!.google.monitoring.v3.Aggregation\x12\x38\n\ncomparison\x18\x04 \x01(\x0e\x32$.google.monitoring.v3.ComparisonType\x12\x17\n\x0fthreshold_value\x18\x05 \x01(\x01\x12+\n\x08\x64uration\x18\x06 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x44\n\x07trigger\x18\x07 \x01(\x0b\x32\x33.google.monitoring.v3.AlertPolicy.Condition.Trigger\x1a\xcb\x01\n\rMetricAbsence\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x37\n\x0c\x61ggregations\x18\x05 \x03(\x0b\x32!.google.monitoring.v3.Aggregation\x12+\n\x08\x64uration\x18\x02 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x44\n\x07trigger\x18\x03 \x01(\x0b\x32\x33.google.monitoring.v3.AlertPolicy.Condition.TriggerB\x0b\n\tcondition\x1a\x31\n\x0fUserLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"a\n\x15\x43onditionCombinerType\x12\x17\n\x13\x43OMBINE_UNSPECIFIED\x10\x00\x12\x07\n\x03\x41ND\x10\x01\x12\x06\n\x02OR\x10\x02\x12\x1e\n\x1a\x41ND_WITH_MATCHING_RESOURCE\x10\x03\x42\xa2\x01\n\x18\x63om.google.monitoring.v3B\nAlertProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
     ),
     dependencies=[
+        google_dot_api_dot_annotations__pb2.DESCRIPTOR,
         google_dot_cloud_dot_monitoring__v3_dot_proto_dot_common__pb2.DESCRIPTOR,
         google_dot_cloud_dot_monitoring__v3_dot_proto_dot_mutation__record__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_duration__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_wrappers__pb2.DESCRIPTOR,
-        google_dot_rpc_dot_status__pb2.DESCRIPTOR,
     ],
 )
 
@@ -75,8 +75,8 @@ _ALERTPOLICY_CONDITIONCOMBINERTYPE = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=None,
-    serialized_start=1833,
-    serialized_end=1930,
+    serialized_start=1800,
+    serialized_end=1897,
 )
 _sym_db.RegisterEnumDescriptor(_ALERTPOLICY_CONDITIONCOMBINERTYPE)
 
@@ -133,8 +133,8 @@ _ALERTPOLICY_DOCUMENTATION = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=838,
-    serialized_end=889,
+    serialized_start=805,
+    serialized_end=856,
 )
 
 _ALERTPOLICY_CONDITION_TRIGGER = _descriptor.Descriptor(
@@ -197,8 +197,8 @@ _ALERTPOLICY_CONDITION_TRIGGER = _descriptor.Descriptor(
             fields=[],
         )
     ],
-    serialized_start=1120,
-    serialized_end=1173,
+    serialized_start=1087,
+    serialized_end=1140,
 )
 
 _ALERTPOLICY_CONDITION_METRICTHRESHOLD = _descriptor.Descriptor(
@@ -361,8 +361,8 @@ _ALERTPOLICY_CONDITION_METRICTHRESHOLD = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1176,
-    serialized_end=1561,
+    serialized_start=1143,
+    serialized_end=1528,
 )
 
 _ALERTPOLICY_CONDITION_METRICABSENCE = _descriptor.Descriptor(
@@ -453,8 +453,8 @@ _ALERTPOLICY_CONDITION_METRICABSENCE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1564,
-    serialized_end=1767,
+    serialized_start=1531,
+    serialized_end=1734,
 )
 
 _ALERTPOLICY_CONDITION = _descriptor.Descriptor(
@@ -557,8 +557,8 @@ _ALERTPOLICY_CONDITION = _descriptor.Descriptor(
             fields=[],
         )
     ],
-    serialized_start=892,
-    serialized_end=1780,
+    serialized_start=859,
+    serialized_end=1747,
 )
 
 _ALERTPOLICY_USERLABELSENTRY = _descriptor.Descriptor(
@@ -613,8 +613,8 @@ _ALERTPOLICY_USERLABELSENTRY = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1782,
-    serialized_end=1831,
+    serialized_start=1749,
+    serialized_end=1798,
 )
 
 _ALERTPOLICY = _descriptor.Descriptor(
@@ -751,27 +751,9 @@ _ALERTPOLICY = _descriptor.Descriptor(
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
-            name="validity",
-            full_name="google.monitoring.v3.AlertPolicy.validity",
-            index=7,
-            number=18,
-            type=11,
-            cpp_type=10,
-            label=1,
-            has_default_value=False,
-            default_value=None,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
             name="notification_channels",
             full_name="google.monitoring.v3.AlertPolicy.notification_channels",
-            index=8,
+            index=7,
             number=14,
             type=9,
             cpp_type=9,
@@ -789,7 +771,7 @@ _ALERTPOLICY = _descriptor.Descriptor(
         _descriptor.FieldDescriptor(
             name="creation_record",
             full_name="google.monitoring.v3.AlertPolicy.creation_record",
-            index=9,
+            index=8,
             number=10,
             type=11,
             cpp_type=10,
@@ -807,7 +789,7 @@ _ALERTPOLICY = _descriptor.Descriptor(
         _descriptor.FieldDescriptor(
             name="mutation_record",
             full_name="google.monitoring.v3.AlertPolicy.mutation_record",
-            index=10,
+            index=9,
             number=11,
             type=11,
             cpp_type=10,
@@ -835,8 +817,8 @@ _ALERTPOLICY = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=263,
-    serialized_end=1930,
+    serialized_start=268,
+    serialized_end=1897,
 )
 
 _ALERTPOLICY_DOCUMENTATION.containing_type = _ALERTPOLICY
@@ -914,9 +896,6 @@ _ALERTPOLICY.fields_by_name["combiner"].enum_type = _ALERTPOLICY_CONDITIONCOMBIN
 _ALERTPOLICY.fields_by_name[
     "enabled"
 ].message_type = google_dot_protobuf_dot_wrappers__pb2._BOOLVALUE
-_ALERTPOLICY.fields_by_name[
-    "validity"
-].message_type = google_dot_rpc_dot_status__pb2._STATUS
 _ALERTPOLICY.fields_by_name[
     "creation_record"
 ].message_type = (
@@ -1243,10 +1222,6 @@ AlertPolicy = _reflection.GeneratedProtocolMessageType(
           if it has not been populated. The field should always be
           populated on List and Get operations, unless a field
           projection has been specified that strips it out.
-      validity:
-          Read-only description of how the alert policy is invalid. OK
-          if the alert policy is valid. If not OK, the alert policy will
-          not generate incidents.
       notification_channels:
           Identifies the notification channels to which notifications
           should be sent when incidents are opened or closed or when new

--- a/monitoring/google/cloud/monitoring_v3/proto/alert_service.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/alert_service.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import "google/api/annotations.proto";
 import "google/monitoring/v3/alert.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
-import "google/api/client.proto";
 
 option csharp_namespace = "Google.Cloud.Monitoring.V3";
 option go_package = "google.golang.org/genproto/googleapis/monitoring/v3;monitoring";
@@ -40,14 +39,9 @@ option php_namespace = "Google\\Cloud\\Monitoring\\V3";
 // which can be reached by clicking the "Monitoring" tab in
 // [Cloud Console](https://console.cloud.google.com/).
 service AlertPolicyService {
-  option (google.api.default_host) = "monitoring.googleapis.com";
-  option (google.api.oauth_scopes) =
-      "https://www.googleapis.com/auth/cloud-platform,"
-      "https://www.googleapis.com/auth/monitoring,"
-      "https://www.googleapis.com/auth/monitoring.read";
-
   // Lists the existing alerting policies for the project.
-  rpc ListAlertPolicies(ListAlertPoliciesRequest) returns (ListAlertPoliciesResponse) {
+  rpc ListAlertPolicies(ListAlertPoliciesRequest)
+      returns (ListAlertPoliciesResponse) {
     option (google.api.http) = {
       get: "/v3/{name=projects/*}/alertPolicies"
     };
@@ -69,7 +63,8 @@ service AlertPolicyService {
   }
 
   // Deletes an alerting policy.
-  rpc DeleteAlertPolicy(DeleteAlertPolicyRequest) returns (google.protobuf.Empty) {
+  rpc DeleteAlertPolicy(DeleteAlertPolicyRequest)
+      returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v3/{name=projects/*/alertPolicies/*}"
     };

--- a/monitoring/google/cloud/monitoring_v3/proto/alert_service_pb2.py
+++ b/monitoring/google/cloud/monitoring_v3/proto/alert_service_pb2.py
@@ -21,7 +21,6 @@ from google.cloud.monitoring_v3.proto import (
 )
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from google.protobuf import field_mask_pb2 as google_dot_protobuf_dot_field__mask__pb2
-from google.api import client_pb2 as google_dot_api_dot_client__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -32,14 +31,13 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         "\n\030com.google.monitoring.v3B\021AlertServiceProtoP\001Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\252\002\032Google.Cloud.Monitoring.V3\312\002\032Google\\Cloud\\Monitoring\\V3"
     ),
     serialized_pb=_b(
-        '\n4google/cloud/monitoring_v3/proto/alert_service.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a,google/cloud/monitoring_v3/proto/alert.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a google/protobuf/field_mask.proto\x1a\x17google/api/client.proto"a\n\x18\x43reateAlertPolicyRequest\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x37\n\x0c\x61lert_policy\x18\x02 \x01(\x0b\x32!.google.monitoring.v3.AlertPolicy"%\n\x15GetAlertPolicyRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"q\n\x18ListAlertPoliciesRequest\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x05 \x01(\t\x12\x10\n\x08order_by\x18\x06 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"o\n\x19ListAlertPoliciesResponse\x12\x39\n\x0e\x61lert_policies\x18\x03 \x03(\x0b\x32!.google.monitoring.v3.AlertPolicy\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"\x84\x01\n\x18UpdateAlertPolicyRequest\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask\x12\x37\n\x0c\x61lert_policy\x18\x03 \x01(\x0b\x32!.google.monitoring.v3.AlertPolicy"(\n\x18\x44\x65leteAlertPolicyRequest\x12\x0c\n\x04name\x18\x03 \x01(\t2\xda\x07\n\x12\x41lertPolicyService\x12\xa1\x01\n\x11ListAlertPolicies\x12..google.monitoring.v3.ListAlertPoliciesRequest\x1a/.google.monitoring.v3.ListAlertPoliciesResponse"+\x82\xd3\xe4\x93\x02%\x12#/v3/{name=projects/*}/alertPolicies\x12\x8f\x01\n\x0eGetAlertPolicy\x12+.google.monitoring.v3.GetAlertPolicyRequest\x1a!.google.monitoring.v3.AlertPolicy"-\x82\xd3\xe4\x93\x02\'\x12%/v3/{name=projects/*/alertPolicies/*}\x12\xa1\x01\n\x11\x43reateAlertPolicy\x12..google.monitoring.v3.CreateAlertPolicyRequest\x1a!.google.monitoring.v3.AlertPolicy"9\x82\xd3\xe4\x93\x02\x33"#/v3/{name=projects/*}/alertPolicies:\x0c\x61lert_policy\x12\x8a\x01\n\x11\x44\x65leteAlertPolicy\x12..google.monitoring.v3.DeleteAlertPolicyRequest\x1a\x16.google.protobuf.Empty"-\x82\xd3\xe4\x93\x02\'*%/v3/{name=projects/*/alertPolicies/*}\x12\xb0\x01\n\x11UpdateAlertPolicy\x12..google.monitoring.v3.UpdateAlertPolicyRequest\x1a!.google.monitoring.v3.AlertPolicy"H\x82\xd3\xe4\x93\x02\x42\x32\x32/v3/{alert_policy.name=projects/*/alertPolicies/*}:\x0c\x61lert_policy\x1a\xa9\x01\xca\x41\x19monitoring.googleapis.com\xd2\x41\x89\x01https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/monitoring.readB\xa9\x01\n\x18\x63om.google.monitoring.v3B\x11\x41lertServiceProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
+        '\n4google/cloud/monitoring_v3/proto/alert_service.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a,google/cloud/monitoring_v3/proto/alert.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a google/protobuf/field_mask.proto"a\n\x18\x43reateAlertPolicyRequest\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x37\n\x0c\x61lert_policy\x18\x02 \x01(\x0b\x32!.google.monitoring.v3.AlertPolicy"%\n\x15GetAlertPolicyRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"q\n\x18ListAlertPoliciesRequest\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x05 \x01(\t\x12\x10\n\x08order_by\x18\x06 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"o\n\x19ListAlertPoliciesResponse\x12\x39\n\x0e\x61lert_policies\x18\x03 \x03(\x0b\x32!.google.monitoring.v3.AlertPolicy\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"\x84\x01\n\x18UpdateAlertPolicyRequest\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask\x12\x37\n\x0c\x61lert_policy\x18\x03 \x01(\x0b\x32!.google.monitoring.v3.AlertPolicy"(\n\x18\x44\x65leteAlertPolicyRequest\x12\x0c\n\x04name\x18\x03 \x01(\t2\xae\x06\n\x12\x41lertPolicyService\x12\xa1\x01\n\x11ListAlertPolicies\x12..google.monitoring.v3.ListAlertPoliciesRequest\x1a/.google.monitoring.v3.ListAlertPoliciesResponse"+\x82\xd3\xe4\x93\x02%\x12#/v3/{name=projects/*}/alertPolicies\x12\x8f\x01\n\x0eGetAlertPolicy\x12+.google.monitoring.v3.GetAlertPolicyRequest\x1a!.google.monitoring.v3.AlertPolicy"-\x82\xd3\xe4\x93\x02\'\x12%/v3/{name=projects/*/alertPolicies/*}\x12\xa1\x01\n\x11\x43reateAlertPolicy\x12..google.monitoring.v3.CreateAlertPolicyRequest\x1a!.google.monitoring.v3.AlertPolicy"9\x82\xd3\xe4\x93\x02\x33"#/v3/{name=projects/*}/alertPolicies:\x0c\x61lert_policy\x12\x8a\x01\n\x11\x44\x65leteAlertPolicy\x12..google.monitoring.v3.DeleteAlertPolicyRequest\x1a\x16.google.protobuf.Empty"-\x82\xd3\xe4\x93\x02\'*%/v3/{name=projects/*/alertPolicies/*}\x12\xb0\x01\n\x11UpdateAlertPolicy\x12..google.monitoring.v3.UpdateAlertPolicyRequest\x1a!.google.monitoring.v3.AlertPolicy"H\x82\xd3\xe4\x93\x02\x42\x32\x32/v3/{alert_policy.name=projects/*/alertPolicies/*}:\x0c\x61lert_policyB\xa9\x01\n\x18\x63om.google.monitoring.v3B\x11\x41lertServiceProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
     ),
     dependencies=[
         google_dot_api_dot_annotations__pb2.DESCRIPTOR,
         google_dot_cloud_dot_monitoring__v3_dot_proto_dot_alert__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_field__mask__pb2.DESCRIPTOR,
-        google_dot_api_dot_client__pb2.DESCRIPTOR,
     ],
 )
 
@@ -96,8 +94,8 @@ _CREATEALERTPOLICYREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=242,
-    serialized_end=339,
+    serialized_start=217,
+    serialized_end=314,
 )
 
 
@@ -135,8 +133,8 @@ _GETALERTPOLICYREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=341,
-    serialized_end=378,
+    serialized_start=316,
+    serialized_end=353,
 )
 
 
@@ -246,8 +244,8 @@ _LISTALERTPOLICIESREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=380,
-    serialized_end=493,
+    serialized_start=355,
+    serialized_end=468,
 )
 
 
@@ -303,8 +301,8 @@ _LISTALERTPOLICIESRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=495,
-    serialized_end=606,
+    serialized_start=470,
+    serialized_end=581,
 )
 
 
@@ -360,8 +358,8 @@ _UPDATEALERTPOLICYREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=609,
-    serialized_end=741,
+    serialized_start=584,
+    serialized_end=716,
 )
 
 
@@ -399,8 +397,8 @@ _DELETEALERTPOLICYREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=743,
-    serialized_end=783,
+    serialized_start=718,
+    serialized_end=758,
 )
 
 _CREATEALERTPOLICYREQUEST.fields_by_name[
@@ -614,11 +612,9 @@ _ALERTPOLICYSERVICE = _descriptor.ServiceDescriptor(
     full_name="google.monitoring.v3.AlertPolicyService",
     file=DESCRIPTOR,
     index=0,
-    serialized_options=_b(
-        "\312A\031monitoring.googleapis.com\322A\211\001https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/monitoring.read"
-    ),
-    serialized_start=786,
-    serialized_end=1772,
+    serialized_options=None,
+    serialized_start=761,
+    serialized_end=1575,
     methods=[
         _descriptor.MethodDescriptor(
             name="ListAlertPolicies",

--- a/monitoring/google/cloud/monitoring_v3/proto/common.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/common.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ syntax = "proto3";
 
 package google.monitoring.v3;
 
+import "google/api/annotations.proto";
 import "google/api/distribution.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
@@ -51,23 +52,9 @@ message TypedValue {
   }
 }
 
-// A closed time interval. It extends from the start time to the end time, and includes both: `[startTime, endTime]`. Valid time intervals depend on the [`MetricKind`](/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors#MetricKind) of the metric value. In no case can the end time be earlier than the start time.
-//
-// * For a `GAUGE` metric, the `startTime` value is technically optional; if
-//   no value is specified, the start time defaults to the value of the
-//   end time, and the interval represents a single point in time. Such an
-//   interval is valid only for `GAUGE` metrics, which are point-in-time
-//   measurements.
-//
-// * For `DELTA` and `CUMULATIVE` metrics, the start time must be earlier
-//   than the end time.
-//
-// * In all cases, the start time of the next interval must be
-//   at least a microsecond after the end time of the previous interval.
-//   Because the interval is closed, if the start time of a new interval
-//   is the same as the end time of the previous interval, data written
-//   at the new start time could overwrite data written at the previous
-//   end time.
+// A time interval extending just after a start time through an end time.
+// If the start time is the same as the end time, then the interval
+// represents a single point in time.
 message TimeInterval {
   // Required. The end of the time interval.
   google.protobuf.Timestamp end_time = 2;

--- a/monitoring/google/cloud/monitoring_v3/proto/common_pb2.py
+++ b/monitoring/google/cloud/monitoring_v3/proto/common_pb2.py
@@ -17,6 +17,7 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
+from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 from google.api import distribution_pb2 as google_dot_api_dot_distribution__pb2
 from google.protobuf import duration_pb2 as google_dot_protobuf_dot_duration__pb2
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
@@ -30,9 +31,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         "\n\030com.google.monitoring.v3B\013CommonProtoP\001Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\252\002\032Google.Cloud.Monitoring.V3\312\002\032Google\\Cloud\\Monitoring\\V3"
     ),
     serialized_pb=_b(
-        '\n-google/cloud/monitoring_v3/proto/common.proto\x12\x14google.monitoring.v3\x1a\x1dgoogle/api/distribution.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto"\xaa\x01\n\nTypedValue\x12\x14\n\nbool_value\x18\x01 \x01(\x08H\x00\x12\x15\n\x0bint64_value\x18\x02 \x01(\x03H\x00\x12\x16\n\x0c\x64ouble_value\x18\x03 \x01(\x01H\x00\x12\x16\n\x0cstring_value\x18\x04 \x01(\tH\x00\x12\x36\n\x12\x64istribution_value\x18\x05 \x01(\x0b\x32\x18.google.api.DistributionH\x00\x42\x07\n\x05value"l\n\x0cTimeInterval\x12,\n\x08\x65nd_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12.\n\nstart_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp"\xad\x07\n\x0b\x41ggregation\x12\x33\n\x10\x61lignment_period\x18\x01 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x45\n\x12per_series_aligner\x18\x02 \x01(\x0e\x32).google.monitoring.v3.Aggregation.Aligner\x12G\n\x14\x63ross_series_reducer\x18\x04 \x01(\x0e\x32).google.monitoring.v3.Aggregation.Reducer\x12\x17\n\x0fgroup_by_fields\x18\x05 \x03(\t"\x8b\x03\n\x07\x41ligner\x12\x0e\n\nALIGN_NONE\x10\x00\x12\x0f\n\x0b\x41LIGN_DELTA\x10\x01\x12\x0e\n\nALIGN_RATE\x10\x02\x12\x15\n\x11\x41LIGN_INTERPOLATE\x10\x03\x12\x14\n\x10\x41LIGN_NEXT_OLDER\x10\x04\x12\r\n\tALIGN_MIN\x10\n\x12\r\n\tALIGN_MAX\x10\x0b\x12\x0e\n\nALIGN_MEAN\x10\x0c\x12\x0f\n\x0b\x41LIGN_COUNT\x10\r\x12\r\n\tALIGN_SUM\x10\x0e\x12\x10\n\x0c\x41LIGN_STDDEV\x10\x0f\x12\x14\n\x10\x41LIGN_COUNT_TRUE\x10\x10\x12\x15\n\x11\x41LIGN_COUNT_FALSE\x10\x18\x12\x17\n\x13\x41LIGN_FRACTION_TRUE\x10\x11\x12\x17\n\x13\x41LIGN_PERCENTILE_99\x10\x12\x12\x17\n\x13\x41LIGN_PERCENTILE_95\x10\x13\x12\x17\n\x13\x41LIGN_PERCENTILE_50\x10\x14\x12\x17\n\x13\x41LIGN_PERCENTILE_05\x10\x15\x12\x18\n\x14\x41LIGN_PERCENT_CHANGE\x10\x17"\xb1\x02\n\x07Reducer\x12\x0f\n\x0bREDUCE_NONE\x10\x00\x12\x0f\n\x0bREDUCE_MEAN\x10\x01\x12\x0e\n\nREDUCE_MIN\x10\x02\x12\x0e\n\nREDUCE_MAX\x10\x03\x12\x0e\n\nREDUCE_SUM\x10\x04\x12\x11\n\rREDUCE_STDDEV\x10\x05\x12\x10\n\x0cREDUCE_COUNT\x10\x06\x12\x15\n\x11REDUCE_COUNT_TRUE\x10\x07\x12\x16\n\x12REDUCE_COUNT_FALSE\x10\x0f\x12\x18\n\x14REDUCE_FRACTION_TRUE\x10\x08\x12\x18\n\x14REDUCE_PERCENTILE_99\x10\t\x12\x18\n\x14REDUCE_PERCENTILE_95\x10\n\x12\x18\n\x14REDUCE_PERCENTILE_50\x10\x0b\x12\x18\n\x14REDUCE_PERCENTILE_05\x10\x0c*\x9e\x01\n\x0e\x43omparisonType\x12\x1a\n\x16\x43OMPARISON_UNSPECIFIED\x10\x00\x12\x11\n\rCOMPARISON_GT\x10\x01\x12\x11\n\rCOMPARISON_GE\x10\x02\x12\x11\n\rCOMPARISON_LT\x10\x03\x12\x11\n\rCOMPARISON_LE\x10\x04\x12\x11\n\rCOMPARISON_EQ\x10\x05\x12\x11\n\rCOMPARISON_NE\x10\x06*a\n\x0bServiceTier\x12\x1c\n\x18SERVICE_TIER_UNSPECIFIED\x10\x00\x12\x16\n\x12SERVICE_TIER_BASIC\x10\x01\x12\x18\n\x14SERVICE_TIER_PREMIUM\x10\x02\x1a\x02\x18\x01\x42\xa3\x01\n\x18\x63om.google.monitoring.v3B\x0b\x43ommonProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
+        '\n-google/cloud/monitoring_v3/proto/common.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a\x1dgoogle/api/distribution.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto"\xaa\x01\n\nTypedValue\x12\x14\n\nbool_value\x18\x01 \x01(\x08H\x00\x12\x15\n\x0bint64_value\x18\x02 \x01(\x03H\x00\x12\x16\n\x0c\x64ouble_value\x18\x03 \x01(\x01H\x00\x12\x16\n\x0cstring_value\x18\x04 \x01(\tH\x00\x12\x36\n\x12\x64istribution_value\x18\x05 \x01(\x0b\x32\x18.google.api.DistributionH\x00\x42\x07\n\x05value"l\n\x0cTimeInterval\x12,\n\x08\x65nd_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12.\n\nstart_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp"\xad\x07\n\x0b\x41ggregation\x12\x33\n\x10\x61lignment_period\x18\x01 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x45\n\x12per_series_aligner\x18\x02 \x01(\x0e\x32).google.monitoring.v3.Aggregation.Aligner\x12G\n\x14\x63ross_series_reducer\x18\x04 \x01(\x0e\x32).google.monitoring.v3.Aggregation.Reducer\x12\x17\n\x0fgroup_by_fields\x18\x05 \x03(\t"\x8b\x03\n\x07\x41ligner\x12\x0e\n\nALIGN_NONE\x10\x00\x12\x0f\n\x0b\x41LIGN_DELTA\x10\x01\x12\x0e\n\nALIGN_RATE\x10\x02\x12\x15\n\x11\x41LIGN_INTERPOLATE\x10\x03\x12\x14\n\x10\x41LIGN_NEXT_OLDER\x10\x04\x12\r\n\tALIGN_MIN\x10\n\x12\r\n\tALIGN_MAX\x10\x0b\x12\x0e\n\nALIGN_MEAN\x10\x0c\x12\x0f\n\x0b\x41LIGN_COUNT\x10\r\x12\r\n\tALIGN_SUM\x10\x0e\x12\x10\n\x0c\x41LIGN_STDDEV\x10\x0f\x12\x14\n\x10\x41LIGN_COUNT_TRUE\x10\x10\x12\x15\n\x11\x41LIGN_COUNT_FALSE\x10\x18\x12\x17\n\x13\x41LIGN_FRACTION_TRUE\x10\x11\x12\x17\n\x13\x41LIGN_PERCENTILE_99\x10\x12\x12\x17\n\x13\x41LIGN_PERCENTILE_95\x10\x13\x12\x17\n\x13\x41LIGN_PERCENTILE_50\x10\x14\x12\x17\n\x13\x41LIGN_PERCENTILE_05\x10\x15\x12\x18\n\x14\x41LIGN_PERCENT_CHANGE\x10\x17"\xb1\x02\n\x07Reducer\x12\x0f\n\x0bREDUCE_NONE\x10\x00\x12\x0f\n\x0bREDUCE_MEAN\x10\x01\x12\x0e\n\nREDUCE_MIN\x10\x02\x12\x0e\n\nREDUCE_MAX\x10\x03\x12\x0e\n\nREDUCE_SUM\x10\x04\x12\x11\n\rREDUCE_STDDEV\x10\x05\x12\x10\n\x0cREDUCE_COUNT\x10\x06\x12\x15\n\x11REDUCE_COUNT_TRUE\x10\x07\x12\x16\n\x12REDUCE_COUNT_FALSE\x10\x0f\x12\x18\n\x14REDUCE_FRACTION_TRUE\x10\x08\x12\x18\n\x14REDUCE_PERCENTILE_99\x10\t\x12\x18\n\x14REDUCE_PERCENTILE_95\x10\n\x12\x18\n\x14REDUCE_PERCENTILE_50\x10\x0b\x12\x18\n\x14REDUCE_PERCENTILE_05\x10\x0c*\x9e\x01\n\x0e\x43omparisonType\x12\x1a\n\x16\x43OMPARISON_UNSPECIFIED\x10\x00\x12\x11\n\rCOMPARISON_GT\x10\x01\x12\x11\n\rCOMPARISON_GE\x10\x02\x12\x11\n\rCOMPARISON_LT\x10\x03\x12\x11\n\rCOMPARISON_LE\x10\x04\x12\x11\n\rCOMPARISON_EQ\x10\x05\x12\x11\n\rCOMPARISON_NE\x10\x06*a\n\x0bServiceTier\x12\x1c\n\x18SERVICE_TIER_UNSPECIFIED\x10\x00\x12\x16\n\x12SERVICE_TIER_BASIC\x10\x01\x12\x18\n\x14SERVICE_TIER_PREMIUM\x10\x02\x1a\x02\x18\x01\x42\xa3\x01\n\x18\x63om.google.monitoring.v3B\x0b\x43ommonProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
     ),
     dependencies=[
+        google_dot_api_dot_annotations__pb2.DESCRIPTOR,
         google_dot_api_dot_distribution__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_duration__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,
@@ -73,8 +75,8 @@ _COMPARISONTYPE = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=None,
-    serialized_start=1395,
-    serialized_end=1553,
+    serialized_start=1425,
+    serialized_end=1583,
 )
 _sym_db.RegisterEnumDescriptor(_COMPARISONTYPE)
 
@@ -109,8 +111,8 @@ _SERVICETIER = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=_b("\030\001"),
-    serialized_start=1555,
-    serialized_end=1652,
+    serialized_start=1585,
+    serialized_end=1682,
 )
 _sym_db.RegisterEnumDescriptor(_SERVICETIER)
 
@@ -233,8 +235,8 @@ _AGGREGATION_ALIGNER = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=None,
-    serialized_start=689,
-    serialized_end=1084,
+    serialized_start=719,
+    serialized_end=1114,
 )
 _sym_db.RegisterEnumDescriptor(_AGGREGATION_ALIGNER)
 
@@ -317,8 +319,8 @@ _AGGREGATION_REDUCER = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=None,
-    serialized_start=1087,
-    serialized_end=1392,
+    serialized_start=1117,
+    serialized_end=1422,
 )
 _sym_db.RegisterEnumDescriptor(_AGGREGATION_REDUCER)
 
@@ -437,8 +439,8 @@ _TYPEDVALUE = _descriptor.Descriptor(
             fields=[],
         )
     ],
-    serialized_start=168,
-    serialized_end=338,
+    serialized_start=198,
+    serialized_end=368,
 )
 
 
@@ -494,8 +496,8 @@ _TIMEINTERVAL = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=340,
-    serialized_end=448,
+    serialized_start=370,
+    serialized_end=478,
 )
 
 
@@ -587,8 +589,8 @@ _AGGREGATION = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=451,
-    serialized_end=1392,
+    serialized_start=481,
+    serialized_end=1422,
 )
 
 _TYPEDVALUE.fields_by_name[
@@ -680,27 +682,9 @@ TimeInterval = _reflection.GeneratedProtocolMessageType(
     dict(
         DESCRIPTOR=_TIMEINTERVAL,
         __module__="google.cloud.monitoring_v3.proto.common_pb2",
-        __doc__="""A closed time interval. It extends from the start time to the end time,
-  and includes both: ``[startTime, endTime]``. Valid time intervals depend
-  on the
-  ```MetricKind`` </monitoring/api/ref_v3/rest/v3/projects.metricDescriptors#MetricKind>`__
-  of the metric value. In no case can the end time be earlier than the
-  start time.
-  
-  -  For a ``GAUGE`` metric, the ``startTime`` value is technically
-     optional; if no value is specified, the start time defaults to the
-     value of the end time, and the interval represents a single point in
-     time. Such an interval is valid only for ``GAUGE`` metrics, which are
-     point-in-time measurements.
-  
-  -  For ``DELTA`` and ``CUMULATIVE`` metrics, the start time must be
-     earlier than the end time.
-  
-  -  In all cases, the start time of the next interval must be at least a
-     microsecond after the end time of the previous interval. Because the
-     interval is closed, if the start time of a new interval is the same
-     as the end time of the previous interval, data written at the new
-     start time could overwrite data written at the previous end time.
+        __doc__="""A time interval extending just after a start time through an end time.
+  If the start time is the same as the end time, then the interval
+  represents a single point in time.
   
   
   Attributes:

--- a/monitoring/google/cloud/monitoring_v3/proto/dropped_labels.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/dropped_labels.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,12 @@ syntax = "proto3";
 
 package google.monitoring.v3;
 
+import "google/api/annotations.proto";
+
 option go_package = "google.golang.org/genproto/googleapis/monitoring/v3;monitoring";
+option java_multiple_files = true;
+option java_outer_classname = "DroppedLabelsProto";
+option java_package = "com.google.monitoring.v3";
 
 // A set of (label, value) pairs which were dropped during aggregation, attached
 // to google.api.Distribution.Exemplars in google.api.Distribution values during

--- a/monitoring/google/cloud/monitoring_v3/proto/dropped_labels_pb2.py
+++ b/monitoring/google/cloud/monitoring_v3/proto/dropped_labels_pb2.py
@@ -15,16 +15,20 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
+from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
+
+
 DESCRIPTOR = _descriptor.FileDescriptor(
     name="google/cloud/monitoring_v3/proto/dropped_labels.proto",
     package="google.monitoring.v3",
     syntax="proto3",
     serialized_options=_b(
-        "Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring"
+        "\n\030com.google.monitoring.v3B\022DroppedLabelsProtoP\001Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring"
     ),
     serialized_pb=_b(
-        '\n5google/cloud/monitoring_v3/proto/dropped_labels.proto\x12\x14google.monitoring.v3"|\n\rDroppedLabels\x12=\n\x05label\x18\x01 \x03(\x0b\x32..google.monitoring.v3.DroppedLabels.LabelEntry\x1a,\n\nLabelEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42@Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoringb\x06proto3'
+        '\n5google/cloud/monitoring_v3/proto/dropped_labels.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto"|\n\rDroppedLabels\x12=\n\x05label\x18\x01 \x03(\x0b\x32..google.monitoring.v3.DroppedLabels.LabelEntry\x1a,\n\nLabelEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42p\n\x18\x63om.google.monitoring.v3B\x12\x44roppedLabelsProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoringb\x06proto3'
     ),
+    dependencies=[google_dot_api_dot_annotations__pb2.DESCRIPTOR],
 )
 
 
@@ -80,8 +84,8 @@ _DROPPEDLABELS_LABELENTRY = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=159,
-    serialized_end=203,
+    serialized_start=189,
+    serialized_end=233,
 )
 
 _DROPPEDLABELS = _descriptor.Descriptor(
@@ -118,8 +122,8 @@ _DROPPEDLABELS = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=79,
-    serialized_end=203,
+    serialized_start=109,
+    serialized_end=233,
 )
 
 _DROPPEDLABELS_LABELENTRY.containing_type = _DROPPEDLABELS

--- a/monitoring/google/cloud/monitoring_v3/proto/group.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/group.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/google/cloud/monitoring_v3/proto/group_service.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/group_service.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import "google/api/monitored_resource.proto";
 import "google/monitoring/v3/common.proto";
 import "google/monitoring/v3/group.proto";
 import "google/protobuf/empty.proto";
-import "google/api/client.proto";
 
 option csharp_namespace = "Google.Cloud.Monitoring.V3";
 option go_package = "google.golang.org/genproto/googleapis/monitoring/v3;monitoring";
@@ -44,12 +43,6 @@ option php_namespace = "Google\\Cloud\\Monitoring\\V3";
 // updated automatically as monitored resources are added and removed
 // from the infrastructure.
 service GroupService {
-  option (google.api.default_host) = "monitoring.googleapis.com";
-  option (google.api.oauth_scopes) =
-      "https://www.googleapis.com/auth/cloud-platform,"
-      "https://www.googleapis.com/auth/monitoring,"
-      "https://www.googleapis.com/auth/monitoring.read";
-
   // Lists the existing groups.
   rpc ListGroups(ListGroupsRequest) returns (ListGroupsResponse) {
     option (google.api.http) = {
@@ -89,7 +82,8 @@ service GroupService {
   }
 
   // Lists the monitored resources that are members of a group.
-  rpc ListGroupMembers(ListGroupMembersRequest) returns (ListGroupMembersResponse) {
+  rpc ListGroupMembers(ListGroupMembersRequest)
+      returns (ListGroupMembersResponse) {
     option (google.api.http) = {
       get: "/v3/{name=projects/*/groups/*}/members"
     };
@@ -176,17 +170,11 @@ message UpdateGroupRequest {
   bool validate_only = 3;
 }
 
-// The `DeleteGroup` request. The default behavior is to be able to delete a
-// single group without any descendants.
+// The `DeleteGroup` request. You can only delete a group if it has no children.
 message DeleteGroupRequest {
   // The group to delete. The format is
   // `"projects/{project_id_or_number}/groups/{group_id}"`.
   string name = 3;
-
-  // If this field is true, then the request means to delete a group with all
-  // its descendants. Otherwise, the request means to delete a group only when
-  // it has no descendants. The default value is false.
-  bool recursive = 4;
 }
 
 // The `ListGroupMembers` request.

--- a/monitoring/google/cloud/monitoring_v3/proto/group_service_pb2.py
+++ b/monitoring/google/cloud/monitoring_v3/proto/group_service_pb2.py
@@ -26,7 +26,6 @@ from google.cloud.monitoring_v3.proto import (
     group_pb2 as google_dot_cloud_dot_monitoring__v3_dot_proto_dot_group__pb2,
 )
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
-from google.api import client_pb2 as google_dot_api_dot_client__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -37,7 +36,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         "\n\030com.google.monitoring.v3B\021GroupServiceProtoP\001Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\252\002\032Google.Cloud.Monitoring.V3\312\002\032Google\\Cloud\\Monitoring\\V3"
     ),
     serialized_pb=_b(
-        '\n4google/cloud/monitoring_v3/proto/group_service.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a#google/api/monitored_resource.proto\x1a-google/cloud/monitoring_v3/proto/common.proto\x1a,google/cloud/monitoring_v3/proto/group.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x17google/api/client.proto"\xad\x01\n\x11ListGroupsRequest\x12\x0c\n\x04name\x18\x07 \x01(\t\x12\x1b\n\x11\x63hildren_of_group\x18\x02 \x01(\tH\x00\x12\x1c\n\x12\x61ncestors_of_group\x18\x03 \x01(\tH\x00\x12\x1e\n\x14\x64\x65scendants_of_group\x18\x04 \x01(\tH\x00\x12\x11\n\tpage_size\x18\x05 \x01(\x05\x12\x12\n\npage_token\x18\x06 \x01(\tB\x08\n\x06\x66ilter"Y\n\x12ListGroupsResponse\x12*\n\x05group\x18\x01 \x03(\x0b\x32\x1b.google.monitoring.v3.Group\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"\x1f\n\x0fGetGroupRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"e\n\x12\x43reateGroupRequest\x12\x0c\n\x04name\x18\x04 \x01(\t\x12*\n\x05group\x18\x02 \x01(\x0b\x32\x1b.google.monitoring.v3.Group\x12\x15\n\rvalidate_only\x18\x03 \x01(\x08"W\n\x12UpdateGroupRequest\x12*\n\x05group\x18\x02 \x01(\x0b\x32\x1b.google.monitoring.v3.Group\x12\x15\n\rvalidate_only\x18\x03 \x01(\x08"5\n\x12\x44\x65leteGroupRequest\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x11\n\trecursive\x18\x04 \x01(\x08"\x94\x01\n\x17ListGroupMembersRequest\x12\x0c\n\x04name\x18\x07 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x05 \x01(\t\x12\x34\n\x08interval\x18\x06 \x01(\x0b\x32".google.monitoring.v3.TimeInterval"w\n\x18ListGroupMembersResponse\x12.\n\x07members\x18\x01 \x03(\x0b\x32\x1d.google.api.MonitoredResource\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\x12\x12\n\ntotal_size\x18\x03 \x01(\x05\x32\xe7\x07\n\x0cGroupService\x12\x85\x01\n\nListGroups\x12\'.google.monitoring.v3.ListGroupsRequest\x1a(.google.monitoring.v3.ListGroupsResponse"$\x82\xd3\xe4\x93\x02\x1e\x12\x1c/v3/{name=projects/*}/groups\x12v\n\x08GetGroup\x12%.google.monitoring.v3.GetGroupRequest\x1a\x1b.google.monitoring.v3.Group"&\x82\xd3\xe4\x93\x02 \x12\x1e/v3/{name=projects/*/groups/*}\x12\x81\x01\n\x0b\x43reateGroup\x12(.google.monitoring.v3.CreateGroupRequest\x1a\x1b.google.monitoring.v3.Group"+\x82\xd3\xe4\x93\x02%"\x1c/v3/{name=projects/*}/groups:\x05group\x12\x89\x01\n\x0bUpdateGroup\x12(.google.monitoring.v3.UpdateGroupRequest\x1a\x1b.google.monitoring.v3.Group"3\x82\xd3\xe4\x93\x02-\x1a$/v3/{group.name=projects/*/groups/*}:\x05group\x12w\n\x0b\x44\x65leteGroup\x12(.google.monitoring.v3.DeleteGroupRequest\x1a\x16.google.protobuf.Empty"&\x82\xd3\xe4\x93\x02 *\x1e/v3/{name=projects/*/groups/*}\x12\xa1\x01\n\x10ListGroupMembers\x12-.google.monitoring.v3.ListGroupMembersRequest\x1a..google.monitoring.v3.ListGroupMembersResponse".\x82\xd3\xe4\x93\x02(\x12&/v3/{name=projects/*/groups/*}/members\x1a\xa9\x01\xca\x41\x19monitoring.googleapis.com\xd2\x41\x89\x01https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/monitoring.readB\xa9\x01\n\x18\x63om.google.monitoring.v3B\x11GroupServiceProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
+        '\n4google/cloud/monitoring_v3/proto/group_service.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a#google/api/monitored_resource.proto\x1a-google/cloud/monitoring_v3/proto/common.proto\x1a,google/cloud/monitoring_v3/proto/group.proto\x1a\x1bgoogle/protobuf/empty.proto"\xad\x01\n\x11ListGroupsRequest\x12\x0c\n\x04name\x18\x07 \x01(\t\x12\x1b\n\x11\x63hildren_of_group\x18\x02 \x01(\tH\x00\x12\x1c\n\x12\x61ncestors_of_group\x18\x03 \x01(\tH\x00\x12\x1e\n\x14\x64\x65scendants_of_group\x18\x04 \x01(\tH\x00\x12\x11\n\tpage_size\x18\x05 \x01(\x05\x12\x12\n\npage_token\x18\x06 \x01(\tB\x08\n\x06\x66ilter"Y\n\x12ListGroupsResponse\x12*\n\x05group\x18\x01 \x03(\x0b\x32\x1b.google.monitoring.v3.Group\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"\x1f\n\x0fGetGroupRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"e\n\x12\x43reateGroupRequest\x12\x0c\n\x04name\x18\x04 \x01(\t\x12*\n\x05group\x18\x02 \x01(\x0b\x32\x1b.google.monitoring.v3.Group\x12\x15\n\rvalidate_only\x18\x03 \x01(\x08"W\n\x12UpdateGroupRequest\x12*\n\x05group\x18\x02 \x01(\x0b\x32\x1b.google.monitoring.v3.Group\x12\x15\n\rvalidate_only\x18\x03 \x01(\x08""\n\x12\x44\x65leteGroupRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"\x94\x01\n\x17ListGroupMembersRequest\x12\x0c\n\x04name\x18\x07 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x05 \x01(\t\x12\x34\n\x08interval\x18\x06 \x01(\x0b\x32".google.monitoring.v3.TimeInterval"w\n\x18ListGroupMembersResponse\x12.\n\x07members\x18\x01 \x03(\x0b\x32\x1d.google.api.MonitoredResource\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\x12\x12\n\ntotal_size\x18\x03 \x01(\x05\x32\xbb\x06\n\x0cGroupService\x12\x85\x01\n\nListGroups\x12\'.google.monitoring.v3.ListGroupsRequest\x1a(.google.monitoring.v3.ListGroupsResponse"$\x82\xd3\xe4\x93\x02\x1e\x12\x1c/v3/{name=projects/*}/groups\x12v\n\x08GetGroup\x12%.google.monitoring.v3.GetGroupRequest\x1a\x1b.google.monitoring.v3.Group"&\x82\xd3\xe4\x93\x02 \x12\x1e/v3/{name=projects/*/groups/*}\x12\x81\x01\n\x0b\x43reateGroup\x12(.google.monitoring.v3.CreateGroupRequest\x1a\x1b.google.monitoring.v3.Group"+\x82\xd3\xe4\x93\x02%"\x1c/v3/{name=projects/*}/groups:\x05group\x12\x89\x01\n\x0bUpdateGroup\x12(.google.monitoring.v3.UpdateGroupRequest\x1a\x1b.google.monitoring.v3.Group"3\x82\xd3\xe4\x93\x02-\x1a$/v3/{group.name=projects/*/groups/*}:\x05group\x12w\n\x0b\x44\x65leteGroup\x12(.google.monitoring.v3.DeleteGroupRequest\x1a\x16.google.protobuf.Empty"&\x82\xd3\xe4\x93\x02 *\x1e/v3/{name=projects/*/groups/*}\x12\xa1\x01\n\x10ListGroupMembers\x12-.google.monitoring.v3.ListGroupMembersRequest\x1a..google.monitoring.v3.ListGroupMembersResponse".\x82\xd3\xe4\x93\x02(\x12&/v3/{name=projects/*/groups/*}/membersB\xa9\x01\n\x18\x63om.google.monitoring.v3B\x11GroupServiceProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
     ),
     dependencies=[
         google_dot_api_dot_annotations__pb2.DESCRIPTOR,
@@ -45,7 +44,6 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         google_dot_cloud_dot_monitoring__v3_dot_proto_dot_common__pb2.DESCRIPTOR,
         google_dot_cloud_dot_monitoring__v3_dot_proto_dot_group__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,
-        google_dot_api_dot_client__pb2.DESCRIPTOR,
     ],
 )
 
@@ -182,8 +180,8 @@ _LISTGROUPSREQUEST = _descriptor.Descriptor(
             fields=[],
         )
     ],
-    serialized_start=293,
-    serialized_end=466,
+    serialized_start=268,
+    serialized_end=441,
 )
 
 
@@ -239,8 +237,8 @@ _LISTGROUPSRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=468,
-    serialized_end=557,
+    serialized_start=443,
+    serialized_end=532,
 )
 
 
@@ -278,8 +276,8 @@ _GETGROUPREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=559,
-    serialized_end=590,
+    serialized_start=534,
+    serialized_end=565,
 )
 
 
@@ -353,8 +351,8 @@ _CREATEGROUPREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=592,
-    serialized_end=693,
+    serialized_start=567,
+    serialized_end=668,
 )
 
 
@@ -410,8 +408,8 @@ _UPDATEGROUPREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=695,
-    serialized_end=782,
+    serialized_start=670,
+    serialized_end=757,
 )
 
 
@@ -439,25 +437,7 @@ _DELETEGROUPREQUEST = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="recursive",
-            full_name="google.monitoring.v3.DeleteGroupRequest.recursive",
-            index=1,
-            number=4,
-            type=8,
-            cpp_type=7,
-            label=1,
-            has_default_value=False,
-            default_value=False,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
+        )
     ],
     extensions=[],
     nested_types=[],
@@ -467,8 +447,8 @@ _DELETEGROUPREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=784,
-    serialized_end=837,
+    serialized_start=759,
+    serialized_end=793,
 )
 
 
@@ -578,8 +558,8 @@ _LISTGROUPMEMBERSREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=840,
-    serialized_end=988,
+    serialized_start=796,
+    serialized_end=944,
 )
 
 
@@ -653,8 +633,8 @@ _LISTGROUPMEMBERSRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=990,
-    serialized_end=1109,
+    serialized_start=946,
+    serialized_end=1065,
 )
 
 _LISTGROUPSREQUEST.oneofs_by_name["filter"].fields.append(
@@ -848,19 +828,14 @@ DeleteGroupRequest = _reflection.GeneratedProtocolMessageType(
     dict(
         DESCRIPTOR=_DELETEGROUPREQUEST,
         __module__="google.cloud.monitoring_v3.proto.group_service_pb2",
-        __doc__="""The ``DeleteGroup`` request. The default behavior is to be able to
-  delete a single group without any descendants.
+        __doc__="""The ``DeleteGroup`` request. You can only delete a group if it has no
+  children.
   
   
   Attributes:
       name:
           The group to delete. The format is
           ``"projects/{project_id_or_number}/groups/{group_id}"``.
-      recursive:
-          If this field is true, then the request means to delete a
-          group with all its descendants. Otherwise, the request means
-          to delete a group only when it has no descendants. The default
-          value is false.
   """,
         # @@protoc_insertion_point(class_scope:google.monitoring.v3.DeleteGroupRequest)
     ),
@@ -941,11 +916,9 @@ _GROUPSERVICE = _descriptor.ServiceDescriptor(
     full_name="google.monitoring.v3.GroupService",
     file=DESCRIPTOR,
     index=0,
-    serialized_options=_b(
-        "\312A\031monitoring.googleapis.com\322A\211\001https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/monitoring.read"
-    ),
-    serialized_start=1112,
-    serialized_end=2111,
+    serialized_options=None,
+    serialized_start=1068,
+    serialized_end=1895,
     methods=[
         _descriptor.MethodDescriptor(
             name="ListGroups",

--- a/monitoring/google/cloud/monitoring_v3/proto/metric.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/metric.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ syntax = "proto3";
 
 package google.monitoring.v3;
 
-import "google/api/distribution.proto";
+import "google/api/annotations.proto";
 import "google/api/label.proto";
 import "google/api/metric.proto";
 import "google/api/monitored_resource.proto";

--- a/monitoring/google/cloud/monitoring_v3/proto/metric_pb2.py
+++ b/monitoring/google/cloud/monitoring_v3/proto/metric_pb2.py
@@ -15,7 +15,7 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
-from google.api import distribution_pb2 as google_dot_api_dot_distribution__pb2
+from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 from google.api import label_pb2 as google_dot_api_dot_label__pb2
 from google.api import metric_pb2 as google_dot_api_dot_metric__pb2
 from google.api import (
@@ -34,10 +34,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         "\n\030com.google.monitoring.v3B\013MetricProtoP\001Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\252\002\032Google.Cloud.Monitoring.V3\312\002\032Google\\Cloud\\Monitoring\\V3"
     ),
     serialized_pb=_b(
-        '\n-google/cloud/monitoring_v3/proto/metric.proto\x12\x14google.monitoring.v3\x1a\x1dgoogle/api/distribution.proto\x1a\x16google/api/label.proto\x1a\x17google/api/metric.proto\x1a#google/api/monitored_resource.proto\x1a-google/cloud/monitoring_v3/proto/common.proto"n\n\x05Point\x12\x34\n\x08interval\x18\x01 \x01(\x0b\x32".google.monitoring.v3.TimeInterval\x12/\n\x05value\x18\x02 \x01(\x0b\x32 .google.monitoring.v3.TypedValue"\xc1\x02\n\nTimeSeries\x12"\n\x06metric\x18\x01 \x01(\x0b\x32\x12.google.api.Metric\x12/\n\x08resource\x18\x02 \x01(\x0b\x32\x1d.google.api.MonitoredResource\x12\x37\n\x08metadata\x18\x07 \x01(\x0b\x32%.google.api.MonitoredResourceMetadata\x12<\n\x0bmetric_kind\x18\x03 \x01(\x0e\x32\'.google.api.MetricDescriptor.MetricKind\x12:\n\nvalue_type\x18\x04 \x01(\x0e\x32&.google.api.MetricDescriptor.ValueType\x12+\n\x06points\x18\x05 \x03(\x0b\x32\x1b.google.monitoring.v3.PointB\xa3\x01\n\x18\x63om.google.monitoring.v3B\x0bMetricProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
+        '\n-google/cloud/monitoring_v3/proto/metric.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a\x16google/api/label.proto\x1a\x17google/api/metric.proto\x1a#google/api/monitored_resource.proto\x1a-google/cloud/monitoring_v3/proto/common.proto"n\n\x05Point\x12\x34\n\x08interval\x18\x01 \x01(\x0b\x32".google.monitoring.v3.TimeInterval\x12/\n\x05value\x18\x02 \x01(\x0b\x32 .google.monitoring.v3.TypedValue"\xc1\x02\n\nTimeSeries\x12"\n\x06metric\x18\x01 \x01(\x0b\x32\x12.google.api.Metric\x12/\n\x08resource\x18\x02 \x01(\x0b\x32\x1d.google.api.MonitoredResource\x12\x37\n\x08metadata\x18\x07 \x01(\x0b\x32%.google.api.MonitoredResourceMetadata\x12<\n\x0bmetric_kind\x18\x03 \x01(\x0e\x32\'.google.api.MetricDescriptor.MetricKind\x12:\n\nvalue_type\x18\x04 \x01(\x0e\x32&.google.api.MetricDescriptor.ValueType\x12+\n\x06points\x18\x05 \x03(\x0b\x32\x1b.google.monitoring.v3.PointB\xa3\x01\n\x18\x63om.google.monitoring.v3B\x0bMetricProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
     ),
     dependencies=[
-        google_dot_api_dot_distribution__pb2.DESCRIPTOR,
+        google_dot_api_dot_annotations__pb2.DESCRIPTOR,
         google_dot_api_dot_label__pb2.DESCRIPTOR,
         google_dot_api_dot_metric__pb2.DESCRIPTOR,
         google_dot_api_dot_monitored__resource__pb2.DESCRIPTOR,
@@ -98,8 +98,8 @@ _POINT = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=235,
-    serialized_end=345,
+    serialized_start=234,
+    serialized_end=344,
 )
 
 
@@ -227,8 +227,8 @@ _TIMESERIES = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=348,
-    serialized_end=669,
+    serialized_start=347,
+    serialized_end=668,
 )
 
 _POINT.fields_by_name[

--- a/monitoring/google/cloud/monitoring_v3/proto/metric_service.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/metric_service.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,13 +20,11 @@ package google.monitoring.v3;
 import "google/api/annotations.proto";
 import "google/api/metric.proto";
 import "google/api/monitored_resource.proto";
-import "google/monitoring/v3/alert.proto";
 import "google/monitoring/v3/common.proto";
 import "google/monitoring/v3/metric.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/rpc/status.proto";
-import "google/api/client.proto";
 
 option csharp_namespace = "Google.Cloud.Monitoring.V3";
 option go_package = "google.golang.org/genproto/googleapis/monitoring/v3;monitoring";
@@ -38,36 +36,37 @@ option php_namespace = "Google\\Cloud\\Monitoring\\V3";
 // Manages metric descriptors, monitored resource descriptors, and
 // time series data.
 service MetricService {
-  option (google.api.default_host) = "monitoring.googleapis.com";
-  option (google.api.oauth_scopes) =
-      "https://www.googleapis.com/auth/cloud-platform,"
-      "https://www.googleapis.com/auth/monitoring,"
-      "https://www.googleapis.com/auth/monitoring.read,"
-      "https://www.googleapis.com/auth/monitoring.write";
-
-  // Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
-  rpc ListMonitoredResourceDescriptors(ListMonitoredResourceDescriptorsRequest) returns (ListMonitoredResourceDescriptorsResponse) {
+  // Lists monitored resource descriptors that match a filter. This method does
+  // not require a Stackdriver account.
+  rpc ListMonitoredResourceDescriptors(ListMonitoredResourceDescriptorsRequest)
+      returns (ListMonitoredResourceDescriptorsResponse) {
     option (google.api.http) = {
       get: "/v3/{name=projects/*}/monitoredResourceDescriptors"
     };
   }
 
-  // Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
-  rpc GetMonitoredResourceDescriptor(GetMonitoredResourceDescriptorRequest) returns (google.api.MonitoredResourceDescriptor) {
+  // Gets a single monitored resource descriptor. This method does not require a
+  // Stackdriver account.
+  rpc GetMonitoredResourceDescriptor(GetMonitoredResourceDescriptorRequest)
+      returns (google.api.MonitoredResourceDescriptor) {
     option (google.api.http) = {
       get: "/v3/{name=projects/*/monitoredResourceDescriptors/*}"
     };
   }
 
-  // Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
-  rpc ListMetricDescriptors(ListMetricDescriptorsRequest) returns (ListMetricDescriptorsResponse) {
+  // Lists metric descriptors that match a filter. This method does not require
+  // a Stackdriver account.
+  rpc ListMetricDescriptors(ListMetricDescriptorsRequest)
+      returns (ListMetricDescriptorsResponse) {
     option (google.api.http) = {
       get: "/v3/{name=projects/*}/metricDescriptors"
     };
   }
 
-  // Gets a single metric descriptor. This method does not require a Stackdriver account.
-  rpc GetMetricDescriptor(GetMetricDescriptorRequest) returns (google.api.MetricDescriptor) {
+  // Gets a single metric descriptor. This method does not require a Stackdriver
+  // account.
+  rpc GetMetricDescriptor(GetMetricDescriptorRequest)
+      returns (google.api.MetricDescriptor) {
     option (google.api.http) = {
       get: "/v3/{name=projects/*/metricDescriptors/**}"
     };
@@ -76,7 +75,8 @@ service MetricService {
   // Creates a new metric descriptor.
   // User-created metric descriptors define
   // [custom metrics](/monitoring/custom-metrics).
-  rpc CreateMetricDescriptor(CreateMetricDescriptorRequest) returns (google.api.MetricDescriptor) {
+  rpc CreateMetricDescriptor(CreateMetricDescriptorRequest)
+      returns (google.api.MetricDescriptor) {
     option (google.api.http) = {
       post: "/v3/{name=projects/*}/metricDescriptors"
       body: "metric_descriptor"
@@ -85,13 +85,15 @@ service MetricService {
 
   // Deletes a metric descriptor. Only user-created
   // [custom metrics](/monitoring/custom-metrics) can be deleted.
-  rpc DeleteMetricDescriptor(DeleteMetricDescriptorRequest) returns (google.protobuf.Empty) {
+  rpc DeleteMetricDescriptor(DeleteMetricDescriptorRequest)
+      returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v3/{name=projects/*/metricDescriptors/**}"
     };
   }
 
-  // Lists time series that match a filter. This method does not require a Stackdriver account.
+  // Lists time series that match a filter. This method does not require a
+  // Stackdriver account.
   rpc ListTimeSeries(ListTimeSeriesRequest) returns (ListTimeSeriesResponse) {
     option (google.api.http) = {
       get: "/v3/{name=projects/*}/timeSeries"
@@ -102,7 +104,8 @@ service MetricService {
   // The response is empty if all time series in the request were written.
   // If any time series could not be written, a corresponding failure message is
   // included in the error response.
-  rpc CreateTimeSeries(CreateTimeSeriesRequest) returns (google.protobuf.Empty) {
+  rpc CreateTimeSeries(CreateTimeSeriesRequest)
+      returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/v3/{name=projects/*}/timeSeries"
       body: "*"
@@ -244,7 +247,7 @@ message ListTimeSeriesRequest {
   // example:
   //
   //     metric.type = "compute.googleapis.com/instance/cpu/usage_time" AND
-  //         metric.labels.instance_name = "my-instance-name"
+  //         metric.label.instance_name = "my-instance-name"
   string filter = 2;
 
   // The time interval for which results should be returned. Only time series
@@ -303,8 +306,6 @@ message CreateTimeSeriesRequest {
   // point must be more recent than any other point in its time series.  Each
   // `TimeSeries` value must fully specify a unique time series by supplying
   // all label values for the metric and the monitored resource.
-  //
-  // The maximum number of `TimeSeries` objects per `Create` request is 200.
   repeated TimeSeries time_series = 2;
 }
 

--- a/monitoring/google/cloud/monitoring_v3/proto/metric_service_pb2.py
+++ b/monitoring/google/cloud/monitoring_v3/proto/metric_service_pb2.py
@@ -21,9 +21,6 @@ from google.api import (
     monitored_resource_pb2 as google_dot_api_dot_monitored__resource__pb2,
 )
 from google.cloud.monitoring_v3.proto import (
-    alert_pb2 as google_dot_cloud_dot_monitoring__v3_dot_proto_dot_alert__pb2,
-)
-from google.cloud.monitoring_v3.proto import (
     common_pb2 as google_dot_cloud_dot_monitoring__v3_dot_proto_dot_common__pb2,
 )
 from google.cloud.monitoring_v3.proto import (
@@ -32,7 +29,6 @@ from google.cloud.monitoring_v3.proto import (
 from google.protobuf import duration_pb2 as google_dot_protobuf_dot_duration__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from google.rpc import status_pb2 as google_dot_rpc_dot_status__pb2
-from google.api import client_pb2 as google_dot_api_dot_client__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -43,19 +39,17 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         "\n\030com.google.monitoring.v3B\022MetricServiceProtoP\001Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\252\002\032Google.Cloud.Monitoring.V3\312\002\032Google\\Cloud\\Monitoring\\V3"
     ),
     serialized_pb=_b(
-        '\n5google/cloud/monitoring_v3/proto/metric_service.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a\x17google/api/metric.proto\x1a#google/api/monitored_resource.proto\x1a,google/cloud/monitoring_v3/proto/alert.proto\x1a-google/cloud/monitoring_v3/proto/common.proto\x1a-google/cloud/monitoring_v3/proto/metric.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x17google/rpc/status.proto\x1a\x17google/api/client.proto"n\n\'ListMonitoredResourceDescriptorsRequest\x12\x0c\n\x04name\x18\x05 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t"\x8a\x01\n(ListMonitoredResourceDescriptorsResponse\x12\x45\n\x14resource_descriptors\x18\x01 \x03(\x0b\x32\'.google.api.MonitoredResourceDescriptor\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"5\n%GetMonitoredResourceDescriptorRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"c\n\x1cListMetricDescriptorsRequest\x12\x0c\n\x04name\x18\x05 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t"r\n\x1dListMetricDescriptorsResponse\x12\x38\n\x12metric_descriptors\x18\x01 \x03(\x0b\x32\x1c.google.api.MetricDescriptor\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"*\n\x1aGetMetricDescriptorRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"f\n\x1d\x43reateMetricDescriptorRequest\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x37\n\x11metric_descriptor\x18\x02 \x01(\x0b\x32\x1c.google.api.MetricDescriptor"-\n\x1d\x44\x65leteMetricDescriptorRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"\xcf\x02\n\x15ListTimeSeriesRequest\x12\x0c\n\x04name\x18\n \x01(\t\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x34\n\x08interval\x18\x04 \x01(\x0b\x32".google.monitoring.v3.TimeInterval\x12\x36\n\x0b\x61ggregation\x18\x05 \x01(\x0b\x32!.google.monitoring.v3.Aggregation\x12\x10\n\x08order_by\x18\x06 \x01(\t\x12H\n\x04view\x18\x07 \x01(\x0e\x32:.google.monitoring.v3.ListTimeSeriesRequest.TimeSeriesView\x12\x11\n\tpage_size\x18\x08 \x01(\x05\x12\x12\n\npage_token\x18\t \x01(\t"\'\n\x0eTimeSeriesView\x12\x08\n\x04\x46ULL\x10\x00\x12\x0b\n\x07HEADERS\x10\x01"\x96\x01\n\x16ListTimeSeriesResponse\x12\x35\n\x0btime_series\x18\x01 \x03(\x0b\x32 .google.monitoring.v3.TimeSeries\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\x12,\n\x10\x65xecution_errors\x18\x03 \x03(\x0b\x32\x12.google.rpc.Status"^\n\x17\x43reateTimeSeriesRequest\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x35\n\x0btime_series\x18\x02 \x03(\x0b\x32 .google.monitoring.v3.TimeSeries"r\n\x15\x43reateTimeSeriesError\x12\x35\n\x0btime_series\x18\x01 \x01(\x0b\x32 .google.monitoring.v3.TimeSeries\x12"\n\x06status\x18\x02 \x01(\x0b\x32\x12.google.rpc.Status2\xd2\x0c\n\rMetricService\x12\xdd\x01\n ListMonitoredResourceDescriptors\x12=.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest\x1a>.google.monitoring.v3.ListMonitoredResourceDescriptorsResponse":\x82\xd3\xe4\x93\x02\x34\x12\x32/v3/{name=projects/*}/monitoredResourceDescriptors\x12\xc4\x01\n\x1eGetMonitoredResourceDescriptor\x12;.google.monitoring.v3.GetMonitoredResourceDescriptorRequest\x1a\'.google.api.MonitoredResourceDescriptor"<\x82\xd3\xe4\x93\x02\x36\x12\x34/v3/{name=projects/*/monitoredResourceDescriptors/*}\x12\xb1\x01\n\x15ListMetricDescriptors\x12\x32.google.monitoring.v3.ListMetricDescriptorsRequest\x1a\x33.google.monitoring.v3.ListMetricDescriptorsResponse"/\x82\xd3\xe4\x93\x02)\x12\'/v3/{name=projects/*}/metricDescriptors\x12\x99\x01\n\x13GetMetricDescriptor\x12\x30.google.monitoring.v3.GetMetricDescriptorRequest\x1a\x1c.google.api.MetricDescriptor"2\x82\xd3\xe4\x93\x02,\x12*/v3/{name=projects/*/metricDescriptors/**}\x12\xaf\x01\n\x16\x43reateMetricDescriptor\x12\x33.google.monitoring.v3.CreateMetricDescriptorRequest\x1a\x1c.google.api.MetricDescriptor"B\x82\xd3\xe4\x93\x02<"\'/v3/{name=projects/*}/metricDescriptors:\x11metric_descriptor\x12\x99\x01\n\x16\x44\x65leteMetricDescriptor\x12\x33.google.monitoring.v3.DeleteMetricDescriptorRequest\x1a\x16.google.protobuf.Empty"2\x82\xd3\xe4\x93\x02,**/v3/{name=projects/*/metricDescriptors/**}\x12\x95\x01\n\x0eListTimeSeries\x12+.google.monitoring.v3.ListTimeSeriesRequest\x1a,.google.monitoring.v3.ListTimeSeriesResponse"(\x82\xd3\xe4\x93\x02"\x12 /v3/{name=projects/*}/timeSeries\x12\x86\x01\n\x10\x43reateTimeSeries\x12-.google.monitoring.v3.CreateTimeSeriesRequest\x1a\x16.google.protobuf.Empty"+\x82\xd3\xe4\x93\x02%" /v3/{name=projects/*}/timeSeries:\x01*\x1a\xda\x01\xca\x41\x19monitoring.googleapis.com\xd2\x41\xba\x01https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/monitoring.read,https://www.googleapis.com/auth/monitoring.writeB\xaa\x01\n\x18\x63om.google.monitoring.v3B\x12MetricServiceProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
+        '\n5google/cloud/monitoring_v3/proto/metric_service.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a\x17google/api/metric.proto\x1a#google/api/monitored_resource.proto\x1a-google/cloud/monitoring_v3/proto/common.proto\x1a-google/cloud/monitoring_v3/proto/metric.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x17google/rpc/status.proto"n\n\'ListMonitoredResourceDescriptorsRequest\x12\x0c\n\x04name\x18\x05 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t"\x8a\x01\n(ListMonitoredResourceDescriptorsResponse\x12\x45\n\x14resource_descriptors\x18\x01 \x03(\x0b\x32\'.google.api.MonitoredResourceDescriptor\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"5\n%GetMonitoredResourceDescriptorRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"c\n\x1cListMetricDescriptorsRequest\x12\x0c\n\x04name\x18\x05 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t"r\n\x1dListMetricDescriptorsResponse\x12\x38\n\x12metric_descriptors\x18\x01 \x03(\x0b\x32\x1c.google.api.MetricDescriptor\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"*\n\x1aGetMetricDescriptorRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"f\n\x1d\x43reateMetricDescriptorRequest\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x37\n\x11metric_descriptor\x18\x02 \x01(\x0b\x32\x1c.google.api.MetricDescriptor"-\n\x1d\x44\x65leteMetricDescriptorRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"\xcf\x02\n\x15ListTimeSeriesRequest\x12\x0c\n\x04name\x18\n \x01(\t\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x34\n\x08interval\x18\x04 \x01(\x0b\x32".google.monitoring.v3.TimeInterval\x12\x36\n\x0b\x61ggregation\x18\x05 \x01(\x0b\x32!.google.monitoring.v3.Aggregation\x12\x10\n\x08order_by\x18\x06 \x01(\t\x12H\n\x04view\x18\x07 \x01(\x0e\x32:.google.monitoring.v3.ListTimeSeriesRequest.TimeSeriesView\x12\x11\n\tpage_size\x18\x08 \x01(\x05\x12\x12\n\npage_token\x18\t \x01(\t"\'\n\x0eTimeSeriesView\x12\x08\n\x04\x46ULL\x10\x00\x12\x0b\n\x07HEADERS\x10\x01"\x96\x01\n\x16ListTimeSeriesResponse\x12\x35\n\x0btime_series\x18\x01 \x03(\x0b\x32 .google.monitoring.v3.TimeSeries\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\x12,\n\x10\x65xecution_errors\x18\x03 \x03(\x0b\x32\x12.google.rpc.Status"^\n\x17\x43reateTimeSeriesRequest\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x35\n\x0btime_series\x18\x02 \x03(\x0b\x32 .google.monitoring.v3.TimeSeries"r\n\x15\x43reateTimeSeriesError\x12\x35\n\x0btime_series\x18\x01 \x01(\x0b\x32 .google.monitoring.v3.TimeSeries\x12"\n\x06status\x18\x02 \x01(\x0b\x32\x12.google.rpc.Status2\xf5\n\n\rMetricService\x12\xdd\x01\n ListMonitoredResourceDescriptors\x12=.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest\x1a>.google.monitoring.v3.ListMonitoredResourceDescriptorsResponse":\x82\xd3\xe4\x93\x02\x34\x12\x32/v3/{name=projects/*}/monitoredResourceDescriptors\x12\xc4\x01\n\x1eGetMonitoredResourceDescriptor\x12;.google.monitoring.v3.GetMonitoredResourceDescriptorRequest\x1a\'.google.api.MonitoredResourceDescriptor"<\x82\xd3\xe4\x93\x02\x36\x12\x34/v3/{name=projects/*/monitoredResourceDescriptors/*}\x12\xb1\x01\n\x15ListMetricDescriptors\x12\x32.google.monitoring.v3.ListMetricDescriptorsRequest\x1a\x33.google.monitoring.v3.ListMetricDescriptorsResponse"/\x82\xd3\xe4\x93\x02)\x12\'/v3/{name=projects/*}/metricDescriptors\x12\x99\x01\n\x13GetMetricDescriptor\x12\x30.google.monitoring.v3.GetMetricDescriptorRequest\x1a\x1c.google.api.MetricDescriptor"2\x82\xd3\xe4\x93\x02,\x12*/v3/{name=projects/*/metricDescriptors/**}\x12\xaf\x01\n\x16\x43reateMetricDescriptor\x12\x33.google.monitoring.v3.CreateMetricDescriptorRequest\x1a\x1c.google.api.MetricDescriptor"B\x82\xd3\xe4\x93\x02<"\'/v3/{name=projects/*}/metricDescriptors:\x11metric_descriptor\x12\x99\x01\n\x16\x44\x65leteMetricDescriptor\x12\x33.google.monitoring.v3.DeleteMetricDescriptorRequest\x1a\x16.google.protobuf.Empty"2\x82\xd3\xe4\x93\x02,**/v3/{name=projects/*/metricDescriptors/**}\x12\x95\x01\n\x0eListTimeSeries\x12+.google.monitoring.v3.ListTimeSeriesRequest\x1a,.google.monitoring.v3.ListTimeSeriesResponse"(\x82\xd3\xe4\x93\x02"\x12 /v3/{name=projects/*}/timeSeries\x12\x86\x01\n\x10\x43reateTimeSeries\x12-.google.monitoring.v3.CreateTimeSeriesRequest\x1a\x16.google.protobuf.Empty"+\x82\xd3\xe4\x93\x02%" /v3/{name=projects/*}/timeSeries:\x01*B\xaa\x01\n\x18\x63om.google.monitoring.v3B\x12MetricServiceProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
     ),
     dependencies=[
         google_dot_api_dot_annotations__pb2.DESCRIPTOR,
         google_dot_api_dot_metric__pb2.DESCRIPTOR,
         google_dot_api_dot_monitored__resource__pb2.DESCRIPTOR,
-        google_dot_cloud_dot_monitoring__v3_dot_proto_dot_alert__pb2.DESCRIPTOR,
         google_dot_cloud_dot_monitoring__v3_dot_proto_dot_common__pb2.DESCRIPTOR,
         google_dot_cloud_dot_monitoring__v3_dot_proto_dot_metric__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_duration__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,
         google_dot_rpc_dot_status__pb2.DESCRIPTOR,
-        google_dot_api_dot_client__pb2.DESCRIPTOR,
     ],
 )
 
@@ -75,8 +69,8 @@ _LISTTIMESERIESREQUEST_TIMESERIESVIEW = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=None,
-    serialized_start=1439,
-    serialized_end=1478,
+    serialized_start=1368,
+    serialized_end=1407,
 )
 _sym_db.RegisterEnumDescriptor(_LISTTIMESERIESREQUEST_TIMESERIESVIEW)
 
@@ -169,8 +163,8 @@ _LISTMONITOREDRESOURCEDESCRIPTORSREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=422,
-    serialized_end=532,
+    serialized_start=351,
+    serialized_end=461,
 )
 
 
@@ -226,8 +220,8 @@ _LISTMONITOREDRESOURCEDESCRIPTORSRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=535,
-    serialized_end=673,
+    serialized_start=464,
+    serialized_end=602,
 )
 
 
@@ -265,8 +259,8 @@ _GETMONITOREDRESOURCEDESCRIPTORREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=675,
-    serialized_end=728,
+    serialized_start=604,
+    serialized_end=657,
 )
 
 
@@ -358,8 +352,8 @@ _LISTMETRICDESCRIPTORSREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=730,
-    serialized_end=829,
+    serialized_start=659,
+    serialized_end=758,
 )
 
 
@@ -415,8 +409,8 @@ _LISTMETRICDESCRIPTORSRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=831,
-    serialized_end=945,
+    serialized_start=760,
+    serialized_end=874,
 )
 
 
@@ -454,8 +448,8 @@ _GETMETRICDESCRIPTORREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=947,
-    serialized_end=989,
+    serialized_start=876,
+    serialized_end=918,
 )
 
 
@@ -511,8 +505,8 @@ _CREATEMETRICDESCRIPTORREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=991,
-    serialized_end=1093,
+    serialized_start=920,
+    serialized_end=1022,
 )
 
 
@@ -550,8 +544,8 @@ _DELETEMETRICDESCRIPTORREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1095,
-    serialized_end=1140,
+    serialized_start=1024,
+    serialized_end=1069,
 )
 
 
@@ -715,8 +709,8 @@ _LISTTIMESERIESREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1143,
-    serialized_end=1478,
+    serialized_start=1072,
+    serialized_end=1407,
 )
 
 
@@ -790,8 +784,8 @@ _LISTTIMESERIESRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1481,
-    serialized_end=1631,
+    serialized_start=1410,
+    serialized_end=1560,
 )
 
 
@@ -847,8 +841,8 @@ _CREATETIMESERIESREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1633,
-    serialized_end=1727,
+    serialized_start=1562,
+    serialized_end=1656,
 )
 
 
@@ -904,8 +898,8 @@ _CREATETIMESERIESERROR = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1729,
-    serialized_end=1843,
+    serialized_start=1658,
+    serialized_end=1772,
 )
 
 _LISTMONITOREDRESOURCEDESCRIPTORSRESPONSE.fields_by_name[
@@ -1207,7 +1201,7 @@ ListTimeSeriesRequest = _reflection.GeneratedProtocolMessageType(
           must specify a single metric type, and can additionally
           specify metric labels and other information. For example:  ::
           metric.type = "compute.googleapis.com/instance/cpu/usage_time"
-          AND         metric.labels.instance_name = "my-instance-name"
+          AND         metric.label.instance_name = "my-instance-name"
       interval:
           The time interval for which results should be returned. Only
           time series that contain data points in the specified interval
@@ -1285,8 +1279,7 @@ CreateTimeSeriesRequest = _reflection.GeneratedProtocolMessageType(
           data point must be more recent than any other point in its
           time series. Each ``TimeSeries`` value must fully specify a
           unique time series by supplying all label values for the
-          metric and the monitored resource.  The maximum number of
-          ``TimeSeries`` objects per ``Create`` request is 200.
+          metric and the monitored resource.
   """,
         # @@protoc_insertion_point(class_scope:google.monitoring.v3.CreateTimeSeriesRequest)
     ),
@@ -1324,11 +1317,9 @@ _METRICSERVICE = _descriptor.ServiceDescriptor(
     full_name="google.monitoring.v3.MetricService",
     file=DESCRIPTOR,
     index=0,
-    serialized_options=_b(
-        "\312A\031monitoring.googleapis.com\322A\272\001https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/monitoring.read,https://www.googleapis.com/auth/monitoring.write"
-    ),
-    serialized_start=1846,
-    serialized_end=3464,
+    serialized_options=None,
+    serialized_start=1775,
+    serialized_end=3172,
     methods=[
         _descriptor.MethodDescriptor(
             name="ListMonitoredResourceDescriptors",

--- a/monitoring/google/cloud/monitoring_v3/proto/metric_service_pb2_grpc.py
+++ b/monitoring/google/cloud/monitoring_v3/proto/metric_service_pb2_grpc.py
@@ -70,28 +70,32 @@ class MetricServiceServicer(object):
   """
 
     def ListMonitoredResourceDescriptors(self, request, context):
-        """Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
+        """Lists monitored resource descriptors that match a filter. This method does
+    not require a Stackdriver account.
     """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetMonitoredResourceDescriptor(self, request, context):
-        """Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
+        """Gets a single monitored resource descriptor. This method does not require a
+    Stackdriver account.
     """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListMetricDescriptors(self, request, context):
-        """Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
+        """Lists metric descriptors that match a filter. This method does not require
+    a Stackdriver account.
     """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetMetricDescriptor(self, request, context):
-        """Gets a single metric descriptor. This method does not require a Stackdriver account.
+        """Gets a single metric descriptor. This method does not require a Stackdriver
+    account.
     """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
@@ -115,7 +119,8 @@ class MetricServiceServicer(object):
         raise NotImplementedError("Method not implemented!")
 
     def ListTimeSeries(self, request, context):
-        """Lists time series that match a filter. This method does not require a Stackdriver account.
+        """Lists time series that match a filter. This method does not require a
+    Stackdriver account.
     """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")

--- a/monitoring/google/cloud/monitoring_v3/proto/mutation_record.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/mutation_record.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/google/cloud/monitoring_v3/proto/notification.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/notification.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ syntax = "proto3";
 
 package google.monitoring.v3;
 
+import "google/api/annotations.proto";
 import "google/api/label.proto";
 import "google/monitoring/v3/common.proto";
 import "google/protobuf/wrappers.proto";
@@ -93,7 +94,9 @@ message NotificationChannel {
   }
 
   // The type of the notification channel. This field matches the
-  // value of the [NotificationChannelDescriptor.type][google.monitoring.v3.NotificationChannelDescriptor.type] field.
+  // value of the
+  // [NotificationChannelDescriptor.type][google.monitoring.v3.NotificationChannelDescriptor.type]
+  // field.
   string type = 1;
 
   // The full REST resource name for this channel. The syntax is:
@@ -111,13 +114,13 @@ message NotificationChannel {
 
   // An optional human-readable description of this notification channel. This
   // description may provide additional details, beyond the display
-  // name, for the channel. This may not exceed 1024 Unicode characters.
+  // name, for the channel. This may not exceeed 1024 Unicode characters.
   string description = 4;
 
   // Configuration fields that define the channel and its behavior. The
   // permissible and required labels are specified in the
-  // [NotificationChannelDescriptor.labels][google.monitoring.v3.NotificationChannelDescriptor.labels] of the
-  // `NotificationChannelDescriptor` corresponding to the `type` field.
+  // [NotificationChannelDescriptor.labels][google.monitoring.v3.NotificationChannelDescriptor.labels]
+  // of the `NotificationChannelDescriptor` corresponding to the `type` field.
   map<string, string> labels = 5;
 
   // User-supplied key/value data that does not need to conform to

--- a/monitoring/google/cloud/monitoring_v3/proto/notification_pb2.py
+++ b/monitoring/google/cloud/monitoring_v3/proto/notification_pb2.py
@@ -15,6 +15,7 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
+from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 from google.api import label_pb2 as google_dot_api_dot_label__pb2
 from google.cloud.monitoring_v3.proto import (
     common_pb2 as google_dot_cloud_dot_monitoring__v3_dot_proto_dot_common__pb2,
@@ -30,9 +31,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         "\n\030com.google.monitoring.v3B\021NotificationProtoP\001Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\252\002\032Google.Cloud.Monitoring.V3\312\002\032Google\\Cloud\\Monitoring\\V3"
     ),
     serialized_pb=_b(
-        '\n3google/cloud/monitoring_v3/proto/notification.proto\x12\x14google.monitoring.v3\x1a\x16google/api/label.proto\x1a-google/cloud/monitoring_v3/proto/common.proto\x1a\x1egoogle/protobuf/wrappers.proto"\xd3\x01\n\x1dNotificationChannelDescriptor\x12\x0c\n\x04name\x18\x06 \x01(\t\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12+\n\x06labels\x18\x04 \x03(\x0b\x32\x1b.google.api.LabelDescriptor\x12>\n\x0fsupported_tiers\x18\x05 \x03(\x0e\x32!.google.monitoring.v3.ServiceTierB\x02\x18\x01"\xb6\x04\n\x13NotificationChannel\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x06 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x03 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\x45\n\x06labels\x18\x05 \x03(\x0b\x32\x35.google.monitoring.v3.NotificationChannel.LabelsEntry\x12N\n\x0buser_labels\x18\x08 \x03(\x0b\x32\x39.google.monitoring.v3.NotificationChannel.UserLabelsEntry\x12Y\n\x13verification_status\x18\t \x01(\x0e\x32<.google.monitoring.v3.NotificationChannel.VerificationStatus\x12+\n\x07\x65nabled\x18\x0b \x01(\x0b\x32\x1a.google.protobuf.BoolValue\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x31\n\x0fUserLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"W\n\x12VerificationStatus\x12#\n\x1fVERIFICATION_STATUS_UNSPECIFIED\x10\x00\x12\x0e\n\nUNVERIFIED\x10\x01\x12\x0c\n\x08VERIFIED\x10\x02\x42\xa9\x01\n\x18\x63om.google.monitoring.v3B\x11NotificationProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
+        '\n3google/cloud/monitoring_v3/proto/notification.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a\x16google/api/label.proto\x1a-google/cloud/monitoring_v3/proto/common.proto\x1a\x1egoogle/protobuf/wrappers.proto"\xd3\x01\n\x1dNotificationChannelDescriptor\x12\x0c\n\x04name\x18\x06 \x01(\t\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12+\n\x06labels\x18\x04 \x03(\x0b\x32\x1b.google.api.LabelDescriptor\x12>\n\x0fsupported_tiers\x18\x05 \x03(\x0e\x32!.google.monitoring.v3.ServiceTierB\x02\x18\x01"\xb6\x04\n\x13NotificationChannel\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x06 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x03 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\x45\n\x06labels\x18\x05 \x03(\x0b\x32\x35.google.monitoring.v3.NotificationChannel.LabelsEntry\x12N\n\x0buser_labels\x18\x08 \x03(\x0b\x32\x39.google.monitoring.v3.NotificationChannel.UserLabelsEntry\x12Y\n\x13verification_status\x18\t \x01(\x0e\x32<.google.monitoring.v3.NotificationChannel.VerificationStatus\x12+\n\x07\x65nabled\x18\x0b \x01(\x0b\x32\x1a.google.protobuf.BoolValue\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x31\n\x0fUserLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"W\n\x12VerificationStatus\x12#\n\x1fVERIFICATION_STATUS_UNSPECIFIED\x10\x00\x12\x0e\n\nUNVERIFIED\x10\x01\x12\x0c\n\x08VERIFIED\x10\x02\x42\xa9\x01\n\x18\x63om.google.monitoring.v3B\x11NotificationProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
     ),
     dependencies=[
+        google_dot_api_dot_annotations__pb2.DESCRIPTOR,
         google_dot_api_dot_label__pb2.DESCRIPTOR,
         google_dot_cloud_dot_monitoring__v3_dot_proto_dot_common__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_wrappers__pb2.DESCRIPTOR,
@@ -62,8 +64,8 @@ _NOTIFICATIONCHANNEL_VERIFICATIONSTATUS = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=None,
-    serialized_start=874,
-    serialized_end=961,
+    serialized_start=904,
+    serialized_end=991,
 )
 _sym_db.RegisterEnumDescriptor(_NOTIFICATIONCHANNEL_VERIFICATIONSTATUS)
 
@@ -192,8 +194,8 @@ _NOTIFICATIONCHANNELDESCRIPTOR = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=181,
-    serialized_end=392,
+    serialized_start=211,
+    serialized_end=422,
 )
 
 
@@ -249,8 +251,8 @@ _NOTIFICATIONCHANNEL_LABELSENTRY = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=776,
-    serialized_end=821,
+    serialized_start=806,
+    serialized_end=851,
 )
 
 _NOTIFICATIONCHANNEL_USERLABELSENTRY = _descriptor.Descriptor(
@@ -305,8 +307,8 @@ _NOTIFICATIONCHANNEL_USERLABELSENTRY = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=823,
-    serialized_end=872,
+    serialized_start=853,
+    serialized_end=902,
 )
 
 _NOTIFICATIONCHANNEL = _descriptor.Descriptor(
@@ -472,8 +474,8 @@ _NOTIFICATIONCHANNEL = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=395,
-    serialized_end=961,
+    serialized_start=425,
+    serialized_end=991,
 )
 
 _NOTIFICATIONCHANNELDESCRIPTOR.fields_by_name[
@@ -594,7 +596,7 @@ NotificationChannel = _reflection.GeneratedProtocolMessageType(
       description:
           An optional human-readable description of this notification
           channel. This description may provide additional details,
-          beyond the display name, for the channel. This may not exceed
+          beyond the display name, for the channel. This may not exceeed
           1024 Unicode characters.
       labels:
           Configuration fields that define the channel and its behavior.

--- a/monitoring/google/cloud/monitoring_v3/proto/notification_service.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/notification_service.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-import "google/api/client.proto";
 
 option csharp_namespace = "Google.Cloud.Monitoring.V3";
 option go_package = "google.golang.org/genproto/googleapis/monitoring/v3;monitoring";
@@ -35,15 +34,11 @@ option php_namespace = "Google\\Cloud\\Monitoring\\V3";
 // The Notification Channel API provides access to configuration that
 // controls how messages related to incidents are sent.
 service NotificationChannelService {
-  option (google.api.default_host) = "monitoring.googleapis.com";
-  option (google.api.oauth_scopes) =
-      "https://www.googleapis.com/auth/cloud-platform,"
-      "https://www.googleapis.com/auth/monitoring,"
-      "https://www.googleapis.com/auth/monitoring.read";
-
   // Lists the descriptors for supported channel types. The use of descriptors
   // makes it possible for new channel types to be dynamically added.
-  rpc ListNotificationChannelDescriptors(ListNotificationChannelDescriptorsRequest) returns (ListNotificationChannelDescriptorsResponse) {
+  rpc ListNotificationChannelDescriptors(
+      ListNotificationChannelDescriptorsRequest)
+      returns (ListNotificationChannelDescriptorsResponse) {
     option (google.api.http) = {
       get: "/v3/{name=projects/*}/notificationChannelDescriptors"
     };
@@ -51,14 +46,16 @@ service NotificationChannelService {
 
   // Gets a single channel descriptor. The descriptor indicates which fields
   // are expected / permitted for a notification channel of the given type.
-  rpc GetNotificationChannelDescriptor(GetNotificationChannelDescriptorRequest) returns (NotificationChannelDescriptor) {
+  rpc GetNotificationChannelDescriptor(GetNotificationChannelDescriptorRequest)
+      returns (NotificationChannelDescriptor) {
     option (google.api.http) = {
       get: "/v3/{name=projects/*/notificationChannelDescriptors/*}"
     };
   }
 
   // Lists the notification channels that have been created for the project.
-  rpc ListNotificationChannels(ListNotificationChannelsRequest) returns (ListNotificationChannelsResponse) {
+  rpc ListNotificationChannels(ListNotificationChannelsRequest)
+      returns (ListNotificationChannelsResponse) {
     option (google.api.http) = {
       get: "/v3/{name=projects/*}/notificationChannels"
     };
@@ -69,7 +66,8 @@ service NotificationChannelService {
   // response may truncate or omit passwords, API keys, or other private key
   // matter and thus the response may not be 100% identical to the information
   // that was supplied in the call to the create method.
-  rpc GetNotificationChannel(GetNotificationChannelRequest) returns (NotificationChannel) {
+  rpc GetNotificationChannel(GetNotificationChannelRequest)
+      returns (NotificationChannel) {
     option (google.api.http) = {
       get: "/v3/{name=projects/*/notificationChannels/*}"
     };
@@ -77,7 +75,8 @@ service NotificationChannelService {
 
   // Creates a new notification channel, representing a single notification
   // endpoint such as an email address, SMS number, or PagerDuty service.
-  rpc CreateNotificationChannel(CreateNotificationChannelRequest) returns (NotificationChannel) {
+  rpc CreateNotificationChannel(CreateNotificationChannelRequest)
+      returns (NotificationChannel) {
     option (google.api.http) = {
       post: "/v3/{name=projects/*}/notificationChannels"
       body: "notification_channel"
@@ -86,7 +85,8 @@ service NotificationChannelService {
 
   // Updates a notification channel. Fields not specified in the field mask
   // remain unchanged.
-  rpc UpdateNotificationChannel(UpdateNotificationChannelRequest) returns (NotificationChannel) {
+  rpc UpdateNotificationChannel(UpdateNotificationChannelRequest)
+      returns (NotificationChannel) {
     option (google.api.http) = {
       patch: "/v3/{notification_channel.name=projects/*/notificationChannels/*}"
       body: "notification_channel"
@@ -94,7 +94,8 @@ service NotificationChannelService {
   }
 
   // Deletes a notification channel.
-  rpc DeleteNotificationChannel(DeleteNotificationChannelRequest) returns (google.protobuf.Empty) {
+  rpc DeleteNotificationChannel(DeleteNotificationChannelRequest)
+      returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v3/{name=projects/*/notificationChannels/*}"
     };
@@ -102,7 +103,9 @@ service NotificationChannelService {
 
   // Causes a verification code to be delivered to the channel. The code
   // can then be supplied in `VerifyNotificationChannel` to verify the channel.
-  rpc SendNotificationChannelVerificationCode(SendNotificationChannelVerificationCodeRequest) returns (google.protobuf.Empty) {
+  rpc SendNotificationChannelVerificationCode(
+      SendNotificationChannelVerificationCodeRequest)
+      returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/v3/{name=projects/*/notificationChannels/*}:sendVerificationCode"
       body: "*"
@@ -130,7 +133,9 @@ service NotificationChannelService {
   // have a shorter expiration (e.g. codes such as "G-123456") whereas
   // GetVerificationCode() will typically return a much longer, websafe base
   // 64 encoded string that has a longer expiration time.
-  rpc GetNotificationChannelVerificationCode(GetNotificationChannelVerificationCodeRequest) returns (GetNotificationChannelVerificationCodeResponse) {
+  rpc GetNotificationChannelVerificationCode(
+      GetNotificationChannelVerificationCodeRequest)
+      returns (GetNotificationChannelVerificationCodeResponse) {
     option (google.api.http) = {
       post: "/v3/{name=projects/*/notificationChannels/*}:getVerificationCode"
       body: "*"
@@ -140,7 +145,8 @@ service NotificationChannelService {
   // Verifies a `NotificationChannel` by proving receipt of the code
   // delivered to the channel as a result of calling
   // `SendNotificationChannelVerificationCode`.
-  rpc VerifyNotificationChannel(VerifyNotificationChannelRequest) returns (NotificationChannel) {
+  rpc VerifyNotificationChannel(VerifyNotificationChannelRequest)
+      returns (NotificationChannel) {
     option (google.api.http) = {
       post: "/v3/{name=projects/*/notificationChannels/*}:verify"
       body: "*"

--- a/monitoring/google/cloud/monitoring_v3/proto/notification_service_pb2.py
+++ b/monitoring/google/cloud/monitoring_v3/proto/notification_service_pb2.py
@@ -23,7 +23,6 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from google.protobuf import field_mask_pb2 as google_dot_protobuf_dot_field__mask__pb2
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
-from google.api import client_pb2 as google_dot_api_dot_client__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -34,7 +33,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         "\n\030com.google.monitoring.v3B\030NotificationServiceProtoP\001Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\252\002\032Google.Cloud.Monitoring.V3\312\002\032Google\\Cloud\\Monitoring\\V3"
     ),
     serialized_pb=_b(
-        '\n;google/cloud/monitoring_v3/proto/notification_service.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a\x33google/cloud/monitoring_v3/proto/notification.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a google/protobuf/field_mask.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17google/api/client.proto"`\n)ListNotificationChannelDescriptorsRequest\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"\x97\x01\n*ListNotificationChannelDescriptorsResponse\x12P\n\x13\x63hannel_descriptors\x18\x01 \x03(\x0b\x32\x33.google.monitoring.v3.NotificationChannelDescriptor\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"7\n\'GetNotificationChannelDescriptorRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"y\n CreateNotificationChannelRequest\x12\x0c\n\x04name\x18\x03 \x01(\t\x12G\n\x14notification_channel\x18\x02 \x01(\x0b\x32).google.monitoring.v3.NotificationChannel"x\n\x1fListNotificationChannelsRequest\x12\x0c\n\x04name\x18\x05 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x06 \x01(\t\x12\x10\n\x08order_by\x18\x07 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t"\x85\x01\n ListNotificationChannelsResponse\x12H\n\x15notification_channels\x18\x03 \x03(\x0b\x32).google.monitoring.v3.NotificationChannel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"-\n\x1dGetNotificationChannelRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"\x9c\x01\n UpdateNotificationChannelRequest\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask\x12G\n\x14notification_channel\x18\x03 \x01(\x0b\x32).google.monitoring.v3.NotificationChannel"?\n DeleteNotificationChannelRequest\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\r\n\x05\x66orce\x18\x05 \x01(\x08">\n.SendNotificationChannelVerificationCodeRequest\x12\x0c\n\x04name\x18\x01 \x01(\t"n\n-GetNotificationChannelVerificationCodeRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12/\n\x0b\x65xpire_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp"o\n.GetNotificationChannelVerificationCodeResponse\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12/\n\x0b\x65xpire_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp">\n VerifyNotificationChannelRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x63ode\x18\x02 \x01(\t2\xe7\x11\n\x1aNotificationChannelService\x12\xe5\x01\n"ListNotificationChannelDescriptors\x12?.google.monitoring.v3.ListNotificationChannelDescriptorsRequest\x1a@.google.monitoring.v3.ListNotificationChannelDescriptorsResponse"<\x82\xd3\xe4\x93\x02\x36\x12\x34/v3/{name=projects/*}/notificationChannelDescriptors\x12\xd6\x01\n GetNotificationChannelDescriptor\x12=.google.monitoring.v3.GetNotificationChannelDescriptorRequest\x1a\x33.google.monitoring.v3.NotificationChannelDescriptor">\x82\xd3\xe4\x93\x02\x38\x12\x36/v3/{name=projects/*/notificationChannelDescriptors/*}\x12\xbd\x01\n\x18ListNotificationChannels\x12\x35.google.monitoring.v3.ListNotificationChannelsRequest\x1a\x36.google.monitoring.v3.ListNotificationChannelsResponse"2\x82\xd3\xe4\x93\x02,\x12*/v3/{name=projects/*}/notificationChannels\x12\xae\x01\n\x16GetNotificationChannel\x12\x33.google.monitoring.v3.GetNotificationChannelRequest\x1a).google.monitoring.v3.NotificationChannel"4\x82\xd3\xe4\x93\x02.\x12,/v3/{name=projects/*/notificationChannels/*}\x12\xc8\x01\n\x19\x43reateNotificationChannel\x12\x36.google.monitoring.v3.CreateNotificationChannelRequest\x1a).google.monitoring.v3.NotificationChannel"H\x82\xd3\xe4\x93\x02\x42"*/v3/{name=projects/*}/notificationChannels:\x14notification_channel\x12\xdf\x01\n\x19UpdateNotificationChannel\x12\x36.google.monitoring.v3.UpdateNotificationChannelRequest\x1a).google.monitoring.v3.NotificationChannel"_\x82\xd3\xe4\x93\x02Y2A/v3/{notification_channel.name=projects/*/notificationChannels/*}:\x14notification_channel\x12\xa1\x01\n\x19\x44\x65leteNotificationChannel\x12\x36.google.monitoring.v3.DeleteNotificationChannelRequest\x1a\x16.google.protobuf.Empty"4\x82\xd3\xe4\x93\x02.*,/v3/{name=projects/*/notificationChannels/*}\x12\xd5\x01\n\'SendNotificationChannelVerificationCode\x12\x44.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest\x1a\x16.google.protobuf.Empty"L\x82\xd3\xe4\x93\x02\x46"A/v3/{name=projects/*/notificationChannels/*}:sendVerificationCode:\x01*\x12\x80\x02\n&GetNotificationChannelVerificationCode\x12\x43.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest\x1a\x44.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse"K\x82\xd3\xe4\x93\x02\x45"@/v3/{name=projects/*/notificationChannels/*}:getVerificationCode:\x01*\x12\xbe\x01\n\x19VerifyNotificationChannel\x12\x36.google.monitoring.v3.VerifyNotificationChannelRequest\x1a).google.monitoring.v3.NotificationChannel">\x82\xd3\xe4\x93\x02\x38"3/v3/{name=projects/*/notificationChannels/*}:verify:\x01*\x1a\xa9\x01\xca\x41\x19monitoring.googleapis.com\xd2\x41\x89\x01https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/monitoring.readB\xb0\x01\n\x18\x63om.google.monitoring.v3B\x18NotificationServiceProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
+        '\n;google/cloud/monitoring_v3/proto/notification_service.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a\x33google/cloud/monitoring_v3/proto/notification.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a google/protobuf/field_mask.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto"`\n)ListNotificationChannelDescriptorsRequest\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"\x97\x01\n*ListNotificationChannelDescriptorsResponse\x12P\n\x13\x63hannel_descriptors\x18\x01 \x03(\x0b\x32\x33.google.monitoring.v3.NotificationChannelDescriptor\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"7\n\'GetNotificationChannelDescriptorRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"y\n CreateNotificationChannelRequest\x12\x0c\n\x04name\x18\x03 \x01(\t\x12G\n\x14notification_channel\x18\x02 \x01(\x0b\x32).google.monitoring.v3.NotificationChannel"x\n\x1fListNotificationChannelsRequest\x12\x0c\n\x04name\x18\x05 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x06 \x01(\t\x12\x10\n\x08order_by\x18\x07 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t"\x85\x01\n ListNotificationChannelsResponse\x12H\n\x15notification_channels\x18\x03 \x03(\x0b\x32).google.monitoring.v3.NotificationChannel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t"-\n\x1dGetNotificationChannelRequest\x12\x0c\n\x04name\x18\x03 \x01(\t"\x9c\x01\n UpdateNotificationChannelRequest\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask\x12G\n\x14notification_channel\x18\x03 \x01(\x0b\x32).google.monitoring.v3.NotificationChannel"?\n DeleteNotificationChannelRequest\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\r\n\x05\x66orce\x18\x05 \x01(\x08">\n.SendNotificationChannelVerificationCodeRequest\x12\x0c\n\x04name\x18\x01 \x01(\t"n\n-GetNotificationChannelVerificationCodeRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12/\n\x0b\x65xpire_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp"o\n.GetNotificationChannelVerificationCodeResponse\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12/\n\x0b\x65xpire_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp">\n VerifyNotificationChannelRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x63ode\x18\x02 \x01(\t2\xbb\x10\n\x1aNotificationChannelService\x12\xe5\x01\n"ListNotificationChannelDescriptors\x12?.google.monitoring.v3.ListNotificationChannelDescriptorsRequest\x1a@.google.monitoring.v3.ListNotificationChannelDescriptorsResponse"<\x82\xd3\xe4\x93\x02\x36\x12\x34/v3/{name=projects/*}/notificationChannelDescriptors\x12\xd6\x01\n GetNotificationChannelDescriptor\x12=.google.monitoring.v3.GetNotificationChannelDescriptorRequest\x1a\x33.google.monitoring.v3.NotificationChannelDescriptor">\x82\xd3\xe4\x93\x02\x38\x12\x36/v3/{name=projects/*/notificationChannelDescriptors/*}\x12\xbd\x01\n\x18ListNotificationChannels\x12\x35.google.monitoring.v3.ListNotificationChannelsRequest\x1a\x36.google.monitoring.v3.ListNotificationChannelsResponse"2\x82\xd3\xe4\x93\x02,\x12*/v3/{name=projects/*}/notificationChannels\x12\xae\x01\n\x16GetNotificationChannel\x12\x33.google.monitoring.v3.GetNotificationChannelRequest\x1a).google.monitoring.v3.NotificationChannel"4\x82\xd3\xe4\x93\x02.\x12,/v3/{name=projects/*/notificationChannels/*}\x12\xc8\x01\n\x19\x43reateNotificationChannel\x12\x36.google.monitoring.v3.CreateNotificationChannelRequest\x1a).google.monitoring.v3.NotificationChannel"H\x82\xd3\xe4\x93\x02\x42"*/v3/{name=projects/*}/notificationChannels:\x14notification_channel\x12\xdf\x01\n\x19UpdateNotificationChannel\x12\x36.google.monitoring.v3.UpdateNotificationChannelRequest\x1a).google.monitoring.v3.NotificationChannel"_\x82\xd3\xe4\x93\x02Y2A/v3/{notification_channel.name=projects/*/notificationChannels/*}:\x14notification_channel\x12\xa1\x01\n\x19\x44\x65leteNotificationChannel\x12\x36.google.monitoring.v3.DeleteNotificationChannelRequest\x1a\x16.google.protobuf.Empty"4\x82\xd3\xe4\x93\x02.*,/v3/{name=projects/*/notificationChannels/*}\x12\xd5\x01\n\'SendNotificationChannelVerificationCode\x12\x44.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest\x1a\x16.google.protobuf.Empty"L\x82\xd3\xe4\x93\x02\x46"A/v3/{name=projects/*/notificationChannels/*}:sendVerificationCode:\x01*\x12\x80\x02\n&GetNotificationChannelVerificationCode\x12\x43.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest\x1a\x44.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse"K\x82\xd3\xe4\x93\x02\x45"@/v3/{name=projects/*/notificationChannels/*}:getVerificationCode:\x01*\x12\xbe\x01\n\x19VerifyNotificationChannel\x12\x36.google.monitoring.v3.VerifyNotificationChannelRequest\x1a).google.monitoring.v3.NotificationChannel">\x82\xd3\xe4\x93\x02\x38"3/v3/{name=projects/*/notificationChannels/*}:verify:\x01*B\xb0\x01\n\x18\x63om.google.monitoring.v3B\x18NotificationServiceProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
     ),
     dependencies=[
         google_dot_api_dot_annotations__pb2.DESCRIPTOR,
@@ -43,7 +42,6 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         google_dot_protobuf_dot_field__mask__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,
-        google_dot_api_dot_client__pb2.DESCRIPTOR,
     ],
 )
 
@@ -118,8 +116,8 @@ _LISTNOTIFICATIONCHANNELDESCRIPTORSREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=319,
-    serialized_end=415,
+    serialized_start=294,
+    serialized_end=390,
 )
 
 
@@ -175,8 +173,8 @@ _LISTNOTIFICATIONCHANNELDESCRIPTORSRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=418,
-    serialized_end=569,
+    serialized_start=393,
+    serialized_end=544,
 )
 
 
@@ -214,8 +212,8 @@ _GETNOTIFICATIONCHANNELDESCRIPTORREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=571,
-    serialized_end=626,
+    serialized_start=546,
+    serialized_end=601,
 )
 
 
@@ -271,8 +269,8 @@ _CREATENOTIFICATIONCHANNELREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=628,
-    serialized_end=749,
+    serialized_start=603,
+    serialized_end=724,
 )
 
 
@@ -382,8 +380,8 @@ _LISTNOTIFICATIONCHANNELSREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=751,
-    serialized_end=871,
+    serialized_start=726,
+    serialized_end=846,
 )
 
 
@@ -439,8 +437,8 @@ _LISTNOTIFICATIONCHANNELSRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=874,
-    serialized_end=1007,
+    serialized_start=849,
+    serialized_end=982,
 )
 
 
@@ -478,8 +476,8 @@ _GETNOTIFICATIONCHANNELREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1009,
-    serialized_end=1054,
+    serialized_start=984,
+    serialized_end=1029,
 )
 
 
@@ -535,8 +533,8 @@ _UPDATENOTIFICATIONCHANNELREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1057,
-    serialized_end=1213,
+    serialized_start=1032,
+    serialized_end=1188,
 )
 
 
@@ -592,8 +590,8 @@ _DELETENOTIFICATIONCHANNELREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1215,
-    serialized_end=1278,
+    serialized_start=1190,
+    serialized_end=1253,
 )
 
 
@@ -631,8 +629,8 @@ _SENDNOTIFICATIONCHANNELVERIFICATIONCODEREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1280,
-    serialized_end=1342,
+    serialized_start=1255,
+    serialized_end=1317,
 )
 
 
@@ -688,8 +686,8 @@ _GETNOTIFICATIONCHANNELVERIFICATIONCODEREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1344,
-    serialized_end=1454,
+    serialized_start=1319,
+    serialized_end=1429,
 )
 
 
@@ -745,8 +743,8 @@ _GETNOTIFICATIONCHANNELVERIFICATIONCODERESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1456,
-    serialized_end=1567,
+    serialized_start=1431,
+    serialized_end=1542,
 )
 
 
@@ -802,8 +800,8 @@ _VERIFYNOTIFICATIONCHANNELREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1569,
-    serialized_end=1631,
+    serialized_start=1544,
+    serialized_end=1606,
 )
 
 _LISTNOTIFICATIONCHANNELDESCRIPTORSRESPONSE.fields_by_name[
@@ -1225,11 +1223,9 @@ _NOTIFICATIONCHANNELSERVICE = _descriptor.ServiceDescriptor(
     full_name="google.monitoring.v3.NotificationChannelService",
     file=DESCRIPTOR,
     index=0,
-    serialized_options=_b(
-        "\312A\031monitoring.googleapis.com\322A\211\001https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/monitoring.read"
-    ),
-    serialized_start=1634,
-    serialized_end=3913,
+    serialized_options=None,
+    serialized_start=1609,
+    serialized_end=3716,
     methods=[
         _descriptor.MethodDescriptor(
             name="ListNotificationChannelDescriptors",

--- a/monitoring/google/cloud/monitoring_v3/proto/span_context.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/span_context.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/monitoring/google/cloud/monitoring_v3/proto/uptime.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/uptime.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,51 +27,11 @@ option java_outer_classname = "UptimeProto";
 option java_package = "com.google.monitoring.v3";
 option php_namespace = "Google\\Cloud\\Monitoring\\V3";
 
-// The regions from which an uptime check can be run.
-enum UptimeCheckRegion {
-  // Default value if no region is specified. Will result in uptime checks
-  // running from all regions.
-  REGION_UNSPECIFIED = 0;
-
-  // Allows checks to run from locations within the United States of America.
-  USA = 1;
-
-  // Allows checks to run from locations within the continent of Europe.
-  EUROPE = 2;
-
-  // Allows checks to run from locations within the continent of South
-  // America.
-  SOUTH_AMERICA = 3;
-
-  // Allows checks to run from locations within the Asia Pacific area (ex:
-  // Singapore).
-  ASIA_PACIFIC = 4;
-}
-
 // An internal checker allows uptime checks to run on private/internal GCP
 // resources.
 message InternalChecker {
-  option deprecated = true;
-
-  // Operational states for an internal checker.
-  enum State {
-    // An internal checker should never be in the unspecified state.
-    UNSPECIFIED = 0;
-
-    // The checker is being created, provisioned, and configured. A checker in
-    // this state can be returned by ListInternalCheckers or GetInternalChecker,
-    // as well as by examining the longrunning.Operation that created it.
-    CREATING = 1;
-
-    // The checker is running and available for use. A checker in this state
-    // can be returned by ListInternalCheckers or GetInternalChecker as well
-    // as by examining the longrunning.Operation that created it.
-    // If a checker is being torn down, it is neither visible nor usable, so
-    // there is no "deleting" or "down" state.
-    RUNNING = 2;
-  }
-
   // A unique resource name for this InternalChecker. The format is:
+  //
   //
   //   `projects/[PROJECT_ID]/internalCheckers/[INTERNAL_CHECKER_ID]`.
   //
@@ -95,26 +55,6 @@ message InternalChecker {
   // The GCP project_id where the internal checker lives. Not necessary
   // the same as the workspace project.
   string peer_project_id = 6;
-
-  // The current operational state of the internal checker.
-  State state = 7;
-}
-
-// The supported resource types that can be used as values of
-// `group_resource.resource_type`.
-// `INSTANCE` includes `gce_instance` and `aws_ec2_instance` resource types.
-// The resource types `gae_app` and `uptime_url` are not valid here because
-// group checks on App Engine modules and URLs are not allowed.
-enum GroupResourceType {
-  // Default value (not valid).
-  RESOURCE_TYPE_UNSPECIFIED = 0;
-
-  // A group of instances from Google Cloud Platform (GCP) or
-  // Amazon Web Services (AWS).
-  INSTANCE = 1;
-
-  // A group of Amazon ELB load balancers.
-  AWS_ELB_LOAD_BALANCER = 2;
 }
 
 // This message configures which resources and services to monitor for
@@ -149,8 +89,7 @@ message UptimeCheckConfig {
 
     // The path to the page to run the check against. Will be combined with the
     // host (specified within the MonitoredResource) and port to construct the
-    // full URL. Optional (defaults to "/"). If the provided path does not
-    // begin with "/", it will be prepended automatically.
+    // full URL. Optional (defaults to "/").
     string path = 2;
 
     // The port to the page to run the check against. Will be combined with host
@@ -179,11 +118,6 @@ message UptimeCheckConfig {
     // cause the first to be overwritten by the second.
     // The maximum number of headers allowed is 100.
     map<string, string> headers = 6;
-
-    // Boolean specifying whether to validate SSL certificates.
-    // Only applies to uptime_url checks. If use_ssl is false, setting this to
-    // true has no effect.
-    bool validate_ssl = 7;
   }
 
   // Information required for a TCP uptime check request.
@@ -197,33 +131,8 @@ message UptimeCheckConfig {
   // Used to perform string matching. It allows substring and regular
   // expressions, together with their negations.
   message ContentMatcher {
-    // Options to perform content matching.
-    enum ContentMatcherOption {
-      // No content macher option specified. Treated as CONTAINS_STRING.
-      CONTENT_MATCHER_OPTION_UNSPECIFIED = 0;
-
-      // Allows checking substring matching.
-      // Default value for previous versions without option.
-      CONTAINS_STRING = 1;
-
-      // Allows checking negation of substring matching (doesn't contain the
-      // substring).
-      NOT_CONTAINS_STRING = 2;
-
-      // Allows checking regular expression matching.
-      MATCHES_REGEX = 3;
-
-      // Allows checking negation of regular expression matching.
-      NOT_MATCHES_REGEX = 4;
-    }
-
     // String or regex content to match (max 1024 bytes)
     string content = 1;
-
-    // The matcher representing content match options which the check will run
-    // with. If the field is not specified (in previous versions), the option is
-    // set to be CONTAINS_STRING which performs content substring matching.
-    ContentMatcherOption matcher = 2;
   }
 
   // A unique resource name for this UptimeCheckConfig. The format is:
@@ -270,7 +179,7 @@ message UptimeCheckConfig {
   // How often, in seconds, the uptime check is performed.
   // Currently, the only supported values are `60s` (1 minute), `300s`
   // (5 minutes), `600s` (10 minutes), and `900s` (15 minutes). Optional,
-  // defaults to `60s`.
+  // defaults to `300s`.
   google.protobuf.Duration period = 7;
 
   // The maximum amount of time to wait for the request to complete (must be
@@ -292,10 +201,16 @@ message UptimeCheckConfig {
   // regions.
   repeated UptimeCheckRegion selected_regions = 10;
 
+  // If this is true, then checks are made only from the 'internal_checkers'.
+  // If it is false, then checks are made only from the 'selected_regions'.
+  // It is an error to provide 'selected_regions' when is_internal is true,
+  // or to provide 'internal_checkers' when is_internal is false.
+  bool is_internal = 15;
+
   // The internal checkers that this check will egress from. If `is_internal` is
   // true and this list is empty, the check will egress from all the
   // InternalCheckers configured for the project that owns this CheckConfig.
-  repeated InternalChecker internal_checkers = 14 [deprecated = true];
+  repeated InternalChecker internal_checkers = 14;
 }
 
 // Contains the region, location, and list of IP
@@ -315,4 +230,42 @@ message UptimeCheckIp {
   // IP addresses being in IPv4 format indefinitely and should support
   // interpreting this field in either IPv4 or IPv6 format.
   string ip_address = 3;
+}
+
+// The regions from which an uptime check can be run.
+enum UptimeCheckRegion {
+  // Default value if no region is specified. Will result in uptime checks
+  // running from all regions.
+  REGION_UNSPECIFIED = 0;
+
+  // Allows checks to run from locations within the United States of America.
+  USA = 1;
+
+  // Allows checks to run from locations within the continent of Europe.
+  EUROPE = 2;
+
+  // Allows checks to run from locations within the continent of South
+  // America.
+  SOUTH_AMERICA = 3;
+
+  // Allows checks to run from locations within the Asia Pacific area (ex:
+  // Singapore).
+  ASIA_PACIFIC = 4;
+}
+
+// The supported resource types that can be used as values of
+// `group_resource.resource_type`.
+// `INSTANCE` includes `gce_instance` and `aws_ec2_instance` resource types.
+// The resource types `gae_app` and `uptime_url` are not valid here because
+// group checks on App Engine modules and URLs are not allowed.
+enum GroupResourceType {
+  // Default value (not valid).
+  RESOURCE_TYPE_UNSPECIFIED = 0;
+
+  // A group of instances from Google Cloud Platform (GCP) or
+  // Amazon Web Services (AWS).
+  INSTANCE = 1;
+
+  // A group of Amazon ELB load balancers.
+  AWS_ELB_LOAD_BALANCER = 2;
 }

--- a/monitoring/google/cloud/monitoring_v3/proto/uptime_pb2.py
+++ b/monitoring/google/cloud/monitoring_v3/proto/uptime_pb2.py
@@ -30,7 +30,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         "\n\030com.google.monitoring.v3B\013UptimeProtoP\001Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\252\002\032Google.Cloud.Monitoring.V3\312\002\032Google\\Cloud\\Monitoring\\V3"
     ),
     serialized_pb=_b(
-        '\n-google/cloud/monitoring_v3/proto/uptime.proto\x12\x14google.monitoring.v3\x1a#google/api/monitored_resource.proto\x1a\x1egoogle/protobuf/duration.proto"\xe6\x01\n\x0fInternalChecker\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x02 \x01(\t\x12\x0f\n\x07network\x18\x03 \x01(\t\x12\x10\n\x08gcp_zone\x18\x04 \x01(\t\x12\x17\n\x0fpeer_project_id\x18\x06 \x01(\t\x12:\n\x05state\x18\x07 \x01(\x0e\x32+.google.monitoring.v3.InternalChecker.State"3\n\x05State\x12\x0f\n\x0bUNSPECIFIED\x10\x00\x12\x0c\n\x08\x43REATING\x10\x01\x12\x0b\n\x07RUNNING\x10\x02:\x02\x18\x01"\xbe\x0b\n\x11UptimeCheckConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x02 \x01(\t\x12;\n\x12monitored_resource\x18\x03 \x01(\x0b\x32\x1d.google.api.MonitoredResourceH\x00\x12O\n\x0eresource_group\x18\x04 \x01(\x0b\x32\x35.google.monitoring.v3.UptimeCheckConfig.ResourceGroupH\x00\x12G\n\nhttp_check\x18\x05 \x01(\x0b\x32\x31.google.monitoring.v3.UptimeCheckConfig.HttpCheckH\x01\x12\x45\n\ttcp_check\x18\x06 \x01(\x0b\x32\x30.google.monitoring.v3.UptimeCheckConfig.TcpCheckH\x01\x12)\n\x06period\x18\x07 \x01(\x0b\x32\x19.google.protobuf.Duration\x12*\n\x07timeout\x18\x08 \x01(\x0b\x32\x19.google.protobuf.Duration\x12P\n\x10\x63ontent_matchers\x18\t \x03(\x0b\x32\x36.google.monitoring.v3.UptimeCheckConfig.ContentMatcher\x12\x41\n\x10selected_regions\x18\n \x03(\x0e\x32\'.google.monitoring.v3.UptimeCheckRegion\x12\x44\n\x11internal_checkers\x18\x0e \x03(\x0b\x32%.google.monitoring.v3.InternalCheckerB\x02\x18\x01\x1a\x61\n\rResourceGroup\x12\x10\n\x08group_id\x18\x01 \x01(\t\x12>\n\rresource_type\x18\x02 \x01(\x0e\x32\'.google.monitoring.v3.GroupResourceType\x1a\xfa\x02\n\tHttpCheck\x12\x0f\n\x07use_ssl\x18\x01 \x01(\x08\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x0c\n\x04port\x18\x03 \x01(\x05\x12X\n\tauth_info\x18\x04 \x01(\x0b\x32\x45.google.monitoring.v3.UptimeCheckConfig.HttpCheck.BasicAuthentication\x12\x14\n\x0cmask_headers\x18\x05 \x01(\x08\x12O\n\x07headers\x18\x06 \x03(\x0b\x32>.google.monitoring.v3.UptimeCheckConfig.HttpCheck.HeadersEntry\x12\x14\n\x0cvalidate_ssl\x18\x07 \x01(\x08\x1a\x39\n\x13\x42\x61sicAuthentication\x12\x10\n\x08username\x18\x01 \x01(\t\x12\x10\n\x08password\x18\x02 \x01(\t\x1a.\n\x0cHeadersEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x18\n\x08TcpCheck\x12\x0c\n\x04port\x18\x01 \x01(\x05\x1a\x98\x02\n\x0e\x43ontentMatcher\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\x12\\\n\x07matcher\x18\x02 \x01(\x0e\x32K.google.monitoring.v3.UptimeCheckConfig.ContentMatcher.ContentMatcherOption"\x96\x01\n\x14\x43ontentMatcherOption\x12&\n"CONTENT_MATCHER_OPTION_UNSPECIFIED\x10\x00\x12\x13\n\x0f\x43ONTAINS_STRING\x10\x01\x12\x17\n\x13NOT_CONTAINS_STRING\x10\x02\x12\x11\n\rMATCHES_REGEX\x10\x03\x12\x15\n\x11NOT_MATCHES_REGEX\x10\x04\x42\n\n\x08resourceB\x14\n\x12\x63heck_request_type"n\n\rUptimeCheckIp\x12\x37\n\x06region\x18\x01 \x01(\x0e\x32\'.google.monitoring.v3.UptimeCheckRegion\x12\x10\n\x08location\x18\x02 \x01(\t\x12\x12\n\nip_address\x18\x03 \x01(\t*e\n\x11UptimeCheckRegion\x12\x16\n\x12REGION_UNSPECIFIED\x10\x00\x12\x07\n\x03USA\x10\x01\x12\n\n\x06\x45UROPE\x10\x02\x12\x11\n\rSOUTH_AMERICA\x10\x03\x12\x10\n\x0c\x41SIA_PACIFIC\x10\x04*[\n\x11GroupResourceType\x12\x1d\n\x19RESOURCE_TYPE_UNSPECIFIED\x10\x00\x12\x0c\n\x08INSTANCE\x10\x01\x12\x19\n\x15\x41WS_ELB_LOAD_BALANCER\x10\x02\x42\xa3\x01\n\x18\x63om.google.monitoring.v3B\x0bUptimeProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
+        "\n-google/cloud/monitoring_v3/proto/uptime.proto\x12\x14google.monitoring.v3\x1a#google/api/monitored_resource.proto\x1a\x1egoogle/protobuf/duration.proto\"q\n\x0fInternalChecker\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x02 \x01(\t\x12\x0f\n\x07network\x18\x03 \x01(\t\x12\x10\n\x08gcp_zone\x18\x04 \x01(\t\x12\x17\n\x0fpeer_project_id\x18\x06 \x01(\t\"\xc1\t\n\x11UptimeCheckConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x02 \x01(\t\x12;\n\x12monitored_resource\x18\x03 \x01(\x0b\x32\x1d.google.api.MonitoredResourceH\x00\x12O\n\x0eresource_group\x18\x04 \x01(\x0b\x32\x35.google.monitoring.v3.UptimeCheckConfig.ResourceGroupH\x00\x12G\n\nhttp_check\x18\x05 \x01(\x0b\x32\x31.google.monitoring.v3.UptimeCheckConfig.HttpCheckH\x01\x12\x45\n\ttcp_check\x18\x06 \x01(\x0b\x32\x30.google.monitoring.v3.UptimeCheckConfig.TcpCheckH\x01\x12)\n\x06period\x18\x07 \x01(\x0b\x32\x19.google.protobuf.Duration\x12*\n\x07timeout\x18\x08 \x01(\x0b\x32\x19.google.protobuf.Duration\x12P\n\x10\x63ontent_matchers\x18\t \x03(\x0b\x32\x36.google.monitoring.v3.UptimeCheckConfig.ContentMatcher\x12\x41\n\x10selected_regions\x18\n \x03(\x0e\x32'.google.monitoring.v3.UptimeCheckRegion\x12\x13\n\x0bis_internal\x18\x0f \x01(\x08\x12@\n\x11internal_checkers\x18\x0e \x03(\x0b\x32%.google.monitoring.v3.InternalChecker\x1a\x61\n\rResourceGroup\x12\x10\n\x08group_id\x18\x01 \x01(\t\x12>\n\rresource_type\x18\x02 \x01(\x0e\x32'.google.monitoring.v3.GroupResourceType\x1a\xe4\x02\n\tHttpCheck\x12\x0f\n\x07use_ssl\x18\x01 \x01(\x08\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x0c\n\x04port\x18\x03 \x01(\x05\x12X\n\tauth_info\x18\x04 \x01(\x0b\x32\x45.google.monitoring.v3.UptimeCheckConfig.HttpCheck.BasicAuthentication\x12\x14\n\x0cmask_headers\x18\x05 \x01(\x08\x12O\n\x07headers\x18\x06 \x03(\x0b\x32>.google.monitoring.v3.UptimeCheckConfig.HttpCheck.HeadersEntry\x1a\x39\n\x13\x42\x61sicAuthentication\x12\x10\n\x08username\x18\x01 \x01(\t\x12\x10\n\x08password\x18\x02 \x01(\t\x1a.\n\x0cHeadersEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x18\n\x08TcpCheck\x12\x0c\n\x04port\x18\x01 \x01(\x05\x1a!\n\x0e\x43ontentMatcher\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\tB\n\n\x08resourceB\x14\n\x12\x63heck_request_type\"n\n\rUptimeCheckIp\x12\x37\n\x06region\x18\x01 \x01(\x0e\x32'.google.monitoring.v3.UptimeCheckRegion\x12\x10\n\x08location\x18\x02 \x01(\t\x12\x12\n\nip_address\x18\x03 \x01(\t*e\n\x11UptimeCheckRegion\x12\x16\n\x12REGION_UNSPECIFIED\x10\x00\x12\x07\n\x03USA\x10\x01\x12\n\n\x06\x45UROPE\x10\x02\x12\x11\n\rSOUTH_AMERICA\x10\x03\x12\x10\n\x0c\x41SIA_PACIFIC\x10\x04*[\n\x11GroupResourceType\x12\x1d\n\x19RESOURCE_TYPE_UNSPECIFIED\x10\x00\x12\x0c\n\x08INSTANCE\x10\x01\x12\x19\n\x15\x41WS_ELB_LOAD_BALANCER\x10\x02\x42\xa3\x01\n\x18\x63om.google.monitoring.v3B\x0bUptimeProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3"
     ),
     dependencies=[
         google_dot_api_dot_monitored__resource__pb2.DESCRIPTOR,
@@ -66,8 +66,8 @@ _UPTIMECHECKREGION = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=None,
-    serialized_start=1958,
-    serialized_end=2059,
+    serialized_start=1587,
+    serialized_end=1688,
 )
 _sym_db.RegisterEnumDescriptor(_UPTIMECHECKREGION)
 
@@ -98,8 +98,8 @@ _GROUPRESOURCETYPE = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=None,
-    serialized_start=2061,
-    serialized_end=2152,
+    serialized_start=1690,
+    serialized_end=1781,
 )
 _sym_db.RegisterEnumDescriptor(_GROUPRESOURCETYPE)
 
@@ -112,75 +112,6 @@ ASIA_PACIFIC = 4
 RESOURCE_TYPE_UNSPECIFIED = 0
 INSTANCE = 1
 AWS_ELB_LOAD_BALANCER = 2
-
-
-_INTERNALCHECKER_STATE = _descriptor.EnumDescriptor(
-    name="State",
-    full_name="google.monitoring.v3.InternalChecker.State",
-    filename=None,
-    file=DESCRIPTOR,
-    values=[
-        _descriptor.EnumValueDescriptor(
-            name="UNSPECIFIED", index=0, number=0, serialized_options=None, type=None
-        ),
-        _descriptor.EnumValueDescriptor(
-            name="CREATING", index=1, number=1, serialized_options=None, type=None
-        ),
-        _descriptor.EnumValueDescriptor(
-            name="RUNNING", index=2, number=2, serialized_options=None, type=None
-        ),
-    ],
-    containing_type=None,
-    serialized_options=None,
-    serialized_start=316,
-    serialized_end=367,
-)
-_sym_db.RegisterEnumDescriptor(_INTERNALCHECKER_STATE)
-
-_UPTIMECHECKCONFIG_CONTENTMATCHER_CONTENTMATCHEROPTION = _descriptor.EnumDescriptor(
-    name="ContentMatcherOption",
-    full_name="google.monitoring.v3.UptimeCheckConfig.ContentMatcher.ContentMatcherOption",
-    filename=None,
-    file=DESCRIPTOR,
-    values=[
-        _descriptor.EnumValueDescriptor(
-            name="CONTENT_MATCHER_OPTION_UNSPECIFIED",
-            index=0,
-            number=0,
-            serialized_options=None,
-            type=None,
-        ),
-        _descriptor.EnumValueDescriptor(
-            name="CONTAINS_STRING",
-            index=1,
-            number=1,
-            serialized_options=None,
-            type=None,
-        ),
-        _descriptor.EnumValueDescriptor(
-            name="NOT_CONTAINS_STRING",
-            index=2,
-            number=2,
-            serialized_options=None,
-            type=None,
-        ),
-        _descriptor.EnumValueDescriptor(
-            name="MATCHES_REGEX", index=3, number=3, serialized_options=None, type=None
-        ),
-        _descriptor.EnumValueDescriptor(
-            name="NOT_MATCHES_REGEX",
-            index=4,
-            number=4,
-            serialized_options=None,
-            type=None,
-        ),
-    ],
-    containing_type=None,
-    serialized_options=None,
-    serialized_start=1660,
-    serialized_end=1810,
-)
-_sym_db.RegisterEnumDescriptor(_UPTIMECHECKCONFIG_CONTENTMATCHER_CONTENTMATCHEROPTION)
 
 
 _INTERNALCHECKER = _descriptor.Descriptor(
@@ -280,35 +211,17 @@ _INTERNALCHECKER = _descriptor.Descriptor(
             serialized_options=None,
             file=DESCRIPTOR,
         ),
-        _descriptor.FieldDescriptor(
-            name="state",
-            full_name="google.monitoring.v3.InternalChecker.state",
-            index=5,
-            number=7,
-            type=14,
-            cpp_type=8,
-            label=1,
-            has_default_value=False,
-            default_value=0,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
     ],
     extensions=[],
     nested_types=[],
-    enum_types=[_INTERNALCHECKER_STATE],
-    serialized_options=_b("\030\001"),
+    enum_types=[],
+    serialized_options=None,
     is_extendable=False,
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=141,
-    serialized_end=371,
+    serialized_start=140,
+    serialized_end=253,
 )
 
 
@@ -364,8 +277,8 @@ _UPTIMECHECKCONFIG_RESOURCEGROUP = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1023,
-    serialized_end=1120,
+    serialized_start=922,
+    serialized_end=1019,
 )
 
 _UPTIMECHECKCONFIG_HTTPCHECK_BASICAUTHENTICATION = _descriptor.Descriptor(
@@ -420,8 +333,8 @@ _UPTIMECHECKCONFIG_HTTPCHECK_BASICAUTHENTICATION = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1396,
-    serialized_end=1453,
+    serialized_start=1273,
+    serialized_end=1330,
 )
 
 _UPTIMECHECKCONFIG_HTTPCHECK_HEADERSENTRY = _descriptor.Descriptor(
@@ -476,8 +389,8 @@ _UPTIMECHECKCONFIG_HTTPCHECK_HEADERSENTRY = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1455,
-    serialized_end=1501,
+    serialized_start=1332,
+    serialized_end=1378,
 )
 
 _UPTIMECHECKCONFIG_HTTPCHECK = _descriptor.Descriptor(
@@ -595,24 +508,6 @@ _UPTIMECHECKCONFIG_HTTPCHECK = _descriptor.Descriptor(
             serialized_options=None,
             file=DESCRIPTOR,
         ),
-        _descriptor.FieldDescriptor(
-            name="validate_ssl",
-            full_name="google.monitoring.v3.UptimeCheckConfig.HttpCheck.validate_ssl",
-            index=6,
-            number=7,
-            type=8,
-            cpp_type=7,
-            label=1,
-            has_default_value=False,
-            default_value=False,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
     ],
     extensions=[],
     nested_types=[
@@ -625,8 +520,8 @@ _UPTIMECHECKCONFIG_HTTPCHECK = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1123,
-    serialized_end=1501,
+    serialized_start=1022,
+    serialized_end=1378,
 )
 
 _UPTIMECHECKCONFIG_TCPCHECK = _descriptor.Descriptor(
@@ -663,8 +558,8 @@ _UPTIMECHECKCONFIG_TCPCHECK = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1503,
-    serialized_end=1527,
+    serialized_start=1380,
+    serialized_end=1404,
 )
 
 _UPTIMECHECKCONFIG_CONTENTMATCHER = _descriptor.Descriptor(
@@ -691,36 +586,18 @@ _UPTIMECHECKCONFIG_CONTENTMATCHER = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="matcher",
-            full_name="google.monitoring.v3.UptimeCheckConfig.ContentMatcher.matcher",
-            index=1,
-            number=2,
-            type=14,
-            cpp_type=8,
-            label=1,
-            has_default_value=False,
-            default_value=0,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
+        )
     ],
     extensions=[],
     nested_types=[],
-    enum_types=[_UPTIMECHECKCONFIG_CONTENTMATCHER_CONTENTMATCHEROPTION],
+    enum_types=[],
     serialized_options=None,
     is_extendable=False,
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1530,
-    serialized_end=1810,
+    serialized_start=1406,
+    serialized_end=1439,
 )
 
 _UPTIMECHECKCONFIG = _descriptor.Descriptor(
@@ -911,9 +788,27 @@ _UPTIMECHECKCONFIG = _descriptor.Descriptor(
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
+            name="is_internal",
+            full_name="google.monitoring.v3.UptimeCheckConfig.is_internal",
+            index=10,
+            number=15,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
             name="internal_checkers",
             full_name="google.monitoring.v3.UptimeCheckConfig.internal_checkers",
-            index=10,
+            index=11,
             number=14,
             type=11,
             cpp_type=10,
@@ -925,7 +820,7 @@ _UPTIMECHECKCONFIG = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            serialized_options=_b("\030\001"),
+            serialized_options=None,
             file=DESCRIPTOR,
         ),
     ],
@@ -957,8 +852,8 @@ _UPTIMECHECKCONFIG = _descriptor.Descriptor(
             fields=[],
         ),
     ],
-    serialized_start=374,
-    serialized_end=1844,
+    serialized_start=256,
+    serialized_end=1473,
 )
 
 
@@ -1032,12 +927,10 @@ _UPTIMECHECKIP = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1846,
-    serialized_end=1956,
+    serialized_start=1475,
+    serialized_end=1585,
 )
 
-_INTERNALCHECKER.fields_by_name["state"].enum_type = _INTERNALCHECKER_STATE
-_INTERNALCHECKER_STATE.containing_type = _INTERNALCHECKER
 _UPTIMECHECKCONFIG_RESOURCEGROUP.fields_by_name[
     "resource_type"
 ].enum_type = _GROUPRESOURCETYPE
@@ -1054,13 +947,7 @@ _UPTIMECHECKCONFIG_HTTPCHECK.fields_by_name[
 ].message_type = _UPTIMECHECKCONFIG_HTTPCHECK_HEADERSENTRY
 _UPTIMECHECKCONFIG_HTTPCHECK.containing_type = _UPTIMECHECKCONFIG
 _UPTIMECHECKCONFIG_TCPCHECK.containing_type = _UPTIMECHECKCONFIG
-_UPTIMECHECKCONFIG_CONTENTMATCHER.fields_by_name[
-    "matcher"
-].enum_type = _UPTIMECHECKCONFIG_CONTENTMATCHER_CONTENTMATCHEROPTION
 _UPTIMECHECKCONFIG_CONTENTMATCHER.containing_type = _UPTIMECHECKCONFIG
-_UPTIMECHECKCONFIG_CONTENTMATCHER_CONTENTMATCHEROPTION.containing_type = (
-    _UPTIMECHECKCONFIG_CONTENTMATCHER
-)
 _UPTIMECHECKCONFIG.fields_by_name[
     "monitored_resource"
 ].message_type = google_dot_api_dot_monitored__resource__pb2._MONITOREDRESOURCE
@@ -1147,8 +1034,6 @@ InternalChecker = _reflection.GeneratedProtocolMessageType(
       peer_project_id:
           The GCP project\_id where the internal checker lives. Not
           necessary the same as the workspace project.
-      state:
-          The current operational state of the internal checker.
   """,
         # @@protoc_insertion_point(class_scope:google.monitoring.v3.InternalChecker)
     ),
@@ -1224,8 +1109,7 @@ UptimeCheckConfig = _reflection.GeneratedProtocolMessageType(
             The path to the page to run the check against. Will be
             combined with the host (specified within the
             MonitoredResource) and port to construct the full URL.
-            Optional (defaults to "/"). If the provided path does not
-            begin with "/", it will be prepended automatically.
+            Optional (defaults to "/").
         port:
             The port to the page to run the check against. Will be
             combined with host (specified within the MonitoredResource)
@@ -1252,10 +1136,6 @@ UptimeCheckConfig = _reflection.GeneratedProtocolMessageType(
             Entering two separate headers with the same key in a Create
             call will cause the first to be overwritten by the second. The
             maximum number of headers allowed is 100.
-        validate_ssl:
-            Boolean specifying whether to validate SSL certificates. Only
-            applies to uptime\_url checks. If use\_ssl is false, setting
-            this to true has no effect.
     """,
                 # @@protoc_insertion_point(class_scope:google.monitoring.v3.UptimeCheckConfig.HttpCheck)
             ),
@@ -1291,11 +1171,6 @@ UptimeCheckConfig = _reflection.GeneratedProtocolMessageType(
     Attributes:
         content:
             String or regex content to match (max 1024 bytes)
-        matcher:
-            The matcher representing content match options which the check
-            will run with. If the field is not specified (in previous
-            versions), the option is set to be CONTAINS\_STRING which
-            performs content substring matching.
     """,
                 # @@protoc_insertion_point(class_scope:google.monitoring.v3.UptimeCheckConfig.ContentMatcher)
             ),
@@ -1339,7 +1214,7 @@ UptimeCheckConfig = _reflection.GeneratedProtocolMessageType(
           How often, in seconds, the uptime check is performed.
           Currently, the only supported values are ``60s`` (1 minute),
           ``300s`` (5 minutes), ``600s`` (10 minutes), and ``900s`` (15
-          minutes). Optional, defaults to ``60s``.
+          minutes). Optional, defaults to ``300s``.
       timeout:
           The maximum amount of time to wait for the request to complete
           (must be between 1 and 60 seconds). Required.
@@ -1357,6 +1232,12 @@ UptimeCheckConfig = _reflection.GeneratedProtocolMessageType(
           minimum of 3 locations must be provided, or an error message
           is returned. Not specifying this field will result in uptime
           checks running from all regions.
+      is_internal:
+          If this is true, then checks are made only from the
+          'internal\_checkers'. If it is false, then checks are made
+          only from the 'selected\_regions'. It is an error to provide
+          'selected\_regions' when is\_internal is true, or to provide
+          'internal\_checkers' when is\_internal is false.
       internal_checkers:
           The internal checkers that this check will egress from. If
           ``is_internal`` is true and this list is empty, the check will
@@ -1407,7 +1288,5 @@ _sym_db.RegisterMessage(UptimeCheckIp)
 
 
 DESCRIPTOR._options = None
-_INTERNALCHECKER._options = None
 _UPTIMECHECKCONFIG_HTTPCHECK_HEADERSENTRY._options = None
-_UPTIMECHECKCONFIG.fields_by_name["internal_checkers"]._options = None
 # @@protoc_insertion_point(module_scope)

--- a/monitoring/google/cloud/monitoring_v3/proto/uptime_service.proto
+++ b/monitoring/google/cloud/monitoring_v3/proto/uptime_service.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,10 +19,8 @@ package google.monitoring.v3;
 
 import "google/api/annotations.proto";
 import "google/monitoring/v3/uptime.proto";
-import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
-import "google/api/client.proto";
 
 option csharp_namespace = "Google.Cloud.Monitoring.V3";
 option go_package = "google.golang.org/genproto/googleapis/monitoring/v3;monitoring";
@@ -40,29 +38,26 @@ option php_namespace = "Google\\Cloud\\Monitoring\\V3";
 // clicking on "Monitoring" on the left-hand side to navigate to Stackdriver,
 // and then clicking on "Uptime".
 service UptimeCheckService {
-  option (google.api.default_host) = "monitoring.googleapis.com";
-  option (google.api.oauth_scopes) =
-      "https://www.googleapis.com/auth/cloud-platform,"
-      "https://www.googleapis.com/auth/monitoring,"
-      "https://www.googleapis.com/auth/monitoring.read";
-
   // Lists the existing valid uptime check configurations for the project,
   // leaving out any invalid configurations.
-  rpc ListUptimeCheckConfigs(ListUptimeCheckConfigsRequest) returns (ListUptimeCheckConfigsResponse) {
+  rpc ListUptimeCheckConfigs(ListUptimeCheckConfigsRequest)
+      returns (ListUptimeCheckConfigsResponse) {
     option (google.api.http) = {
       get: "/v3/{parent=projects/*}/uptimeCheckConfigs"
     };
   }
 
   // Gets a single uptime check configuration.
-  rpc GetUptimeCheckConfig(GetUptimeCheckConfigRequest) returns (UptimeCheckConfig) {
+  rpc GetUptimeCheckConfig(GetUptimeCheckConfigRequest)
+      returns (UptimeCheckConfig) {
     option (google.api.http) = {
       get: "/v3/{name=projects/*/uptimeCheckConfigs/*}"
     };
   }
 
   // Creates a new uptime check configuration.
-  rpc CreateUptimeCheckConfig(CreateUptimeCheckConfigRequest) returns (UptimeCheckConfig) {
+  rpc CreateUptimeCheckConfig(CreateUptimeCheckConfigRequest)
+      returns (UptimeCheckConfig) {
     option (google.api.http) = {
       post: "/v3/{parent=projects/*}/uptimeCheckConfigs"
       body: "uptime_check_config"
@@ -73,7 +68,8 @@ service UptimeCheckService {
   // configuration with a new one or replace only certain fields in the current
   // configuration by specifying the fields to be updated via `"updateMask"`.
   // Returns the updated configuration.
-  rpc UpdateUptimeCheckConfig(UpdateUptimeCheckConfigRequest) returns (UptimeCheckConfig) {
+  rpc UpdateUptimeCheckConfig(UpdateUptimeCheckConfigRequest)
+      returns (UptimeCheckConfig) {
     option (google.api.http) = {
       patch: "/v3/{uptime_check_config.name=projects/*/uptimeCheckConfigs/*}"
       body: "uptime_check_config"
@@ -83,14 +79,16 @@ service UptimeCheckService {
   // Deletes an uptime check configuration. Note that this method will fail
   // if the uptime check configuration is referenced by an alert policy or
   // other dependent configs that would be rendered invalid by the deletion.
-  rpc DeleteUptimeCheckConfig(DeleteUptimeCheckConfigRequest) returns (google.protobuf.Empty) {
+  rpc DeleteUptimeCheckConfig(DeleteUptimeCheckConfigRequest)
+      returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v3/{name=projects/*/uptimeCheckConfigs/*}"
     };
   }
 
   // Returns the list of IPs that checkers run from
-  rpc ListUptimeCheckIps(ListUptimeCheckIpsRequest) returns (ListUptimeCheckIpsResponse) {
+  rpc ListUptimeCheckIps(ListUptimeCheckIpsRequest)
+      returns (ListUptimeCheckIpsResponse) {
     option (google.api.http) = {
       get: "/v3/uptimeCheckIps"
     };

--- a/monitoring/google/cloud/monitoring_v3/proto/uptime_service_pb2.py
+++ b/monitoring/google/cloud/monitoring_v3/proto/uptime_service_pb2.py
@@ -19,10 +19,8 @@ from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 from google.cloud.monitoring_v3.proto import (
     uptime_pb2 as google_dot_cloud_dot_monitoring__v3_dot_proto_dot_uptime__pb2,
 )
-from google.protobuf import duration_pb2 as google_dot_protobuf_dot_duration__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from google.protobuf import field_mask_pb2 as google_dot_protobuf_dot_field__mask__pb2
-from google.api import client_pb2 as google_dot_api_dot_client__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -33,15 +31,13 @@ DESCRIPTOR = _descriptor.FileDescriptor(
         "\n\030com.google.monitoring.v3B\022UptimeServiceProtoP\001Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\252\002\032Google.Cloud.Monitoring.V3\312\002\032Google\\Cloud\\Monitoring\\V3"
     ),
     serialized_pb=_b(
-        '\n5google/cloud/monitoring_v3/proto/uptime_service.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a-google/cloud/monitoring_v3/proto/uptime.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a google/protobuf/field_mask.proto\x1a\x17google/api/client.proto"V\n\x1dListUptimeCheckConfigsRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t"\x94\x01\n\x1eListUptimeCheckConfigsResponse\x12\x45\n\x14uptime_check_configs\x18\x01 \x03(\x0b\x32\'.google.monitoring.v3.UptimeCheckConfig\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\x12\x12\n\ntotal_size\x18\x03 \x01(\x05"+\n\x1bGetUptimeCheckConfigRequest\x12\x0c\n\x04name\x18\x01 \x01(\t"v\n\x1e\x43reateUptimeCheckConfigRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x44\n\x13uptime_check_config\x18\x02 \x01(\x0b\x32\'.google.monitoring.v3.UptimeCheckConfig"\x97\x01\n\x1eUpdateUptimeCheckConfigRequest\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask\x12\x44\n\x13uptime_check_config\x18\x03 \x01(\x0b\x32\'.google.monitoring.v3.UptimeCheckConfig".\n\x1e\x44\x65leteUptimeCheckConfigRequest\x12\x0c\n\x04name\x18\x01 \x01(\t"B\n\x19ListUptimeCheckIpsRequest\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"t\n\x1aListUptimeCheckIpsResponse\x12=\n\x10uptime_check_ips\x18\x01 \x03(\x0b\x32#.google.monitoring.v3.UptimeCheckIp\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t2\xf3\t\n\x12UptimeCheckService\x12\xb7\x01\n\x16ListUptimeCheckConfigs\x12\x33.google.monitoring.v3.ListUptimeCheckConfigsRequest\x1a\x34.google.monitoring.v3.ListUptimeCheckConfigsResponse"2\x82\xd3\xe4\x93\x02,\x12*/v3/{parent=projects/*}/uptimeCheckConfigs\x12\xa6\x01\n\x14GetUptimeCheckConfig\x12\x31.google.monitoring.v3.GetUptimeCheckConfigRequest\x1a\'.google.monitoring.v3.UptimeCheckConfig"2\x82\xd3\xe4\x93\x02,\x12*/v3/{name=projects/*/uptimeCheckConfigs/*}\x12\xc1\x01\n\x17\x43reateUptimeCheckConfig\x12\x34.google.monitoring.v3.CreateUptimeCheckConfigRequest\x1a\'.google.monitoring.v3.UptimeCheckConfig"G\x82\xd3\xe4\x93\x02\x41"*/v3/{parent=projects/*}/uptimeCheckConfigs:\x13uptime_check_config\x12\xd5\x01\n\x17UpdateUptimeCheckConfig\x12\x34.google.monitoring.v3.UpdateUptimeCheckConfigRequest\x1a\'.google.monitoring.v3.UptimeCheckConfig"[\x82\xd3\xe4\x93\x02U2>/v3/{uptime_check_config.name=projects/*/uptimeCheckConfigs/*}:\x13uptime_check_config\x12\x9b\x01\n\x17\x44\x65leteUptimeCheckConfig\x12\x34.google.monitoring.v3.DeleteUptimeCheckConfigRequest\x1a\x16.google.protobuf.Empty"2\x82\xd3\xe4\x93\x02,**/v3/{name=projects/*/uptimeCheckConfigs/*}\x12\x93\x01\n\x12ListUptimeCheckIps\x12/.google.monitoring.v3.ListUptimeCheckIpsRequest\x1a\x30.google.monitoring.v3.ListUptimeCheckIpsResponse"\x1a\x82\xd3\xe4\x93\x02\x14\x12\x12/v3/uptimeCheckIps\x1a\xa9\x01\xca\x41\x19monitoring.googleapis.com\xd2\x41\x89\x01https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/monitoring.readB\xaa\x01\n\x18\x63om.google.monitoring.v3B\x12UptimeServiceProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
+        '\n5google/cloud/monitoring_v3/proto/uptime_service.proto\x12\x14google.monitoring.v3\x1a\x1cgoogle/api/annotations.proto\x1a-google/cloud/monitoring_v3/proto/uptime.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a google/protobuf/field_mask.proto"V\n\x1dListUptimeCheckConfigsRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t"\x94\x01\n\x1eListUptimeCheckConfigsResponse\x12\x45\n\x14uptime_check_configs\x18\x01 \x03(\x0b\x32\'.google.monitoring.v3.UptimeCheckConfig\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\x12\x12\n\ntotal_size\x18\x03 \x01(\x05"+\n\x1bGetUptimeCheckConfigRequest\x12\x0c\n\x04name\x18\x01 \x01(\t"v\n\x1e\x43reateUptimeCheckConfigRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x44\n\x13uptime_check_config\x18\x02 \x01(\x0b\x32\'.google.monitoring.v3.UptimeCheckConfig"\x97\x01\n\x1eUpdateUptimeCheckConfigRequest\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask\x12\x44\n\x13uptime_check_config\x18\x03 \x01(\x0b\x32\'.google.monitoring.v3.UptimeCheckConfig".\n\x1e\x44\x65leteUptimeCheckConfigRequest\x12\x0c\n\x04name\x18\x01 \x01(\t"B\n\x19ListUptimeCheckIpsRequest\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t"t\n\x1aListUptimeCheckIpsResponse\x12=\n\x10uptime_check_ips\x18\x01 \x03(\x0b\x32#.google.monitoring.v3.UptimeCheckIp\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t2\xc7\x08\n\x12UptimeCheckService\x12\xb7\x01\n\x16ListUptimeCheckConfigs\x12\x33.google.monitoring.v3.ListUptimeCheckConfigsRequest\x1a\x34.google.monitoring.v3.ListUptimeCheckConfigsResponse"2\x82\xd3\xe4\x93\x02,\x12*/v3/{parent=projects/*}/uptimeCheckConfigs\x12\xa6\x01\n\x14GetUptimeCheckConfig\x12\x31.google.monitoring.v3.GetUptimeCheckConfigRequest\x1a\'.google.monitoring.v3.UptimeCheckConfig"2\x82\xd3\xe4\x93\x02,\x12*/v3/{name=projects/*/uptimeCheckConfigs/*}\x12\xc1\x01\n\x17\x43reateUptimeCheckConfig\x12\x34.google.monitoring.v3.CreateUptimeCheckConfigRequest\x1a\'.google.monitoring.v3.UptimeCheckConfig"G\x82\xd3\xe4\x93\x02\x41"*/v3/{parent=projects/*}/uptimeCheckConfigs:\x13uptime_check_config\x12\xd5\x01\n\x17UpdateUptimeCheckConfig\x12\x34.google.monitoring.v3.UpdateUptimeCheckConfigRequest\x1a\'.google.monitoring.v3.UptimeCheckConfig"[\x82\xd3\xe4\x93\x02U2>/v3/{uptime_check_config.name=projects/*/uptimeCheckConfigs/*}:\x13uptime_check_config\x12\x9b\x01\n\x17\x44\x65leteUptimeCheckConfig\x12\x34.google.monitoring.v3.DeleteUptimeCheckConfigRequest\x1a\x16.google.protobuf.Empty"2\x82\xd3\xe4\x93\x02,**/v3/{name=projects/*/uptimeCheckConfigs/*}\x12\x93\x01\n\x12ListUptimeCheckIps\x12/.google.monitoring.v3.ListUptimeCheckIpsRequest\x1a\x30.google.monitoring.v3.ListUptimeCheckIpsResponse"\x1a\x82\xd3\xe4\x93\x02\x14\x12\x12/v3/uptimeCheckIpsB\xaa\x01\n\x18\x63om.google.monitoring.v3B\x12UptimeServiceProtoP\x01Z>google.golang.org/genproto/googleapis/monitoring/v3;monitoring\xaa\x02\x1aGoogle.Cloud.Monitoring.V3\xca\x02\x1aGoogle\\Cloud\\Monitoring\\V3b\x06proto3'
     ),
     dependencies=[
         google_dot_api_dot_annotations__pb2.DESCRIPTOR,
         google_dot_cloud_dot_monitoring__v3_dot_proto_dot_uptime__pb2.DESCRIPTOR,
-        google_dot_protobuf_dot_duration__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,
         google_dot_protobuf_dot_field__mask__pb2.DESCRIPTOR,
-        google_dot_api_dot_client__pb2.DESCRIPTOR,
     ],
 )
 
@@ -116,8 +112,8 @@ _LISTUPTIMECHECKCONFIGSREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=276,
-    serialized_end=362,
+    serialized_start=219,
+    serialized_end=305,
 )
 
 
@@ -191,8 +187,8 @@ _LISTUPTIMECHECKCONFIGSRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=365,
-    serialized_end=513,
+    serialized_start=308,
+    serialized_end=456,
 )
 
 
@@ -230,8 +226,8 @@ _GETUPTIMECHECKCONFIGREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=515,
-    serialized_end=558,
+    serialized_start=458,
+    serialized_end=501,
 )
 
 
@@ -287,8 +283,8 @@ _CREATEUPTIMECHECKCONFIGREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=560,
-    serialized_end=678,
+    serialized_start=503,
+    serialized_end=621,
 )
 
 
@@ -344,8 +340,8 @@ _UPDATEUPTIMECHECKCONFIGREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=681,
-    serialized_end=832,
+    serialized_start=624,
+    serialized_end=775,
 )
 
 
@@ -383,8 +379,8 @@ _DELETEUPTIMECHECKCONFIGREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=834,
-    serialized_end=880,
+    serialized_start=777,
+    serialized_end=823,
 )
 
 
@@ -440,8 +436,8 @@ _LISTUPTIMECHECKIPSREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=882,
-    serialized_end=948,
+    serialized_start=825,
+    serialized_end=891,
 )
 
 
@@ -497,8 +493,8 @@ _LISTUPTIMECHECKIPSRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=950,
-    serialized_end=1066,
+    serialized_start=893,
+    serialized_end=1009,
 )
 
 _LISTUPTIMECHECKCONFIGSRESPONSE.fields_by_name[
@@ -762,11 +758,9 @@ _UPTIMECHECKSERVICE = _descriptor.ServiceDescriptor(
     full_name="google.monitoring.v3.UptimeCheckService",
     file=DESCRIPTOR,
     index=0,
-    serialized_options=_b(
-        "\312A\031monitoring.googleapis.com\322A\211\001https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/monitoring.read"
-    ),
-    serialized_start=1069,
-    serialized_end=2336,
+    serialized_options=None,
+    serialized_start=1012,
+    serialized_end=2107,
     methods=[
         _descriptor.MethodDescriptor(
             name="ListUptimeCheckConfigs",

--- a/monitoring/synth.metadata
+++ b/monitoring/synth.metadata
@@ -1,19 +1,18 @@
 {
-  "updateTime": "2019-09-12T12:26:54.957905Z",
+  "updateTime": "2019-08-06T18:17:03.571363Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.36.2",
-        "dockerImage": "googleapis/artman@sha256:0e6f3a668cd68afc768ecbe08817cf6e56a0e64fcbdb1c58c3b97492d12418a1"
+        "version": "0.32.1",
+        "dockerImage": "googleapis/artman@sha256:a684d40ba9a4e15946f5f2ca6b4bd9fe301192f522e9de4fff622118775f309b"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1cb29d0fd49437d8e5d7de327e258739e998f01c",
-        "internalRef": "268598527"
+        "sha": "53e641721f965a485af64331cfea9e5522294d78"
       }
     },
     {

--- a/monitoring/tests/unit/gapic/v3/test_uptime_check_service_client_v3.py
+++ b/monitoring/tests/unit/gapic/v3/test_uptime_check_service_client_v3.py
@@ -118,7 +118,12 @@ class TestUptimeCheckServiceClient(object):
         # Setup Expected Response
         name_2 = "name2-1052831874"
         display_name = "displayName1615086568"
-        expected_response = {"name": name_2, "display_name": display_name}
+        is_internal = True
+        expected_response = {
+            "name": name_2,
+            "display_name": display_name,
+            "is_internal": is_internal,
+        }
         expected_response = uptime_pb2.UptimeCheckConfig(**expected_response)
 
         # Mock the API response
@@ -157,7 +162,12 @@ class TestUptimeCheckServiceClient(object):
         # Setup Expected Response
         name = "name3373707"
         display_name = "displayName1615086568"
-        expected_response = {"name": name, "display_name": display_name}
+        is_internal = True
+        expected_response = {
+            "name": name,
+            "display_name": display_name,
+            "is_internal": is_internal,
+        }
         expected_response = uptime_pb2.UptimeCheckConfig(**expected_response)
 
         # Mock the API response
@@ -200,7 +210,12 @@ class TestUptimeCheckServiceClient(object):
         # Setup Expected Response
         name = "name3373707"
         display_name = "displayName1615086568"
-        expected_response = {"name": name, "display_name": display_name}
+        is_internal = True
+        expected_response = {
+            "name": name,
+            "display_name": display_name,
+            "is_internal": is_internal,
+        }
         expected_response = uptime_pb2.UptimeCheckConfig(**expected_response)
 
         # Mock the API response


### PR DESCRIPTION
Reverts googleapis/google-cloud-python#9218

Jon Skeet discovered another breaking change in the proto change that triggered this PR. (`is_internal` is removed, rather than being marked deprecated.)