### PR TITLE
chore: add emacs' auto-save files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ htmlcov
 # VS Code
 .vscode
 
+# emacs
+*~
+
 # Built documentation
 docs/_build
 */docs/_build


### PR DESCRIPTION
*~ are the auto-save files generated when editing with emacs:
 https://emacsredux.com/blog/2013/05/09/keep-backup-and-auto-save-files-out-of-the-way/

More reference: https://stackoverflow.com/a/28709885/11097495