### PR TITLE
chore(error_reporting): pin 'google-cloud-logging >= 1.14.0, < 2.0.0dev

### DIFF
--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -28,7 +28,7 @@ version = "0.32.1"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-cloud-logging>=1.11.0, <2.0dev"]
+dependencies = ["google-cloud-logging>=1.14.0, <2.0dev"]
 extras = {}
 
 


### PR DESCRIPTION
Toward #8686.