### PR TITLE
docs(storage): clarify docstring for 'Blob.download_as_string'

### DIFF
--- a/storage/docs/snippets.py
+++ b/storage/docs/snippets.py
@@ -39,7 +39,7 @@ def storage_get_started(client, to_delete):
     bucket = client.get_bucket("bucket-id-here")
     # Then do other things...
     blob = bucket.get_blob("/remote/path/to/file.txt")
-    assert blob.download_as_string() == "My old contents!"
+    assert blob.download_as_string() == b"My old contents!"
     blob.upload_from_string("New contents!")
     blob2 = bucket.blob("/remote/path/storage.txt")
     blob2.upload_from_filename(filename="/local/path.txt")

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -714,10 +714,6 @@ class Blob(_PropertyMixin):
     def download_as_string(self, client=None, start=None, end=None):
         """Download the contents of this blob as a bytes object.
 
-        .. note::
-            the method name, ``download_as_string`` was chosen for
-            compatibility with the ``boto`` library's API.
-
         If :attr:`user_project` is set on the bucket, bills the API request
         to that project.
 

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -712,7 +712,11 @@ class Blob(_PropertyMixin):
             os.utime(file_obj.name, (mtime, mtime))
 
     def download_as_string(self, client=None, start=None, end=None):
-        """Download the contents of this blob as a string.
+        """Download the contents of this blob as a bytes object.
+
+        .. note::
+            the method name, ``download_as_string`` was chosen for
+            compatibility with the ``boto`` library's API.
 
         If :attr:`user_project` is set on the bucket, bills the API request
         to that project.


### PR DESCRIPTION
Specify that the returned value is bytes in the summary, and note the
historical reason for the confused method name.

Closes #9290.