### PR TITLE
fix(automl): fix TypeError when passing a client_info to automl TablesClient

### DIFF
--- a/automl/google/cloud/automl_v1beta1/tables/tables_client.py
+++ b/automl/google/cloud/automl_v1beta1/tables/tables_client.py
@@ -104,18 +104,18 @@ class TablesClient(object):
         else:
             client_info_.user_agent = user_agent
             client_info_.gapic_version = version
-        kwargs["client_info"] = client_info_
+        kwargs.pop("client_info", None)
 
         if client is None:
             self.auto_ml_client = gapic.auto_ml_client.AutoMlClient(
-                credentials=credentials, **kwargs
+                credentials=credentials, client_info=client_info_, **kwargs
             )
         else:
             self.auto_ml_client = client
 
         if prediction_client is None:
             self.prediction_client = gapic.prediction_service_client.PredictionServiceClient(
-                credentials=credentials, **kwargs
+                credentials=credentials, client_info=client_info_, **kwargs
             )
         else:
             self.prediction_client = prediction_client

--- a/automl/google/cloud/automl_v1beta1/tables/tables_client.py
+++ b/automl/google/cloud/automl_v1beta1/tables/tables_client.py
@@ -104,17 +104,18 @@ class TablesClient(object):
         else:
             client_info_.user_agent = user_agent
             client_info_.gapic_version = version
+        kwargs["client_info"] = client_info_
 
         if client is None:
             self.auto_ml_client = gapic.auto_ml_client.AutoMlClient(
-                credentials=credentials, client_info=client_info_, **kwargs
+                credentials=credentials, **kwargs
             )
         else:
             self.auto_ml_client = client
 
         if prediction_client is None:
             self.prediction_client = gapic.prediction_service_client.PredictionServiceClient(
-                credentials=credentials, client_info=client_info_, **kwargs
+                credentials=credentials, **kwargs
             )
         else:
             self.prediction_client = prediction_client

--- a/automl/tests/unit/gapic/v1beta1/test_tables_client_v1beta1.py
+++ b/automl/tests/unit/gapic/v1beta1/test_tables_client_v1beta1.py
@@ -1424,7 +1424,7 @@ class TestTablesClient(object):
         _, prediction_client_kwargs = MockPredictionClient.call_args
         assert "credentials" in prediction_client_kwargs
         assert prediction_client_kwargs["credentials"] == credentials_mock
-    
+
     def test_prediction_client_client_info(self):
         client_info_mock = mock.Mock()
         patch_prediction_client = mock.patch(

--- a/automl/tests/unit/gapic/v1beta1/test_tables_client_v1beta1.py
+++ b/automl/tests/unit/gapic/v1beta1/test_tables_client_v1beta1.py
@@ -1424,3 +1424,14 @@ class TestTablesClient(object):
         _, prediction_client_kwargs = MockPredictionClient.call_args
         assert "credentials" in prediction_client_kwargs
         assert prediction_client_kwargs["credentials"] == credentials_mock
+    
+    def test_prediction_client_client_info(self):
+        client_info_mock = mock.Mock()
+        patch_prediction_client = mock.patch(
+            "google.cloud.automl_v1beta1.gapic.prediction_service_client.PredictionServiceClient"
+        )
+        with patch_prediction_client as MockPredictionClient:
+            client = automl_v1beta1.TablesClient(client_info=client_info_mock)
+        _, prediction_client_kwargs = MockPredictionClient.call_args
+        assert "client_info" in prediction_client_kwargs
+        assert prediction_client_kwargs["client_info"] == client_info_mock


### PR DESCRIPTION
Ensures the ClientInfo object isn't passed in twice to the underlying clients (AutoMLClient and PredictionServiceClient) from the Table Client.

Fixes #9948 🦕