### PR TITLE
feat(bigquery): add `create_bqstorage_client` param to `to_dataframe` and `to_arrow`

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -353,6 +353,19 @@ class Client(ClientWithProject):
 
         return DatasetReference(project, dataset_id)
 
+    def _create_bqstorage_client(self):
+        """Create a BigQuery Storage API client using this client's credentials.
+
+        Returns:
+            google.cloud.bigquery_storage_v1beta1.BigQueryStorageClient:
+                A BigQuery Storage API client.
+        """
+        from google.cloud import bigquery_storage_v1beta1
+
+        return bigquery_storage_v1beta1.BigQueryStorageClient(
+            credentials=self._credentials
+        )
+
     def create_dataset(self, dataset, exists_ok=False, retry=DEFAULT_RETRY):
         """API call: create the dataset via a POST request.
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -3152,7 +3152,12 @@ class QueryJob(_AsyncJob):
 
     # If changing the signature of this method, make sure to apply the same
     # changes to table.RowIterator.to_arrow()
-    def to_arrow(self, progress_bar_type=None, bqstorage_client=None):
+    def to_arrow(
+        self,
+        progress_bar_type=None,
+        bqstorage_client=None,
+        create_bqstorage_client=False,
+    ):
         """[Beta] Create a class:`pyarrow.Table` by loading all pages of a
         table or query.
 
@@ -3185,6 +3190,16 @@ class QueryJob(_AsyncJob):
 
                 Reading from a specific partition or snapshot is not
                 currently supported by this method.
+            create_bqstorage_client (bool):
+                **Beta Feature** Optional. If ``True``, create a BigQuery
+                Storage API client using the default API settings. The
+                BigQuery Storage API is a faster way to fetch rows from
+                BigQuery. See the ``bqstorage_client`` parameter for more
+                information.
+
+                This argument does nothing if ``bqstorage_client`` is supplied.
+
+                ..versionadded:: 1.22.0
 
         Returns:
             pyarrow.Table
@@ -3199,12 +3214,20 @@ class QueryJob(_AsyncJob):
         ..versionadded:: 1.17.0
         """
         return self.result().to_arrow(
-            progress_bar_type=progress_bar_type, bqstorage_client=bqstorage_client
+            progress_bar_type=progress_bar_type,
+            bqstorage_client=bqstorage_client,
+            create_bqstorage_client=create_bqstorage_client,
         )
 
     # If changing the signature of this method, make sure to apply the same
     # changes to table.RowIterator.to_dataframe()
-    def to_dataframe(self, bqstorage_client=None, dtypes=None, progress_bar_type=None):
+    def to_dataframe(
+        self,
+        bqstorage_client=None,
+        dtypes=None,
+        progress_bar_type=None,
+        create_bqstorage_client=False,
+    ):
         """Return a pandas DataFrame from a QueryJob
 
         Args:
@@ -3237,6 +3260,16 @@ class QueryJob(_AsyncJob):
                 for details.
 
                 ..versionadded:: 1.11.0
+            create_bqstorage_client (bool):
+                **Beta Feature** Optional. If ``True``, create a BigQuery
+                Storage API client using the default API settings. The
+                BigQuery Storage API is a faster way to fetch rows from
+                BigQuery. See the ``bqstorage_client`` parameter for more
+                information.
+
+                This argument does nothing if ``bqstorage_client`` is supplied.
+
+                ..versionadded:: 1.22.0
 
         Returns:
             A :class:`~pandas.DataFrame` populated with row data and column
@@ -3250,6 +3283,7 @@ class QueryJob(_AsyncJob):
             bqstorage_client=bqstorage_client,
             dtypes=dtypes,
             progress_bar_type=progress_bar_type,
+            create_bqstorage_client=create_bqstorage_client,
         )
 
     def __iter__(self):

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -3199,7 +3199,7 @@ class QueryJob(_AsyncJob):
 
                 This argument does nothing if ``bqstorage_client`` is supplied.
 
