### PR TITLE
fix: add ability to use single-row transactions

### DIFF
--- a/bigtable/google/cloud/bigtable/row.py
+++ b/bigtable/google/cloud/bigtable/row.py
@@ -582,6 +582,7 @@ class ConditionalRow(_SetDeleteRow):
             table_name=self._table.name,
             row_key=self._row_key,
             predicate_filter=self._filter.to_pb(),
+            app_profile_id=self._table._app_profile_id,
             true_mutations=true_mutations,
             false_mutations=false_mutations,
         )
@@ -908,7 +909,10 @@ class AppendRow(Row):
 
         data_client = self._table._instance._client.table_data_client
         row_response = data_client.read_modify_write_row(
-            table_name=self._table.name, row_key=self._row_key, rules=self._rule_pb_list
+            table_name=self._table.name,
+            row_key=self._row_key,
+            rules=self._rule_pb_list,
+            app_profile_id=self._table._app_profile_id
         )
 
         # Reset modifications after commit-ing request.

--- a/bigtable/google/cloud/bigtable/row.py
+++ b/bigtable/google/cloud/bigtable/row.py
@@ -912,7 +912,7 @@ class AppendRow(Row):
             table_name=self._table.name,
             row_key=self._row_key,
             rules=self._rule_pb_list,
-            app_profile_id=self._table._app_profile_id
+            app_profile_id=self._table._app_profile_id,
         )
 
         # Reset modifications after commit-ing request.


### PR DESCRIPTION
Fixes #10018 🦕

Tested manually with the following script, no longer getting ` google.api_core.exceptions.FailedPrecondition: 400 Single-row transactions are not allowed by this app profile` and confirmed data was written to my test table.
```python
#!/usr/bin/env python

from google.cloud.bigtable.client import Client
from google.cloud.bigtable.row import ConditionalRow
from google.cloud.bigtable.row_filters import PassAllFilter

PROJECT_ID="<PROJECT_ID>"
INSTANCE_ID="<INSTANCE_ID>"
TABLE_ID="<TABLE_ID>"
APP_PROFILE_ID="<APP_PROFILE_ID>"

client = Client(project=PROJECT_ID)
instance = client.instance(instance_id=INSTANCE_ID)
table = instance.table(table_id=TABLE_ID, app_profile_id=APP_PROFILE_ID)

row_cond = ConditionalRow(b'test_conditional', table, PassAllFilter(True))
row_cond.set_cell('test_column_family', 'test_column_qualifier', 'test_cell_value', timestamp=None, state=False)
row_cond.commit()

row = table.row("test_append", append=True)
row.append_cell_value(u'test_column_family', b'test_column_qualifier', b'test-value')
row.commit()
```