### PR TITLE
feat(spanner): add batch_create_session calls to session pools

### DIFF
--- a/spanner/google/cloud/spanner_v1/pool.py
+++ b/spanner/google/cloud/spanner_v1/pool.py
@@ -20,6 +20,7 @@ from six.moves import queue
 from six.moves import xrange
 
 from google.cloud.exceptions import NotFound
+from google.cloud.spanner_v1._helpers import _metadata_with_prefix
 
 
 _NOW = datetime.datetime.utcnow  # unit tests may replace
@@ -166,11 +167,22 @@ class FixedSizePool(AbstractSessionPool):
                          when needed.
         """
         self._database = database
+        api = database.spanner_api
+        created_session_count = 0
+        metadata = _metadata_with_prefix(database.name)
 
         while not self._sessions.full():
-            session = self._new_session()
-            session.create()
-            self._sessions.put(session)
+            resp = api.batch_create_sessions(
+                database.name,
+                session_count=self.size - created_session_count,
+                timeout=self.default_timeout,
+                metadata=metadata,
+            )
+            for session_pb in resp.session:
+                session = self._new_session()
+                session._session_id = session_pb.name.split("/")[-1]
+                self._sessions.put(session)
+            created_session_count += len(resp.session)
 
     def get(self, timeout=None):  # pylint: disable=arguments-differ
         """Check a session out from the pool.
@@ -350,11 +362,22 @@ class PingingPool(AbstractSessionPool):
                          when needed.
         """
         self._database = database
+        api = database.spanner_api
+        metadata = _metadata_with_prefix(database.name)
+        created_session_count = 0
 
-        for _ in xrange(self.size):
-            session = self._new_session()
-            session.create()
-            self.put(session)
+        while created_session_count < self.size:
+            resp = api.batch_create_sessions(
+                database.name,
+                session_count=self.size - created_session_count,
+                timeout=self.default_timeout,
+                metadata=metadata,
+            )
+            for session_pb in resp.session:
+                session = self._new_session()
+                session._session_id = session_pb.name.split("/")[-1]
+                self._sessions.put(session)
+            created_session_count += len(resp.session)
 
     def get(self, timeout=None):  # pylint: disable=arguments-differ
         """Check a session out from the pool.

--- a/spanner/google/cloud/spanner_v1/pool.py
+++ b/spanner/google/cloud/spanner_v1/pool.py
@@ -172,7 +172,7 @@ class FixedSizePool(AbstractSessionPool):
         while not self._sessions.full():
             resp = api.batch_create_sessions(
                 database.name,
-                session_count=self.size - self._sessions.qsize(),
+                self.size - self._sessions.qsize(),
                 timeout=self.default_timeout,
                 metadata=metadata,
             )
@@ -366,7 +366,7 @@ class PingingPool(AbstractSessionPool):
         while created_session_count < self.size:
             resp = api.batch_create_sessions(
                 database.name,
-                session_count=self.size - created_session_count,
+                self.size - created_session_count,
                 timeout=self.default_timeout,
                 metadata=metadata,
             )

--- a/spanner/google/cloud/spanner_v1/pool.py
+++ b/spanner/google/cloud/spanner_v1/pool.py
@@ -17,7 +17,6 @@
 import datetime
 
 from six.moves import queue
-from six.moves import xrange
 
 from google.cloud.exceptions import NotFound
 from google.cloud.spanner_v1._helpers import _metadata_with_prefix

--- a/spanner/google/cloud/spanner_v1/pool.py
+++ b/spanner/google/cloud/spanner_v1/pool.py
@@ -376,7 +376,7 @@ class PingingPool(AbstractSessionPool):
             for session_pb in resp.session:
                 session = self._new_session()
                 session._session_id = session_pb.name.split("/")[-1]
-                self._sessions.put(session)
+                self.put(session)
             created_session_count += len(resp.session)
 
     def get(self, timeout=None):  # pylint: disable=arguments-differ

--- a/spanner/tests/unit/test_pool.py
+++ b/spanner/tests/unit/test_pool.py
@@ -527,7 +527,6 @@ class TestPingingPool(unittest.TestCase):
         database = _Database("name")
         session = _Session(database)
 
-
         with _Monkey(MUT, _NOW=lambda: now):
             pool.put(session)
 
@@ -883,16 +882,18 @@ class _Database(object):
         self._sessions = []
 
         def mock_batch_create_sessions(db, session_count=10, timeout=10, metadata=[]):
-             from google.cloud.spanner_v1.proto import spanner_pb2
-             response = spanner_pb2.BatchCreateSessionsResponse()
-             if session_count < 2:
-                 response.session.add()
-             else:
-                 response.session.add()
-                 response.session.add()
-             return response
+            from google.cloud.spanner_v1.proto import spanner_pb2
+
+            response = spanner_pb2.BatchCreateSessionsResponse()
+            if session_count < 2:
+                response.session.add()
+            else:
+                response.session.add()
+                response.session.add()
+            return response
 
         from google.cloud.spanner_v1.gapic.spanner_client import SpannerClient
+
         self.spanner_api = mock.create_autospec(SpannerClient, instance=True)
         self.spanner_api.batch_create_sessions.side_effect = mock_batch_create_sessions
 


### PR DESCRIPTION
Currently, session pools are filled by creating single sessions. For large session pool sizes (>1000) this can be incredibly slow as it requires >1000 requests to be made to the server sequentially. Using batch_create_session calls to fill the pools will reduce the number of requests by a factor of 100 which will greatly reduce the start up time.

The BurstyPool does not use batch_create_session as it is designed to create sessions on an "as needed" basis rather than filling a queue.