### PR TITLE
fix(videointelligence): revert #9440; make `features` a keyword parameter

### DIFF
--- a/videointelligence/google/cloud/videointelligence_v1/gapic/video_intelligence_service_client.py
+++ b/videointelligence/google/cloud/videointelligence_v1/gapic/video_intelligence_service_client.py
@@ -191,9 +191,9 @@ class VideoIntelligenceServiceClient(object):
     # Service calls
     def annotate_video(
         self,
-        features,
         input_uri=None,
         input_content=None,
+        features=None,
         video_context=None,
         output_uri=None,
         location_id=None,
@@ -213,11 +213,11 @@ class VideoIntelligenceServiceClient(object):
             >>>
             >>> client = videointelligence_v1.VideoIntelligenceServiceClient()
             >>>
+            >>> input_uri = 'gs://cloud-samples-data/video/cat.mp4'
             >>> features_element = enums.Feature.LABEL_DETECTION
             >>> features = [features_element]
-            >>> input_uri = 'gs://cloud-samples-data/video/cat.mp4'
             >>>
-            >>> response = client.annotate_video(features, input_uri=input_uri)
+            >>> response = client.annotate_video(input_uri=input_uri, features=features)
             >>>
             >>> def callback(operation_future):
             ...     # Handle result.
@@ -229,7 +229,6 @@ class VideoIntelligenceServiceClient(object):
             >>> metadata = response.metadata()
 
         Args:
-            features (list[~google.cloud.videointelligence_v1.types.Feature]): Required. Requested video annotation features.
             input_uri (str): Input video location. Currently, only `Google Cloud
                 Storage <https://cloud.google.com/storage/>`__ URIs are supported, which
                 must be specified in the following format: ``gs://bucket-id/object-id``
@@ -242,6 +241,7 @@ class VideoIntelligenceServiceClient(object):
                 request as ``input_content``. If set, ``input_content`` should be unset.
             input_content (bytes): The video data bytes. If unset, the input video(s) should be specified
                 via ``input_uri``. If set, ``input_uri`` should be unset.
+            features (list[~google.cloud.videointelligence_v1.types.Feature]): Required. Requested video annotation features.
             video_context (Union[dict, ~google.cloud.videointelligence_v1.types.VideoContext]): Additional video context and/or feature-specific parameters.
 
                 If a dict is provided, it must be of the same form as the protobuf
@@ -288,9 +288,9 @@ class VideoIntelligenceServiceClient(object):
             )
 
         request = video_intelligence_pb2.AnnotateVideoRequest(
-            features=features,
             input_uri=input_uri,
             input_content=input_content,
+            features=features,
             video_context=video_context,
             output_uri=output_uri,
             location_id=location_id,

--- a/videointelligence/google/cloud/videointelligence_v1/gapic/video_intelligence_service_client_config.py
+++ b/videointelligence/google/cloud/videointelligence_v1/gapic/video_intelligence_service_client_config.py
@@ -7,19 +7,19 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
-                    "retry_delay_multiplier": 1.3,
-                    "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_retry_delay_millis": 1000,
+                    "retry_delay_multiplier": 2.5,
+                    "max_retry_delay_millis": 120000,
+                    "initial_rpc_timeout_millis": 120000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
+                    "max_rpc_timeout_millis": 120000,
                     "total_timeout_millis": 600000,
                 }
             },
             "methods": {
                 "AnnotateVideo": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "non_idempotent",
+                    "retry_codes_name": "idempotent",
                     "retry_params_name": "default",
                 }
             },

--- a/videointelligence/google/cloud/videointelligence_v1/gapic/video_intelligence_service_client_config.py
+++ b/videointelligence/google/cloud/videointelligence_v1/gapic/video_intelligence_service_client_config.py
@@ -7,19 +7,19 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 1000,
-                    "retry_delay_multiplier": 2.5,
-                    "max_retry_delay_millis": 120000,
-                    "initial_rpc_timeout_millis": 120000,
+                    "initial_retry_delay_millis": 100,
+                    "retry_delay_multiplier": 1.3,
+                    "max_retry_delay_millis": 60000,
+                    "initial_rpc_timeout_millis": 20000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 120000,
+                    "max_rpc_timeout_millis": 20000,
                     "total_timeout_millis": 600000,
                 }
             },
             "methods": {
                 "AnnotateVideo": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "idempotent",
+                    "retry_codes_name": "non_idempotent",
                     "retry_params_name": "default",
                 }
             },

--- a/videointelligence/tests/unit/gapic/v1/test_video_intelligence_service_client_v1.py
+++ b/videointelligence/tests/unit/gapic/v1/test_video_intelligence_service_client_v1.py
@@ -83,17 +83,17 @@ class TestVideoIntelligenceServiceClient(object):
             client = videointelligence_v1.VideoIntelligenceServiceClient()
 
         # Setup Request
+        input_uri = "gs://cloud-samples-data/video/cat.mp4"
         features_element = enums.Feature.LABEL_DETECTION
         features = [features_element]
-        input_uri = "gs://cloud-samples-data/video/cat.mp4"
 
-        response = client.annotate_video(features, input_uri=input_uri)
+        response = client.annotate_video(input_uri=input_uri, features=features)
         result = response.result()
         assert expected_response == result
 
         assert len(channel.requests) == 1
         expected_request = video_intelligence_pb2.AnnotateVideoRequest(
-            features=features, input_uri=input_uri
+            input_uri=input_uri, features=features
         )
         actual_request = channel.requests[0][1]
         assert expected_request == actual_request
@@ -114,10 +114,10 @@ class TestVideoIntelligenceServiceClient(object):
             client = videointelligence_v1.VideoIntelligenceServiceClient()
 
         # Setup Request
+        input_uri = "gs://cloud-samples-data/video/cat.mp4"
         features_element = enums.Feature.LABEL_DETECTION
         features = [features_element]
-        input_uri = "gs://cloud-samples-data/video/cat.mp4"
 
-        response = client.annotate_video(features, input_uri=input_uri)
+        response = client.annotate_video(input_uri=input_uri, features=features)
         exception = response.exception()
         assert exception.errors[0] == error


### PR DESCRIPTION
Creating this for a rollback.

Python sample code code was passing the keyword argument `input_uri` positionally before this change. Adding a required parameter changed the parameter order and broke existing code.

```
from google.cloud import videointelligence

video_client = videointelligence.VideoIntelligenceServiceClient()
features = [videointelligence.enums.Feature.LABEL_DETECTION]
operation = video_client.annotate_video(
    'gs://cloud-samples-data/video/cat.mp4', features=features)
print('\nProcessing video for label annotations:')

But I have a problem with the video annotation function, I get the following error message:
TypeError                                 Traceback (most recent call last)
<ipython-input-24-5eb4216acaf7> in <module>
      4 features = [videointelligence.enums.Feature.LABEL_DETECTION]
      5 operation = video_client.annotate_video(
----> 6     'gs://cloud-samples-data/video/cat.mp4', features=features)
      7 print('\nProcessing video for label annotations:')

TypeError: annotate_video() got multiple values for argument 'features'
```

Note: We're still debating what to do about this longer term. I may add a synth replace to make this semi-permanent until the transition to the microgenerator. Alternatively we may take this change but do a major version bump to indicate that it is breaking.