### PR TITLE
docs(storage): add hmac_key and notification documentation rst files.

### DIFF
--- a/storage/docs/hmac_key.rst
+++ b/storage/docs/hmac_key.rst
@@ -1,0 +1,6 @@
+HMAC Key Metadata
+~~~~~~~~~~~~~~~~~
+
+.. automodule:: google.cloud.storage.hmac_key
+  :members:
+  :show-inheritance:

--- a/storage/docs/index.rst
+++ b/storage/docs/index.rst
@@ -19,6 +19,8 @@ API Reference
   acl
   batch
   constants
+  hmac_key
+  notification
 
 Changelog
 ---------

--- a/storage/docs/notification.rst
+++ b/storage/docs/notification.rst
@@ -1,0 +1,6 @@
+Notification
+~~~~~~~~~~~~
+
+.. automodule:: google.cloud.storage.notification
+  :members:
+  :show-inheritance:


### PR DESCRIPTION
Adding missing documentation for hmac_key and notification metadata objects. 

Fixes Issue: https://github.com/googleapis/google-cloud-python/issues/9528