### PR TITLE
test(dlp): ensure GOOGLE_CLOUD_TESTS_IN_VPCSC is down cast for env variables

### DIFF
--- a/dlp/noxfile.py
+++ b/dlp/noxfile.py
@@ -119,7 +119,7 @@ def system(session):
     session.install("-e", ".")
 
     # Additional setup for VPCSC system tests
-    if os.environ.get("GOOGLE_CLOUD_TESTS_IN_VPCSC") != "true":
+    if os.environ.get("GOOGLE_CLOUD_TESTS_IN_VPCSC").lower() != "true":
         # Unset PROJECT_ID, since VPCSC system tests expect this to be a project
         # within the VPCSC perimeter.
         env = {


### PR DESCRIPTION
Fixes bug reported by siddinesh@, in which `True` is passed rather than `true`. Causes Kokoro tests to break outside of git. This will ensure GOOGLE_CLOUD_TESTS_IN_VPCSC is always tested against `true` as is the expected behavior. 