### PR TITLE
feat(storage): add opt-in raw download support

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -31,7 +31,7 @@ release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     'enum34; python_version < "3.4"',
     "google-cloud-core >= 1.0.3, < 2.0dev",
-    "google-resumable-media >= 0.3.1, != 0.4.0, < 0.5.0dev",
+    "google-resumable-media >= 0.3.1, != 0.4.0, < 0.6.0dev",
     "protobuf >= 3.6.0",
 ]
 extras = {

--- a/storage/setup.py
+++ b/storage/setup.py
@@ -31,7 +31,7 @@ release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-auth >= 1.2.0",
     "google-cloud-core >= 1.0.3, < 2.0dev",
-    "google-resumable-media >= 0.3.1, != 0.4.0, < 0.5dev",
+    "google-resumable-media >= 0.5.0, < 0.6dev",
 ]
 extras = {}
 

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -623,7 +623,7 @@ class TestStorageWriteFiles(TestStorageFiles):
         self.assertEqual(file_contents, stored_contents)
 
     def test_upload_gzip_encoded_download_raw(self):
-        payload = b'DEADBEEF' * 1000
+        payload = b"DEADBEEF" * 1000
         raw_stream = io.BytesIO()
         with gzip.GzipFile(fileobj=raw_stream, mode="wb") as gzip_stream:
             gzip_stream.write(payload)

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -14,7 +14,9 @@
 
 import base64
 import datetime
+import gzip
 import hashlib
+import io
 import os
 import re
 import tempfile
@@ -619,6 +621,23 @@ class TestStorageWriteFiles(TestStorageFiles):
             stored_contents = file_obj.read()
 
         self.assertEqual(file_contents, stored_contents)
+
+    def test_upload_gzip_encoded_download_raw(self):
+        payload = b'DEADBEEF' * 1000
+        raw_stream = io.BytesIO()
+        with gzip.GzipFile(fileobj=raw_stream, mode="wb") as gzip_stream:
+            gzip_stream.write(payload)
+        zipped = raw_stream.getvalue()
+
+        blob = self.bucket.blob("test_gzipped.gz")
+        blob.content_encoding = "gzip"
+        blob.upload_from_file(raw_stream, rewind=True)
+
+        expanded = blob.download_as_string()
+        self.assertEqual(expanded, payload)
+
+        raw = blob.download_as_string(raw_download=True)
+        self.assertEqual(raw, zipped)
 
 
 class TestUnicode(unittest.TestCase):

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -845,128 +845,106 @@ class Test_Blob(unittest.TestCase):
         )
         self.assertEqual(transport.request.mock_calls, [call, call])
 
-    def test__do_download_simple(self):
+    def test__do_download_wo_chunks_wo_range(self):
         blob_name = "blob-name"
-        # Create a fake client/bucket and use them in the Blob() constructor.
         client = mock.Mock(_credentials=_make_credentials(), spec=["_credentials"])
         bucket = _Bucket(client)
         blob = self._make_one(blob_name, bucket=bucket)
-
-        # Make sure this will not be chunked.
         self.assertIsNone(blob.chunk_size)
 
-        transport = mock.Mock(spec=["request"])
-        transport.request.return_value = self._mock_requests_response(
-            http_client.OK,
-            {"content-length": "6", "content-range": "bytes 0-5/6"},
-            content=b"abcdef",
-            stream=True,
-        )
+        transport = object()
         file_obj = io.BytesIO()
         download_url = "http://test.invalid"
         headers = {}
-        blob._do_download(transport, file_obj, download_url, headers)
-        # Make sure the download was as expected.
-        self.assertEqual(file_obj.getvalue(), b"abcdef")
 
