### PR TITLE
fix(pubsub): include request overhead when computing publish batch size overflow

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/publisher/_batch/base.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/_batch/base.py
@@ -75,9 +75,12 @@ class Batch(object):
     def size(self):
         """Return the total size of all of the messages currently in the batch.
 
+        The size includes any overhead of the actual ``PublishRequest`` that is
+        sent to the backend.
+
         Returns:
             int: The total size of all of the messages currently
-                 in the batch, in bytes.
+                 in the batch (including the request overhead), in bytes.
         """
         raise NotImplementedError
 

--- a/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -313,7 +313,7 @@ class Batch(base.Batch):
             new_size = self._size + size_increase
             new_count = len(self._messages) + 1
 
-            size_limit = min(self.settings.max_bytes, _SERVER_PUBLISH_MAX_BYTES)
+            size_limit = min(self._settings.max_bytes, _SERVER_PUBLISH_MAX_BYTES)
             overflow = new_size > size_limit or new_count >= self._settings.max_messages
 
             if not self._messages or not overflow:

--- a/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -289,6 +289,10 @@ class Batch(base.Batch):
             the :class:`~concurrent.futures.Future` interface or :data:`None`.
             If :data:`None` is returned, that signals that the batch cannot
             accept a message.
+
+        Raises:
+            pubsub_v1.publisher.exceptions.MessageTooLargeError: If publishing
+                the ``message`` would exceed the max size limit on the backend.
         """
         # Coerce the type, just in case.
         if not isinstance(message, types.PubsubMessage):
@@ -308,7 +312,7 @@ class Batch(base.Batch):
                     "request that would exceed the maximum allowed size on the "
                     "backend ({} bytes).".format(_SERVER_PUBLISH_MAX_BYTES)
                 )
-                raise ValueError(err_msg)
+                raise exceptions.MessageTooLargeError(err_msg)
 
             new_size = self._size + size_increase
             new_count = len(self._messages) + 1

--- a/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/_batch/thread.py
@@ -90,7 +90,7 @@ class Batch(base.Batch):
         # If max latency is specified, start a thread to monitor the batch and
         # commit when the max latency is reached.
         self._thread = None
-        if autocommit and self._settings.max_latency < float("inf"):
+        if autocommit and self.settings.max_latency < float("inf"):
             self._thread = threading.Thread(
                 name="Thread-MonitorBatchPublisher", target=self.monitor
             )
@@ -259,14 +259,14 @@ class Batch(base.Batch):
     def monitor(self):
         """Commit this batch after sufficient time has elapsed.
 
