### PR TITLE
fix: add gcloud-python user agent header

### DIFF
--- a/api_core/google/api_core/client_info.py
+++ b/api_core/google/api_core/client_info.py
@@ -92,5 +92,6 @@ class ClientInfo(object):
 
         if self.client_library_version is not None:
             ua += "gccl/{client_library_version} "
+            ua += "gcloud-python/{client_library_version} "
 
         return ua.format(**self.__dict__).strip()


### PR DESCRIPTION
Some metrics systems expect gcloud-{lang}/{library_version} 