### PR TITLE
chore(datacatalog): add codeowners for data catalog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,10 @@ docs/bigquery_datatransfer/ @googleapis/api-bigquery
 bigquery_storage/           @googleapis/api-bigquery
 docs/bigquery_storage/      @googleapis/api-bigquery
 
+# Data Catalog isn't technically part of BigQuery, but it's closely related.
+datacatalog/                @googleapis/api-bigquery
+docs/datacatalog/           @googleapis/api-bigquery
+
 # Pubsub
 pubsub/                     @anguillanneuf @plamut @pradn
 docs/pubsub                 @anguillanneuf @plamut @pradn


### PR DESCRIPTION
I'm the primary owner of Data Catalog for now, as it's needed for some BigQuery features.