### PR TITLE
test(dlp): ensure env is always set; fix typo in test_deidentify_content

### DIFF
--- a/dlp/noxfile.py
+++ b/dlp/noxfile.py
@@ -118,6 +118,7 @@ def system(session):
     session.install("-e", "../test_utils/")
     session.install("-e", ".")
 
+    env = {}
     # Additional setup for VPCSC system tests
     if os.environ.get("GOOGLE_CLOUD_TESTS_IN_VPCSC", "false").lower() != "true":
         # Unset PROJECT_ID, since VPCSC system tests expect this to be a project

--- a/dlp/tests/system/gapic/v2/test_system_dlp_service_v2_vpcsc.py
+++ b/dlp/tests/system/gapic/v2/test_system_dlp_service_v2_vpcsc.py
@@ -96,7 +96,7 @@ class TestSystemDlpService(object):
         name_inside = client.project_path(PROJECT_INSIDE)
         delayed_inside = lambda: client.deidentify_content(name_inside)
         name_outside = client.project_path(PROJECT_OUTSIDE)
-        delayed_outside = lambda: client.deidentify_conent(name_outside)
+        delayed_outside = lambda: client.deidentify_content(name_outside)
         TestSystemDlpService._do_test(delayed_inside, delayed_outside)
 
     @pytest.mark.skipif(


### PR DESCRIPTION
Ensure env variable is always set. If GOOGLE_CLOUD_TESTS_IN_VPCSC check fails, we will pass in an unset variable. Additionally, correct conent -> content in test_deidentify_content, preventing noisy failures.