-        This simply sleeps for ``self._settings.max_latency`` seconds,
+        This simply sleeps for ``self.settings.max_latency`` seconds,
         and then calls commit unless the batch has already been committed.
         """
         # NOTE: This blocks; it is up to the calling code to call it
         #       in a separate thread.
 
         # Sleep for however long we should be waiting.
-        time.sleep(self._settings.max_latency)
+        time.sleep(self.settings.max_latency)
 
         _LOGGER.debug("Monitor is waking up")
         return self._commit()
@@ -313,8 +313,8 @@ class Batch(base.Batch):
             new_size = self._size + size_increase
             new_count = len(self._messages) + 1
 
-            size_limit = min(self._settings.max_bytes, _SERVER_PUBLISH_MAX_BYTES)
-            overflow = new_size > size_limit or new_count >= self._settings.max_messages
+            size_limit = min(self.settings.max_bytes, _SERVER_PUBLISH_MAX_BYTES)
+            overflow = new_size > size_limit or new_count >= self.settings.max_messages
 
             if not self._messages or not overflow:
 

--- a/pubsub/google/cloud/pubsub_v1/publisher/exceptions.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/exceptions.py
@@ -22,4 +22,8 @@ class PublishError(GoogleAPICallError):
     pass
 
 
-__all__ = ("PublishError", "TimeoutError")
+class MessageTooLargeError(ValueError):
+    """Attempt to publish a message that would exceed the server max size limit."""
+
+
+__all__ = ("MessageTooLargeError", "PublishError", "TimeoutError")

--- a/pubsub/google/cloud/pubsub_v1/types.py
+++ b/pubsub/google/cloud/pubsub_v1/types.py
@@ -48,7 +48,9 @@ if sys.version_info >= (3, 5):
     BatchSettings.__doc__ = "The settings for batch publishing the messages."
     BatchSettings.max_bytes.__doc__ = (
         "The maximum total size of the messages to collect before automatically "
-        "publishing the batch."
+        "publishing the batch, including any byte size overhead of the publish "
+        "request itself. The maximum value is bound by the server-side limit of "
+        "10_000_000 bytes."
     )
     BatchSettings.max_latency.__doc__ = (
         "The maximum number of seconds to wait for additional messages before "

--- a/pubsub/tests/system.py
+++ b/pubsub/tests/system.py
@@ -74,26 +74,24 @@ def cleanup():
 
 
 def test_publish_messages(publisher, topic_path, cleanup):
-    futures = []
     # Make sure the topic gets deleted.
     cleanup.append((publisher.delete_topic, topic_path))
 
     publisher.create_topic(topic_path)
-    for index in six.moves.range(500):
-        futures.append(
-            publisher.publish(
-                topic_path,
-                b"The hail in Wales falls mainly on the snails.",
-                num=str(index),
-            )
+
+    futures = [
+        publisher.publish(
+            topic_path, b"The hail in Wales falls mainly on the snails.", num=str(i)
         )
+        for i in six.moves.range(500)
+    ]
+
     for future in futures:
         result = future.result()
         assert isinstance(result, six.string_types)
 
 
 def test_publish_large_messages(publisher, topic_path, cleanup):
-    futures = []
     # Make sure the topic gets deleted.
     cleanup.append((publisher.delete_topic, topic_path))
 
@@ -112,8 +110,7 @@ def test_publish_large_messages(publisher, topic_path, cleanup):
     )
     publisher.create_topic(topic_path)
 
-    for index in six.moves.range(5):
-        futures.append(publisher.publish(topic_path, msg_data, num=str(index)))
+    futures = [publisher.publish(topic_path, msg_data, num=str(i)) for i in range(5)]
 
     # If the publishing logic correctly split all messages into more than a
     # single batch despite a high BatchSettings.max_bytes limit, there should

--- a/pubsub/tests/unit/pubsub_v1/publisher/batch/test_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/batch/test_thread.py
@@ -41,7 +41,7 @@ def create_batch(autocommit=False, topic="topic_name", **batch_settings):
         autocommit (bool): Whether the batch should commit after
             ``max_latency`` seconds. By default, this is ``False``
             for unit testing.
-        autocommit (topic): The name of the topic the batch should publish
+        topic (str): The name of the topic the batch should publish
             the messages to.
         batch_settings (dict): Arguments passed on to the
             :class:``~.pubsub_v1.types.BatchSettings`` constructor.
@@ -319,11 +319,10 @@ def test_publish_updating_batch_size():
     # The size should have been incremented by the sum of the size
     # contributions of each message to the PublishRequest.
     base_request_size = types.PublishRequest(topic="topic_foo").ByteSize()
-    msg_size_overheads = [
+    expected_request_size = base_request_size + sum(
         types.PublishRequest(messages=[msg]).ByteSize() for msg in messages
-    ]
+    )
 
-    expected_request_size = base_request_size + sum(msg_size_overheads)
     assert batch.size == expected_request_size
     assert batch.size > 0  # I do not always trust protobuf.
 

--- a/pubsub/tests/unit/pubsub_v1/publisher/batch/test_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/batch/test_thread.py
@@ -383,12 +383,8 @@ def test_publish_single_message_size_exceeds_server_size_limit():
     ).ByteSize()
     assert request_size == 1001  # sanity check, just above the (mocked) server limit
 
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(exceptions.MessageTooLargeError):
         batch.publish(big_message)
-
-    error_msg = str(error)
-    assert "too large" in error_msg
-    assert "1000 bytes" in error_msg
 
 
 @mock.patch.object(thread, "_SERVER_PUBLISH_MAX_BYTES", 1000)

--- a/pubsub/tests/unit/pubsub_v1/publisher/batch/test_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/batch/test_thread.py
@@ -34,13 +34,15 @@ def create_client():
     return publisher.Client(credentials=creds)
 
 
-def create_batch(autocommit=False, **batch_settings):
+def create_batch(autocommit=False, topic="topic_name", **batch_settings):
     """Return a batch object suitable for testing.
 
     Args:
         autocommit (bool): Whether the batch should commit after
             ``max_latency`` seconds. By default, this is ``False``
             for unit testing.
+        autocommit (topic): The name of the topic the batch should publish
+            the messages to.
         batch_settings (dict): Arguments passed on to the
             :class:``~.pubsub_v1.types.BatchSettings`` constructor.
 
