### PR TITLE
docs(automl): fix docstring formatting

### DIFF
--- a/automl/docs/conf.py
+++ b/automl/docs/conf.py
@@ -344,7 +344,7 @@ intersphinx_mapping = {
     "google-gax": ("https://gax-python.readthedocs.io/en/latest/", None),
     "google.api_core": ("https://googleapis.dev/python/google-api-core/latest", None),
     "grpc": ("https://grpc.io/grpc/python/", None),
-    "requests": ("https://requests.kennethreitz.org/en/master/", None),
+    "requests": ("https://requests.readthedocs.org/en/latest", None),
     "fastavro": ("https://fastavro.readthedocs.io/en/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
 }

--- a/automl/google/cloud/automl_v1beta1/proto/io_pb2.py
+++ b/automl/google/cloud/automl_v1beta1/proto/io_pb2.py
@@ -1046,74 +1046,7 @@ InputConfig = _reflection.GeneratedProtocolMessageType(
      are supported now, and each document may be up to 2MB large.
      Currently, annotations on documents cannot be specified at import.
      Three sample CSV rows: TRAIN,gs://folder/file1.jsonl
-     VALIDATE,gs://folder/file2.jsonl TEST,gs://folder/file3.jsonl Sample
-     in-line JSON Lines file for entity extraction (presented here with
-     artificial line breaks, but the only actual line break is denoted by
-     ``\\n``).: { "document": { "document\_text": {"content": "dog
-     cat"} "layout": [ { "text\_segment": { "start\_offset": 0,
-     "end\_offset": 3, }, "page\_number": 1, "bounding\_poly": {
-     "normalized\_vertices": [ {"x": 0.1, "y": 0.1}, {"x": 0.1, "y": 0.3},
-     {"x": 0.3, "y": 0.3}, {"x": 0.3, "y": 0.1}, ], },
-     "text\_segment\_type": TOKEN, }, { "text\_segment": {
-     "start\_offset": 4, "end\_offset": 7, }, "page\_number": 1,
-     "bounding\_poly": { "normalized\_vertices": [ {"x": 0.4, "y": 0.1},
-     {"x": 0.4, "y": 0.3}, {"x": 0.8, "y": 0.3}, {"x": 0.8, "y": 0.1}, ],
-     }, "text\_segment\_type": TOKEN, }
-  
-     ::
-  
-               ],
-               "document_dimensions": {
-                 "width": 8.27,
-                 "height": 11.69,
-                 "unit": INCH,
-               }
-               "page_count": 1,
-             },
-             "annotations": [
-               {
-                 "display_name": "animal",
-                 "text_extraction": {"text_segment": {"start_offset": 0,
-                 "end_offset": 3}}
-               },
-               {
-                 "display_name": "animal",
-                 "text_extraction": {"text_segment": {"start_offset": 4,
-                 "end_offset": 7}}
-               }
-             ],
-           }\\n
-           {
-              "text_snippet": {
-                "content": "This dog is good."
-              },
-              "annotations": [
-                {
-                  "display_name": "animal",
-                  "text_extraction": {
-                    "text_segment": {"start_offset": 5, "end_offset": 8}
-                  }
-                }
-              ]
-           }
-         Sample document JSON Lines file (presented here with artificial line
-         breaks, but the only actual line break is denoted by \n).:
-           {
-             "document": {
-               "input_config": {
-                 "gcs_source": { "input_uris": [ "gs://folder/document1.pdf" ]
-                 }
-               }
-             }
-           }\\n
-           {
-             "document": {
-               "input_config": {
-                 "gcs_source": { "input_uris": [ "gs://folder/document2.pdf" ]
-                 }
-               }
-             }
-           }
+     VALIDATE,gs://folder/file2.jsonl TEST,gs://folder/file3.jsonl 
   
   -  For Text Classification: CSV file(s) with each line in format:
      ML\_USE,(TEXT\_SNIPPET \| GCS\_FILE\_PATH),LABEL,LABEL,...
@@ -1314,33 +1247,7 @@ BatchPredictInputConfig = _reflection.GeneratedProtocolMessageType(
      contain, per line, a proto that wraps a Document proto with
      input\_config set. Only PDF documents are supported now, and each
      document must be up to 2MB large. Any given .JSONL file must be 100MB
-     or smaller, and no more than 20 files may be given. Sample in-line
-     JSON Lines file (presented here with artificial line breaks, but the
-     only actual line break is denoted by ``\\n``): { "id":
-     "my\_first\_id", "text\_snippet": { "content": "dog car cat"},
-     "text\_features": [ { "text\_segment": {"start\_offset": 4,
-     "end\_offset": 6}, "structural\_type": PARAGRAPH, "bounding\_poly": {
-     "normalized\_vertices": [ {"x": 0.1, "y": 0.1}, {"x": 0.1, "y": 0.3},
-     {"x": 0.3, "y": 0.3}, {"x": 0.3, "y": 0.1}, ] }, } ], }:raw-latex:`\n
-           {
-             "id": "2",
-             "text_snippet": {
-               "content": "An elaborate content",
-               "mime_type": "text/plain"
-             }
-           }` Sample document JSON Lines file (presented here with
-     artificial line breaks, but the only actual line break is denoted by
-     ``\\n``).: { "document": { "input\_config": { "gcs\_source":
-     { "input\_uris": [ "gs://folder/document1.pdf" ] } } }
-     }:raw-latex:`\n
-           {
-             "document": {
-               "input_config": {
-                 "gcs_source": { "input_uris": [ "gs://folder/document2.pdf" ]
-                 }
-               }
-             }
-           }`
+     or smaller, and no more than 20 files may be given. 
   
   -  For Tables: Either
      [gcs\_source][google.cloud.automl.v1beta1.InputConfig.gcs\_source] or

--- a/automl/synth.metadata
+++ b/automl/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-11-13T20:54:28.686825Z",
+  "updateTime": "2019-11-13T22:56:51.489853Z",
   "sources": [
     {
       "generator": {
@@ -12,8 +12,8 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "dec8fd8ea5dc464496606189ba4b8949188639c8",
-        "internalRef": "280225437"
+        "sha": "218164b3deba1075979c9dca5f71461379e42dd1",
+        "internalRef": "280279014"
       }
     },
     {

--- a/automl/synth.py
+++ b/automl/synth.py
@@ -111,13 +111,13 @@ s.replace(
 s.replace("google/cloud/**/io_pb2.py", r":raw-latex:`\\t `", r"\\\\t")
 
 # Remove html bits that can't be rendered correctly
-s.replace("google/cloud/**/io_pb2.py", 
+s.replace("google/cloud/automl_v1/**/io_pb2.py", 
 r""".. raw:: html.+?
      \</.+?\>""",
 r"", flags=re.DOTALL)
 
 # Remove raw-latex wrapping newline
-s.replace("google/cloud/**/io_pb2.py",
+s.replace("google/cloud/automl_v1/**/io_pb2.py",
 r""":raw-latex:`\\n`""",
 r"``\\\\n``")
 
@@ -125,7 +125,6 @@ r"``\\\\n``")
 s.replace("google/cloud/**/io_pb2.py",
 r"\}\\n",
 r"}\\\\n")
-
 
 # ----------------------------------------------------------------------------
 # Add templated files


### PR DESCRIPTION
#9628 (unintentionally) changed v1beta1 AND v1 docstrings. This reverts that change and just preserves fixes to v1 docstrings.

The AutoML docstrings are still borked, but it appears sphinx can build them with these changes :woman_shrugging: 