### PR TITLE
chore(automl): reduce Pandas version requirement

### DIFF
--- a/automl/setup.py
+++ b/automl/setup.py
@@ -26,7 +26,7 @@ dependencies = [
     'enum34; python_version < "3.4"',
 ]
 extras = {
-    "pandas": ["pandas>=0.24.0"],
+    "pandas": ["pandas>=0.17.1"],
     "storage": ["google-cloud-storage >= 1.18.0, < 2.0.0dev"],
 }
 


### PR DESCRIPTION
The current pandas version 0.24.0 is unnecessarily high. Pandas 0.17
was the version with the most breaking changes in recent history, so
something after that will get most customers. This also aligns with
BigQuery Python SDK.

More context: https://github.com/googleapis/google-cloud-python/pull/9647#issuecomment-553127471
