### PR TITLE
fix(bigquery): import Mapping from collections.abc not from collections

### DIFF
--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -14,7 +14,7 @@
 
 """Schemas for BigQuery tables / queries."""
 
-import collections
+from collections.abc import Mapping
 
 from google.cloud.bigquery_v2 import types
 
@@ -281,7 +281,7 @@ def _to_schema_fields(schema):
         instance or a compatible mapping representation of the field.
     """
     for field in schema:
-        if not isinstance(field, (SchemaField, collections.Mapping)):
+        if not isinstance(field, (SchemaField, Mapping)):
             raise ValueError(
                 "Schema items must either be fields or compatible "
                 "mapping representations."

--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -14,7 +14,7 @@
 
 """Schemas for BigQuery tables / queries."""
 
-from collections import abc
+from six.moves import collections_abc
 
 from google.cloud.bigquery_v2 import types
 
@@ -281,7 +281,7 @@ def _to_schema_fields(schema):
         instance or a compatible mapping representation of the field.
     """
     for field in schema:
-        if not isinstance(field, (SchemaField, abc.Mapping)):
+        if not isinstance(field, (SchemaField, collections_abc.Mapping)):
             raise ValueError(
                 "Schema items must either be fields or compatible "
                 "mapping representations."

--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -14,7 +14,7 @@
 
 """Schemas for BigQuery tables / queries."""
 
-from collections.abc import Mapping
+from collections import abc
 
 from google.cloud.bigquery_v2 import types
 
@@ -281,7 +281,7 @@ def _to_schema_fields(schema):
         instance or a compatible mapping representation of the field.
     """
     for field in schema:
-        if not isinstance(field, (SchemaField, Mapping)):
+        if not isinstance(field, (SchemaField, abc.Mapping)):
             raise ValueError(
                 "Schema items must either be fields or compatible "
                 "mapping representations."


### PR DESCRIPTION
Getting following deprecation warning in Bigquery:
```
File "/usr/local/lib/python3.7/dist-packages/google/cloud/bigquery/job.py", line 3216, in __iter__
    return iter(self.result())
  File "/usr/local/lib/python3.7/dist-packages/google/cloud/bigquery/job.py", line 3105, in result
    dest_table = Table(dest_table_ref, schema=schema)
  File "/usr/local/lib/python3.7/dist-packages/google/cloud/bigquery/table.py", line 335, in __init__
    self.schema = schema
  File "/usr/local/lib/python3.7/dist-packages/google/cloud/bigquery/table.py", line 400, in schema
    value = _to_schema_fields(value)
  File "/usr/local/lib/python3.7/dist-packages/google/cloud/bigquery/schema.py", line 284, in _to_schema_fields
    if not isinstance(field, (SchemaField, collections.Mapping)):
  File "/usr/lib/python3.7/collections/__init__.py", line 52, in __getattr__
    DeprecationWarning, stacklevel=2)
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```