### PR TITLE
feat(api_core): provide a 'raw_page' field for page_iterator.Page

### DIFF
--- a/api_core/.coveragerc
+++ b/api_core/.coveragerc
@@ -11,5 +11,3 @@ exclude_lines =
     def __repr__
     # Ignore abstract methods
     raise NotImplementedError
-    # Ignore assert False, meant to prevent false positive tests
-    assert False

--- a/api_core/.coveragerc
+++ b/api_core/.coveragerc
@@ -13,3 +13,4 @@ exclude_lines =
     raise NotImplementedError
     # Ignore assert False, meant to prevent false positive tests
     assert False
+    

--- a/api_core/.coveragerc
+++ b/api_core/.coveragerc
@@ -11,3 +11,5 @@ exclude_lines =
     def __repr__
     # Ignore abstract methods
     raise NotImplementedError
+    # Ignore assert False, meant to prevent false positive tests
+    assert False

--- a/api_core/.coveragerc
+++ b/api_core/.coveragerc
@@ -13,4 +13,3 @@ exclude_lines =
     raise NotImplementedError
     # Ignore assert False, meant to prevent false positive tests
     assert False
-    

--- a/api_core/google/api_core/page_iterator.py
+++ b/api_core/google/api_core/page_iterator.py
@@ -100,7 +100,7 @@ class Page(object):
             The raw page response.
     """
 
-    def __init__(self, parent, items, item_to_value, raw_page):
+    def __init__(self, parent, items, item_to_value, raw_page=None):
         self._parent = parent
         self._num_items = len(items)
         self._remaining = self._num_items
@@ -368,7 +368,7 @@ class HTTPIterator(Iterator):
         if self._has_next_page():
             response = self._get_next_page_response()
             items = response.get(self._items_key, ())
-            page = Page(self, items, self.item_to_value, response)
+            page = Page(self, items, self.item_to_value, raw_page=response)
             self._page_start(self, page, response)
             self.next_page_token = response.get(self._next_token)
             return page
@@ -462,7 +462,7 @@ class _GAXIterator(Iterator):
         """
         try:
             items = six.next(self._gax_page_iter)
-            page = Page(self, items, self.item_to_value, None)
+            page = Page(self, items, self.item_to_value)
             self.next_page_token = self._gax_page_iter.page_token or None
             return page
         except StopIteration:
@@ -535,7 +535,7 @@ class GRPCIterator(Iterator):
 
         self.next_page_token = getattr(response, self._response_token_field)
         items = getattr(response, self._items_field)
-        page = Page(self, items, self.item_to_value, response)
+        page = Page(self, items, self.item_to_value, raw_page=response)
 
         return page
 

--- a/api_core/google/api_core/page_iterator.py
+++ b/api_core/google/api_core/page_iterator.py
@@ -96,14 +96,22 @@ class Page(object):
             Callable to convert an item from the type in the raw API response
             into the native object. Will be called with the iterator and a
             single item.
+        raw_page Optional[google.protobuf.message.Message]:
+            The raw page response.
     """
 
-    def __init__(self, parent, items, item_to_value):
+    def __init__(self, parent, items, item_to_value, raw_page):
         self._parent = parent
         self._num_items = len(items)
         self._remaining = self._num_items
         self._item_iter = iter(items)
         self._item_to_value = item_to_value
+        self._raw_page = raw_page
+
+    @property
+    def raw_page(self):
+        """google.protobuf.message.Message"""
+        return self._raw_page
 
     @property
     def num_items(self):
@@ -360,7 +368,7 @@ class HTTPIterator(Iterator):
         if self._has_next_page():
             response = self._get_next_page_response()
             items = response.get(self._items_key, ())
-            page = Page(self, items, self.item_to_value)
+            page = Page(self, items, self.item_to_value, response)
             self._page_start(self, page, response)
             self.next_page_token = response.get(self._next_token)
             return page
@@ -454,7 +462,7 @@ class _GAXIterator(Iterator):
         """
         try:
             items = six.next(self._gax_page_iter)
-            page = Page(self, items, self.item_to_value)
+            page = Page(self, items, self.item_to_value, None)
             self.next_page_token = self._gax_page_iter.page_token or None
             return page
         except StopIteration:
@@ -527,7 +535,7 @@ class GRPCIterator(Iterator):
 
         self.next_page_token = getattr(response, self._response_token_field)
         items = getattr(response, self._items_field)
