### PR TITLE
fix(translate): make default `format_` `html` in v2

### DIFF
--- a/translate/google/cloud/translate_v2/client.py
+++ b/translate/google/cloud/translate_v2/client.py
@@ -195,7 +195,7 @@ class Client(BaseClient):
         self,
         values,
         target_language=None,
-        format_=None,
+        format_='html',
         source_language=None,
         customization_ids=(),
         model=None,
@@ -214,7 +214,8 @@ class Client(BaseClient):
 
         :type format_: str
         :param format_: (Optional) One of ``text`` or ``html``, to specify
-                        if the input text is plain text or HTML.
+                        if the input text is plain text or HTML. Defaults to 
+                        ``html``.
 
         :type source_language: str
         :param source_language: (Optional) The language of the text to

--- a/translate/google/cloud/translate_v2/client.py
+++ b/translate/google/cloud/translate_v2/client.py
@@ -195,7 +195,7 @@ class Client(BaseClient):
         self,
         values,
         target_language=None,
-        format_='html',
+        format_="html",
         source_language=None,
         customization_ids=(),
         model=None,


### PR DESCRIPTION
By default, the API treats input as html https://cloud.google.com/translate/docs/reference/rest/v2/translate#query-parameters. Make this more clear by setting the default value to `html` and explaining this in the docstring.

Fixes internal issue 144073108