### PR TITLE
fix(pubsub): split large (mod)ACK requests into smaller ones

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -37,15 +37,15 @@ _MAX_BATCH_LATENCY = 0.01
 """The maximum amount of time in seconds to wait for additional request items
 before processing the next batch of requests."""
 
-_ACK_IDS_BATCH_SIZE = 3000
+_ACK_IDS_BATCH_SIZE = 2500
 """The maximum number of ACK IDs to send in a single StreamingPullRequest.
 
 The backend imposes a maximum request size limit of 524288 bytes (512 KiB) per
 acknowledge / modifyAckDeadline request. ACK IDs have a maximum size of 164
-bytes, thus we cannot send more than o 524288/164 ~= 3197 ACK IDs in a single
+bytes, thus we cannot send more than o 524288/176 ~= 2979 ACK IDs in a single
 StreamingPullRequest message.
 
-Accounting for some overhead, we should thus only send a maximum of 3000 ACK
+Accounting for some overhead, we should thus only send a maximum of 2500 ACK
 IDs at a time.
 """
 

--- a/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/dispatcher.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from __future__ import division
 
 import collections
+import itertools
 import logging
+import math
 import threading
 
 from google.cloud.pubsub_v1 import types
@@ -33,6 +36,18 @@ _MAX_BATCH_SIZE = 100
 _MAX_BATCH_LATENCY = 0.01
 """The maximum amount of time in seconds to wait for additional request items
 before processing the next batch of requests."""
+
+_ACK_IDS_BATCH_SIZE = 3000
+"""The maximum number of ACK IDs to send in a single StreamingPullRequest.
+
+The backend imposes a maximum request size limit of 524288 bytes (512 KiB) per
+acknowledge / modifyAckDeadline request. ACK IDs have a maximum size of 164
+bytes, thus we cannot send more than o 524288/164 ~= 3197 ACK IDs in a single
+StreamingPullRequest message.
+
+Accounting for some overhead, we should thus only send a maximum of 3000 ACK
+IDs at a time.
+"""
 
 
 class Dispatcher(object):
@@ -119,9 +134,16 @@ class Dispatcher(object):
             if time_to_ack is not None:
                 self._manager.ack_histogram.add(time_to_ack)
 
-        ack_ids = [item.ack_id for item in items]
-        request = types.StreamingPullRequest(ack_ids=ack_ids)
-        self._manager.send(request)
+        # We must potentially split the request into multiple smaller requests
+        # to avoid the server-side max request size limit.
+        ack_ids = (item.ack_id for item in items)
+        total_chunks = int(math.ceil(len(items) / _ACK_IDS_BATCH_SIZE))
+
+        for _ in range(total_chunks):
+            request = types.StreamingPullRequest(
+                ack_ids=itertools.islice(ack_ids, _ACK_IDS_BATCH_SIZE)
+            )
+            self._manager.send(request)
 
         # Remove the message from lease management.
         self.drop(items)
@@ -150,13 +172,18 @@ class Dispatcher(object):
         Args:
             items(Sequence[ModAckRequest]): The items to modify.
         """
-        ack_ids = [item.ack_id for item in items]
-        seconds = [item.seconds for item in items]
+        # We must potentially split the request into multiple smaller requests
+        # to avoid the server-side max request size limit.
+        ack_ids = (item.ack_id for item in items)
+        seconds = (item.seconds for item in items)
+        total_chunks = int(math.ceil(len(items) / _ACK_IDS_BATCH_SIZE))
 
-        request = types.StreamingPullRequest(
-            modify_deadline_ack_ids=ack_ids, modify_deadline_seconds=seconds
-        )
-        self._manager.send(request)
+        for _ in range(total_chunks):
+            request = types.StreamingPullRequest(
+                modify_deadline_ack_ids=itertools.islice(ack_ids, _ACK_IDS_BATCH_SIZE),
+                modify_deadline_seconds=itertools.islice(seconds, _ACK_IDS_BATCH_SIZE),
+            )
+            self._manager.send(request)
 
     def nack(self, items):
         """Explicitly deny receipt of messages.

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_dispatcher.py
@@ -102,9 +102,9 @@ def test_ack_splitting_large_payload():
     dispatcher_ = dispatcher.Dispatcher(manager, mock.sentinel.queue)
 
     items = [
-        # use realistic lengths for ACK IDs (max 164 bytes)
-        requests.AckRequest(ack_id=str(i).zfill(164), byte_size=0, time_to_ack=20)
-        for i in range(6001)
+        # use realistic lengths for ACK IDs (max 176 bytes)
+        requests.AckRequest(ack_id=str(i).zfill(176), byte_size=0, time_to_ack=20)
+        for i in range(5001)
     ]
     dispatcher_.ack(items)
 