@@ -49,7 +51,7 @@ def create_batch(autocommit=False, **batch_settings):
     """
     client = create_client()
     settings = types.BatchSettings(**batch_settings)
-    return Batch(client, "topic_name", settings, autocommit=autocommit)
+    return Batch(client, topic, settings, autocommit=autocommit)
 
 
 def test_init():
@@ -299,8 +301,8 @@ def test_monitor_already_committed():
     assert batch._status == status
 
 
-def test_publish():
-    batch = create_batch()
+def test_publish_updating_batch_size():
+    batch = create_batch(topic="topic_foo")
     messages = (
         types.PubsubMessage(data=b"foobarbaz"),
         types.PubsubMessage(data=b"spameggs"),
@@ -314,22 +316,28 @@ def test_publish():
     assert len(batch.messages) == 3
     assert batch._futures == futures
 
-    # The size should have been incremented by the sum of the size of the
-    # messages.
-    expected_size = sum([message_pb.ByteSize() for message_pb in messages])
-    assert batch.size == expected_size
+    # The size should have been incremented by the sum of the size
+    # contributions of each message to the PublishRequest.
+    base_request_size = types.PublishRequest(topic="topic_foo").ByteSize()
+    msg_size_overheads = [
+        types.PublishRequest(messages=[msg]).ByteSize() for msg in messages
+    ]
+
+    expected_request_size = base_request_size + sum(msg_size_overheads)
+    assert batch.size == expected_request_size
     assert batch.size > 0  # I do not always trust protobuf.
 
 
 def test_publish_not_will_accept():
-    batch = create_batch(max_messages=0)
+    batch = create_batch(topic="topic_foo", max_messages=0)
+    base_request_size = types.PublishRequest(topic="topic_foo").ByteSize()
 
     # Publish the message.
     message = types.PubsubMessage(data=b"foobarbaz")
     future = batch.publish(message)
 
     assert future is None
-    assert batch.size == 0
+    assert batch.size == base_request_size
     assert batch.messages == []
     assert batch._futures == []
 
@@ -359,6 +367,51 @@ def test_publish_exceed_max_messages():
 
         assert future is None
         assert batch._futures == futures
+
+
+@mock.patch.object(thread, "_SERVER_PUBLISH_MAX_BYTES", 1000)
+def test_publish_single_message_size_exceeds_server_size_limit():
+    batch = create_batch(
+        topic="topic_foo",
+        max_messages=1000,
+        max_bytes=1000 * 1000,  # way larger than (mocked) server side limit
+    )
+
+    big_message = types.PubsubMessage(data=b"x" * 984)
+
+    request_size = types.PublishRequest(
+        topic="topic_foo", messages=[big_message]
+    ).ByteSize()
+    assert request_size == 1001  # sanity check, just above the (mocked) server limit
+
+    with pytest.raises(ValueError) as error:
+        batch.publish(big_message)
+
+    error_msg = str(error)
+    assert "too large" in error_msg
+    assert "1000 bytes" in error_msg
+
+
+@mock.patch.object(thread, "_SERVER_PUBLISH_MAX_BYTES", 1000)
+def test_publish_total_messages_size_exceeds_server_size_limit():
+    batch = create_batch(topic="topic_foo", max_messages=10, max_bytes=1500)
+
+    messages = (
+        types.PubsubMessage(data=b"x" * 500),
+        types.PubsubMessage(data=b"x" * 600),
+    )
+
+    # Sanity check - request size is still below BatchSettings.max_bytes,
+    # but it exceeds the server-side size limit.
+    request_size = types.PublishRequest(topic="topic_foo", messages=messages).ByteSize()
+    assert 1000 < request_size < 1500
+
+    with mock.patch.object(batch, "commit") as fake_commit:
+        batch.publish(messages[0])
+        batch.publish(messages[1])
+
+    # The server side limit should kick in and cause a commit.
+    fake_commit.assert_called_once()
 
 
 def test_publish_dict():


### PR DESCRIPTION
Fixes #7108. 

This PR fixes the logic that computes the publish batch size overflow, taking the total request message size overhead into account. The improved logic prevents the server-side errors simular to the following:

> google.api_core.exceptions.InvalidArgument: 400 The value for request_size is too large. You passed 10000096 in the request, but the maximum value is 10000000.

### How to test

(see also the system test in this PR)

- Create a pubisher client with `BatchSettings.max_bytes` substantially larger than 10_000_000, and `BatchSettings.max_latency` to one second (so that the publish autocommit does not kick in too soon).
- Quickly publish a few sizable messages to a topic. Their total size should slightly exceed 10_000_000 bytes.

**Actual result (before the fix):**
The backend responds with a "400 InvalidArgument" error.

**Expected result (after the fix):**
All messages are successfully published (the code splits them into multiple publish batches).

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

