### PR TITLE
feat(storage): support predefined ACLs in 'Bucket.create'

### DIFF
--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -595,7 +595,14 @@ class Bucket(_PropertyMixin):
         except NotFound:
             return False
 
-    def create(self, client=None, project=None, location=None):
+    def create(
+        self,
+        client=None,
+        project=None,
+        location=None,
+        predefined_acl=None,
+        predefined_default_object_acl=None,
+    ):
         """Creates current bucket.
 
         If the bucket already exists, will raise
@@ -622,6 +629,16 @@ class Bucket(_PropertyMixin):
         :param location: Optional. The location of the bucket. If not passed,
                          the default location, US, will be used. See
                          https://cloud.google.com/storage/docs/bucket-locations
+
+        :type predefined_acl: str
+        :param predefined_acl:
+            Optional. Name of predefined ACL to apply to bucket. See:
+            https://cloud.google.com/storage/docs/access-control/lists#predefined-acl
+
+        :type predefined_default_object_acl: str
+        :param predefined_default_object_acl:
+            Optional. Name of predefined ACL to apply to bucket's objects. See:
+            https://cloud.google.com/storage/docs/access-control/lists#predefined-acl
         """
         if self.user_project is not None:
             raise ValueError("Cannot create bucket with 'user_project' set.")
@@ -635,6 +652,17 @@ class Bucket(_PropertyMixin):
             raise ValueError("Client project not set:  pass an explicit project.")
 
         query_params = {"project": project}
+
+        if predefined_acl is not None:
+            predefined_acl = BucketACL.validate_predefined(predefined_acl)
+            query_params["predefinedAcl"] = predefined_acl
+
+        if predefined_default_object_acl is not None:
+            predefined_default_object_acl = DefaultObjectACL.validate_predefined(
+                predefined_default_object_acl
+            )
+            query_params["predefinedDefaultObjectAcl"] = predefined_default_object_acl
+
         properties = {key: self._properties[key] for key in self._changes}
         properties["name"] = self.name
 

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -646,6 +646,60 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["query_params"], {"project": PROJECT})
         self.assertEqual(kw["data"], DATA)
 
+    def test_create_w_predefined_acl_invalid(self):
+        PROJECT = "PROJECT"
+        BUCKET_NAME = "bucket-name"
+        DATA = {"name": BUCKET_NAME}
+        connection = _Connection(DATA)
+        client = _Client(connection, project=PROJECT)
+        bucket = self._make_one(client=client, name=BUCKET_NAME)
+
+        with self.assertRaises(ValueError):
+            bucket.create(predefined_acl="bogus")
+
+    def test_create_w_predefined_acl_valid(self):
+        PROJECT = "PROJECT"
+        BUCKET_NAME = "bucket-name"
+        DATA = {"name": BUCKET_NAME}
+        connection = _Connection(DATA)
+        client = _Client(connection, project=PROJECT)
+        bucket = self._make_one(client=client, name=BUCKET_NAME)
+        bucket.create(predefined_acl="publicRead")
+
+        kw, = connection._requested
+        self.assertEqual(kw["method"], "POST")
+        self.assertEqual(kw["path"], "/b")
+        expected_qp = {"project": PROJECT, "predefinedAcl": "publicRead"}
+        self.assertEqual(kw["query_params"], expected_qp)
+        self.assertEqual(kw["data"], DATA)
+
+    def test_create_w_predefined_default_object_acl_invalid(self):
+        PROJECT = "PROJECT"
+        BUCKET_NAME = "bucket-name"
+        DATA = {"name": BUCKET_NAME}
+        connection = _Connection(DATA)
+        client = _Client(connection, project=PROJECT)
+        bucket = self._make_one(client=client, name=BUCKET_NAME)
+
+        with self.assertRaises(ValueError):
+            bucket.create(predefined_default_object_acl="bogus")
+
+    def test_create_w_predefined_default_object_acl_valid(self):
+        PROJECT = "PROJECT"
+        BUCKET_NAME = "bucket-name"
+        DATA = {"name": BUCKET_NAME}
+        connection = _Connection(DATA)
+        client = _Client(connection, project=PROJECT)
+        bucket = self._make_one(client=client, name=BUCKET_NAME)
+        bucket.create(predefined_default_object_acl="publicRead")
+
+        kw, = connection._requested
+        self.assertEqual(kw["method"], "POST")
+        self.assertEqual(kw["path"], "/b")
+        expected_qp = {"project": PROJECT, "predefinedDefaultObjectAcl": "publicRead"}
+        self.assertEqual(kw["query_params"], expected_qp)
+        self.assertEqual(kw["data"], DATA)
+
     def test_acl_property(self):
         from google.cloud.storage.acl import BucketACL
 


### PR DESCRIPTION
Closes #9295.