### PR TITLE
chore: pin `google-cloud-core >= 1.0.3, < 2.0.0dev`.

### DIFF
--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -29,8 +29,8 @@ version = '1.0.0'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
-    'google-api-core[grpc] >= 1.14.0, < 2.0.0dev',
-    "google-cloud-core >= 1.0.0, < 2.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
+    "google-cloud-core >= 1.0.3, < 2.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
 ]
 extras = {

--- a/dns/setup.py
+++ b/dns/setup.py
@@ -29,7 +29,7 @@ version = '0.30.2'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    "google-cloud-core >= 1.0.0, < 2.0dev",
+    "google-cloud-core >= 1.0.3, < 2.0dev",
 ]
 extras = {
 }

--- a/firestore/setup.py
+++ b/firestore/setup.py
@@ -30,7 +30,7 @@ version = "1.4.0"
 release_status = "Development Status :: 4 - Beta"
 dependencies = [
     "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
-    "google-cloud-core >= 1.0.0, < 2.0dev",
+    "google-cloud-core >= 1.0.3, < 2.0dev",
     "pytz",
 ]
 extras = {}

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -29,8 +29,8 @@ version = '1.13.0'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
-    'google-api-core[grpc] >= 1.14.0, < 2.0.0dev',
-    "google-cloud-core >= 1.0.0, < 2.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
+    "google-cloud-core >= 1.0.3, < 2.0dev",
 ]
 extras = {
 }

--- a/runtimeconfig/setup.py
+++ b/runtimeconfig/setup.py
@@ -29,7 +29,7 @@ version = '0.29.2'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    "google-cloud-core >= 1.0.0, < 2.0dev",
+    "google-cloud-core >= 1.0.3, < 2.0dev",
 ]
 extras = {
 }

--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -30,7 +30,7 @@ version = "1.10.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc, grpcgcp] >= 1.14.0, < 2.0.0dev",
-    "google-cloud-core >= 1.0.0, < 2.0dev",
+    "google-cloud-core >= 1.0.3, < 2.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
 ]
 extras = {}

--- a/trace/setup.py
+++ b/trace/setup.py
@@ -29,8 +29,8 @@ version = '0.22.1'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    'google-api-core[grpc] >= 1.14.0, < 2.0.0dev',
-    "google-cloud-core >= 1.0.0, < 2.0dev",
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
+    "google-cloud-core >= 1.0.3, < 2.0dev",
 ]
 extras = {
 }


### PR DESCRIPTION
Toward #8686 