### PR TITLE
feat(pubsub): add stop method

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/futures.py
+++ b/pubsub/google/cloud/pubsub_v1/futures.py
@@ -74,9 +74,7 @@ class Future(google.api_core.future.Future):
             bool: ``True`` if this method has not yet completed, or
                 ``False`` if it has completed.
         """
-        if self.done():
-            return False
-        return True
+        return not self.done()
 
     def done(self):
         """Return True the future is done, False otherwise.

--- a/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -140,17 +140,6 @@ class Batch(base.Batch):
         """
         return self._status
 
-    def wait(self):
-        """If commit is in progress, waits until all of the futures resolved.
-
-        .. note::
-
-            This method blocks until all futures of this batch resolved.
-        """
-        if self._status != base.BatchStatus.ACCEPTING_MESSAGES:
-            for future in self._futures:
-                future.result()
-
     def commit(self):
         """Actually publish all of the messages on the active batch.
 

--- a/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -137,6 +137,17 @@ class Batch(base.Batch):
         """
         return self._status
 
+    def wait(self):
+        """If commit in progress, waits until all of the futures resolved.
+
+        .. note::
+
+            This method blocks until all futures of this batch resolved.
+        """
+        if self._status in (base.BatchStatus.STARTING, base.BatchStatus.IN_PROGRESS):
+            for future in self._futures:
+                future.result()
+
     def commit(self):
         """Actually publish all of the messages on the active batch.
 

--- a/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -74,10 +74,10 @@ class Batch(base.Batch):
         self._state_lock = threading.Lock()
         # These members are all communicated between threads; ensure that
         # any writes to them use the "state lock" to remain atomic.
-        self._futures = []
         # _futures list should remain unchanged after batch
         # status changed from ACCEPTING_MESSAGES to any other
         # in order to avoid race conditions
+        self._futures = []
         self._messages = []
         self._size = 0
         self._status = base.BatchStatus.ACCEPTING_MESSAGES

--- a/pubsub/google/cloud/pubsub_v1/publisher/client.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/client.py
@@ -252,7 +252,7 @@ class Client(object):
         # If it is literally anything else, complain loudly about it.
         if not isinstance(data, six.binary_type):
             raise TypeError(
-                "Data being published to Pub/Sub must be sent " "as a bytestring."
+                "Data being published to Pub/Sub must be sent as a bytestring."
             )
 
         # Coerce all attributes to text strings.

--- a/pubsub/google/cloud/pubsub_v1/publisher/client.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/client.py
@@ -274,3 +274,22 @@ class Client(object):
                 batch = self._batch(topic, create=True)
 
         return future
+
+    def stop(self):
+        """Immediately publish all outstanding batches.
+
+        This asynchronously pushes all outstanding messages
+        and waits until all futures resolved. Method should be
+        invoked prior to deleting this Client object in order
+        to ensure that no pending messages are lost.
+
+        .. note::
+
+            This method blocks until all futures of all
+            batches resolved.
+        """
+        for topic in self._batches:
+            self._batches[topic].commit()
+
+        for topic in self._batches:
+            self._batches[topic].wait()

--- a/pubsub/google/cloud/pubsub_v1/publisher/client.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/client.py
@@ -294,8 +294,8 @@ class Client(object):
         .. note::
 
             This method is non-blocking. Use `Future()` objects
-            returned by `publish()` to make sure all messages
-            sent or failed.
+            returned by `publish()` to make sure all publish
+            requests completed, either in success or error.
         """
         if self._is_stopped:
             raise ValueError("Cannot stop a publisher already stopped.")

--- a/pubsub/google/cloud/pubsub_v1/publisher/client.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/client.py
@@ -244,7 +244,7 @@ class Client(object):
             instance of that class).
 
         Raises:
-            ValueError:
+            RuntimeError:
                 If called after publisher has been stopped
                 by a `stop()` method call.
         """

--- a/pubsub/google/cloud/pubsub_v1/publisher/client.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/client.py
@@ -273,7 +273,7 @@ class Client(object):
         # Delegate the publishing to the batch.
         with self._batch_lock:
             if self._is_stopped:
-                raise ValueError("Cannot publish on a stopped publisher.")
+                raise RuntimeError("Cannot publish on a stopped publisher.")
 
             batch = self._batch(topic)
             future = None