@@ -187,9 +187,9 @@ def test_modify_ack_deadline_splitting_large_payload():
     dispatcher_ = dispatcher.Dispatcher(manager, mock.sentinel.queue)
 
     items = [
-        # use realistic lengths for ACK IDs (max 164 bytes)
-        requests.ModAckRequest(ack_id=str(i).zfill(164), seconds=60)
-        for i in range(6001)
+        # use realistic lengths for ACK IDs (max 176 bytes)
+        requests.ModAckRequest(ack_id=str(i).zfill(176), seconds=60)
+        for i in range(5001)
     ]
     dispatcher_.modify_ack_deadline(items)
 


### PR DESCRIPTION
Fixes #9103.

There is a server-side limit on the maximum size of ACK and modACK requests, which can be hit if the leaser tries to manage too many messages in a single requests. This PR avoids the problem by splitting such large requests into multiple smaller requests.

### How to test

**Steps to reproduce:**
 - publish a lot of messages to a topic (significantly more than 3000)
 - subscribe to that topic using a streaming pull and a callback that processes messages for a non-negligible amount of time (e.g. 1 second)
- observe the DEBUG log

**Actual result (before the fix):**
The following error can be observed in the log output:
```
google.api_core.exceptions.InvalidArgument: 400 Request payload size exceeds the limit: 524288 bytes.
```

**Expected result (after the fix):**
There is no error, mass-acknowledging leased messages works just fine.

The following script might come helpful:
<details>
    <summary>reproduce_9103.py</summary>

```py
import itertools
import logging
import os
import threading
import time
from argparse import ArgumentParser

from google import api_core
from google.cloud import pubsub_v1

logging.basicConfig(
    format='%(asctime)s %(levelname)s %(threadName)s: %(message)s', level=logging.INFO)
logger = logging.getLogger()
logger.setLevel("DEBUG")


log_format = (
    "%(levelname)-8s [%(asctime)s] %(threadName)-33s "
    "[%(name)s] [%(filename)s:%(lineno)d][%(funcName)s] %(message)s"
)

logging.basicConfig(
    level=logging.DEBUG, format=log_format
)


def msg_handler(message):
    """Message handler."""
    SLEEP_FOR = 1

    logging.info(f"\x1b[1m[{message.message_id}] got message with content: {str(message.data)} (ack_id: {message.ack_id})\x1b[0m")
    logging.info(f"\x1b[1m[{message.message_id}] sleeping for {SLEEP_FOR} seconds\x1b[0m")

    time.sleep(SLEEP_FOR)
    logging.info(f"\x1b[1m[[{message.message_id}] done sleeping, sending ack()\x1b[0m")

    message.ack()


def _publish_messages(publisher, topic_path, batch_sizes):
    """Publish ``count`` messages in batches and wait until completion."""
    publish_futures = []
    msg_counter = itertools.count(start=1)

    for batch_size in batch_sizes:
        msg_batch = _make_messages(count=batch_size)
        for msg in msg_batch:
            future = publisher.publish(
                topic_path, msg, seq_num=str(next(msg_counter))
            )
            publish_futures.append(future)
        time.sleep(0.1)

    # wait untill all messages have been successfully published
    for future in publish_futures:
        future.result(timeout=30)

def _make_messages(count):
    messages = [
        u"message {}/{}".format(i, count).encode("utf-8")
        for i in range(1, count + 1)
    ]
    return messages


def main():
    PROJECT_ID = "TODO: set"
    SUBSCRIPTION_NAME = "TODO: set"
    TOPIC_NAME = "TODO: set"

    publisher = pubsub_v1.PublisherClient()
    subscriber = pubsub_v1.SubscriberClient()

    topic_path = publisher.topic_path(PROJECT_ID, TOPIC_NAME)
    subscription_path = subscriber.subscription_path(PROJECT_ID, SUBSCRIPTION_NAME)

    try:
        publisher.create_topic(topic_path)
        subscriber.create_subscription(subscription_path, topic_path)
    except api_core.exceptions.AlreadyExists as exc:
        pass

    #batch_sizes = (400, 600, 700, 300, 500, 500, 250, 750)  # total: 4000
    batch_sizes = (4000,)
    _publish_messages(publisher, topic_path, batch_sizes=batch_sizes)

    # now subscribe and do the main part, check for max pending messages
    total_messages = sum(batch_sizes)
    flow_control = pubsub_v1.types.FlowControl(max_messages=total_messages)
    subscription_future = subscriber.subscribe(
        subscription_path, msg_handler, flow_control=flow_control
    )

    logging.info("Starting streaming pull...")    
    future = subscriber.subscribe(
        subscription_path, msg_handler, flow_control=flow_control
    )
    logging.info("Streming pull started")

    time.sleep(5)

    try:
        future.result()
    except KeyboardInterrupt:
        logging.info("Interrupted, cancelling")
        future.cancel()


if __name__ == '__main__':
    main()

```
</details>