### PR TITLE
docs(bigquery): add sample to read from query destination table

### DIFF
--- a/bigquery/samples/query_pagination.py
+++ b/bigquery/samples/query_pagination.py
@@ -1,0 +1,53 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def query_pagination(client):
+
+    # [START bigquery_query_pagination]
+    # TODO(developer): Import the client library.
+    # from google.cloud import bigquery
+
+    # TODO(developer): Construct a BigQuery client object.
+    # client = bigquery.Client()
+
+    query = """
+        SELECT name, SUM(number) as total_people
+        FROM `bigquery-public-data.usa_names.usa_1910_2013`
+        GROUP BY name
+        ORDER BY total_people DESC
+    """
+    query_job = client.query(query)  # Make an API request.
+    query_job.result()  # Wait for the query to complete.
+
+    # Get the destination table for the query results.
+    #
+    # All queries write to a destination table. If a destination table is not
+    # specified, the BigQuery populates it with a reference to a temporary
+    # anonymous table after the query completes.
+    destination = query_job.destination
+
+    # Get the schema (and other properties) for the destination table.
+    #
+    # A schema is useful for converting from BigQuery types to Python types.
+    destination = client.get_table(destination)
+
+    # Download rows.
+    #
+    # The client library automatically handles pagination.
+    print("The query data:")
+    rows = client.list_rows(destination, max_results=20)
+    for row in rows:
+        print("name={}, count={}".format(row["name"], row["total_people"]))
+    # [END bigquery_query_pagination]

--- a/bigquery/samples/tests/test_query_pagination.py
+++ b/bigquery/samples/tests/test_query_pagination.py
@@ -1,0 +1,23 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .. import query_pagination
+
+
+def test_query_pagination(capsys, client):
+
+    query_pagination.query_pagination(client)
+    out, _ = capsys.readouterr()
+    assert "The query data:" in out
+    assert "name=James, count=4942431" in out


### PR DESCRIPTION
This sample addresses internal issue 134774673, in which we recieved
feedback that it's not clear how to paginate through the results of a
query. This sample shows that all completed queries have a destination
table, which can be read from with tabledata.list.

Note: The client library avoids the extra call to `get_table` if query
results are read directly from the QueryJob, but it's confusing to show
that we're able to get the schema from a private API call to
getQueryResults.
