### PR TITLE
docs(core): fix Google Auth Credentials help link

### DIFF
--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -29,7 +29,7 @@ from google.oauth2 import service_account
 
 _GOOGLE_AUTH_CREDENTIALS_HELP = (
     "This library only supports credentials from google-auth-library-python. "
-    "See https://google-cloud-python.readthedocs.io/en/latest/core/auth.html "
+    "See https://google-auth.readthedocs.io/en/latest/ "
     "for help on authentication with this library."
 )
 


### PR DESCRIPTION
This PR fixes the wrong URL link in `_GOOGLE_AUTH_CREDENTIALS_HELP`