-        transport.request.assert_called_once_with(
-            "GET",
-            download_url,
-            data=None,
-            headers=headers,
-            stream=True,
-            timeout=mock.ANY,
+        with mock.patch("google.cloud.storage.blob.Download") as patched:
+            blob._do_download(transport, file_obj, download_url, headers)
+
+        patched.assert_called_once_with(
+            download_url, stream=file_obj, headers=headers, start=None, end=None
         )
+        patched.return_value.consume.assert_called_once_with(transport)
 
-    def test__do_download_simple_with_range(self):
+    def test__do_download_wo_chunks_w_range(self):
         blob_name = "blob-name"
-        # Create a fake client/bucket and use them in the Blob() constructor.
         client = mock.Mock(_credentials=_make_credentials(), spec=["_credentials"])
         bucket = _Bucket(client)
         blob = self._make_one(blob_name, bucket=bucket)
-
-        # Make sure this will not be chunked.
         self.assertIsNone(blob.chunk_size)
 
-        transport = mock.Mock(spec=["request"])
-        transport.request.return_value = self._mock_requests_response(
-            http_client.OK,
-            {"content-length": "3", "content-range": "bytes 1-3"},
-            content=b"bcd",
-            stream=True,
-        )
+        transport = object()
         file_obj = io.BytesIO()
         download_url = "http://test.invalid"
         headers = {}
-        blob._do_download(transport, file_obj, download_url, headers, start=1, end=3)
-        # Make sure the download was as expected.
-        self.assertEqual(file_obj.getvalue(), b"bcd")
-        self.assertEqual(headers["range"], "bytes=1-3")
 
-        transport.request.assert_called_once_with(
-            "GET",
-            download_url,
-            data=None,
-            headers=headers,
-            stream=True,
-            timeout=mock.ANY,
+        with mock.patch("google.cloud.storage.blob.Download") as patched:
+            blob._do_download(
+                transport, file_obj, download_url, headers, start=1, end=3
+            )
+
+        patched.assert_called_once_with(
+            download_url, stream=file_obj, headers=headers, start=1, end=3
         )
+        patched.return_value.consume.assert_called_once_with(transport)
 
-    def test__do_download_chunked(self):
+    def test__do_download_w_chunks_wo_range(self):
         blob_name = "blob-name"
-        # Create a fake client/bucket and use them in the Blob() constructor.
         client = mock.Mock(_credentials=_make_credentials(), spec=["_credentials"])
         bucket = _Bucket(client)
         blob = self._make_one(blob_name, bucket=bucket)
-
-        # Modify the blob so there there will be 2 chunks of size 3.
         blob._CHUNK_SIZE_MULTIPLE = 1
-        blob.chunk_size = 3
+        chunk_size = blob.chunk_size = 3
 
-        transport = self._mock_download_transport()
+        transport = object()
         file_obj = io.BytesIO()
         download_url = "http://test.invalid"
         headers = {}
-        blob._do_download(transport, file_obj, download_url, headers)
-        # Make sure the download was as expected.
-        self.assertEqual(file_obj.getvalue(), b"abcdef")
 
-        # Check that the transport was called exactly twice.
-        self.assertEqual(transport.request.call_count, 2)
-        # ``headers`` was modified (in place) once for each API call.
-        self.assertEqual(headers, {"range": "bytes=3-5"})
-        call = mock.call(
-            "GET", download_url, data=None, headers=headers, timeout=mock.ANY
+        download = mock.Mock(finished=False, spec=["finished", "consume_next_chunk"])
+
+        def side_effect(_):
+            download.finished = True
+
+        download.consume_next_chunk.side_effect = side_effect
+
+        with mock.patch("google.cloud.storage.blob.ChunkedDownload") as patched:
+            patched.return_value = download
+            blob._do_download(transport, file_obj, download_url, headers)
+
+        patched.assert_called_once_with(
+            download_url, chunk_size, file_obj, headers=headers, start=0, end=None
         )
-        self.assertEqual(transport.request.mock_calls, [call, call])
+        download.consume_next_chunk.assert_called_once_with(transport)
 
-    def test__do_download_chunked_with_range(self):
+    def test__do_download_w_chunks_w_range(self):
         blob_name = "blob-name"
-        # Create a fake client/bucket and use them in the Blob() constructor.
         client = mock.Mock(_credentials=_make_credentials(), spec=["_credentials"])
         bucket = _Bucket(client)
         blob = self._make_one(blob_name, bucket=bucket)
-
-        # Modify the blob so there there will be 2 chunks of size 2.
         blob._CHUNK_SIZE_MULTIPLE = 1
-        blob.chunk_size = 2
+        chunk_size = blob.chunk_size = 2
 
-        transport = self._mock_download_transport_range()
+        transport = object()
         file_obj = io.BytesIO()
         download_url = "http://test.invalid"
         headers = {}
-        blob._do_download(transport, file_obj, download_url, headers, start=1, end=4)
-        # Make sure the download was as expected.
-        self.assertEqual(file_obj.getvalue(), b"bcde")
 
-        # Check that the transport was called exactly twice.
-        self.assertEqual(transport.request.call_count, 2)
-        # ``headers`` was modified (in place) once for each API call.
-        self.assertEqual(headers, {"range": "bytes=3-4"})
-        call = mock.call(
-            "GET", download_url, data=None, headers=headers, timeout=mock.ANY
+        download = mock.Mock(finished=False, spec=["finished", "consume_next_chunk"])
+
+        def side_effect(_):
+            download.finished = True
+
+        download.consume_next_chunk.side_effect = side_effect
+
+        with mock.patch("google.cloud.storage.blob.ChunkedDownload") as patched:
+            patched.return_value = download
+            blob._do_download(
+                transport, file_obj, download_url, headers, start=1, end=4
+            )
+        patched.assert_called_once_with(
+            download_url, chunk_size, file_obj, headers=headers, start=1, end=4
         )
-        self.assertEqual(transport.request.mock_calls, [call, call])
+        download.consume_next_chunk.assert_called_once_with(transport)
 
     def test_download_to_file_with_failure(self):
         from google.cloud import exceptions

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -893,21 +893,21 @@ class Test_Blob(unittest.TestCase):
         download.consume_next_chunk.assert_called_once_with(transport)
 
     def test_download_to_file_with_failure(self):
+        import requests
         from google.resumable_media import InvalidResponse
         from google.cloud import exceptions
 
-        raw_response = self._mock_requests_response(
-            http_client.NOT_FOUND, {}, content=b"Not Found"
-        )
+        raw_response = requests.Response()
+        raw_response.status_code = http_client.NOT_FOUND
+        raw_request = requests.Request("GET", "http://example.com")
+        raw_response.request = raw_request.prepare()
         grmp_response = InvalidResponse(raw_response)
 
         blob_name = "blob-name"
         media_link = "http://test.invalid"
-        # Create a fake client/bucket and use them in the Blob() constructor.
         client = mock.Mock(spec=[u"_http"])
         bucket = _Bucket(client)
         blob = self._make_one(blob_name, bucket=bucket)
-        # Set the media link on the blob
         blob._properties["mediaLink"] = media_link
         blob._do_download = mock.Mock()
         blob._do_download.side_effect = grmp_response


### PR DESCRIPTION
Note to reviewers:  this is likely better viewed commit-by-commit.

Bumps `google-resumable-media` dependency for `google-cloud-storage` to require >= 0.5.0, while `google-cloud-bigquery` just allows it (BigQuery doesn't use the download classes).

Closes #9565.