### PR TITLE
docs(cloudbuild): fix link to client lib docs

### DIFF
--- a/cloudbuild/README.rst
+++ b/cloudbuild/README.rst
@@ -8,7 +8,7 @@ Python Client for Cloud Build API (`Alpha`_)
 
 .. _Alpha: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
 .. _Cloud Build API: https://cloud.google.com/cloud-build
-.. _Client Library Documentation: https://googleapis.github.io/google-cloud-python/latest/cloudbuild/usage.html
+.. _Client Library Documentation: https://googleapis.dev/python/cloudbuild/latest
 .. _Product Documentation:  https://cloud.google.com/cloud-build
 
 Quick Start

--- a/cloudbuild/synth.metadata
+++ b/cloudbuild/synth.metadata
@@ -1,26 +1,19 @@
 {
-  "updateTime": "2019-10-22T20:39:41.016824Z",
+  "updateTime": "2019-11-07T22:07:36.473613Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.40.2",
-        "dockerImage": "googleapis/artman@sha256:3b8f7d9b4c206843ce08053474f5c64ae4d388ff7d995e68b59fb65edf73eeb9"
+        "version": "0.41.0",
+        "dockerImage": "googleapis/artman@sha256:75b38a3b073a7b243545f2332463096624c802bb1e56b8cb6f22ba1ecd325fa9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a9589347c884dd62c45b5852c1b86ff346bf98dc",
-        "internalRef": "276110444"
-      }
-    },
-    {
-      "template": {
-        "name": "python_library",
-        "origin": "synthtool.gcp",
-        "version": "0.0.0+dev"
+        "sha": "0ed34e9fdf601dfc37eb24c40e17495b86771ff4",
+        "internalRef": "279147036"
       }
     }
   ],

--- a/cloudbuild/synth.py
+++ b/cloudbuild/synth.py
@@ -39,6 +39,7 @@ s.move(
         'nox*.py',
         'setup.py',
         'setup.cfg',
+        'README.rst'
         '**/*.proto'
         'google/cloud/devtools/__init__.py'  # declare this as a namespace package
     ],
@@ -57,23 +58,9 @@ s.replace(
 
 # Rename package to `google-cloud-build`
 s.replace(
-    ["**/*.rst", "**/*.py", "**/*.md"],
-    "google-cloud-build",
+    ["**/*.rst", "*/**/*.py", "**/*.md"],
+    "google-cloud-cloudbuild",
     "google-cloud-build"
-)
-
-# Fix reference to product documentation
-s.replace(
-    'README.rst',
-    'https://cloud\.google\.com/cloudbuild',
-    'https://cloud.google.com/cloud-build'
-)
-
-# Fix link to auth
-s.replace(
-    'README.rst',
-    'https://googleapis\.github\.io/google-cloud-python/latest/core/auth\.html',
-    'https://googleapis.dev/python/google-api-core/latest/auth.html'
 )
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
* Fixes the link to client lib docs
* Fixes a bad synth replace. (It was replacing the `google-cloud-cloudbuild` in synth.py :sweat_smile:)  