### PR TITLE
docs(datastore): remove duplication of API

### DIFF
--- a/datastore/README.rst
+++ b/datastore/README.rst
@@ -105,7 +105,7 @@ Example Usage
 Next Steps
 ~~~~~~~~~~
 
--  Read the `Client Library Documentation`_ for Google Cloud Datastore API
+-  Read the `Client Library Documentation`_ for Google Cloud Datastore
    API to see other available methods on the client.
 -  Read the `Product documentation`_ to learn
    more about the product and see How-to Guides.

--- a/error_reporting/README.rst
+++ b/error_reporting/README.rst
@@ -85,7 +85,7 @@ Windows
 Next Steps
 ~~~~~~~~~~
 
--  Read the `Client Library Documentation`_ for Google Cloud Datastore API
+-  Read the `Client Library Documentation`_ for Google Cloud Datastore
    API to see other available methods on the client.
 -  Read the `Product documentation`_ to learn
    more about the product and see How-to Guides.


### PR DESCRIPTION
Noticed that `API` was repeated, possibly not caught since it was on a newline in the readme.

I could not find another reference to _Google Cloud Datastore API API_.

Reject my change if I am mistaken.
Thanks