### PR TITLE
fix: don't report a gapic version for storage

### DIFF
--- a/storage/google/cloud/storage/_http.py
+++ b/storage/google/cloud/storage/_http.py
@@ -34,7 +34,6 @@ class Connection(_http.JSONConnection):
     def __init__(self, client, client_info=None, api_endpoint=DEFAULT_API_ENDPOINT):
         super(Connection, self).__init__(client, client_info)
         self.API_BASE_URL = api_endpoint
-        self._client_info.gapic_version = __version__
         self._client_info.client_library_version = __version__
 
     API_VERSION = "v1"


### PR DESCRIPTION
As storage libraries don't have a gapic layer we shouldn't indicate a version in our headers.
