### PR TITLE
[Syntax Review] Additional types of SampleGen code samples

### DIFF
--- a/language/samples/v1/samplegen_map_field_access.py
+++ b/language/samples/v1/samplegen_map_field_access.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_map_field_access")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-language
+
+# sample-metadata
+#   title: This sample reads and loops over a map field in the response
+#   description: This sample reads and loops over a map field in the response
+#   usage: python3 samples/v1/samplegen_map_field_access.py
+
+# [START samplegen_map_field_access]
+from google.cloud import language_v1
+from google.cloud.language_v1 import enums
+
+
+def sample_analyze_entities():
+    """This sample reads and loops over a map field in the response"""
+
+    client = language_v1.LanguageServiceClient()
+
+    type_ = enums.Document.Type.PLAIN_TEXT
+    language = "en"
+
+    # The text content to analyze
+    content = "Googleplex is at 1600 Amphitheatre Parkway, Mountain View, CA."
+    document = {"type": type_, "language": language, "content": content}
+
+    response = client.analyze_entities(document)
+    for entity in response.entities:
+        # Each detected entity has a map of metadata:
+        map_ = entity.metadata
+        # Access value by key:
+        print(u"URL: {}".format(map_["wikipedia_url"]))
+        # Loop over keys and values:
+        for key, value in map_.items():
+            print(u"{}: {}".format(key, value))
+
+        # Loop over just keys:
+        for the_key, _ in map_.items():
+            print(u"Key: {}".format(the_key))
+
+        # Loop over just values:
+        for _, the_value in map_.items():
+            print(u"Value: {}".format(the_value))
+
+
+# [END samplegen_map_field_access]
+
+
+def main():
+    sample_analyze_entities()
+
+
+if __name__ == "__main__":
+    main()

--- a/language/samples/v1/samplegen_map_field_access.py
+++ b/language/samples/v1/samplegen_map_field_access.py
@@ -43,20 +43,18 @@ def sample_analyze_entities():
 
     response = client.analyze_entities(document)
     for entity in response.entities:
-        # Each detected entity has a map of metadata:
-        map_ = entity.metadata
         # Access value by key:
-        print(u"URL: {}".format(map_["wikipedia_url"]))
+        print(u"URL: {}".format(entity.metadata["wikipedia_url"]))
         # Loop over keys and values:
-        for key, value in map_.items():
+        for key, value in entity.metadata.items():
             print(u"{}: {}".format(key, value))
 
         # Loop over just keys:
-        for the_key, _ in map_.items():
+        for the_key, _ in entity.metadata.items():
             print(u"Key: {}".format(the_key))
 
         # Loop over just values:
-        for _, the_value in map_.items():
+        for _, the_value in entity.metadata.items():
             print(u"Value: {}".format(the_value))
 
 

--- a/speech/samples/v1p1beta1/samplegen_lro.py
+++ b/speech/samples/v1p1beta1/samplegen_lro.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("LongRunningPromise",  "samplegen_lro")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-speech
+
+# sample-metadata
+#   title: Calling Long-Running API method
+#   description: Calling Long-Running API method
+#   usage: python3 samples/v1p1beta1/samplegen_lro.py
+
+# [START samplegen_lro]
+from google.cloud import speech_v1p1beta1
+from google.cloud.speech_v1p1beta1 import enums
+
+
+def sample_long_running_recognize():
+    """Calling Long-Running API method"""
+
+    client = speech_v1p1beta1.SpeechClient()
+
+    encoding = enums.RecognitionConfig.AudioEncoding.MP3
+    config = {"encoding": encoding}
+    uri = "gs://[BUCKET]/[FILENAME]"
+    audio = {"uri": uri}
+
+    operation = client.long_running_recognize(config, audio)
+
+    print(u"Waiting for operation to complete...")
+    response = operation.result()
+
+    # Your audio has been transcribed.
+    print(u"Transcript: {}".format(response.results[0].alternatives[0].transcript))
+
+
+# [END samplegen_lro]
+
+
+def main():
+    sample_long_running_recognize()
+
+
+if __name__ == "__main__":
+    main()

--- a/speech/samples/v1p1beta1/samplegen_read_and_write_files.py
+++ b/speech/samples/v1p1beta1/samplegen_read_and_write_files.py
@@ -20,8 +20,8 @@
 #   pip install google-cloud-speech
 
 # sample-metadata
-#   title: Showing repeated fields (in request and response)
-#   description: Showing repeated fields (in request and response)
+#   title: Read binary file into bytes field & write string in response to file
+#   description: Read binary file into bytes field & write string in response to file
 #   usage: python3 samples/v1p1beta1/samplegen_read_and_write_files.py
 
 # [START samplegen_read_and_write_files]
@@ -31,7 +31,7 @@ import io
 
 
 def sample_recognize():