@@ -300,9 +300,9 @@ class Client(object):
         """
         with self._batch_lock:
             if self._is_stopped:
-                raise ValueError("Cannot stop a publisher already stopped.")
+                raise RuntimeError("Cannot stop a publisher already stopped.")
 
             self._is_stopped = True
 
-            for topic in self._batches:
-                self._batches[topic].commit()
+            for batch in self._batches.values():
+                batch.commit()

--- a/pubsub/google/cloud/pubsub_v1/publisher/client.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/client.py
@@ -304,5 +304,5 @@ class Client(object):
 
             self._is_stopped = True
 
-        for topic in self._batches:
-            self._batches[topic].commit()
+            for topic in self._batches:
+                self._batches[topic].commit()

--- a/pubsub/google/cloud/pubsub_v1/publisher/client.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/client.py
@@ -134,7 +134,7 @@ class Client(object):
         # The batches on the publisher client are responsible for holding
         # messages. One batch exists for each topic.
         self._batch_lock = self._batch_class.make_lock()
-        self._stoping_lock = threading.Lock()
+        self._stopping_lock = threading.Lock()
         self._batches = {}
         self._is_stopped = False
 
@@ -251,7 +251,7 @@ class Client(object):
                 If called after publisher has been stopped
                 by a `stop()` method call.
         """
-        with self._stoping_lock:
+        with self._stopping_lock:
             if self._is_stopped:
                 raise ValueError("Cannot publish on a stopped publisher.")
         # Sanity check: Is the data being sent as a bytestring?
@@ -300,7 +300,7 @@ class Client(object):
             returned by `publish()` to make sure all publish
             requests completed, either in success or error.
         """
-        with self._stoping_lock:
+        with self._stopping_lock:
             if self._is_stopped:
                 raise ValueError("Cannot stop a publisher already stopped.")
 

--- a/pubsub/google/cloud/pubsub_v1/publisher/client.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/client.py
@@ -295,7 +295,7 @@ class Client(object):
 
             This method is non-blocking. Use `Future()` objects
             returned by `publish()` to make sure all messages
-            sent or failed to.
+            sent or failed.
         """
         if self._is_stopped:
             raise ValueError("Cannot stop a publisher already stopped.")

--- a/pubsub/tests/unit/pubsub_v1/publisher/batch/test_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/batch/test_thread.py
@@ -252,31 +252,6 @@ def test_block__commmit_api_error():
         assert future.exception() == error
 
 
