### PR TITLE
fix(pubsub): handle None in on response callback

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py
@@ -542,6 +542,13 @@ class StreamingPullManager(object):
         After the messages have all had their ack deadline updated, execute
         the callback for each message using the executor.
         """
+        if response is None:
+            _LOGGER.debug(
+                "Response callback invoked with None, likely due to a "
+                "transport shutdown."
+            )
+            return
+
         _LOGGER.debug(
             "Processing %s received message(s), currenty on hold %s (bytes %s).",
             len(response.received_messages),

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_streaming_pull_manager.py
@@ -721,6 +721,21 @@ def test__on_response_with_leaser_overload():
             assert msg.message_id in ("2", "3")
 
 
+def test__on_response_none_data(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    manager, _, dispatcher, leaser, _, scheduler = make_running_manager()
+    manager._callback = mock.sentinel.callback
+
+    # adjust message bookkeeping in leaser
+    fake_leaser_add(leaser, init_msg_count=0, assumed_msg_size=10)
+
+    manager._on_response(response=None)
+
+    scheduler.schedule.assert_not_called()
+    assert "callback invoked with None" in caplog.text
+
+
 def test_retryable_stream_errors():
     # Make sure the config matches our hard-coded tuple of exceptions.
     interfaces = subscriber_client_config.config["interfaces"]


### PR DESCRIPTION
Fixes #9975.

This PR fixes an error that can occur when the streaming pull manager is being shut down when the underlying RPC gets shut down.

When that happens, the StreamingPullManager's _on_response() method is invoked with `None` (as opposed to a `StreamingPullResponse` instance). This commit handles this case gracefully.

### How to test
(this is how I managed to reproduce the error on my machine consistently)

- Use PubSub `v1.1.0` (the bug does reportedly not occur in an earlier version, e.g. `v1.0.2`)
- Create a topic and a subscription to that topic.
- (optional) Set logging level to DEBUG.
- Start pulling messages from the subscription using the subscriber's streaming pull.
- While pulling messages, generate a keyboard interrupt, and cancel the streaming pull future as a response to the interrupt.
(alternative: close the channel manually: `subscriber.api.transport.channel.close()`

**Actual result** (before the fix):
An error occurs during the shutdown (_"'NoneType' object has no attribute 'received_messages'"_) in one of the background threads.

**Expected result** (after the fix):
No error occurs, and the streaming pull shuts down cleanly (check the DEBUG log output for details).

A sketch of the test script:
```py
subscriber = pubsub_v1.SubscriberClient()
future = subscriber.subscribe(SUBSCRIPTION_PATH, callback=lambda msg: None)

try:
    future.result()
except KeyboardInterrupt:
    future.cancel()
```

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