-    """Showing repeated fields (in request and response)"""
+    """Read binary file into bytes field & write string in response to file"""
 
     client = speech_v1p1beta1.SpeechClient()
 

--- a/speech/samples/v1p1beta1/samplegen_read_and_write_files.py
+++ b/speech/samples/v1p1beta1/samplegen_read_and_write_files.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_read_and_write_files")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-speech
+
+# sample-metadata
+#   title: Showing repeated fields (in request and response)
+#   description: Showing repeated fields (in request and response)
+#   usage: python3 samples/v1p1beta1/samplegen_read_and_write_files.py
+
+# [START samplegen_read_and_write_files]
+from google.cloud import speech_v1p1beta1
+from google.cloud.speech_v1p1beta1 import enums
+import io
+
+
+def sample_recognize():
+    """Showing repeated fields (in request and response)"""
+
+    client = speech_v1p1beta1.SpeechClient()
+
+    encoding = enums.RecognitionConfig.AudioEncoding.MP3
+    config = {"encoding": encoding}
+
+    # The bytes from this file will be read into `content`
+    with io.open("path/to/file.mp3", "rb") as f:
+        content = f.read()
+    audio = {"content": content}
+
+    response = client.recognize(config, audio)
+    # Your audio has been transcribed.
+    # Writing audio transcript to transcript.txt for demonstration:
+    with open("transcript.txt", "w") as out:
+        out.write(response.results[0].alternatives[0].transcript)
+
+
+# [END samplegen_read_and_write_files]
+
+
+def main():
+    sample_recognize()
+
+
+if __name__ == "__main__":
+    main()

--- a/speech/samples/v1p1beta1/samplegen_repeated_fields.py
+++ b/speech/samples/v1p1beta1/samplegen_repeated_fields.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_repeated_fields")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-speech
+
+# sample-metadata
+#   title: Showing repeated fields (in request and response)
+#   description: Showing repeated fields (in request and response)
+#   usage: python3 samples/v1p1beta1/samplegen_repeated_fields.py
+
+# [START samplegen_repeated_fields]
+from google.cloud import speech_v1p1beta1
+from google.cloud.speech_v1p1beta1 import enums
+
+
+def sample_recognize():
+    """Showing repeated fields (in request and response)"""
+
+    client = speech_v1p1beta1.SpeechClient()
+
+    encoding = enums.RecognitionConfig.AudioEncoding.MP3
+
+    # A list of strings containing words and phrases "hints"
+    phrases_element = "Fox in socks"
+    phrases_element_2 = "Knox in box"
+    phrases = [phrases_element, phrases_element_2]
+    speech_contexts_element = {"phrases": phrases}
+    speech_contexts = [speech_contexts_element]
+    config = {"encoding": encoding, "speech_contexts": speech_contexts}
+    uri = "gs://[BUCKET]/[FILENAME]"
+    audio = {"uri": uri}
+
+    response = client.recognize(config, audio)
+    # Loop over all transcription results
+    for result in response.results:
+        # The first "alternative" of each result contains most likely transcription
+        alternative = result.alternatives[0]
+        print(u"Transcription of result: {}".format(alternative.transcript))
+
+
+# [END samplegen_repeated_fields]
+
+
+def main():
+    sample_recognize()
+
+
+if __name__ == "__main__":
+    main()

--- a/texttospeech/samples/v1/samplegen_write_bytes_to_file.py
+++ b/texttospeech/samples/v1/samplegen_write_bytes_to_file.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_write_bytes_to_file")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-texttospeech
+
+# sample-metadata
+#   title: Synthesize an .mp3 file with audio saying the provided phrase
+#   description: Synthesize an .mp3 file with audio saying the provided phrase
+#   usage: python3 samples/v1/samplegen_write_bytes_to_file.py
+
+# [START samplegen_write_bytes_to_file]
+from google.cloud import texttospeech_v1
+from google.cloud.texttospeech_v1 import enums
+
+
+def sample_synthesize_speech():
+    """Synthesize an .mp3 file with audio saying the provided phrase"""
+
+    client = texttospeech_v1.TextToSpeechClient()
+
+    text = "Hello, world!"
+    input_ = {"text": text}
+    language_code = "en"
+    voice = {"language_code": language_code}
+    audio_encoding = enums.AudioEncoding.MP3
+    audio_config = {"audio_encoding": audio_encoding}
+
+    response = client.synthesize_speech(input_, voice, audio_config)
+    print(u"Writing the synthsized results to output.mp3")
+    with open("output.mp3", "wb") as out:
+        out.write(response.audio_content)
+
+
+# [END samplegen_write_bytes_to_file]
+
+
+def main():
+    sample_synthesize_speech()
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/samples/v1/samplegen_basics.py
+++ b/vision/samples/v1/samplegen_basics.py
@@ -29,7 +29,12 @@ from google.cloud import vision_v1
 
 
 def sample_create_product_set(display_name):
