### PR TITLE
fix(pubsub): update batching and flow control parameters to be same as the other client libraries

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/types.py
+++ b/pubsub/google/cloud/pubsub_v1/types.py
@@ -39,9 +39,9 @@ BatchSettings = collections.namedtuple(
     "BatchSettings", ["max_bytes", "max_latency", "max_messages"]
 )
 BatchSettings.__new__.__defaults__ = (
-    1000 * 1000 * 10,  # max_bytes: documented "10 MB", enforced 10000000
-    0.05,  # max_latency: 0.05 seconds
-    1000,  # max_messages: 1,000
+    1 * 1000 * 1000,  # max_bytes: 1 MB
+    0.01,  # max_latency: 10 ms
+    100,  # max_messages: 100
 )
 
 if sys.version_info >= (3, 5):
@@ -70,8 +70,8 @@ FlowControl = collections.namedtuple(
 )
 FlowControl.__new__.__defaults__ = (
     100 * 1024 * 1024,  # max_bytes: 100mb
-    100,  # max_messages: 100
-    2 * 60 * 60,  # max_lease_duration: 2 hours.
+    1000,  # max_messages: 1000
+    1 * 60 * 60,  # max_lease_duration: 1 hour.
 )
 
 if sys.version_info >= (3, 5):

--- a/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -31,9 +31,9 @@ def test_init():
     # A plain client should have an `api` (the underlying GAPIC) and a
     # batch settings object, which should have the defaults.
     assert isinstance(client.api, publisher_client.PublisherClient)
-    assert client.batch_settings.max_bytes == 10 * 1000 * 1000
-    assert client.batch_settings.max_latency == 0.05
-    assert client.batch_settings.max_messages == 1000
+    assert client.batch_settings.max_bytes == 1 * 1000 * 1000
+    assert client.batch_settings.max_latency == 0.01
+    assert client.batch_settings.max_messages == 100
 
 
 def test_init_w_custom_transport():
@@ -44,9 +44,9 @@ def test_init_w_custom_transport():
     # batch settings object, which should have the defaults.
     assert isinstance(client.api, publisher_client.PublisherClient)
     assert client.api.transport is transport
-    assert client.batch_settings.max_bytes == 10 * 1000 * 1000
-    assert client.batch_settings.max_latency == 0.05
-    assert client.batch_settings.max_messages == 1000
+    assert client.batch_settings.max_bytes == 1 * 1000 * 1000
+    assert client.batch_settings.max_latency == 0.01
+    assert client.batch_settings.max_messages == 100
 
 
 def test_init_emulator(monkeypatch):

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -660,9 +660,9 @@ def test__on_response_with_leaser_overload():
         ]
     )
 
-    # Adjust message bookkeeping in leaser. Pick 99 messages, which is just below
+    # Adjust message bookkeeping in leaser. Pick 999 messages, which is just below
     # the default FlowControl.max_messages limit.
-    fake_leaser_add(leaser, init_msg_count=99, init_bytes=990)
+    fake_leaser_add(leaser, init_msg_count=999, init_bytes=990)
 
     # Actually run the method and prove that modack and schedule
     # are called in the expected way.

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -662,7 +662,7 @@ def test__on_response_with_leaser_overload():
 
     # Adjust message bookkeeping in leaser. Pick 999 messages, which is just below
     # the default FlowControl.max_messages limit.
-    fake_leaser_add(leaser, init_msg_count=999, init_bytes=990)
+    fake_leaser_add(leaser, init_msg_count=999, init_bytes=9900)
 
     # Actually run the method and prove that modack and schedule
     # are called in the expected way.


### PR DESCRIPTION
Changes:
- Max batch size is reduced from 10 MB to 1 MB
- Max latency before a batch is sent is reduced from 50 ms to 10 ms
- Max messages in a batch is reduced from 1000 messages to 100 messages
- Max messages in flight is increased from 100 messages to 1000 messages
- Max ack extension is reduced from 2 hours to 1 hour
- Also fix tests