### PR TITLE
fix(spanner): return sessions from pool in LIFO order

### DIFF
--- a/spanner/google/cloud/spanner_v1/pool.py
+++ b/spanner/google/cloud/spanner_v1/pool.py
@@ -156,7 +156,7 @@ class FixedSizePool(AbstractSessionPool):
         super(FixedSizePool, self).__init__(labels=labels)
         self.size = size
         self.default_timeout = default_timeout
-        self._sessions = queue.Queue(size)
+        self._sessions = queue.LifoQueue(size)
 
     def bind(self, database):
         """Associate the pool with a database.
@@ -242,7 +242,7 @@ class BurstyPool(AbstractSessionPool):
         super(BurstyPool, self).__init__(labels=labels)
         self.target_size = target_size
         self._database = None
-        self._sessions = queue.Queue(target_size)
+        self._sessions = queue.LifoQueue(target_size)
 
     def bind(self, database):
         """Associate the pool with a database.

--- a/spanner/tests/unit/test_pool.py
+++ b/spanner/tests/unit/test_pool.py
@@ -162,15 +162,16 @@ class TestFixedSizePool(unittest.TestCase):
     def test_get_non_expired(self):
         pool = self._make_one(size=4)
         database = _Database("name")
-        SESSIONS = [_Session(database)] * 4
+        SESSIONS = sorted([_Session(database) for i in range(0, 4)])
         database._sessions.extend(SESSIONS)
         pool.bind(database)
 
-        session = pool.get()
-
-        self.assertIs(session, SESSIONS[0])
-        self.assertTrue(session._exists_checked)
-        self.assertFalse(pool._sessions.full())
+        # check if sessions returned in LIFO order
+        for i in (3, 2, 1, 0):
+            session = pool.get()
+            self.assertIs(session, SESSIONS[i])
+            self.assertTrue(session._exists_checked)
+            self.assertFalse(pool._sessions.full())
 
     def test_get_expired(self):
         pool = self._make_one(size=4)
@@ -875,7 +876,7 @@ class _Database(object):
         self._sessions = []
 
     def session(self):
-        return self._sessions.pop()
+        return self._sessions.pop(0)
 
 
 class _Queue(object):

--- a/spanner/tests/unit/test_pool.py
+++ b/spanner/tests/unit/test_pool.py
@@ -876,6 +876,9 @@ class _Database(object):
         self._sessions = []
 
     def session(self):
+        # always return first session in the list
+        # to avoid reversing the order of putting
+        # sessions into pool (important for order tests)
         return self._sessions.pop(0)
 
 


### PR DESCRIPTION
Change sessions order from FIFO to LIFO. Done only in those pool classes, which don't have priorities.
Towards #9392 