### PR TITLE
fix(api_core): finalize during close of 'ResumableBidiRpc'.

### DIFF
--- a/api_core/google/api_core/bidi.py
+++ b/api_core/google/api_core/bidi.py
@@ -702,6 +702,8 @@ class BackgroundConsumer(object):
             if self._thread is not None:
                 # Resume the thread to wake it up in case it is sleeping.
                 self.resume()
+                # The daemonized thread may itself block, so don't wait
+                # for it longer than a second.
                 self._thread.join(1.0)
                 if self._thread.is_alive():
                     _LOGGER.warning("Background thread did not exit.")

--- a/api_core/google/api_core/bidi.py
+++ b/api_core/google/api_core/bidi.py
@@ -561,6 +561,10 @@ class ResumableBidiRpc(BidiRpc):
     def recv(self):
         return self._recoverable(self._recv)
 
+    def close(self):
+        self._finalize(None)
+        super(ResumableBidiRpc, self).close()
+
     @property
     def is_active(self):
         """bool: True if this stream is currently open and active."""
@@ -698,7 +702,9 @@ class BackgroundConsumer(object):
             if self._thread is not None:
                 # Resume the thread to wake it up in case it is sleeping.
                 self.resume()
-                self._thread.join()
+                self._thread.join(1.0)
+                if self._thread.is_alive():
+                    _LOGGER.warning("Background thread did not exit.")
 
             self._thread = None
 

--- a/api_core/google/api_core/bidi.py
+++ b/api_core/google/api_core/bidi.py
@@ -705,7 +705,7 @@ class BackgroundConsumer(object):
                 # The daemonized thread may itself block, so don't wait
                 # for it longer than a second.
                 self._thread.join(1.0)
-                if self._thread.is_alive():
+                if self._thread.is_alive():  # pragma: NO COVER
                     _LOGGER.warning("Background thread did not exit.")
 
             self._thread = None


### PR DESCRIPTION
Avoid blocking for ill-behaved daemon threads during BiDi shutdown.

Closes #8616, #9008.