### PR TITLE
refactor(bigquery): `to_dataframe` uses faster `to_arrow` + `to_pandas` when `pyarrow` is available

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1519,6 +1519,17 @@ class RowIterator(HTTPIterator):
         if pyarrow is None:
             raise ValueError(_NO_PYARROW_ERROR)
 
+        if (
+            bqstorage_client or create_bqstorage_client
+        ) and self.max_results is not None:
+            warnings.warn(
+                "Cannot use bqstorage_client if max_results is set, "
+                "reverting to fetching data with the tabledata.list endpoint.",
+                stacklevel=2,
+            )
+            create_bqstorage_client = False
+            bqstorage_client = None
+
         owns_bqstorage_client = False
         if not bqstorage_client and create_bqstorage_client:
             owns_bqstorage_client = True
@@ -1674,33 +1685,39 @@ class RowIterator(HTTPIterator):
             create_bqstorage_client = False
             bqstorage_client = None
 
-        owns_bqstorage_client = False
-        if not bqstorage_client and create_bqstorage_client:
-            owns_bqstorage_client = True
-            bqstorage_client = self.client._create_bqstorage_client()
+        if pyarrow is not None:
+            # If pyarrow is available, calling to_arrow, then converting to a
+            # pandas dataframe is about 2x faster. This is because pandas.concat is
+            # rarely no-copy, whereas pyarrow.Table.from_batches + to_pandas is
+            # usually no-copy.
+            record_batch = self.to_arrow(
+                progress_bar_type=progress_bar_type,
+                bqstorage_client=bqstorage_client,
+                create_bqstorage_client=create_bqstorage_client,
+            )
+            df = record_batch.to_pandas()
+            for column in dtypes:
+                df[column] = pandas.Series(df[column], dtype=dtypes[column])
+            return df
 
-        try:
-            progress_bar = self._get_progress_bar(progress_bar_type)
+        # The bqstorage_client is only used if pyarrow is available, so the
+        # rest of this method only needs to account for tabledata.list.
+        progress_bar = self._get_progress_bar(progress_bar_type)
 
-            frames = []
-            for frame in self._to_dataframe_iterable(
-                bqstorage_client=bqstorage_client, dtypes=dtypes
-            ):
-                frames.append(frame)
-
-                if progress_bar is not None:
-                    # In some cases, the number of total rows is not populated
-                    # until the first page of rows is fetched. Update the
-                    # progress bar's total to keep an accurate count.
-                    progress_bar.total = progress_bar.total or self.total_rows
-                    progress_bar.update(len(frame))
+        frames = []
+        for frame in self._to_dataframe_iterable(dtypes=dtypes):
+            frames.append(frame)
 
             if progress_bar is not None:
-                # Indicate that the download has finished.
-                progress_bar.close()
-        finally:
-            if owns_bqstorage_client:
-                bqstorage_client.transport.channel.close()
+                # In some cases, the number of total rows is not populated
+                # until the first page of rows is fetched. Update the
+                # progress bar's total to keep an accurate count.
+                progress_bar.total = progress_bar.total or self.total_rows
+                progress_bar.update(len(frame))
+
+        if progress_bar is not None:
+            # Indicate that the download has finished.
+            progress_bar.close()
 
         # Avoid concatting an empty list.
         if not frames:

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -2369,7 +2369,12 @@ class TestBigQuery(unittest.TestCase):
         row = df.iloc[0]
         # verify the row content
         self.assertEqual(row["string_col"], "Some value")
-        self.assertEqual(row["record_col"], record)
+        expected_keys = tuple(sorted(record.keys()))
+        row_keys = tuple(sorted(row["record_col"].keys()))
+        self.assertEqual(row_keys, expected_keys)
+        # Can't compare numpy arrays, which pyarrow encodes the embedded
+        # repeated column to, so convert to list.
+        self.assertEqual(list(row["record_col"]["nested_repeated"]), [0, 1, 2])
         # verify that nested data can be accessed with indices/keys
         self.assertEqual(row["record_col"]["nested_repeated"][0], 0)
         self.assertEqual(

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -2138,7 +2138,7 @@ class TestRowIterator(unittest.TestCase):
         mock_rows = mock.create_autospec(reader.ReadRowsIterable)
         mock_rowstream.rows.return_value = mock_rows
         page_dataframe = pandas.DataFrame(
-            {"colA": [1, -1], "colC": [2.0, 4.0], "colB": ["abc", "def"],},
+            {"colA": [1, -1], "colC": [2.0, 4.0], "colB": ["abc", "def"]},
         )
         mock_page = mock.create_autospec(reader.ReadRowsPage)
         mock_page.to_dataframe.return_value = page_dataframe

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -1809,7 +1809,10 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(child_field.type.value_type[0].name, "name")
         self.assertEqual(child_field.type.value_type[1].name, "age")
 
-    @unittest.skipIf(pandas is None, "Requires `pandas`")
+    @unittest.skipIf(pyarrow is None, "Requires `pyarrow`")
+    @unittest.skipIf(
+        bigquery_storage_v1beta1 is None, "Requires `google-cloud-bigquery-storage`"
+    )
     def test_to_arrow_max_results_w_create_bqstorage_warning(self):
         from google.cloud.bigquery.schema import SchemaField
 

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -2225,6 +2225,24 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(list(df), ["name", "age"])  # verify the column names
 
     @unittest.skipIf(pandas is None, "Requires `pandas`")
+    def test_to_dataframe_w_empty_results_wo_pyarrow(self):
+        from google.cloud.bigquery.schema import SchemaField
+
+        with mock.patch("google.cloud.bigquery.table.pyarrow", None):
+            schema = [
+                SchemaField("name", "STRING", mode="REQUIRED"),
+                SchemaField("age", "INTEGER", mode="REQUIRED"),
+            ]
+            api_request = mock.Mock(return_value={"rows": []})
+            row_iterator = self._make_one(_mock_client(), api_request, schema=schema)
+
+            df = row_iterator.to_dataframe()
+
+            self.assertIsInstance(df, pandas.DataFrame)
+            self.assertEqual(len(df), 0)  # verify the number of rows
+            self.assertEqual(list(df), ["name", "age"])  # verify the column names
+
+    @unittest.skipIf(pandas is None, "Requires `pandas`")
     def test_to_dataframe_logs_tabledata_list(self):
         from google.cloud.bigquery.table import Table
 


### PR DESCRIPTION
…pyarrow is available

Related to similar PR https://github.com/googleapis/google-cloud-python/pull/9997 but for the `google-cloud-bigquery` library.

Fixes https://issuetracker.google.com/140579733