-def test_wait():
-    batch = create_batch()
-    with mock.patch(
-        "google.cloud.pubsub_v1.publisher.futures.Future.result", return_value=True
-    ) as result_mock:
-        futures = (batch.publish({"data": b"msg"}),)
-
-        batch._status = BatchStatus.IN_PROGRESS
-        futures[0]._completed.set()
-        batch.wait()
-
-        result_mock.assert_called()
-
-
-def test_wait_not_started():
-    batch = create_batch()
-    with mock.patch(
-        "google.cloud.pubsub_v1.publisher.futures.Future.result", return_value=True
-    ) as result_mock:
-        batch.publish({"data": b"msg"})
-        batch.wait()
-
-        result_mock.assert_not_called()
-
-
 def test_block__commmit_retry_error():
     batch = create_batch()
     futures = (

--- a/pubsub/tests/unit/pubsub_v1/publisher/batch/test_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/batch/test_thread.py
@@ -266,6 +266,17 @@ def test_wait():
         result_mock.assert_called()
 
 
+def test_wait_not_started():
+    batch = create_batch()
+    with mock.patch(
+        "google.cloud.pubsub_v1.publisher.futures.Future.result", return_value=True
+    ) as result_mock:
+        batch.publish({"data": b"msg"})
+        batch.wait()
+
+        result_mock.assert_not_called()
+
+
 def test_block__commmit_retry_error():
     batch = create_batch()
     futures = (

--- a/pubsub/tests/unit/pubsub_v1/publisher/batch/test_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/batch/test_thread.py
@@ -252,6 +252,20 @@ def test_block__commmit_api_error():
         assert future.exception() == error
 
 
+def test_wait():
+    batch = create_batch()
+    with mock.patch(
+        "google.cloud.pubsub_v1.publisher.futures.Future.result", return_value=True
+    ) as result_mock:
+        futures = (batch.publish({"data": b"msg"}),)
+
+        batch._status = BatchStatus.IN_PROGRESS
+        futures[0]._completed.set()
+        batch.wait()
+
+        result_mock.assert_called()
+
+
 def test_block__commmit_retry_error():
     batch = create_batch()
     futures = (

--- a/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -210,24 +210,22 @@ def test_stop():
 
     pubsub_msg = types.PubsubMessage(data=b"msg")
 
-    cp = mock.patch.object(batch, "commit")
-    wp = mock.patch.object(batch, "wait")
-    cp2 = mock.patch.object(batch2, "commit")
-    wp2 = mock.patch.object(batch2, "wait")
+    patch = mock.patch.object(batch, "commit")
+    patch2 = mock.patch.object(batch2, "commit")
 
-    with cp as c_mock, cp2 as c_mock2, wp as w_mock, wp2 as w_mock2:
+    with patch as commit_mock, patch2 as commit_mock2:
         batch.publish(pubsub_msg)
         batch2.publish(pubsub_msg)
 
         client.stop()
 
         # check if commit() called
-        c_mock.assert_called()
-        c_mock2.assert_called()
+        commit_mock.assert_called()
+        commit_mock2.assert_called()
 
-        # check if wait() called
-        w_mock.assert_called()
-        w_mock2.assert_called()
+    # check that closed publisher doesn't accept new messages
+    with pytest.raises(ValueError):
+        client.publish("topic1", pubsub_msg)
 
 
 def test_gapic_instance_method():

--- a/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -201,6 +201,35 @@ def test_publish_attrs_type_error():
         client.publish(topic, b"foo", answer=42)
 
 
+def test_stop():
+    creds = mock.Mock(spec=credentials.Credentials)
+    client = publisher.Client(credentials=creds)
+
+    batch = client._batch("topic1", autocommit=False)
+    batch2 = client._batch("topic2", autocommit=False)
+
+    pubsub_msg = types.PubsubMessage(data=b"msg")
+
+    cp = mock.patch.object(batch, "commit")
+    wp = mock.patch.object(batch, "wait")
+    cp2 = mock.patch.object(batch2, "commit")
+    wp2 = mock.patch.object(batch2, "wait")
+
+    with cp as c_mock, cp2 as c_mock2, wp as w_mock, wp2 as w_mock2:
+        batch.publish(pubsub_msg)
+        batch2.publish(pubsub_msg)
+
+        client.stop()
+
+        # check if commit() called
+        c_mock.assert_called()
+        c_mock2.assert_called()
+
+        # check if wait() called
+        w_mock.assert_called()
+        w_mock2.assert_called()
+
+
 def test_gapic_instance_method():
     creds = mock.Mock(spec=credentials.Credentials)
     client = publisher.Client(credentials=creds)

--- a/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -227,6 +227,9 @@ def test_stop():
     with pytest.raises(ValueError):
         client.publish("topic1", pubsub_msg)
 
+    with pytest.raises(ValueError):
+        client.stop()
+
 
 def test_gapic_instance_method():
     creds = mock.Mock(spec=credentials.Credentials)

--- a/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -224,10 +224,10 @@ def test_stop():
         commit_mock2.assert_called()
 
     # check that closed publisher doesn't accept new messages
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         client.publish("topic1", b"msg2")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         client.stop()
 
 

--- a/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -225,7 +225,7 @@ def test_stop():
 
     # check that closed publisher doesn't accept new messages
     with pytest.raises(ValueError):
-        client.publish("topic1", pubsub_msg)
+        client.publish("topic1", b"msg2")
 
     with pytest.raises(ValueError):
         client.stop()


### PR DESCRIPTION
Add `stop()` method, which sends all outstanding messages and waits until all futures resolved. Similar features in [Go](https://github.com/googleapis/google-cloud-go/blob/bdcd41efeb09c795b4c380d194b2a7a19f945176/pubsub/topic.go#L414-L426) and [Java](https://github.com/googleapis/google-cloud-java/blob/bec495ff9106f863098b0089c51cd6a21ca9f6b2/google-cloud-clients/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java#L492-L507).

Closes #4913
Closes #6883