-                ..versionadded:: 1.22.0
+                ..versionadded:: 1.24.0
 
         Returns:
             pyarrow.Table
@@ -3269,7 +3269,7 @@ class QueryJob(_AsyncJob):
 
                 This argument does nothing if ``bqstorage_client`` is supplied.
 
-                ..versionadded:: 1.22.0
+                ..versionadded:: 1.24.0
 
         Returns:
             A :class:`~pandas.DataFrame` populated with row data and column

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1528,7 +1528,9 @@ class RowIterator(HTTPIterator):
             progress_bar = self._get_progress_bar(progress_bar_type)
 
             record_batches = []
-            for record_batch in self._to_arrow_iterable(bqstorage_client=bqstorage_client):
+            for record_batch in self._to_arrow_iterable(
+                bqstorage_client=bqstorage_client
+            ):
                 record_batches.append(record_batch)
 
                 if progress_bar is not None:
@@ -1661,7 +1663,9 @@ class RowIterator(HTTPIterator):
         if dtypes is None:
             dtypes = {}
 
-        if (bqstorage_client or create_bqstorage_client) and self.max_results is not None:
+        if (
+            bqstorage_client or create_bqstorage_client
+        ) and self.max_results is not None:
             warnings.warn(
                 "Cannot use bqstorage_client if max_results is set, "
                 "reverting to fetching data with the tabledata.list endpoint.",

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1456,7 +1456,12 @@ class RowIterator(HTTPIterator):
 
     # If changing the signature of this method, make sure to apply the same
     # changes to job.QueryJob.to_arrow()
-    def to_arrow(self, progress_bar_type=None, bqstorage_client=None):
+    def to_arrow(
+        self,
+        progress_bar_type=None,
+        bqstorage_client=None,
+        create_bqstorage_client=False,
+    ):
         """[Beta] Create a class:`pyarrow.Table` by loading all pages of a
         table or query.
 
@@ -1489,6 +1494,16 @@ class RowIterator(HTTPIterator):
 
                 Reading from a specific partition or snapshot is not
                 currently supported by this method.
+            create_bqstorage_client (bool):
+                **Beta Feature** Optional. If ``True``, create a BigQuery
+                Storage API client using the default API settings. The
+                BigQuery Storage API is a faster way to fetch rows from
+                BigQuery. See the ``bqstorage_client`` parameter for more
+                information.
+
+                This argument does nothing if ``bqstorage_client`` is supplied.
+
+                ..versionadded:: 1.22.0
 
         Returns:
             pyarrow.Table
@@ -1503,6 +1518,9 @@ class RowIterator(HTTPIterator):
         """
         if pyarrow is None:
             raise ValueError(_NO_PYARROW_ERROR)
+
+        if not bqstorage_client and create_bqstorage_client:
+            bqstorage_client = self.client._create_bqstorage_client()
 
         progress_bar = self._get_progress_bar(progress_bar_type)
 
@@ -1558,14 +1576,20 @@ class RowIterator(HTTPIterator):
 
     # If changing the signature of this method, make sure to apply the same
     # changes to job.QueryJob.to_dataframe()
-    def to_dataframe(self, bqstorage_client=None, dtypes=None, progress_bar_type=None):
+    def to_dataframe(
+        self,
+        bqstorage_client=None,
+        dtypes=None,
+        progress_bar_type=None,
+        create_bqstorage_client=False,
+    ):
         """Create a pandas DataFrame by loading all pages of a query.
 
         Args:
             bqstorage_client (google.cloud.bigquery_storage_v1beta1.BigQueryStorageClient):
                 **Beta Feature** Optional. A BigQuery Storage API client. If
                 supplied, use the faster BigQuery Storage API to fetch rows
-                from BigQuery. This API is a billable API.
+                from BigQuery.
 
                 This method requires the ``pyarrow`` and
                 ``google-cloud-bigquery-storage`` libraries.
@@ -1602,6 +1626,16 @@ class RowIterator(HTTPIterator):
                   progress bar as a graphical dialog box.
 
                 ..versionadded:: 1.11.0
+            create_bqstorage_client (bool):
+                **Beta Feature** Optional. If ``True``, create a BigQuery
+                Storage API client using the default API settings. The
+                BigQuery Storage API is a faster way to fetch rows from
+                BigQuery. See the ``bqstorage_client`` parameter for more
+                information.
+
+                This argument does nothing if ``bqstorage_client`` is supplied.
+
+                ..versionadded:: 1.22.0
 
         Returns:
             pandas.DataFrame:
@@ -1620,6 +1654,9 @@ class RowIterator(HTTPIterator):
             raise ValueError(_NO_PANDAS_ERROR)
         if dtypes is None:
             dtypes = {}
+
+        if not bqstorage_client and create_bqstorage_client:
+            bqstorage_client = self.client._create_bqstorage_client()
 
         if bqstorage_client and self.max_results is not None:
             warnings.warn(
@@ -1667,11 +1704,18 @@ class _EmptyRowIterator(object):
     pages = ()
     total_rows = 0
 
-    def to_arrow(self, progress_bar_type=None):
+    def to_arrow(
+        self,
+        progress_bar_type=None,
+        bqstorage_client=None,
+        create_bqstorage_client=False,
+    ):
         """[Beta] Create an empty class:`pyarrow.Table`.
 
         Args:
             progress_bar_type (Optional[str]): Ignored. Added for compatibility with RowIterator.
+            bqstorage_client (Any): Ignored. Added for compatibility with RowIterator.
+            create_bqstorage_client (bool): Ignored. Added for compatibility with RowIterator.
 
         Returns:
             pyarrow.Table: An empty :class:`pyarrow.Table`.
@@ -1680,13 +1724,20 @@ class _EmptyRowIterator(object):
             raise ValueError(_NO_PYARROW_ERROR)
         return pyarrow.Table.from_arrays(())
 
-    def to_dataframe(self, bqstorage_client=None, dtypes=None, progress_bar_type=None):
+    def to_dataframe(
+        self,
+        bqstorage_client=None,
+        dtypes=None,
+        progress_bar_type=None,
+        create_bqstorage_client=False,
+    ):
         """Create an empty dataframe.
 
         Args:
             bqstorage_client (Any): Ignored. Added for compatibility with RowIterator.
             dtypes (Any): Ignored. Added for compatibility with RowIterator.
             progress_bar_type (Any): Ignored. Added for compatibility with RowIterator.
+            create_bqstorage_client (bool): Ignored. Added for compatibility with RowIterator.
 
         Returns:
             pandas.DataFrame: An empty :class:`~pandas.DataFrame`.

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1503,7 +1503,7 @@ class RowIterator(HTTPIterator):
 
                 This argument does nothing if ``bqstorage_client`` is supplied.
 
-                ..versionadded:: 1.22.0
+                ..versionadded:: 1.24.0
 
         Returns:
             pyarrow.Table
@@ -1643,7 +1643,7 @@ class RowIterator(HTTPIterator):
 
                 This argument does nothing if ``bqstorage_client`` is supplied.
 
-                ..versionadded:: 1.22.0
+                ..versionadded:: 1.24.0
 
         Returns:
             pandas.DataFrame:

--- a/bigquery/samples/download_public_data.py
+++ b/bigquery/samples/download_public_data.py
@@ -1,0 +1,33 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def download_public_data(client):
+
+    # [START bigquery_pandas_public_data]
+    # TODO(developer): Import the client library.
+    # from google.cloud import bigquery
+
+    # TODO(developer): Construct a BigQuery client object.
+    # client = bigquery.Client()
+
+    # TODO(developer): Set table_id to the fully-qualified table ID in standard
+    # SQL format, including the project ID and dataset ID.
+    table_id = "bigquery-public-data.usa_names.usa_1910_current"
+
+    # Use the BigQuery Storage API to speed-up downloads of large tables.
+    dataframe = client.list_rows(table_id).to_dataframe(create_bqstorage_client=True)
+
+    print(dataframe.info())
+    # [END bigquery_pandas_public_data]

--- a/bigquery/samples/download_public_data_sandbox.py
+++ b/bigquery/samples/download_public_data_sandbox.py
@@ -1,0 +1,34 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def download_public_data_sandbox(client):
+
+    # [START bigquery_pandas_public_data_sandbox]
+    # TODO(developer): Import the client library.
+    # from google.cloud import bigquery
+
+    # TODO(developer): Construct a BigQuery client object.
+    # client = bigquery.Client()
+
+    # `SELECT *` is an anti-pattern in BigQuery because it is cheaper and
+    # faster to use the BigQuery Storage API directly, but BigQuery Sandbox
+    # users can only use the BigQuery Storage API to download query results.
+    query_string = "SELECT * FROM `bigquery-public-data.usa_names.usa_1910_current`"
+
+    # Use the BigQuery Storage API to speed-up downloads of large tables.
+    dataframe = client.query(query_string).to_dataframe(create_bqstorage_client=True)
+
+    print(dataframe.info())
+    # [END bigquery_pandas_public_data_sandbox]

--- a/bigquery/samples/tests/test_download_public_data.py
+++ b/bigquery/samples/tests/test_download_public_data.py
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .. import download_public_data
+
+
+def test_download_public_data(capsys, client):
+
+    download_public_data.download_public_data(client)
+    out, _ = capsys.readouterr()
+    assert "year" in out
+    assert "gender" in out
+    assert "name" in out

--- a/bigquery/samples/tests/test_download_public_data.py
+++ b/bigquery/samples/tests/test_download_public_data.py
@@ -12,13 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from .. import download_public_data
 
 
-def test_download_public_data(capsys, client):
+def test_download_public_data(caplog, capsys, client):
+    # Enable debug-level logging to verify the BigQuery Storage API is used.
+    caplog.set_level(logging.DEBUG)
 
     download_public_data.download_public_data(client)
     out, _ = capsys.readouterr()
     assert "year" in out
     assert "gender" in out
     assert "name" in out
+
+    assert any(
+        "Started reading table 'bigquery-public-data.usa_names.usa_1910_current' with BQ Storage API session"
+        in message
+        for message in caplog.messages
+    )

--- a/bigquery/samples/tests/test_download_public_data_sandbox.py
+++ b/bigquery/samples/tests/test_download_public_data_sandbox.py
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .. import download_public_data_sandbox
+
+
+def test_download_public_data_sandbox(capsys, client):
+
+    download_public_data_sandbox.download_public_data_sandbox(client)
+    out, _ = capsys.readouterr()
+    assert "year" in out
+    assert "gender" in out
+    assert "name" in out

--- a/bigquery/samples/tests/test_download_public_data_sandbox.py
+++ b/bigquery/samples/tests/test_download_public_data_sandbox.py
@@ -12,13 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from .. import download_public_data_sandbox
 
 
-def test_download_public_data_sandbox(capsys, client):
+def test_download_public_data_sandbox(caplog, capsys, client):
+    # Enable debug-level logging to verify the BigQuery Storage API is used.
+    caplog.set_level(logging.DEBUG)
 
     download_public_data_sandbox.download_public_data_sandbox(client)
-    out, _ = capsys.readouterr()
+    out, err = capsys.readouterr()
     assert "year" in out
     assert "gender" in out
     assert "name" in out
+
+    assert any(
+        # An anonymous table is used because this sample reads from query results.
+        ("Started reading table" in message and "BQ Storage API session" in message)
+        for message in caplog.messages
+    )

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -1886,6 +1886,35 @@ class TestRowIterator(unittest.TestCase):
     @unittest.skipIf(
         bigquery_storage_v1beta1 is None, "Requires `google-cloud-bigquery-storage`"
     )
+    def test_to_arrow_w_bqstorage_creates_client(self):
+        from google.cloud.bigquery import schema
+        from google.cloud.bigquery import table as mut
+
+        mock_client = _mock_client()
+        bqstorage_client = mock.create_autospec(
+            bigquery_storage_v1beta1.BigQueryStorageClient
+        )
+        mock_client._create_bqstorage_client.return_value = bqstorage_client
+        session = bigquery_storage_v1beta1.types.ReadSession()
+        bqstorage_client.create_read_session.return_value = session
+        row_iterator = mut.RowIterator(
+            mock_client,
+            None,  # api_request: ignored
+            None,  # path: ignored
+            [
+                schema.SchemaField("colA", "STRING"),
+                schema.SchemaField("colC", "STRING"),
+                schema.SchemaField("colB", "STRING"),
+            ],
+            table=mut.TableReference.from_string("proj.dset.tbl"),
+        )
+        row_iterator.to_arrow(create_bqstorage_client=True)
+        mock_client._create_bqstorage_client.assert_called_once()
+
+    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
+    @unittest.skipIf(
+        bigquery_storage_v1beta1 is None, "Requires `google-cloud-bigquery-storage`"
+    )
     def test_to_arrow_w_bqstorage_no_streams(self):
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
@@ -2291,6 +2320,35 @@ class TestRowIterator(unittest.TestCase):
             and "tabledata.list" in str(warning)
         ]
         self.assertEqual(len(matches), 1, msg="User warning was not emitted.")
+
+    @unittest.skipIf(pandas is None, "Requires `pandas`")
+    @unittest.skipIf(
+        bigquery_storage_v1beta1 is None, "Requires `google-cloud-bigquery-storage`"
+    )
+    def test_to_dataframe_w_bqstorage_creates_client(self):
+        from google.cloud.bigquery import schema
+        from google.cloud.bigquery import table as mut
+
+        mock_client = _mock_client()
+        bqstorage_client = mock.create_autospec(
+            bigquery_storage_v1beta1.BigQueryStorageClient
+        )
+        mock_client._create_bqstorage_client.return_value = bqstorage_client
+        session = bigquery_storage_v1beta1.types.ReadSession()
+        bqstorage_client.create_read_session.return_value = session
+        row_iterator = mut.RowIterator(
+            mock_client,
+            None,  # api_request: ignored
+            None,  # path: ignored
+            [
+                schema.SchemaField("colA", "STRING"),
+                schema.SchemaField("colC", "STRING"),
+                schema.SchemaField("colB", "STRING"),
+            ],
+            table=mut.TableReference.from_string("proj.dset.tbl"),
+        )
+        row_iterator.to_dataframe(create_bqstorage_client=True)
+        mock_client._create_bqstorage_client.assert_called_once()
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
     @unittest.skipIf(


### PR DESCRIPTION
When the `create_bqstorage_client` parameter is set to `True`, the BigQuery
client constructs a BigQuery Storage API client for you. This removes
the need for boilerplate code to manually construct both clients
explicitly with the same credentials.

Does this make the `bqstorage_client` parameter unnecessary? In most
cases, yes, but there are a few cases where we'll want to continue using
it. Specifically, when partner tools use `to_dataframe`, they should
continue to use `bqstorage_client` so that they can set the correct
amended user-agent strings. `bqstorage_client` is also needed for regional
API endpoints.

TODO
- [x] Add `owns_bqstorage_client` to track if `bqstorage_client` needs its transport closed.
- [x] Add try/finally block where finally closes the transport only if `owns_bqstorage_client` is true.
- [x] Test that client is not created if `max_results` is set.