### PR TITLE
test: check that 'request is prohibited' is in vpcsc exception

### DIFF
--- a/asset/tests/system/test_vpcsc.py
+++ b/asset/tests/system/test_vpcsc.py
@@ -36,7 +36,7 @@ class TestVPCServiceControl(object):
         try:
             responses = call()
         except exceptions.PermissionDenied as e:
-            return e.message == "Request is prohibited by organization's policy"
+            return "Request is prohibited by organization's policy" in e.message
         except:
             pass
         return False

--- a/dlp/tests/system/gapic/v2/test_system_dlp_service_v2_vpcsc.py
+++ b/dlp/tests/system/gapic/v2/test_system_dlp_service_v2_vpcsc.py
@@ -37,7 +37,7 @@ class TestSystemDlpService(object):
         try:
             responses = call()
         except exceptions.PermissionDenied as e:
-            return e.message == "Request is prohibited by organization's policy"
+            return "Request is prohibited by organization's policy" in e.message
         except:
             pass
         return False

--- a/monitoring/tests/system/test_vpcsc_v3.py
+++ b/monitoring/tests/system/test_vpcsc_v3.py
@@ -46,7 +46,7 @@ class TestVPCServiceControlV3(object):
             list(responses)
         except exceptions.PermissionDenied as e:
             logger.debug(e)
-            return e.message == "Request is prohibited by organization's policy"
+            return "Request is prohibited by organization's policy" in e.message
         except Exception as e:
             logger.debug(e)
             pass

--- a/trace/tests/system/gapic/v1/test_system_trace_service_v1_vpcsc.py
+++ b/trace/tests/system/gapic/v1/test_system_trace_service_v1_vpcsc.py
@@ -34,7 +34,7 @@ class TestVPCServiceControlV1(object):
         try:
             responses = call()
         except exceptions.PermissionDenied as e:
-            return e.message == "Request is prohibited by organization's policy"
+            return "Request is prohibited by organization's policy" in e.message
         except:
             return False
         return False

--- a/trace/tests/system/gapic/v2/test_system_trace_service_v2_vpcsc.py
+++ b/trace/tests/system/gapic/v2/test_system_trace_service_v2_vpcsc.py
@@ -34,7 +34,7 @@ class TestVPCServiceControlV2(object):
         try:
             responses = call()
         except exceptions.PermissionDenied as e:
-            return e.message == "Request is prohibited by organization's policy"
+            return "Request is prohibited by organization's policy" in e.message
         except:
             pass
         return False

--- a/translate/tests/system/test_vpcsc.py
+++ b/translate/tests/system/test_vpcsc.py
@@ -53,7 +53,7 @@ class TestVPCServiceControl(object):
             print("responses: ", responses)
         except exceptions.PermissionDenied as e:
             print("PermissionDenied Exception: ", e)
-            return e.message == "Request is prohibited by organization's policy"
+            return "Request is prohibited by organization's policy" in e.message
         except Exception as e:
             print("Other Exception: ", e)
             pass

--- a/vision/tests/system.py
+++ b/vision/tests/system.py
@@ -640,8 +640,8 @@ class TestVisionClientProductSearchVpcsc(VisionSystemTestBase):
                 break
         except google.api_core.exceptions.PermissionDenied as e:
             # Verify the PermissionDenied exception was due to VPC SC.
-            self.assertEqual(
-                e.message, "Request is prohibited by organization's policy"
+            self.assertIn(
+                "Request is prohibited by organization's policy", e.message
             )
             return
         except Exception as e:

--- a/vision/tests/system.py
+++ b/vision/tests/system.py
@@ -640,9 +640,7 @@ class TestVisionClientProductSearchVpcsc(VisionSystemTestBase):
                 break
         except google.api_core.exceptions.PermissionDenied as e:
             # Verify the PermissionDenied exception was due to VPC SC.
-            self.assertIn(
-                "Request is prohibited by organization's policy", e.message
-            )
+            self.assertIn("Request is prohibited by organization's policy", e.message)
             return
         except Exception as e:
             self.fail("Unexpected exception raised: {}".format(e))


### PR DESCRIPTION
Fixes internal issue 143725470

These tests started failing because the error message was modified on the backend. VPCSC folks recommended something like this instead.