### PR TITLE
fix(automl): pass credentials to underlying clients in TableClient

### DIFF
--- a/automl/google/cloud/automl_v1beta1/tables/tables_client.py
+++ b/automl/google/cloud/automl_v1beta1/tables/tables_client.py
@@ -107,14 +107,14 @@ class TablesClient(object):
 
         if client is None:
             self.auto_ml_client = gapic.auto_ml_client.AutoMlClient(
-                client_info=client_info_, **kwargs
+                credentials=credentials, client_info=client_info_, **kwargs
             )
         else:
             self.auto_ml_client = client
 
         if prediction_client is None:
             self.prediction_client = gapic.prediction_service_client.PredictionServiceClient(
-                client_info=client_info_, **kwargs
+                credentials=credentials, client_info=client_info_, **kwargs
             )
         else:
             self.prediction_client = prediction_client

--- a/automl/tests/unit/gapic/v1beta1/test_tables_client_v1beta1.py
+++ b/automl/tests/unit/gapic/v1beta1/test_tables_client_v1beta1.py
@@ -1379,3 +1379,25 @@ class TestTablesClient(object):
             )
         client.auto_ml_client.list_models.assert_not_called()
         client.prediction_client.batch_predict.assert_not_called()
+
+    def test_auto_ml_client_credentials(self):
+        credentials_mock = mock.Mock()
+        patch_auto_ml_client = mock.patch(
+            "google.cloud.automl_v1beta1.gapic.auto_ml_client.AutoMlClient"
+        )
+        with patch_auto_ml_client as MockAutoMlClient:
+            client = automl_v1beta1.TablesClient(credentials=credentials_mock)
+        _, auto_ml_client_kwargs = MockAutoMlClient.call_args
+        assert "credentials" in auto_ml_client_kwargs
+        assert auto_ml_client_kwargs["credentials"] == credentials_mock
+
+    def test_prediction_client_credentials(self):
+        credentials_mock = mock.Mock()
+        patch_prediction_client = mock.patch(
+            "google.cloud.automl_v1beta1.gapic.prediction_service_client.PredictionServiceClient"
+        )
+        with patch_prediction_client as MockPredictionClient:
+            client = automl_v1beta1.TablesClient(credentials=credentials_mock)
+        _, prediction_client_kwargs = MockPredictionClient.call_args
+        assert "credentials" in prediction_client_kwargs
+        assert prediction_client_kwargs["credentials"] == credentials_mock


### PR DESCRIPTION
In automl_v1beta1.TablesClient.__init__(), the credentials are not given to AutoMlClient and PredictionServiceClient, causing inconsistency between the credentials that was passed and the credentials that was actually used for API calls.

This commit ensures that credentials are passed, and add two unittests to catch the behavior.

Fixes #9490 