### PR TITLE
fix(monitoring): make VPCSC env comparison case-insensitive

### DIFF
--- a/monitoring/noxfile.py
+++ b/monitoring/noxfile.py
@@ -123,7 +123,7 @@ def system(session):
 
     # Additional setup for VPCSC system tests
     in_vpc = os.environ.get("GOOGLE_CLOUD_TESTS_IN_VPCSC", "false")
-    if not in_vpc or in_vpc.lower() != "true":
+    if in_vpc.lower() != "true":
         # Unset PROJECT_ID, since VPCSC system tests expect this to be a project
         # within the VPCSC perimeter.
         env = {

--- a/monitoring/noxfile.py
+++ b/monitoring/noxfile.py
@@ -123,7 +123,7 @@ def system(session):
 
     # Additional setup for VPCSC system tests
     in_vpc = os.environ.get("GOOGLE_CLOUD_TESTS_IN_VPCSC")
-    if !in_vpc or in_vpc.lower() != "true":
+    if not in_vpc or in_vpc.lower() != "true":
         # Unset PROJECT_ID, since VPCSC system tests expect this to be a project
         # within the VPCSC perimeter.
         env = {

--- a/monitoring/noxfile.py
+++ b/monitoring/noxfile.py
@@ -122,7 +122,8 @@ def system(session):
     session.install("-e", ".")
 
     # Additional setup for VPCSC system tests
-    if os.environ.get("GOOGLE_CLOUD_TESTS_IN_VPCSC").lower() != "true":
+    in_vpc = os.environ.get("GOOGLE_CLOUD_TESTS_IN_VPCSC")
+    if !in_vpc or in_vpc.lower() != "true":
         # Unset PROJECT_ID, since VPCSC system tests expect this to be a project
         # within the VPCSC perimeter.
         env = {

--- a/monitoring/noxfile.py
+++ b/monitoring/noxfile.py
@@ -122,7 +122,7 @@ def system(session):
     session.install("-e", ".")
 
     # Additional setup for VPCSC system tests
-    in_vpc = os.environ.get("GOOGLE_CLOUD_TESTS_IN_VPCSC")
+    in_vpc = os.environ.get("GOOGLE_CLOUD_TESTS_IN_VPCSC", "false")
     if not in_vpc or in_vpc.lower() != "true":
         # Unset PROJECT_ID, since VPCSC system tests expect this to be a project
         # within the VPCSC perimeter.

--- a/monitoring/noxfile.py
+++ b/monitoring/noxfile.py
@@ -122,7 +122,7 @@ def system(session):
     session.install("-e", ".")
 
     # Additional setup for VPCSC system tests
-    if os.environ.get("GOOGLE_CLOUD_TESTS_IN_VPCSC") != "true":
+    if os.environ.get("GOOGLE_CLOUD_TESTS_IN_VPCSC").lower() != "true":
         # Unset PROJECT_ID, since VPCSC system tests expect this to be a project
         # within the VPCSC perimeter.
         env = {


### PR DESCRIPTION
The actual environment variable value may be `True`, instead of `true`. So just make it case insensitive.