-    """This is the sample description"""
+    """
+    This is the sample description
+
+    Args:
+      display_name Description of the parameter
+    """
 
     client = vision_v1.ProductSearchClient()
 

--- a/vision/samples/v1/samplegen_basics.py
+++ b/vision/samples/v1/samplegen_basics.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_basics")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-vision
+
+# sample-metadata
+#   title: This is the sample title
+#   description: This is the sample description
+#   usage: python3 samples/v1/samplegen_basics.py [--display_name "This is the default value of the display_name request field"]
+
+# [START samplegen_basics]
+from google.cloud import vision_v1
+
+
+def sample_create_product_set(display_name):
+    """This is the sample description"""
+
+    client = vision_v1.ProductSearchClient()
+
+    # display_name = 'This is the default value of the display_name request field'
+
+    # The project and location in which the product set should be created.
+    parent = client.location_path("[PROJECT]", "[LOCATION]")
+    product_set = {"display_name": display_name}
+
+    response = client.create_product_set(parent, product_set)
+    # The API response represents the created product set
+    product_set = response
+    print(u"The full name of the created product set: {}".format(product_set.name))
+
+
+# [END samplegen_basics]
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--display_name",
+        type=str,
+        default="This is the default value of the display_name request field",
+    )
+    args = parser.parse_args()
+
+    sample_create_product_set(args.display_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/samples/v1/samplegen_no_config.py
+++ b/vision/samples/v1/samplegen_no_config.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_no_config")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-vision
+
+# sample-metadata
+#   title:
+#   usage: python3 samples/v1/samplegen_no_config.py
+
+# [START ]
+from google.cloud import vision_v1
+
+
+def sample_create_product_set():
+
+    client = vision_v1.ProductSearchClient()
+
+    parent = client.location_path("[PROJECT]", "[LOCATION]")
+    product_set = {}
+
+    response = client.create_product_set(parent, product_set)
+    print(response)
+
+
+# [END ]
+
+
+def main():
+    sample_create_product_set()
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/samples/v1/samplegen_no_response.py
+++ b/vision/samples/v1/samplegen_no_response.py
@@ -37,7 +37,7 @@ def sample_delete_product_set():
     name = client.product_set_path("[PROJECT]", "[LOCATION]", "[PRODUCT_SET]")
 
     client.delete_product_set(name)
-    # Deleted product set.
+    print(u"Deleted product set.")
 
 
 # [END samplegen_no_response]

--- a/vision/samples/v1/samplegen_no_response.py
+++ b/vision/samples/v1/samplegen_no_response.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_no_response")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-vision
+
+# sample-metadata
+#   title: Delete Product Set (returns Empty)
+#   description: Delete Product Set (returns Empty)
+#   usage: python3 samples/v1/samplegen_no_response.py
+
+# [START samplegen_no_response]
+from google.cloud import vision_v1
+
+
+def sample_delete_product_set():
+    """Delete Product Set (returns Empty)"""
+
+    client = vision_v1.ProductSearchClient()
+
+    # The full name of the product set to delete
+    name = client.product_set_path("[PROJECT]", "[LOCATION]", "[PRODUCT_SET]")
+
+    client.delete_product_set(name)
+    # Deleted product set.
+
+
+# [END samplegen_no_response]
+
+
+def main():
+    sample_delete_product_set()
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/samples/v1/samplegen_paged.py
+++ b/vision/samples/v1/samplegen_paged.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("RequestPagedAll",  "samplegen_paged")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-vision
+
+# sample-metadata
+#   title: List product sets
+#   description: List product sets
+#   usage: python3 samples/v1/samplegen_paged.py
+
+# [START samplegen_paged]
+from google.cloud import vision_v1
+
+
+def sample_list_product_sets():
+    """List product sets"""
+
+    client = vision_v1.ProductSearchClient()
+
+    # The project and location where the product sets are contained.
+    parent = client.location_path("[PROJECT]", "[LOCATION]")
+
+    # Iterate over all results
+    for response_item in client.list_product_sets(parent):
+        # The entity in this iteration represents a product set
+        product_set = response_item
+        print(u"The full name of this product set: {}".format(product_set.name))
+
+
+# [END samplegen_paged]
+
+
+def main():
+    sample_list_product_sets()
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/samples/v1/samplegen_resource_path.py
+++ b/vision/samples/v1/samplegen_resource_path.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT! This is a generated sample ("Request",  "samplegen_resource_path")
+
+# To install the latest published package dependency, execute the following:
+#   pip install google-cloud-vision
+
+# sample-metadata
+#   title: Create product set (demonstrate resource paths)
+#   description: Create product set (demonstrate resource paths)
+#   usage: python3 samples/v1/samplegen_resource_path.py [--project "[PROJECT ID]"]
+
+# [START samplegen_resource_path]
+from google.cloud import vision_v1
+
+
+def sample_create_product_set(project):
+    """
+    Create product set (demonstrate resource paths)
+
+    Args:
+      project The Google Cloud Project for creating this product set
+    """
+
+    client = vision_v1.ProductSearchClient()
+
+    # project = '[PROJECT ID]'
+    parent = client.location_path(project, "us-central1")
+    display_name = "[DISPLAY NAME]"
+    product_set = {"display_name": display_name}
+
+    response = client.create_product_set(parent, product_set)
+    # The API response represents the created product set
+    product_set = response
+    print(u"The full name of the created product set: {}".format(product_set.name))
+
+
+# [END samplegen_resource_path]
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", type=str, default="[PROJECT ID]")
+    args = parser.parse_args()
+
+    sample_create_product_set(args.project)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
> _Follow-up code review PR –_

To **evaluate the readiness** of 🐍 **Python's GAPIC sample generator** for use on [cloud.google.com](https://cloud.google.com),  
this provides a full _**set of samples**_ which _**demonstrate the basic features**_ of generated samples.

> _The .yaml sample config files for these samples can all be found here: [.yaml sample configs](https://github.com/beccasaurus/googleapis/compare/samples-for-syntax-review)_

The [first review Pull Request](https://github.com/googleapis/google-cloud-python/pull/9514) contained samples to show the _basic structure_ as well as _LRO samples_.

This contains samples demonstrating those features and a few more use-cases for review –

| **Sample** | **Description** |
|------------|-----------------|
| [`samplegen_basics.py`](https://github.com/googleapis/google-cloud-python/pull/9970/files#diff-e8316523cb5d6b59f52ba104d6ca6494) | Shows basic structure/anatomy of Python samples |
| [`samplegen_no_config.py`](https://github.com/googleapis/google-cloud-python/pull/9970/files#diff-dedf18a9ca41cbb29de05d1a2c0c2942) | Minimal sample example (zero configuration) |
| [`samplegen_no_response.py`](https://github.com/googleapis/google-cloud-python/pull/9970/files#diff-957468985120c13be596acb8b3e8f80f) | API method which returns Empty |
| [`samplegen_paged.py`](https://github.com/googleapis/google-cloud-python/pull/9970/files#diff-c9d69a27ad945d6015f2f02e54ee15da) | Paged API method (iterates over pages of results) |
| [`samplegen_resource_path.py`](https://github.com/googleapis/google-cloud-python/pull/9970/files#diff-04b3c62b1ec47ffaafcb713dc2a22798) | Sample which requires user's Google Project ID |
| [`samplegen_map_field_access.py`](https://github.com/googleapis/google-cloud-python/pull/9970/files#diff-0ac7074351beb4f3e6698f2884d383b1) | Access map value by key and enumerate keys/values |
| [`samplegen_read_and_write_files.py`](https://github.com/googleapis/google-cloud-python/pull/9970/files#diff-19ff6af9d8696d9ae84236907f29ee4f) | Read binary file into bytes & write string to local file |
| [`samplegen_repeated_fields.py`](https://github.com/googleapis/google-cloud-python/pull/9970/files#diff-c8f9af70ce5bc9d0ccdb976d4bd4f0f5) | Repeated request field & show loop/access by index |
| [`samplegen_write_bytes_to_file.py`](https://github.com/googleapis/google-cloud-python/pull/9970/files#diff-54381aaa9481a571224843fcf7bdaf23) | Write bytes field in response to local file |
| [`samplegen_lro.py`](https://github.com/googleapis/google-cloud-python/pull/9970/files#diff-dd17b8952fced606e8e2ab257724c9ae) | Call long-running operation API endpoint |

This Pull Request is focused on **feedback collection** & a similar PR is being sent to all languages.

Once you've completed your **review** and left **comments**, you may feel free to **close the PR!**

> _We will scope out making all of the requested changes and reach out to language team offline._

#### 🙏 Thanks in advance for your review!

----

P.S. **Nits welcome!** _We'd like to get these as polished as possible for usage on [cloud.google.com](https://cloud.google.com)._

> Please feel free to note in comments whether something is:  🛑 Blocker -vs- 📌 Nit

-----

#### 🔍 Known Issues

 1. Should import libraries w/o version suffix, e.g. `from google.cloud import speech_v1 as speech`
 1. Docstring is missing `:` and is missing type, it should be `var_name (Type): description here`
 1. ❓ **Open Question:** Is the preference to show the method definition or only show method body?

> 📑 ([internal](http://go/samplegen-syntax))