### PR TITLE
Firestore: Update README example to use non-deprecated 'query.get'.

### DIFF
--- a/firestore/README.rst
+++ b/firestore/README.rst
@@ -102,9 +102,8 @@ Example Usage
 
     # Then query for documents
     users_ref = db.collection(u'users')
-    docs = users_ref.get()
 
-    for doc in docs:
+    for doc in users_ref.stream():
         print(u'{} => {}'.format(doc.id, doc.to_dict()))
 
 Next Steps


### PR DESCRIPTION
See [this report](https://github.com/googleapis/google-cloud-python/issues/7534#issuecomment-531969738).