### PR TITLE
Spanner: Fix `run_in_transaction` return value docs

### DIFF
--- a/spanner/google/cloud/spanner_v1/database.py
+++ b/spanner/google/cloud/spanner_v1/database.py
@@ -420,8 +420,11 @@ class Database(object):
                    If passed, "timeout_secs" will be removed and used to
                    override the default timeout.
 
-        :rtype: :class:`datetime.datetime`
-        :returns: timestamp of committed transaction
+        :rtype: Any
+        :returns: The return value of ``func``.
+
+        :raises Exception:
+            reraises any non-ABORT execptions raised by ``func``.
         """
         # Sanity check: Is there a transaction already running?
         # If there is, then raise a red flag. Otherwise, mark that this one


### PR DESCRIPTION
Summary:
These docs used to be correct, but `Session.run_in_transaction` was
changed from returning the commit timestamp to returning the function
value in #3753, and the upstream docs were not updated.

The docs for `run_in_transaction` are now identical across `Database`
and `Session`.

The tests for `run_in_transaction` (in `test_database.py`) are wrong, as
they mock out the session object instead of using a real session, and
they also were not updated in #3753. This change does not fix them.

Test Plan:

```
$ virtualenv -q -p python3.6 ./ve
$ . ./ve/bin/activate
(ve) $ pip install -q google-cloud-spanner==1.10.0
(ve) $ pip freeze | grep google-cloud-spanner
google-cloud-spanner==1.10.0
(ve) $ cat test.py; echo
from google.cloud import spanner_v1

client = spanner_v1.Client()
instance = client.instance("my-instance-name")
database = instance.database("my-database-name")
result = database.run_in_transaction(lambda txn: "ahoy")
print(result)

(ve) $ python test.py
ahoy
```

wchargin-branch: run-in-transaction-rval