### PR TITLE
feat(bigquery): store QueryJob to destination variable on error

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -2903,6 +2903,7 @@ class QueryJob(_AsyncJob):
             super(QueryJob, self)._begin(client=client, retry=retry)
         except exceptions.GoogleCloudError as exc:
             exc.message += self._format_for_exception(self.query, self.job_id)
+            exc.query_job = self
             raise
 
     def result(
@@ -2945,6 +2946,7 @@ class QueryJob(_AsyncJob):
                 )
         except exceptions.GoogleCloudError as exc:
             exc.message += self._format_for_exception(self.query, self.job_id)
+            exc.query_job = self
             raise
 
         # If the query job is complete but there are no query results, this was

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -4337,8 +4337,10 @@ class TestQueryJob(unittest.TestCase, _Base):
         self.assertIsInstance(exc_info.exception, exceptions.GoogleCloudError)
         self.assertEqual(exc_info.exception.code, http_client.BAD_REQUEST)
 
-        full_text = str(exc_info.exception)
+        exc_job_instance = getattr(exc_info.exception, "query_job", None)
+        self.assertIs(exc_job_instance, job)
 
+        full_text = str(exc_info.exception)
         assert job.job_id in full_text
         assert "Query Job SQL Follows" in full_text
 
@@ -4370,8 +4372,10 @@ class TestQueryJob(unittest.TestCase, _Base):
         self.assertIsInstance(exc_info.exception, exceptions.GoogleCloudError)
         self.assertEqual(exc_info.exception.code, http_client.BAD_REQUEST)
 
-        full_text = str(exc_info.exception)
+        exc_job_instance = getattr(exc_info.exception, "query_job", None)
+        self.assertIs(exc_job_instance, job)
 
+        full_text = str(exc_info.exception)
         assert job.job_id in full_text
         assert "Query Job SQL Follows" in full_text
 


### PR DESCRIPTION
Closes #9091.

This PR changes the Jupyter notebook magic to store the relevant QueryJob instance on errors to the specified destination variable (if any).

### How to test
Start an `ipython` session from the `bigquery/` directory, and try to execute a query that results in an error:
```
In [1]: from google.cloud import bigquery
In [2]: %load_ext google.cloud.bigquery
In [3]: %%bigquery target_var --dry_run 
  
        SELECT SELECT * FROM `bigquery-public-data.samples.shakespeare` LIMIT 5; 
```

**Expected result:**
If an error occurs, the target variable is set to a QueryJob instance, allowing further introspection. This happens both in dry runs and actual runs.