### PR TITLE
chore(bigquery): remove duplicate test dependencies

### DIFF
--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -88,7 +88,6 @@ def system(session):
     for local_dep in LOCAL_DEPS:
         session.install("-e", local_dep)
     session.install("-e", os.path.join("..", "storage"))
-    session.install("-e", os.path.join("..", "test_utils"))
     session.install("-e", ".[all]")
 
     # IPython does not support Python 2 after version 5.x
@@ -116,7 +115,6 @@ def snippets(session):
     for local_dep in LOCAL_DEPS:
         session.install("-e", local_dep)
     session.install("-e", os.path.join("..", "storage"))
-    session.install("-e", os.path.join("..", "test_utils"))
     session.install("-e", ".[all]")
 
     # Run py.test against the snippets tests.

--- a/bigquery/noxfile.py
+++ b/bigquery/noxfile.py
@@ -20,11 +20,7 @@ import shutil
 import nox
 
 
-LOCAL_DEPS = (
-    os.path.join("..", "api_core[grpc]"),
-    os.path.join("..", "core"),
-    os.path.join("..", "test_utils"),
-)
+LOCAL_DEPS = (os.path.join("..", "api_core[grpc]"), os.path.join("..", "core"))
 
 BLACK_PATHS = ("docs", "google", "samples", "tests", "noxfile.py", "setup.py")
 
@@ -42,6 +38,7 @@ def default(session):
     for local_dep in LOCAL_DEPS:
         session.install("-e", local_dep)
 
+    session.install("-e", os.path.join("..", "test_utils"))
     dev_install = ".[all]"
     session.install("-e", dev_install)
 
@@ -88,6 +85,7 @@ def system(session):
     for local_dep in LOCAL_DEPS:
         session.install("-e", local_dep)
     session.install("-e", os.path.join("..", "storage"))
+    session.install("-e", os.path.join("..", "test_utils"))
     session.install("-e", ".[all]")
 
     # IPython does not support Python 2 after version 5.x
@@ -115,6 +113,7 @@ def snippets(session):
     for local_dep in LOCAL_DEPS:
         session.install("-e", local_dep)
     session.install("-e", os.path.join("..", "storage"))
+    session.install("-e", os.path.join("..", "test_utils"))
     session.install("-e", ".[all]")
 
     # Run py.test against the snippets tests.


### PR DESCRIPTION
Fixes #9502.

This PR removes redundancy in BigQuery's `noxfile` that results in `test_utils` being installed twice.

(modifying the noxfile directly, as it is not generated by the synth tool in BigQuery)

### How to test
- Run the following nox sessions: `snippets` and `system`. You do not have to wait for them to complete, just make sure the setup phase is completed and the relevant tests start running.

**Actual result (before the fix):**
In both cases `test_utils` are installed twice. In the output:
```
...
nox > pip install -e ../test_utils
...
nox > pip install -e ../test_utils
```

**Expected result (after the fix):**
`test_utils` are only installed once in a session.