-        page = Page(self, items, self.item_to_value)
+        page = Page(self, items, self.item_to_value, response)
 
         return page
 

--- a/api_core/tests/unit/test_page_iterator.py
+++ b/api_core/tests/unit/test_page_iterator.py
@@ -30,7 +30,7 @@ class TestPage(object):
         parent = mock.sentinel.parent
         item_to_value = mock.sentinel.item_to_value
 
-        page = page_iterator.Page(parent, (1, 2, 3), item_to_value)
+        page = page_iterator.Page(parent, (1, 2, 3), item_to_value, None)
 
         assert page.num_items == 3
         assert page.remaining == 3
@@ -38,7 +38,7 @@ class TestPage(object):
         assert page._item_to_value is item_to_value
 
     def test___iter__(self):
-        page = page_iterator.Page(None, (), None)
+        page = page_iterator.Page(None, (), None, None)
         assert iter(page) is page
 
     def test_iterator_calls_parent_item_to_value(self):
@@ -48,7 +48,7 @@ class TestPage(object):
             side_effect=lambda iterator, value: value, spec=["__call__"]
         )
 
-        page = page_iterator.Page(parent, (10, 11, 12), item_to_value)
+        page = page_iterator.Page(parent, (10, 11, 12), item_to_value, None)
         page._remaining = 100
 
         assert item_to_value.call_count == 0
@@ -68,6 +68,22 @@ class TestPage(object):
         assert item_to_value.call_count == 3
         item_to_value.assert_called_with(parent, 12)
         assert page.remaining == 97
+
+    def test_raw_page(self):
+        parent = mock.sentinel.parent
+        item_to_value = mock.sentinel.item_to_value
+
+        raw_page = mock.sentinel.raw_page
+
+        page = page_iterator.Page(parent, (1, 2, 3), item_to_value, raw_page)
+        assert page.raw_page is raw_page
+
+        try:
+            page.raw_page = None
+        except AttributeError:
+            pass
+        else:
+            assert False, "The raw_page attribute should be a read-only property"
 
 
 class PageIteratorImpl(page_iterator.Iterator):
@@ -116,7 +132,7 @@ class TestIterator(object):
     def test__page_iter_increment(self):
         iterator = PageIteratorImpl(None, None)
         page = page_iterator.Page(
-            iterator, ("item",), page_iterator._item_to_value_identity
+            iterator, ("item",), page_iterator._item_to_value_identity, None
         )
         iterator._next_page = mock.Mock(side_effect=[page, None])
 
@@ -147,10 +163,10 @@ class TestIterator(object):
         # Make pages from mock responses
         parent = mock.sentinel.parent
         page1 = page_iterator.Page(
-            parent, (item1, item2), page_iterator._item_to_value_identity
+            parent, (item1, item2), page_iterator._item_to_value_identity, None
         )
         page2 = page_iterator.Page(
-            parent, (item3,), page_iterator._item_to_value_identity
+            parent, (item3,), page_iterator._item_to_value_identity, None
         )
 
         iterator = PageIteratorImpl(None, None)

--- a/api_core/tests/unit/test_page_iterator.py
+++ b/api_core/tests/unit/test_page_iterator.py
@@ -79,7 +79,7 @@ class TestPage(object):
         page = page_iterator.Page(parent, (1, 2, 3), item_to_value, raw_page=raw_page)
         assert page.raw_page is raw_page
 
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             page.raw_page = None
 
 

--- a/api_core/tests/unit/test_page_iterator.py
+++ b/api_core/tests/unit/test_page_iterator.py
@@ -79,7 +79,7 @@ class TestPage(object):
         page = page_iterator.Page(parent, (1, 2, 3), item_to_value, raw_page=raw_page)
         assert page.raw_page is raw_page
 
-        self.assertRaises(AttributeError):
+        with self.assertRaises(AttributeError):
             page.raw_page = None
 
 


### PR DESCRIPTION
Some paginated response messages include additional fields that users
may wish to inspect. This change stores the raw page when constructing a page_iterator.Page and provides an accessor.

In addition to the new and modified unit tests, hand experimentation generates expected behavior:
```python
from google.cloud import automl
client = automl.AutoMlClient()

result = client.list_datasets(...)
for page in result.pages:
    print(f"{page.raw_page}")
```
prints individual pages.