### PR TITLE
style(bigquery): add code samples to lint check

### DIFF
--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -150,6 +150,7 @@ def lint(session):
     session.install("-e", ".")
     session.run("flake8", os.path.join("google", "cloud", "bigquery"))
     session.run("flake8", "tests")
+    session.run("flake8", os.path.join("docs", "samples"))
     session.run("flake8", os.path.join("docs", "snippets.py"))
     session.run("black", "--check", *BLACK_PATHS)
 


### PR DESCRIPTION
Closes #9081.

This PR makes sure that the code samples, too, undergo the lint check (`flake8` specifically, as black already checks the samples).

After experimenting with the synth tool a bit, I realized that the BigQuery's noxfile is _not_ generated by synth from the [template](https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/noxfile.py.j2), thus modified it directly.

### How to test
Introduce a few `flake8`-specific (i.e. not relevant to `black`) lint errors to some of the files in `docs/samples`, such as an unused import, and run the lint check:
```sh
$ nox -f noxfile.py -s lint
```

**Actual result (before the fix):**
The check passes despite the lint issues.

**Expected result (before the fix):**
The check correctly fails and complains about the lint issues.