### PR TITLE
feat(bigquery): allow passing schema as a sequence of dicts

### DIFF
--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -225,8 +225,8 @@ def _row_tuple_from_json(row, schema):
     Args:
         row (Dict): A JSON response row to be converted.
         schema (Sequence[Union[ \
-            Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-            Sequence[Mapping[str, Any]] \
+                :class:`~google.cloud.bigquery.schema.SchemaField`, \
+                Mapping[str, Any] \
         ]]):  Specification of the field types in ``row``.
 
     Returns:
@@ -247,12 +247,12 @@ def _rows_from_json(values, schema):
 
     Args:
         values (Sequence[Dict]): The list of responses (JSON rows) to convert.
-        schema (Union[ \
-                Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-                Sequence[Mapping[str, Any]] \
-        ]):
-            The table's schema. If given as a sequence of dicts, their content
-            must be compatible with
+        schema (Sequence[Union[ \
+                :class:`~google.cloud.bigquery.schema.SchemaField`, \
+                Mapping[str, Any] \
+        ]]):
+            The table's schema. If any item is a mapping, its content must be
+            compatible with
             :meth:`~google.cloud.bigquery.schema.SchemaField.from_api_repr`.
 
     Returns:

--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -224,11 +224,18 @@ def _row_tuple_from_json(row, schema):
 
     Args:
         row (Dict): A JSON response row to be converted.
-        schema (Tuple): A tuple of :class:`~google.cloud.bigquery.schema.SchemaField`.
+        schema (Sequence[Union[ \
+            Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
+            Sequence[Mapping[str, str]] \
+        ]]):  Specification of the field types in ``row``.
 
     Returns:
         Tuple: A tuple of data converted to native types.
     """
+    from google.cloud.bigquery.schema import _to_schema_fields
+
+    schema = _to_schema_fields(schema)
+
     row_data = []
     for field, cell in zip(schema, row["f"]):
         row_data.append(_field_from_json(cell["v"], field))
@@ -236,9 +243,25 @@ def _row_tuple_from_json(row, schema):
 
 
 def _rows_from_json(values, schema):
-    """Convert JSON row data to rows with appropriate types."""
-    from google.cloud.bigquery import Row
+    """Convert JSON row data to rows with appropriate types.
 
+    Args:
+        values (Sequence[Dict]): The list of responses (JSON rows) to convert.
+        schema (Union[ \
+                Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
+                Sequence[Mapping[str, str]] \
+        ]):
+            The table's schema. If given as a sequence of dicts, their content
+            must be compatible with
+            :meth:`~google.cloud.bigquery.schema.SchemaField.from_api_repr`.
+
+    Returns:
+        List[:class:`~google.cloud.bigquery.Row`]
+    """
+    from google.cloud.bigquery import Row
+    from google.cloud.bigquery.schema import _to_schema_fields
+
+    schema = _to_schema_fields(schema)
     field_to_index = _field_to_index_mapping(schema)
     return [Row(_row_tuple_from_json(r, schema), field_to_index) for r in values]
 

--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -226,7 +226,7 @@ def _row_tuple_from_json(row, schema):
         row (Dict): A JSON response row to be converted.
         schema (Sequence[Union[ \
             Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-            Sequence[Mapping[str, str]] \
+            Sequence[Mapping[str, Any]] \
         ]]):  Specification of the field types in ``row``.
 
     Returns:
@@ -249,7 +249,7 @@ def _rows_from_json(values, schema):
         values (Sequence[Dict]): The list of responses (JSON rows) to convert.
         schema (Union[ \
                 Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-                Sequence[Mapping[str, str]] \
+                Sequence[Mapping[str, Any]] \
         ]):
             The table's schema. If given as a sequence of dicts, their content
             must be compatible with

--- a/bigquery/google/cloud/bigquery/_pandas_helpers.py
+++ b/bigquery/google/cloud/bigquery/_pandas_helpers.py
@@ -240,8 +240,8 @@ def dataframe_to_bq_schema(dataframe, bq_schema):
         dataframe (pandas.DataFrame):
             DataFrame for which the client determines the BigQuery schema.
         bq_schema (Sequence[Union[ \
-            Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-            Sequence[Mapping[str, Any]] \
+            :class:`~google.cloud.bigquery.schema.SchemaField`, \
+            Mapping[str, Any] \
         ]]):
             A BigQuery schema. Use this argument to override the autodetected
             type for some or all of the DataFrame columns.
@@ -302,11 +302,11 @@ def dataframe_to_arrow(dataframe, bq_schema):
         dataframe (pandas.DataFrame):
             DataFrame to convert to Arrow table.
         bq_schema (Sequence[Union[ \
-            Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-            Sequence[Mapping[str, Any]] \
+            :class:`~google.cloud.bigquery.schema.SchemaField`, \
+            Mapping[str, Any] \
         ]]):
-            Desired BigQuery schema. Number of columns must match number of
-            columns in the DataFrame.
+            Desired BigQuery schema. The number of columns must match the
+            number of columns in the DataFrame.
 
     Returns:
         pyarrow.Table:
@@ -364,8 +364,8 @@ def dataframe_to_parquet(dataframe, bq_schema, filepath, parquet_compression="SN
         dataframe (pandas.DataFrame):
             DataFrame to convert to Parquet file.
         bq_schema (Sequence[Union[ \
-            Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-            Sequence[Mapping[str, Any]] \
+            :class:`~google.cloud.bigquery.schema.SchemaField`, \
+            Mapping[str, Any] \
         ]]):
             Desired BigQuery schema. Number of columns must match number of
             columns in the DataFrame.
@@ -408,8 +408,8 @@ def download_arrow_tabledata_list(pages, bq_schema):
         pages (Iterator[:class:`google.api_core.page_iterator.Page`]):
             An iterator over the result pages.
         bq_schema (Sequence[Union[ \
-            Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-            Sequence[Mapping[str, Any]] \
+            :class:`~google.cloud.bigquery.schema.SchemaField`, \
+            Mapping[str, Any] \
         ]]):
             A decription of the fields in result pages.
     Yields:
@@ -446,8 +446,8 @@ def download_dataframe_tabledata_list(pages, bq_schema, dtypes):
         pages (Iterator[:class:`google.api_core.page_iterator.Page`]):
             An iterator over the result pages.
         bq_schema (Sequence[Union[ \
-            Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-            Sequence[Mapping[str, Any]] \
+            :class:`~google.cloud.bigquery.schema.SchemaField`, \
+            Mapping[str, Any] \
         ]]):
             A decription of the fields in result pages.
         dtypes(Mapping[str, numpy.dtype]):

--- a/bigquery/google/cloud/bigquery/_pandas_helpers.py
+++ b/bigquery/google/cloud/bigquery/_pandas_helpers.py
@@ -239,7 +239,10 @@ def dataframe_to_bq_schema(dataframe, bq_schema):
     Args:
         dataframe (pandas.DataFrame):
             DataFrame for which the client determines the BigQuery schema.
-        bq_schema (Sequence[google.cloud.bigquery.schema.SchemaField]):
+        bq_schema (Sequence[Union[ \
+            Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
+            Sequence[Mapping[str, str]] \
+        ]]):
             A BigQuery schema. Use this argument to override the autodetected
             type for some or all of the DataFrame columns.
 
@@ -249,6 +252,7 @@ def dataframe_to_bq_schema(dataframe, bq_schema):
             any column cannot be determined.
     """
     if bq_schema:
+        bq_schema = schema._to_schema_fields(bq_schema)
         for field in bq_schema:
             if field.field_type in schema._STRUCT_TYPES:
                 raise ValueError(
@@ -297,7 +301,10 @@ def dataframe_to_arrow(dataframe, bq_schema):
     Args:
         dataframe (pandas.DataFrame):
             DataFrame to convert to Arrow table.
-        bq_schema (Sequence[google.cloud.bigquery.schema.SchemaField]):
+        bq_schema (Sequence[Union[ \
+            Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
+            Sequence[Mapping[str, str]] \
+        ]]):
             Desired BigQuery schema. Number of columns must match number of
             columns in the DataFrame.
 
@@ -310,6 +317,8 @@ def dataframe_to_arrow(dataframe, bq_schema):
     column_and_index_names = set(
         name for name, _ in list_columns_and_indexes(dataframe)
     )
+
+    bq_schema = schema._to_schema_fields(bq_schema)
     bq_field_names = set(field.name for field in bq_schema)
 
     extra_fields = bq_field_names - column_and_index_names
@@ -354,7 +363,10 @@ def dataframe_to_parquet(dataframe, bq_schema, filepath, parquet_compression="SN
     Args:
         dataframe (pandas.DataFrame):
             DataFrame to convert to Parquet file.
-        bq_schema (Sequence[google.cloud.bigquery.schema.SchemaField]):
+        bq_schema (Sequence[Union[ \
+            Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
+            Sequence[Mapping[str, str]] \
+        ]]):
             Desired BigQuery schema. Number of columns must match number of
             columns in the DataFrame.
         filepath (str):
@@ -368,6 +380,7 @@ def dataframe_to_parquet(dataframe, bq_schema, filepath, parquet_compression="SN
     if pyarrow is None:
         raise ValueError("pyarrow is required for BigQuery schema conversion.")
 
+    bq_schema = schema._to_schema_fields(bq_schema)
     arrow_table = dataframe_to_arrow(dataframe, bq_schema)
     pyarrow.parquet.write_table(arrow_table, filepath, compression=parquet_compression)
 
@@ -388,20 +401,24 @@ def _tabledata_list_page_to_arrow(page, column_names, arrow_types):
     return pyarrow.RecordBatch.from_arrays(arrays, names=column_names)
 
 
-def download_arrow_tabledata_list(pages, schema):
+def download_arrow_tabledata_list(pages, bq_schema):
     """Use tabledata.list to construct an iterable of RecordBatches.
 
     Args:
         pages (Iterator[:class:`google.api_core.page_iterator.Page`]):
             An iterator over the result pages.
-        schema (Sequence[google.cloud.bigquery.schema.SchemaField]):
+        bq_schema (Sequence[Union[ \
+            Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
+            Sequence[Mapping[str, str]] \
+        ]]):
             A decription of the fields in result pages.
     Yields:
         :class:`pyarrow.RecordBatch`
         The next page of records as a ``pyarrow`` record batch.
     """
-    column_names = bq_to_arrow_schema(schema) or [field.name for field in schema]
-    arrow_types = [bq_to_arrow_data_type(field) for field in schema]
+    bq_schema = schema._to_schema_fields(bq_schema)
+    column_names = bq_to_arrow_schema(bq_schema) or [field.name for field in bq_schema]
+    arrow_types = [bq_to_arrow_data_type(field) for field in bq_schema]
 
     for page in pages:
         yield _tabledata_list_page_to_arrow(page, column_names, arrow_types)
@@ -422,9 +439,26 @@ def _tabledata_list_page_to_dataframe(page, column_names, dtypes):
     return pandas.DataFrame(columns, columns=column_names)
 
 
-def download_dataframe_tabledata_list(pages, schema, dtypes):
-    """Use (slower, but free) tabledata.list to construct a DataFrame."""
-    column_names = [field.name for field in schema]
+def download_dataframe_tabledata_list(pages, bq_schema, dtypes):
+    """Use (slower, but free) tabledata.list to construct a DataFrame.
+
+    Args:
+        pages (Iterator[:class:`google.api_core.page_iterator.Page`]):
+            An iterator over the result pages.
+        bq_schema (Sequence[Union[ \
+            Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
+            Sequence[Mapping[str, str]] \
+        ]]):
+            A decription of the fields in result pages.
+        dtypes(Mapping[str, numpy.dtype]):
+            The types of columns in result data to hint construction of the
+            resulting DataFrame. Not all column types have to be specified.
+    Yields:
+        :class:`pandas.DataFrame`
+        The next page of records as a ``pandas.DataFrame`` record batch.
+    """
+    bq_schema = schema._to_schema_fields(bq_schema)
+    column_names = [field.name for field in bq_schema]
     for page in pages:
         yield _tabledata_list_page_to_dataframe(page, column_names, dtypes)
 

--- a/bigquery/google/cloud/bigquery/_pandas_helpers.py
+++ b/bigquery/google/cloud/bigquery/_pandas_helpers.py
@@ -241,7 +241,7 @@ def dataframe_to_bq_schema(dataframe, bq_schema):
             DataFrame for which the client determines the BigQuery schema.
         bq_schema (Sequence[Union[ \
             Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-            Sequence[Mapping[str, str]] \
+            Sequence[Mapping[str, Any]] \
         ]]):
             A BigQuery schema. Use this argument to override the autodetected
             type for some or all of the DataFrame columns.
@@ -303,7 +303,7 @@ def dataframe_to_arrow(dataframe, bq_schema):
             DataFrame to convert to Arrow table.
         bq_schema (Sequence[Union[ \
             Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-            Sequence[Mapping[str, str]] \
+            Sequence[Mapping[str, Any]] \
         ]]):
             Desired BigQuery schema. Number of columns must match number of
             columns in the DataFrame.
@@ -365,7 +365,7 @@ def dataframe_to_parquet(dataframe, bq_schema, filepath, parquet_compression="SN
             DataFrame to convert to Parquet file.
         bq_schema (Sequence[Union[ \
             Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-            Sequence[Mapping[str, str]] \
+            Sequence[Mapping[str, Any]] \
         ]]):
             Desired BigQuery schema. Number of columns must match number of
             columns in the DataFrame.
@@ -409,7 +409,7 @@ def download_arrow_tabledata_list(pages, bq_schema):
             An iterator over the result pages.
         bq_schema (Sequence[Union[ \
             Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-            Sequence[Mapping[str, str]] \
+            Sequence[Mapping[str, Any]] \
         ]]):
             A decription of the fields in result pages.
     Yields:
@@ -447,7 +447,7 @@ def download_dataframe_tabledata_list(pages, bq_schema, dtypes):
             An iterator over the result pages.
         bq_schema (Sequence[Union[ \
             Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-            Sequence[Mapping[str, str]] \
+            Sequence[Mapping[str, Any]] \
         ]]):
             A decription of the fields in result pages.
         dtypes(Mapping[str, numpy.dtype]):

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1226,10 +1226,10 @@ class LoadJobConfig(_JobConfig):
 
     @property
     def schema(self):
-        """Union[ \
-               Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-               Sequence[Mapping[str, Any]] \
-        ]: Schema of the destination table.
+        """Sequence[Union[ \
+            :class:`~google.cloud.bigquery.schema.SchemaField`, \
+            Mapping[str, Any] \
+        ]]: Schema of the destination table.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationLoad.FIELDS.schema

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -38,6 +38,7 @@ from google.cloud.bigquery.query import UDFResource
 from google.cloud.bigquery.retry import DEFAULT_RETRY
 from google.cloud.bigquery.routine import RoutineReference
 from google.cloud.bigquery.schema import SchemaField
+from google.cloud.bigquery.schema import _to_schema_fields
 from google.cloud.bigquery.table import _EmptyRowIterator
 from google.cloud.bigquery.table import RangePartitioning
 from google.cloud.bigquery.table import _table_arg_to_table_ref
@@ -1225,8 +1226,10 @@ class LoadJobConfig(_JobConfig):
 
     @property
     def schema(self):
-        """List[google.cloud.bigquery.schema.SchemaField]: Schema of the
-        destination table.
+        """Union[ \
+               Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
+               Sequence[Mapping[str, str]] \
+        ]: Schema of the destination table.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationLoad.FIELDS.schema
@@ -1242,8 +1245,8 @@ class LoadJobConfig(_JobConfig):
             self._del_sub_prop("schema")
             return
 
-        if not all(hasattr(field, "to_api_repr") for field in value):
-            raise ValueError("Schema items must be fields")
+        value = _to_schema_fields(value)
+
         _helpers._set_sub_prop(
             self._properties,
             ["load", "schema", "fields"],

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1228,7 +1228,7 @@ class LoadJobConfig(_JobConfig):
     def schema(self):
         """Union[ \
                Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-               Sequence[Mapping[str, str]] \
+               Sequence[Mapping[str, Any]] \
         ]: Schema of the destination table.
 
         See

--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -266,7 +266,7 @@ def _to_schema_fields(schema):
     Args:
         schema(Union[ \
                Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-               Sequence[Mapping[str, str]] \
+               Sequence[Mapping[str, Any]] \
         ]):
             Table schema to convert. If given as a sequence of
             mappings, their content must be compatible with

--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -264,23 +264,21 @@ def _to_schema_fields(schema):
     """Coerce `schema` to a list of schema field instances.
 
     Args:
-        schema(Union[ \
-               Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-               Sequence[Mapping[str, Any]] \
-        ]):
-            Table schema to convert. If given as a sequence of
-            mappings, their content must be compatible with
+        schema(Sequence[Union[ \
+               :class:`~google.cloud.bigquery.schema.SchemaField`, \
+               Mapping[str, Any] \
+        ]]):
+            Table schema to convert. If some items are passed as mappings,
+            their content must be compatible with
             :meth:`~google.cloud.bigquery.schema.SchemaField.from_api_repr`.
 
     Returns:
         Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`]
 
     Raises:
-        TypeError: If `schema` is not a sequence.
-        ValueError:
-            If any item in the sequence is not a
-            :class:`~google.cloud.bigquery.schema.SchemaField` or a
-            compatible mapping representation of the field.
+        Exception: If ``schema`` is not a sequence, or if any item in the
+        sequence is not a :class:`~google.cloud.bigquery.schema.SchemaField`
+        instance or a compatible mapping representation of the field.
     """
     for field in schema:
         if not isinstance(field, (SchemaField, collections.Mapping)):
@@ -289,10 +287,7 @@ def _to_schema_fields(schema):
                 "mapping representations."
             )
 
-    if schema and not isinstance(schema[0], SchemaField):
-        try:
-            schema = [SchemaField.from_api_repr(field) for field in schema]
-        except Exception as exc:
-            raise ValueError("Invalid field representation: {!r}".format(exc))
-
-    return schema
+    return [
+        field if isinstance(field, SchemaField) else SchemaField.from_api_repr(field)
+        for field in schema
+    ]

--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -265,8 +265,8 @@ def _to_schema_fields(schema):
 
     Args:
         schema(Sequence[Union[ \
-               :class:`~google.cloud.bigquery.schema.SchemaField`, \
-               Mapping[str, Any] \
+            :class:`~google.cloud.bigquery.schema.SchemaField`, \
+            Mapping[str, Any] \
         ]]):
             Table schema to convert. If some items are passed as mappings,
             their content must be compatible with

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -51,9 +51,9 @@ from google.api_core.page_iterator import HTTPIterator
 import google.cloud._helpers
 from google.cloud.bigquery import _helpers
 from google.cloud.bigquery import _pandas_helpers
-from google.cloud.bigquery.schema import SchemaField
 from google.cloud.bigquery.schema import _build_schema_resource
 from google.cloud.bigquery.schema import _parse_schema_resource
+from google.cloud.bigquery.schema import _to_schema_fields
 from google.cloud.bigquery.external_config import ExternalConfig
 from google.cloud.bigquery.encryption_configuration import EncryptionConfiguration
 
@@ -305,8 +305,13 @@ class Table(object):
             A pointer to a table. If ``table_ref`` is a string, it must
             included a project ID, dataset ID, and table ID, each separated
             by ``.``.
-        schema (List[google.cloud.bigquery.schema.SchemaField]):
-            The table's schema
+        schema (Optional[Union[ \
+                Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
+                Sequence[Mapping[str, str]] \
+        ]]):
+            The table's schema. If given as a sequence of dicts, their content
+            must be compatible with
+            :meth:`~google.cloud.bigquery.schema.SchemaField.from_api_repr`.
     """
 
     _PROPERTY_TO_API_FIELD = {
@@ -369,13 +374,17 @@ class Table(object):
 
     @property
     def schema(self):
-        """List[google.cloud.bigquery.schema.SchemaField]: Table's schema.
+        """Union[ \
+               Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
+               Sequence[Mapping[str, str]] \
+        ]: Table's schema.
 
         Raises:
-            TypeError: If 'value' is not a sequence
+            TypeError: If `value` is not a sequence
             ValueError:
                 If any item in the sequence is not a
-                :class:`~google.cloud.bigquery.schema.SchemaField`
+                :class:`~google.cloud.bigquery.schema.SchemaField` or a
+                compatible mapping representation.
         """
         prop = self._properties.get("schema")
         if not prop:
@@ -387,10 +396,10 @@ class Table(object):
     def schema(self, value):
         if value is None:
             self._properties["schema"] = None
-        elif not all(isinstance(field, SchemaField) for field in value):
-            raise ValueError("Schema items must be fields")
-        else:
-            self._properties["schema"] = {"fields": _build_schema_resource(value)}
+            return
+
+        value = _to_schema_fields(value)
+        self._properties["schema"] = {"fields": _build_schema_resource(value)}
 
     @property
     def labels(self):
@@ -1284,6 +1293,13 @@ class RowIterator(HTTPIterator):
         api_request (Callable[google.cloud._http.JSONConnection.api_request]):
             The function to use to make API requests.
         path (str): The method path to query for the list of items.
+        schema (Union[ \
+                Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
+                Sequence[Mapping[str, str]] \
+        ]):
+            The table's schema. If given as a sequence of dicts, their content
+            must be compatible with
+            :meth:`~google.cloud.bigquery.schema.SchemaField.from_api_repr`.
         page_token (str): A token identifying a page in a result set to start
             fetching results from.
         max_results (int, optional): The maximum number of results to fetch.
@@ -1328,6 +1344,7 @@ class RowIterator(HTTPIterator):
             page_start=_rows_page_start,
             next_token="pageToken",
         )
+        schema = _to_schema_fields(schema)
         self._field_to_index = _helpers._field_to_index_mapping(schema)
         self._page_size = page_size
         self._preserve_order = False

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -396,10 +396,9 @@ class Table(object):
     def schema(self, value):
         if value is None:
             self._properties["schema"] = None
-            return
-
-        value = _to_schema_fields(value)
-        self._properties["schema"] = {"fields": _build_schema_resource(value)}
+        else:
+            value = _to_schema_fields(value)
+            self._properties["schema"] = {"fields": _build_schema_resource(value)}
 
     @property
     def labels(self):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -305,12 +305,12 @@ class Table(object):
             A pointer to a table. If ``table_ref`` is a string, it must
             included a project ID, dataset ID, and table ID, each separated
             by ``.``.
-        schema (Optional[Union[ \
-                Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-                Sequence[Mapping[str, Any]] \
-        ]]):
-            The table's schema. If given as a sequence of dicts, their content
-            must be compatible with
+        schema (Optional[Sequence[Union[ \
+                :class:`~google.cloud.bigquery.schema.SchemaField`, \
+                Mapping[str, Any] \
+        ]]]):
+            The table's schema. If any item is a mapping, its content must be
+            compatible with
             :meth:`~google.cloud.bigquery.schema.SchemaField.from_api_repr`.
     """
 
@@ -374,17 +374,17 @@ class Table(object):
 
     @property
     def schema(self):
-        """Union[ \
-               Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-               Sequence[Mapping[str, Any]] \
-        ]: Table's schema.
+        """Sequence[Union[ \
+                :class:`~google.cloud.bigquery.schema.SchemaField`, \
+                Mapping[str, Any] \
+        ]]:
+            Table's schema.
 
         Raises:
-            TypeError: If `value` is not a sequence
-            ValueError:
-                If any item in the sequence is not a
-                :class:`~google.cloud.bigquery.schema.SchemaField` or a
-                compatible mapping representation.
+            Exception:
+                If ``schema`` is not a sequence, or if any item in the sequence
+                is not a :class:`~google.cloud.bigquery.schema.SchemaField`
+                instance or a compatible mapping representation of the field.
         """
         prop = self._properties.get("schema")
         if not prop:
@@ -1292,12 +1292,12 @@ class RowIterator(HTTPIterator):
         api_request (Callable[google.cloud._http.JSONConnection.api_request]):
             The function to use to make API requests.
         path (str): The method path to query for the list of items.
-        schema (Union[ \
-                Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-                Sequence[Mapping[str, Any]] \
-        ]):
-            The table's schema. If given as a sequence of dicts, their content
-            must be compatible with
+        schema (Sequence[Union[ \
+                :class:`~google.cloud.bigquery.schema.SchemaField`, \
+                Mapping[str, Any] \
+        ]]):
+            The table's schema. If any item is a mapping, its content must be
+            compatible with
             :meth:`~google.cloud.bigquery.schema.SchemaField.from_api_repr`.
         page_token (str): A token identifying a page in a result set to start
             fetching results from.

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -307,7 +307,7 @@ class Table(object):
             by ``.``.
         schema (Optional[Union[ \
                 Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-                Sequence[Mapping[str, str]] \
+                Sequence[Mapping[str, Any]] \
         ]]):
             The table's schema. If given as a sequence of dicts, their content
             must be compatible with
@@ -376,7 +376,7 @@ class Table(object):
     def schema(self):
         """Union[ \
                Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-               Sequence[Mapping[str, str]] \
+               Sequence[Mapping[str, Any]] \
         ]: Table's schema.
 
         Raises:
@@ -1294,7 +1294,7 @@ class RowIterator(HTTPIterator):
         path (str): The method path to query for the list of items.
         schema (Union[ \
                 Sequence[:class:`~google.cloud.bigquery.schema.SchemaField`], \
-                Sequence[Mapping[str, str]] \
+                Sequence[Mapping[str, Any]] \
         ]):
             The table's schema. If given as a sequence of dicts, their content
             must be compatible with

--- a/bigquery/samples/query_external_sheets_permanent_table.py
+++ b/bigquery/samples/query_external_sheets_permanent_table.py
@@ -52,8 +52,8 @@ def query_external_sheets_permanent_table(dataset_id):
     external_config.source_uris = [sheet_url]
     external_config.options.skip_leading_rows = 1  # Optionally skip header row.
     external_config.options.range = (
-        "us-states!A20:B49"
-    )  # Optionally set range of the sheet to query from.
+        "us-states!A20:B49"  # Optionally set range of the sheet to query from.
+    )
     table.external_data_configuration = external_config
 
     # Create a permanent table linked to the Sheets file.

--- a/bigquery/samples/query_external_sheets_temporary_table.py
+++ b/bigquery/samples/query_external_sheets_temporary_table.py
@@ -49,8 +49,8 @@ def query_external_sheets_temporary_table():
     ]
     external_config.options.skip_leading_rows = 1  # Optionally skip header row.
     external_config.options.range = (
-        "us-states!A20:B49"
-    )  # Optionally set range of the sheet to query from.
+        "us-states!A20:B49"  # Optionally set range of the sheet to query from.
+    )
     table_id = "us_states"
     job_config = bigquery.QueryJobConfig()
     job_config.table_definitions = {table_id: external_config}

--- a/bigquery/tests/unit/test__pandas_helpers.py
+++ b/bigquery/tests/unit/test__pandas_helpers.py
@@ -619,7 +619,7 @@ def test_list_columns_and_indexes_without_named_index(module_under_test):
 
 @pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
 def test_list_columns_and_indexes_with_named_index_same_as_column_name(
-    module_under_test
+    module_under_test,
 ):
     df_data = collections.OrderedDict(
         [

--- a/bigquery/tests/unit/test__pandas_helpers.py
+++ b/bigquery/tests/unit/test__pandas_helpers.py
@@ -702,6 +702,32 @@ def test_list_columns_and_indexes_with_multiindex(module_under_test):
 
 
 @pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
+def test_dataframe_to_bq_schema_dict_sequence(module_under_test):
+    df_data = collections.OrderedDict(
+        [
+            ("str_column", [u"hello", u"world"]),
+            ("int_column", [42, 8]),
+            ("bool_column", [True, False]),
+        ]
+    )
+    dataframe = pandas.DataFrame(df_data)
+
+    dict_schema = [
+        {"name": "str_column", "type": "STRING", "mode": "NULLABLE"},
+        {"name": "bool_column", "type": "BOOL", "mode": "REQUIRED"},
+    ]
+
+    returned_schema = module_under_test.dataframe_to_bq_schema(dataframe, dict_schema)
+
+    expected_schema = (
+        schema.SchemaField("str_column", "STRING", "NULLABLE"),
+        schema.SchemaField("int_column", "INTEGER", "NULLABLE"),
+        schema.SchemaField("bool_column", "BOOL", "REQUIRED"),
+    )
+    assert returned_schema == expected_schema
+
+
+@pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
 @pytest.mark.skipif(pyarrow is None, reason="Requires `pyarrow`")
 def test_dataframe_to_arrow_with_multiindex(module_under_test):
     bq_schema = (
@@ -857,6 +883,28 @@ def test_dataframe_to_arrow_with_unknown_type(module_under_test):
 
 
 @pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
+@pytest.mark.skipif(pyarrow is None, reason="Requires `pyarrow`")
+def test_dataframe_to_arrow_dict_sequence_schema(module_under_test):
+    dict_schema = [
+        {"name": "field01", "type": "STRING", "mode": "REQUIRED"},
+        {"name": "field02", "type": "BOOL", "mode": "NULLABLE"},
+    ]
+
+    dataframe = pandas.DataFrame(
+        {"field01": [u"hello", u"world"], "field02": [True, False]}
+    )
+
+    arrow_table = module_under_test.dataframe_to_arrow(dataframe, dict_schema)
+    arrow_schema = arrow_table.schema
+
+    expected_fields = [
+        pyarrow.field("field01", "string", nullable=False),
+        pyarrow.field("field02", "bool", nullable=True),
+    ]
+    assert list(arrow_schema) == expected_fields
+
+
+@pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
 def test_dataframe_to_parquet_without_pyarrow(module_under_test, monkeypatch):
     monkeypatch.setattr(module_under_test, "pyarrow", None)
     with pytest.raises(ValueError) as exc_context:
@@ -906,6 +954,36 @@ def test_dataframe_to_parquet_compression_method(module_under_test):
     call_args = fake_write_table.call_args
     assert call_args is not None
     assert call_args.kwargs.get("compression") == "ZSTD"
+
+
+@pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
+@pytest.mark.skipif(pyarrow is None, reason="Requires `pyarrow`")
+def test_dataframe_to_parquet_dict_sequence_schema(module_under_test):
+    dict_schema = [
+        {"name": "field01", "type": "STRING", "mode": "REQUIRED"},
+        {"name": "field02", "type": "BOOL", "mode": "NULLABLE"},
+    ]
+
+    dataframe = pandas.DataFrame(
+        {"field01": [u"hello", u"world"], "field02": [True, False]}
+    )
+
+    write_table_patch = mock.patch.object(
+        module_under_test.pyarrow.parquet, "write_table", autospec=True
+    )
+    to_arrow_patch = mock.patch.object(
+        module_under_test, "dataframe_to_arrow", autospec=True
+    )
+
+    with write_table_patch, to_arrow_patch as fake_to_arrow:
+        module_under_test.dataframe_to_parquet(dataframe, dict_schema, None)
+
+    expected_schema_arg = [
+        schema.SchemaField("field01", "STRING", mode="REQUIRED"),
+        schema.SchemaField("field02", "BOOL", mode="NULLABLE"),
+    ]
+    schema_arg = fake_to_arrow.call_args.args[1]
+    assert schema_arg == expected_schema_arg
 
 
 @pytest.mark.skipif(pyarrow is None, reason="Requires `pyarrow`")
@@ -977,3 +1055,62 @@ def test_download_arrow_tabledata_list_known_field_type(module_under_test):
     col = result.columns[1]
     assert type(col) is pyarrow.lib.StringArray
     assert list(col) == ["2.2", "22.22", "222.222"]
+
+
+@pytest.mark.skipif(pyarrow is None, reason="Requires `pyarrow`")
+def test_download_arrow_tabledata_list_dict_sequence_schema(module_under_test):
+    fake_page = api_core.page_iterator.Page(
+        parent=mock.Mock(),
+        items=[{"page_data": "foo"}],
+        item_to_value=api_core.page_iterator._item_to_value_identity,
+    )
+    fake_page._columns = [[1, 10, 100], ["2.2", "22.22", "222.222"]]
+    pages = [fake_page]
+
+    dict_schema = [
+        {"name": "population_size", "type": "INTEGER", "mode": "NULLABLE"},
+        {"name": "non_alien_field", "type": "STRING", "mode": "NULLABLE"},
+    ]
+
+    results_gen = module_under_test.download_arrow_tabledata_list(pages, dict_schema)
+    result = next(results_gen)
+
+    assert len(result.columns) == 2
+    col = result.columns[0]
+    assert type(col) is pyarrow.lib.Int64Array
+    assert list(col) == [1, 10, 100]
+    col = result.columns[1]
+    assert type(col) is pyarrow.lib.StringArray
+    assert list(col) == ["2.2", "22.22", "222.222"]
+
+
+@pytest.mark.skipif(pandas is None, reason="Requires `pandas`")
+@pytest.mark.skipif(pyarrow is None, reason="Requires `pyarrow`")
+def test_download_dataframe_tabledata_list_dict_sequence_schema(module_under_test):
+    fake_page = api_core.page_iterator.Page(
+        parent=mock.Mock(),
+        items=[{"page_data": "foo"}],
+        item_to_value=api_core.page_iterator._item_to_value_identity,
+    )
+    fake_page._columns = [[1, 10, 100], ["2.2", "22.22", "222.222"]]
+    pages = [fake_page]
+
+    dict_schema = [
+        {"name": "population_size", "type": "INTEGER", "mode": "NULLABLE"},
+        {"name": "non_alien_field", "type": "STRING", "mode": "NULLABLE"},
+    ]
+
+    results_gen = module_under_test.download_dataframe_tabledata_list(
+        pages, dict_schema, dtypes={}
+    )
+    result = next(results_gen)
+
+    expected_result = pandas.DataFrame(
+        collections.OrderedDict(
+            [
+                ("population_size", [1, 10, 100]),
+                ("non_alien_field", ["2.2", "22.22", "222.222"]),
+            ]
+        )
+    )
+    assert result.equals(expected_result)

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -1138,7 +1138,8 @@ class TestClient(unittest.TestCase):
         self.assertEqual(got.table_id, self.TABLE_ID)
 
     def test_create_table_w_schema_and_query(self):
-        from google.cloud.bigquery.table import Table, SchemaField
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery.table import Table
 
         path = "projects/%s/datasets/%s/tables" % (self.PROJECT, self.DS_ID)
         query = "SELECT * from %s:%s" % (self.DS_ID, self.TABLE_ID)
@@ -1753,7 +1754,8 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req[1]["headers"]["If-Match"], "im-an-etag")
 
     def test_update_table(self):
-        from google.cloud.bigquery.table import Table, SchemaField
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery.table import Table
 
         path = "projects/%s/datasets/%s/tables/%s" % (
             self.PROJECT,
@@ -1896,7 +1898,8 @@ class TestClient(unittest.TestCase):
         import datetime
         from google.cloud._helpers import UTC
         from google.cloud._helpers import _millis
-        from google.cloud.bigquery.table import Table, SchemaField
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery.table import Table
 
         path = "projects/%s/datasets/%s/tables/%s" % (
             self.PROJECT,
@@ -4173,7 +4176,7 @@ class TestClient(unittest.TestCase):
         from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_rfc3339
         from google.cloud._helpers import _microseconds_from_datetime
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         WHEN_TS = 1437767599.006
         WHEN = datetime.datetime.utcfromtimestamp(WHEN_TS).replace(tzinfo=UTC)
@@ -4229,7 +4232,8 @@ class TestClient(unittest.TestCase):
         from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_rfc3339
         from google.cloud._helpers import _microseconds_from_datetime
-        from google.cloud.bigquery.table import Table, SchemaField
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery.table import Table
 
         WHEN_TS = 1437767599.006
         WHEN = datetime.datetime.utcfromtimestamp(WHEN_TS).replace(tzinfo=UTC)
@@ -4290,8 +4294,8 @@ class TestClient(unittest.TestCase):
         )
 
     def test_insert_rows_w_list_of_Rows(self):
+        from google.cloud.bigquery.schema import SchemaField
         from google.cloud.bigquery.table import Table
-        from google.cloud.bigquery.table import SchemaField
         from google.cloud.bigquery.table import Row
 
         PATH = "projects/%s/datasets/%s/tables/%s/insertAll" % (
@@ -4335,7 +4339,8 @@ class TestClient(unittest.TestCase):
         )
 
     def test_insert_rows_w_skip_invalid_and_ignore_unknown(self):
-        from google.cloud.bigquery.table import Table, SchemaField
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery.table import Table
 
         PATH = "projects/%s/datasets/%s/tables/%s/insertAll" % (
             self.PROJECT,
@@ -4411,7 +4416,8 @@ class TestClient(unittest.TestCase):
         )
 
     def test_insert_rows_w_repeated_fields(self):
-        from google.cloud.bigquery.table import Table, SchemaField
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery.table import Table
 
         PATH = "projects/%s/datasets/%s/tables/%s/insertAll" % (
             self.PROJECT,
@@ -4504,7 +4510,7 @@ class TestClient(unittest.TestCase):
         )
 
     def test_insert_rows_w_record_schema(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         PATH = "projects/%s/datasets/%s/tables/%s/insertAll" % (
             self.PROJECT,
@@ -4599,6 +4605,7 @@ class TestClient(unittest.TestCase):
 
     def test_insert_rows_w_numeric(self):
         from google.cloud.bigquery import table
+        from google.cloud.bigquery.schema import SchemaField
 
         project = "PROJECT"
         ds_id = "DS_ID"
@@ -4608,10 +4615,7 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=project, credentials=creds, _http=http)
         conn = client._connection = make_connection({})
         table_ref = DatasetReference(project, ds_id).table(table_id)
-        schema = [
-            table.SchemaField("account", "STRING"),
-            table.SchemaField("balance", "NUMERIC"),
-        ]
+        schema = [SchemaField("account", "STRING"), SchemaField("balance", "NUMERIC")]
         insert_table = table.Table(table_ref, schema=schema)
         rows = [
             ("Savings", decimal.Decimal("23.47")),
@@ -4643,7 +4647,7 @@ class TestClient(unittest.TestCase):
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_insert_rows_from_dataframe(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
         from google.cloud.bigquery.table import Table
 
         API_PATH = "/projects/{}/datasets/{}/tables/{}/insertAll".format(
@@ -4719,7 +4723,7 @@ class TestClient(unittest.TestCase):
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_insert_rows_from_dataframe_many_columns(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
         from google.cloud.bigquery.table import Table
 
         API_PATH = "/projects/{}/datasets/{}/tables/{}/insertAll".format(
@@ -4766,8 +4770,9 @@ class TestClient(unittest.TestCase):
         assert actual_calls[0] == expected_call
 
     def test_insert_rows_json(self):
-        from google.cloud.bigquery.table import Table, SchemaField
         from google.cloud.bigquery.dataset import DatasetReference
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery.table import Table
 
         PROJECT = "PROJECT"
         DS_ID = "DS_ID"
@@ -4878,8 +4883,8 @@ class TestClient(unittest.TestCase):
     def test_list_rows(self):
         import datetime
         from google.cloud._helpers import UTC
+        from google.cloud.bigquery.schema import SchemaField
         from google.cloud.bigquery.table import Table
-        from google.cloud.bigquery.table import SchemaField
         from google.cloud.bigquery.table import Row
 
         PATH = "projects/%s/datasets/%s/tables/%s/data" % (
@@ -4979,7 +4984,8 @@ class TestClient(unittest.TestCase):
         self.assertEqual(rows.total_rows, 0)
 
     def test_list_rows_query_params(self):
-        from google.cloud.bigquery.table import Table, SchemaField
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery.table import Table
 
         creds = _make_credentials()
         http = object()
@@ -5001,7 +5007,7 @@ class TestClient(unittest.TestCase):
             self.assertEqual(req[1]["query_params"], test[1], "for kwargs %s" % test[0])
 
     def test_list_rows_repeated_fields(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         PATH = "projects/%s/datasets/%s/tables/%s/data" % (
             self.PROJECT,
@@ -5061,7 +5067,8 @@ class TestClient(unittest.TestCase):
         )
 
     def test_list_rows_w_record_schema(self):
-        from google.cloud.bigquery.table import Table, SchemaField
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery.table import Table
 
         PATH = "projects/%s/datasets/%s/tables/%s/data" % (
             self.PROJECT,

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -843,7 +843,7 @@ class Test_AsyncJob(unittest.TestCase):
 
         set_exception.assert_called_once()
         args, kw = set_exception.call_args
-        exception, = args
+        (exception,) = args
         self.assertIsInstance(exception, NotFound)
         self.assertEqual(exception.message, "testing")
         self.assertEqual(kw, {})

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1532,7 +1532,7 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertEqual(all_props, SchemaField.from_api_repr(all_props_repr))
         self.assertEqual(minimal, SchemaField.from_api_repr(minimal_repr))
 
-    def test_schema_setter(self):
+    def test_schema_setter_fields(self):
         from google.cloud.bigquery.schema import SchemaField
 
         config = self._get_target_class()()
@@ -1554,6 +1554,42 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         self.assertEqual(
             config._properties["load"]["schema"], {"fields": [full_name_repr, age_repr]}
         )
+
+    def test_schema_setter_valid_mappings_list(self):
+        config = self._get_target_class()()
+
+        schema = [
+            {"name": "full_name", "type": "STRING", "mode": "REQUIRED"},
+            {"name": "age", "type": "INTEGER", "mode": "REQUIRED"},
+        ]
+        config.schema = schema
+
+        full_name_repr = {
+            "name": "full_name",
+            "type": "STRING",
+            "mode": "REQUIRED",
+            "description": None,
+        }
+        age_repr = {
+            "name": "age",
+            "type": "INTEGER",
+            "mode": "REQUIRED",
+            "description": None,
+        }
+        self.assertEqual(
+            config._properties["load"]["schema"], {"fields": [full_name_repr, age_repr]}
+        )
+
+    def test_schema_setter_invalid_mappings_list(self):
+        config = self._get_target_class()()
+
+        schema = [
+            {"name": "full_name", "type": "STRING", "mode": "REQUIRED"},
+            {"name": "age", "typeoo": "INTEGER", "mode": "REQUIRED"},
+        ]
+
+        with self.assertRaises(ValueError):
+            config.schema = schema
 
     def test_schema_setter_unsetting_schema(self):
         from google.cloud.bigquery.schema import SchemaField

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1588,7 +1588,7 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
             {"name": "age", "typeoo": "INTEGER", "mode": "REQUIRED"},
         ]
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(Exception):
             config.schema = schema
 
     def test_schema_setter_unsetting_schema(self):

--- a/bigquery/tests/unit/test_schema.py
+++ b/bigquery/tests/unit/test_schema.py
@@ -568,3 +568,69 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
                 ],
             },
         )
+
+
+class Test_to_schema_fields(unittest.TestCase):
+    @staticmethod
+    def _call_fut(schema):
+        from google.cloud.bigquery.schema import _to_schema_fields
+
+        return _to_schema_fields(schema)
+
+    def test_invalid_type(self):
+        schema = [
+            ("full_name", "STRING", "REQUIRED"),
+            ("address", "STRING", "REQUIRED"),
+        ]
+        with self.assertRaises(ValueError):
+            self._call_fut(schema)
+
+    def test_schema_fields_sequence(self):
+        from google.cloud.bigquery.schema import SchemaField
+
+        schema = [
+            SchemaField("full_name", "STRING", mode="REQUIRED"),
+            SchemaField("age", "INT64", mode="NULLABLE"),
+        ]
+        result = self._call_fut(schema)
+        self.assertEqual(result, schema)
+
+    def test_invalid_mapping_representation(self):
+        schema = [
+            {"name": "full_name", "type": "STRING", "mode": "REQUIRED"},
+            {"name": "address", "typeooo": "STRING", "mode": "REQUIRED"},
+        ]
+        with self.assertRaises(ValueError):
+            self._call_fut(schema)
+
+    def test_valid_mapping_representation(self):
+        from google.cloud.bigquery.schema import SchemaField
+
+        schema = [
+            {"name": "full_name", "type": "STRING", "mode": "REQUIRED"},
+            {
+                "name": "residence",
+                "type": "STRUCT",
+                "mode": "NULLABLE",
+                "fields": [
+                    {"name": "foo", "type": "DATE", "mode": "NULLABLE"},
+                    {"name": "bar", "type": "BYTES", "mode": "REQUIRED"},
+                ],
+            },
+        ]
+
+        expected_schema = [
+            SchemaField("full_name", "STRING", mode="REQUIRED"),
+            SchemaField(
+                "residence",
+                "STRUCT",
+                mode="NULLABLE",
+                fields=[
+                    SchemaField("foo", "DATE", mode="NULLABLE"),
+                    SchemaField("bar", "BYTES", mode="REQUIRED"),
+                ],
+            ),
+        ]
+
+        result = self._call_fut(schema)
+        self.assertEqual(result, expected_schema)

--- a/bigquery/tests/unit/test_schema.py
+++ b/bigquery/tests/unit/test_schema.py
@@ -600,7 +600,7 @@ class Test_to_schema_fields(unittest.TestCase):
             {"name": "full_name", "type": "STRING", "mode": "REQUIRED"},
             {"name": "address", "typeooo": "STRING", "mode": "REQUIRED"},
         ]
-        with self.assertRaises(ValueError):
+        with self.assertRaises(Exception):
             self._call_fut(schema)
 
     def test_valid_mapping_representation(self):

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -450,7 +450,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertIsNone(table.clustering_fields)
 
     def test_ctor_w_schema(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
         table_ref = dataset.table(self.TABLE_NAME)
@@ -564,7 +564,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
             table.schema = object()
 
     def test_schema_setter_invalid_field(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
         table_ref = dataset.table(self.TABLE_NAME)
@@ -574,7 +574,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
             table.schema = [full_name, object()]
 
     def test_schema_setter_valid_fields(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
         table_ref = dataset.table(self.TABLE_NAME)
@@ -594,7 +594,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
             table.schema = [full_name, invalid_field]
 
     def test_schema_setter_valid_mapping_representation(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
         table_ref = dataset.table(self.TABLE_NAME)
@@ -1187,7 +1187,8 @@ class Test_row_from_mapping(unittest.TestCase, _SchemaBase):
         self.assertEqual(exc.exception.args, (_TABLE_HAS_NO_SCHEMA,))
 
     def test__row_from_mapping_w_invalid_schema(self):
-        from google.cloud.bigquery.table import Table, SchemaField
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery.table import Table
 
         MAPPING = {
             "full_name": "Phred Phlyntstone",
@@ -1209,7 +1210,8 @@ class Test_row_from_mapping(unittest.TestCase, _SchemaBase):
         self.assertIn("Unknown field mode: BOGUS", str(exc.exception))
 
     def test__row_from_mapping_w_schema(self):
-        from google.cloud.bigquery.table import Table, SchemaField
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery.table import Table
 
         MAPPING = {
             "full_name": "Phred Phlyntstone",
@@ -1556,7 +1558,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(iterator.schema, expected_schema)
 
     def test_iterate(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -1587,7 +1589,7 @@ class TestRowIterator(unittest.TestCase):
         api_request.assert_called_once_with(method="GET", path=path, query_params={})
 
     def test_page_size(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -1613,7 +1615,7 @@ class TestRowIterator(unittest.TestCase):
 
     @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_arrow(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -1695,7 +1697,7 @@ class TestRowIterator(unittest.TestCase):
 
     @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_arrow_w_nulls(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [SchemaField("name", "STRING"), SchemaField("age", "INTEGER")]
         rows = [
@@ -1728,7 +1730,7 @@ class TestRowIterator(unittest.TestCase):
 
     @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_arrow_w_unknown_type(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -1766,7 +1768,7 @@ class TestRowIterator(unittest.TestCase):
 
     @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
     def test_to_arrow_w_empty_table(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -1928,7 +1930,7 @@ class TestRowIterator(unittest.TestCase):
     @mock.patch("tqdm.tqdm_notebook")
     @mock.patch("tqdm.tqdm")
     def test_to_arrow_progress_bar(self, tqdm_mock, tqdm_notebook_mock, tqdm_gui_mock):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -1971,7 +1973,7 @@ class TestRowIterator(unittest.TestCase):
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -2003,7 +2005,7 @@ class TestRowIterator(unittest.TestCase):
     def test_to_dataframe_progress_bar(
         self, tqdm_mock, tqdm_notebook_mock, tqdm_gui_mock
     ):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -2036,7 +2038,7 @@ class TestRowIterator(unittest.TestCase):
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @mock.patch("google.cloud.bigquery.table.tqdm", new=None)
     def test_to_dataframe_no_tqdm_no_progress_bar(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -2061,7 +2063,7 @@ class TestRowIterator(unittest.TestCase):
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @mock.patch("google.cloud.bigquery.table.tqdm", new=None)
     def test_to_dataframe_no_tqdm(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -2094,7 +2096,7 @@ class TestRowIterator(unittest.TestCase):
     @mock.patch("tqdm.tqdm_notebook", new=None)  # will raise TypeError on call
     @mock.patch("tqdm.tqdm", new=None)  # will raise TypeError on call
     def test_to_dataframe_tqdm_error(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -2124,7 +2126,7 @@ class TestRowIterator(unittest.TestCase):
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_w_empty_results(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -2159,7 +2161,7 @@ class TestRowIterator(unittest.TestCase):
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_w_various_types_nullable(self):
         import datetime
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("start_timestamp", "TIMESTAMP"),
@@ -2199,7 +2201,7 @@ class TestRowIterator(unittest.TestCase):
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_column_dtypes(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("start_timestamp", "TIMESTAMP"),
@@ -2237,7 +2239,7 @@ class TestRowIterator(unittest.TestCase):
 
     @mock.patch("google.cloud.bigquery.table.pandas", new=None)
     def test_to_dataframe_error_if_pandas_is_none(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),
@@ -2256,7 +2258,7 @@ class TestRowIterator(unittest.TestCase):
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_max_results_w_bqstorage_warning(self):
-        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.schema import SchemaField
 
         schema = [
             SchemaField("name", "STRING", mode="REQUIRED"),

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -590,7 +590,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         table = self._make_one(table_ref)
         full_name = {"name": "full_name", "type": "STRING", "mode": "REQUIRED"}
         invalid_field = {"name": "full_name", "typeooo": "STRING", "mode": "REQUIRED"}
-        with self.assertRaises(ValueError):
+        with self.assertRaises(Exception):
             table.schema = [full_name, invalid_field]
 
     def test_schema_setter_valid_mapping_representation(self):


### PR DESCRIPTION
Fixes #8196.

This PR adds support for passing BigQuery schema as a sequence of plain dictionaries whose content match the API representation of `schema.SchemaField` instances.

### How to test
THe ticket description should be self-explanatory. The functions/methods that accept a BigQuery schema should now also accept a sequence of well-formed dicts. That includes private helpers, as this new flexibility can be useful even for internal use cases.