### PR TITLE
fix: recover watch stream on more error types

### DIFF
--- a/firestore/google/cloud/firestore_v1/watch.py
+++ b/firestore/google/cloud/firestore_v1/watch.py
@@ -58,7 +58,10 @@ GRPC_STATUS_CODE = {
 }
 _RPC_ERROR_THREAD_NAME = "Thread-OnRpcTerminated"
 _RECOVERABLE_STREAM_EXCEPTIONS = (
+    exceptions.Aborted,
+    exceptions.Cancelled,
     exceptions.Unknown,
+    exceptions.DeadlineExceeded,
     exceptions.ResourceExhausted,
     exceptions.InternalServerError,
     exceptions.ServiceUnavailable,

--- a/firestore/google/cloud/firestore_v1/watch.py
+++ b/firestore/google/cloud/firestore_v1/watch.py
@@ -57,7 +57,14 @@ GRPC_STATUS_CODE = {
     "DO_NOT_USE": -1,
 }
 _RPC_ERROR_THREAD_NAME = "Thread-OnRpcTerminated"
-_RECOVERABLE_STREAM_EXCEPTIONS = (exceptions.ServiceUnavailable,)
+_RECOVERABLE_STREAM_EXCEPTIONS = (
+    exceptions.Unknown,
+    exceptions.DeadlineExceeded,
+    exceptions.ResourceExhausted,
+    exceptions.InternalServerError,
+    exceptions.ServiceUnavailable,
+    exceptions.Unauthenticated,
+)
 _TERMINATING_STREAM_EXCEPTIONS = (exceptions.Cancelled,)
 
 DocTreeEntry = collections.namedtuple("DocTreeEntry", ["value", "index"])

--- a/firestore/google/cloud/firestore_v1/watch.py
+++ b/firestore/google/cloud/firestore_v1/watch.py
@@ -59,7 +59,6 @@ GRPC_STATUS_CODE = {
 _RPC_ERROR_THREAD_NAME = "Thread-OnRpcTerminated"
 _RECOVERABLE_STREAM_EXCEPTIONS = (
     exceptions.Unknown,
-    exceptions.DeadlineExceeded,
     exceptions.ResourceExhausted,
     exceptions.InternalServerError,
     exceptions.ServiceUnavailable,


### PR DESCRIPTION
Watch Retry is more permissive in Go. This PR replicates that in Python.

Fixes #9890 and b/144734355