### PR TITLE
feat(bigquery): add retry parameter to public methods where missing

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -208,7 +208,9 @@ class Client(ClientWithProject):
         self._http._auth_request.session.close()
         self._http.close()
 
-    def get_service_account_email(self, project=None, timeout=None):
+    def get_service_account_email(
+        self, project=None, retry=DEFAULT_RETRY, timeout=None
+    ):
         """Get the email address of the project's BigQuery service account
 
         Note:
@@ -219,8 +221,10 @@ class Client(ClientWithProject):
             project (str, optional):
                 Project ID to use for retreiving service account email.
                 Defaults to the client's project.
+            retry (Optional[google.api_core.retry.Retry]): How to retry the RPC.
             timeout (Optional[float]):
-                The number of seconds to wait for the API response.
+                The number of seconds to wait for the underlying HTTP transport
+                before using ``retry``.
 
         Returns:
             str: service account email address
@@ -237,10 +241,7 @@ class Client(ClientWithProject):
             project = self.project
         path = "/projects/%s/serviceAccount" % (project,)
 
-        # TODO: call thorugh self._call_api() and allow passing in a retry?
-        api_response = self._connection.api_request(
-            method="GET", path=path, timeout=timeout
-        )
+        api_response = self._call_api(retry, method="GET", path=path, timeout=timeout)
         return api_response["email"]
 
     def list_projects(

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -710,7 +710,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         )
         self._set_properties(api_response)
 
-    def cancel(self, client=None, timeout=None):
+    def cancel(self, client=None, retry=DEFAULT_RETRY, timeout=None):
         """API call:  cancel job via a POST request
 
         See
@@ -720,8 +720,10 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
             client (Optional[google.cloud.bigquery.client.Client]):
                 the client to use.  If not passed, falls back to the
                 ``client`` stored on the current dataset.
+            retry (Optional[google.api_core.retry.Retry]): How to retry the RPC.
             timeout (Optional[float]):
-                The number of seconds to wait for the API response.
+                The number of seconds to wait for the underlying HTTP transport
+                before using ``retry``
 
         Returns:
             bool: Boolean indicating that the cancel request was sent.
@@ -732,10 +734,10 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         if self.location:
             extra_params["location"] = self.location
 
-        # TODO: call thorugh client._call_api() and allow passing in a retry?
-        api_response = client._connection.api_request(
+        api_response = client._call_api(
+            retry,
             method="POST",
-            path="%s/cancel" % (self.path,),
+            path="{}/cancel".format(self.path),
             query_params=extra_params,
             timeout=timeout,
         )


### PR DESCRIPTION
Fixes #10019.

This PR adds support for a retry to Client and Job methods where missing.

PR checklist:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
