### PR TITLE
feat(bigquery): add timeout parameter to QueryJob.done() method

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1081,7 +1081,7 @@ class Client(ClientWithProject):
                 raise
 
     def _get_query_results(
-        self, job_id, retry, project=None, timeout_ms=None, location=None
+        self, job_id, retry, project=None, timeout_ms=None, location=None, timeout=None,
     ):
         """Get the query results object for a query job.
 
@@ -1096,6 +1096,9 @@ class Client(ClientWithProject):
                 (Optional) number of milliseconds the the API call should
                 wait for the query to complete before the request times out.
             location (str): Location of the query job.
+            timeout (Optional[float]):
+                The number of seconds to wait for the underlying HTTP transport
+                before retrying the HTTP request.
 
         Returns:
             google.cloud.bigquery.query._QueryResults:
@@ -1122,7 +1125,7 @@ class Client(ClientWithProject):
         # job is complete (from QueryJob.done(), called ultimately from
         # QueryJob.result()). So we don't need to poll here.
         resource = self._call_api(
-            retry, method="GET", path=path, query_params=extra_params
+            retry, method="GET", path=path, query_params=extra_params, timeout=timeout
         )
         return _QueryResults.from_api_repr(resource)
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -14,6 +14,8 @@
 
 """Define API Jobs."""
 
+from __future__ import division
+
 import copy
 import re
 import threading
@@ -3029,9 +3031,9 @@ class QueryJob(_AsyncJob):
 
         if timeout_ms is not None and timeout_ms > 0:
             if timeout is not None:
-                timeout = min(timeout_ms, timeout)
+                timeout = min(timeout_ms / 1000, timeout)
             else:
-                timeout = timeout_ms
+                timeout = timeout_ms / 1000
 
         # Do not refresh is the state is already done, as the job will not
         # change once complete.

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -16,10 +16,12 @@
 
 from __future__ import division
 
+import concurrent.futures
 import copy
 import re
 import threading
 
+import requests
 import six
 from six.moves import http_client
 
@@ -3155,6 +3157,8 @@ class QueryJob(_AsyncJob):
             exc.message += self._format_for_exception(self.query, self.job_id)
             exc.query_job = self
             raise
+        except requests.exceptions.Timeout as exc:
+            six.raise_from(concurrent.futures.TimeoutError, exc)
 
         # If the query job is complete but there are no query results, this was
         # special job, such as a DDL query. Return an empty result set to

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -30,6 +30,8 @@ version = "1.23.1"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     'enum34; python_version < "3.4"',
+    "google-auth >= 1.9.0, < 2.0dev",
+    "google-api-core >= 1.15.0, < 2.0dev",
     "google-cloud-core >= 1.0.3, < 2.0dev",
     "google-resumable-media >= 0.3.1, != 0.4.0, < 0.6.0dev",
     "protobuf >= 3.6.0",

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -226,12 +226,14 @@ class TestClient(unittest.TestCase):
                 project="other-project",
                 location=self.LOCATION,
                 timeout_ms=500,
+                timeout=42,
             )
 
         conn.api_request.assert_called_once_with(
             method="GET",
             path="/projects/other-project/queries/nothere",
             query_params={"maxResults": 0, "timeoutMs": 500, "location": self.LOCATION},
+            timeout=42,
         )
 
     def test__get_query_results_miss_w_client_location(self):
@@ -248,6 +250,7 @@ class TestClient(unittest.TestCase):
             method="GET",
             path="/projects/PROJECT/queries/nothere",
             query_params={"maxResults": 0, "location": self.LOCATION},
+            timeout=None,
         )
 
     def test__get_query_results_hit(self):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -3939,10 +3939,10 @@ class TestQueryJob(unittest.TestCase, _Base):
 
         fake_get_results.assert_called_once()
         call_args = fake_get_results.call_args
-        self.assertEqual(call_args.kwargs.get("timeout"), 8.7)
+        self.assertEqual(call_args.kwargs.get("timeout"), expected_timeout)
 
         call_args = fake_reload.call_args
-        self.assertEqual(call_args.kwargs.get("timeout"), 8.7)
+        self.assertEqual(call_args.kwargs.get("timeout"), expected_timeout)
 
     def test_query_plan(self):
         from google.cloud._helpers import _RFC3339_MICROS


### PR DESCRIPTION
Fixes #7831.
Requires #9873.

This is a proposed fix for the `done()` method getting stuck. It makes sure that the underlying HTTP request does not block indefinitely when retrieving query results, and that any underlying `requests` exceptions are retriable.

### TODO
- [x] Add missing / adjust existing tests.
- [x] Change the behavior of core.Retry to raise a timeout error at (approximately) the retry deadline, and not potentially much later that it. (#9873)
- [x] Add `timeout` parameter to `_http.JSONConnection.api_request()` (#9915)
- [x] Add `timeout` parameter to `google.auth.transport.AuthorizedSession.request()` that BigQuery client uses as its transport (https://github.com/googleapis/google-auth-library-python/pull/406)
- [x] Update BigQuery's `setup.py` to depend on the new `api_core` version, and the new `auth` library version (once the timeout-related changes are merged, and the new versions of those libraries released).