### PR TITLE
doc(bigquery): uncomment `Client` constructor and imports in samples

### DIFF
--- a/bigquery/samples/add_empty_column.py
+++ b/bigquery/samples/add_empty_column.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def add_empty_column(client, table_id):
+def add_empty_column(table_id):
 
     # [START bigquery_add_empty_column]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table
     #                  to add an empty column.

--- a/bigquery/samples/add_empty_column.py
+++ b/bigquery/samples/add_empty_column.py
@@ -18,7 +18,7 @@ def add_empty_column(table_id):
     # [START bigquery_add_empty_column]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table

--- a/bigquery/samples/browse_table_data.py
+++ b/bigquery/samples/browse_table_data.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def browse_table_data(client, table_id):
+def browse_table_data(table_id):
 
     # [START bigquery_browse_table]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to browse data rows.
     # table_id = "your-project.your_dataset.your_table_name"

--- a/bigquery/samples/browse_table_data.py
+++ b/bigquery/samples/browse_table_data.py
@@ -16,10 +16,10 @@
 def browse_table_data(table_id):
 
     # [START bigquery_browse_table]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to browse data rows.

--- a/bigquery/samples/client_list_jobs.py
+++ b/bigquery/samples/client_list_jobs.py
@@ -16,12 +16,12 @@
 def client_list_jobs():
 
     # [START bigquery_list_jobs]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
     import datetime
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # List the 10 most recent jobs in reverse chronological order.

--- a/bigquery/samples/client_list_jobs.py
+++ b/bigquery/samples/client_list_jobs.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 
-def client_list_jobs(client):
+def client_list_jobs():
 
     # [START bigquery_list_jobs]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     import datetime
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # List the 10 most recent jobs in reverse chronological order.
     # Omit the max_results parameter to list jobs from the past 6 months.

--- a/bigquery/samples/client_load_partitioned_table.py
+++ b/bigquery/samples/client_load_partitioned_table.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_load_partitioned_table(client, table_id):
+def client_load_partitioned_table(table_id):
 
     # [START bigquery_load_table_partitioned]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to create.
     # table_id = "your-project.your_dataset.your_table_name"

--- a/bigquery/samples/client_load_partitioned_table.py
+++ b/bigquery/samples/client_load_partitioned_table.py
@@ -18,7 +18,7 @@ def client_load_partitioned_table(table_id):
     # [START bigquery_load_table_partitioned]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to create.

--- a/bigquery/samples/client_query.py
+++ b/bigquery/samples/client_query.py
@@ -16,10 +16,10 @@
 def client_query():
 
     # [START bigquery_query]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     query = """

--- a/bigquery/samples/client_query.py
+++ b/bigquery/samples/client_query.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def client_query(client):
+def client_query():
 
     # [START bigquery_query]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     query = """
         SELECT name, SUM(number) as total_people

--- a/bigquery/samples/client_query_add_column.py
+++ b/bigquery/samples/client_query_add_column.py
@@ -18,7 +18,7 @@ def client_query_add_column(table_id):
     # [START bigquery_add_column_query_append]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the destination table.

--- a/bigquery/samples/client_query_add_column.py
+++ b/bigquery/samples/client_query_add_column.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_query_add_column(client, table_id):
+def client_query_add_column(table_id):
 
     # [START bigquery_add_column_query_append]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the destination table.
     # table_id = "your-project.your_dataset.your_table_name"

--- a/bigquery/samples/client_query_batch.py
+++ b/bigquery/samples/client_query_batch.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_query_batch(client):
+def client_query_batch():
 
     # [START bigquery_query_batch]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     job_config = bigquery.QueryJobConfig(
         # Run at batch priority, which won't count toward concurrent rate limit.

--- a/bigquery/samples/client_query_batch.py
+++ b/bigquery/samples/client_query_batch.py
@@ -18,7 +18,7 @@ def client_query_batch():
     # [START bigquery_query_batch]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     job_config = bigquery.QueryJobConfig(

--- a/bigquery/samples/client_query_destination_table.py
+++ b/bigquery/samples/client_query_destination_table.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_query_destination_table(client, table_id):
+def client_query_destination_table(table_id):
 
     # [START bigquery_query_destination_table]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the destination table.
     # table_id = "your-project.your_dataset.your_table_name"

--- a/bigquery/samples/client_query_destination_table.py
+++ b/bigquery/samples/client_query_destination_table.py
@@ -18,7 +18,7 @@ def client_query_destination_table(table_id):
     # [START bigquery_query_destination_table]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the destination table.

--- a/bigquery/samples/client_query_destination_table_cmek.py
+++ b/bigquery/samples/client_query_destination_table_cmek.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_query_destination_table_cmek(client, table_id, kms_key_name):
+def client_query_destination_table_cmek(table_id, kms_key_name):
 
     # [START bigquery_query_destination_table_cmek]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the destination table.
     # table_id = "your-project.your_dataset.your_table_name"

--- a/bigquery/samples/client_query_destination_table_cmek.py
+++ b/bigquery/samples/client_query_destination_table_cmek.py
@@ -18,7 +18,7 @@ def client_query_destination_table_cmek(table_id, kms_key_name):
     # [START bigquery_query_destination_table_cmek]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the destination table.

--- a/bigquery/samples/client_query_destination_table_legacy.py
+++ b/bigquery/samples/client_query_destination_table_legacy.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_query_destination_table_legacy(client, table_id):
+def client_query_destination_table_legacy(table_id):
 
     # [START bigquery_query_legacy_large_results]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the destination table.
     # table_id = "your-project.your_dataset.your_table_name"

--- a/bigquery/samples/client_query_destination_table_legacy.py
+++ b/bigquery/samples/client_query_destination_table_legacy.py
@@ -18,7 +18,7 @@ def client_query_destination_table_legacy(table_id):
     # [START bigquery_query_legacy_large_results]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the destination table.

--- a/bigquery/samples/client_query_dry_run.py
+++ b/bigquery/samples/client_query_dry_run.py
@@ -18,7 +18,7 @@ def client_query_dry_run():
     # [START bigquery_query_dry_run]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     job_config = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)

--- a/bigquery/samples/client_query_dry_run.py
+++ b/bigquery/samples/client_query_dry_run.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_query_dry_run(client):
+def client_query_dry_run():
 
     # [START bigquery_query_dry_run]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     job_config = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)
 

--- a/bigquery/samples/client_query_legacy_sql.py
+++ b/bigquery/samples/client_query_legacy_sql.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_query_legacy_sql(client):
+def client_query_legacy_sql():
 
     # [START bigquery_query_legacy]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     query = (
         "SELECT name FROM [bigquery-public-data:usa_names.usa_1910_2013] "

--- a/bigquery/samples/client_query_legacy_sql.py
+++ b/bigquery/samples/client_query_legacy_sql.py
@@ -18,7 +18,7 @@ def client_query_legacy_sql():
     # [START bigquery_query_legacy]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     query = (

--- a/bigquery/samples/client_query_relax_column.py
+++ b/bigquery/samples/client_query_relax_column.py
@@ -18,7 +18,7 @@ def client_query_relax_column(table_id):
     # [START bigquery_relax_column_query_append]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the destination table.

--- a/bigquery/samples/client_query_relax_column.py
+++ b/bigquery/samples/client_query_relax_column.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_query_relax_column(client, table_id):
+def client_query_relax_column(table_id):
 
     # [START bigquery_relax_column_query_append]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the destination table.
     # table_id = "your-project.your_dataset.your_table_name"

--- a/bigquery/samples/client_query_w_array_params.py
+++ b/bigquery/samples/client_query_w_array_params.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_query_w_array_params(client):
+def client_query_w_array_params():
 
     # [START bigquery_query_params_arrays]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     query = """
         SELECT name, sum(number) as count

--- a/bigquery/samples/client_query_w_array_params.py
+++ b/bigquery/samples/client_query_w_array_params.py
@@ -18,7 +18,7 @@ def client_query_w_array_params():
     # [START bigquery_query_params_arrays]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     query = """

--- a/bigquery/samples/client_query_w_named_params.py
+++ b/bigquery/samples/client_query_w_named_params.py
@@ -18,7 +18,7 @@ def client_query_w_named_params():
     # [START bigquery_query_params_named]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     query = """

--- a/bigquery/samples/client_query_w_named_params.py
+++ b/bigquery/samples/client_query_w_named_params.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_query_w_named_params(client):
+def client_query_w_named_params():
 
     # [START bigquery_query_params_named]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     query = """
         SELECT word, word_count

--- a/bigquery/samples/client_query_w_positional_params.py
+++ b/bigquery/samples/client_query_w_positional_params.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_query_w_positional_params(client):
+def client_query_w_positional_params():
 
     # [START bigquery_query_params_positional]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     query = """
         SELECT word, word_count

--- a/bigquery/samples/client_query_w_positional_params.py
+++ b/bigquery/samples/client_query_w_positional_params.py
@@ -18,7 +18,7 @@ def client_query_w_positional_params():
     # [START bigquery_query_params_positional]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     query = """

--- a/bigquery/samples/client_query_w_struct_params.py
+++ b/bigquery/samples/client_query_w_struct_params.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def client_query_w_struct_params(client):
+def client_query_w_struct_params():
 
     # [START bigquery_query_params_structs]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     query = "SELECT @struct_value AS s;"
     job_config = bigquery.QueryJobConfig(

--- a/bigquery/samples/client_query_w_struct_params.py
+++ b/bigquery/samples/client_query_w_struct_params.py
@@ -18,7 +18,7 @@ def client_query_w_struct_params():
     # [START bigquery_query_params_structs]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     query = "SELECT @struct_value AS s;"

--- a/bigquery/samples/client_query_w_timestamp_params.py
+++ b/bigquery/samples/client_query_w_timestamp_params.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-def client_query_w_timestamp_params(client):
+def client_query_w_timestamp_params():
 
     # [START bigquery_query_params_timestamps]
     import datetime
@@ -22,7 +22,7 @@ def client_query_w_timestamp_params(client):
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     query = "SELECT TIMESTAMP_ADD(@ts_value, INTERVAL 1 HOUR);"
     job_config = bigquery.QueryJobConfig(

--- a/bigquery/samples/client_query_w_timestamp_params.py
+++ b/bigquery/samples/client_query_w_timestamp_params.py
@@ -21,7 +21,7 @@ def client_query_w_timestamp_params():
     import pytz
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     query = "SELECT TIMESTAMP_ADD(@ts_value, INTERVAL 1 HOUR);"

--- a/bigquery/samples/copy_table.py
+++ b/bigquery/samples/copy_table.py
@@ -16,10 +16,10 @@
 def copy_table(source_table_id, destination_table_id):
 
     # [START bigquery_copy_table]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set source_table_id to the ID of the original table.

--- a/bigquery/samples/copy_table.py
+++ b/bigquery/samples/copy_table.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def copy_table(client, source_table_id, destination_table_id):
+def copy_table(source_table_id, destination_table_id):
 
     # [START bigquery_copy_table]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set source_table_id to the ID of the original table.
     # source_table_id = "your-project.source_dataset.source_table"

--- a/bigquery/samples/copy_table_cmek.py
+++ b/bigquery/samples/copy_table_cmek.py
@@ -18,7 +18,7 @@ def copy_table_cmek(dest_table_id, orig_table_id, kms_key_name):
     # [START bigquery_copy_table_cmek]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dest_table_id to the ID of the destination table.

--- a/bigquery/samples/copy_table_cmek.py
+++ b/bigquery/samples/copy_table_cmek.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def copy_table_cmek(client, dest_table_id, orig_table_id, kms_key_name):
+def copy_table_cmek(dest_table_id, orig_table_id, kms_key_name):
 
     # [START bigquery_copy_table_cmek]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dest_table_id to the ID of the destination table.
     # dest_table_id = "your-project.your_dataset.your_table_name"

--- a/bigquery/samples/copy_table_multiple_source.py
+++ b/bigquery/samples/copy_table_multiple_source.py
@@ -16,10 +16,10 @@
 def copy_table_multiple_source(dest_table_id, table_ids):
 
     # [START bigquery_copy_table_multiple_source]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dest_table_id to the ID of the destination table.

--- a/bigquery/samples/copy_table_multiple_source.py
+++ b/bigquery/samples/copy_table_multiple_source.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def copy_table_multiple_source(client, dest_table_id, table_ids):
+def copy_table_multiple_source(dest_table_id, table_ids):
 
     # [START bigquery_copy_table_multiple_source]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dest_table_id to the ID of the destination table.
     # dest_table_id = "your-project.your_dataset.your_table_name"

--- a/bigquery/samples/create_dataset.py
+++ b/bigquery/samples/create_dataset.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def create_dataset(client, dataset_id):
+def create_dataset(dataset_id):
 
     # [START bigquery_create_dataset]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to create.
     # dataset_id = "{}.your_dataset".format(client.project)

--- a/bigquery/samples/create_dataset.py
+++ b/bigquery/samples/create_dataset.py
@@ -18,7 +18,7 @@ def create_dataset(dataset_id):
     # [START bigquery_create_dataset]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to create.

--- a/bigquery/samples/create_job.py
+++ b/bigquery/samples/create_job.py
@@ -18,7 +18,7 @@ def create_job():
     # [START bigquery_create_job]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     query_job = client.query(

--- a/bigquery/samples/create_job.py
+++ b/bigquery/samples/create_job.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def create_job(client):
+def create_job():
 
     # [START bigquery_create_job]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     query_job = client.query(
         "SELECT country_name from `bigquery-public-data.utility_us.country_code_iso`",

--- a/bigquery/samples/create_routine.py
+++ b/bigquery/samples/create_routine.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def create_routine(client, routine_id):
+def create_routine(routine_id):
 
     # [START bigquery_create_routine]
     from google.cloud import bigquery
     from google.cloud import bigquery_v2
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Choose a fully-qualified ID for the routine.
     # routine_id = "my-project.my_dataset.my_routine"

--- a/bigquery/samples/create_routine.py
+++ b/bigquery/samples/create_routine.py
@@ -19,7 +19,7 @@ def create_routine(routine_id):
     from google.cloud import bigquery
     from google.cloud import bigquery_v2
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Choose a fully-qualified ID for the routine.

--- a/bigquery/samples/create_routine_ddl.py
+++ b/bigquery/samples/create_routine_ddl.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def create_routine_ddl(client, routine_id):
+def create_routine_ddl(routine_id):
 
     # [START bigquery_create_routine_ddl]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Choose a fully-qualified ID for the routine.
     # routine_id = "my-project.my_dataset.my_routine"

--- a/bigquery/samples/create_routine_ddl.py
+++ b/bigquery/samples/create_routine_ddl.py
@@ -16,10 +16,10 @@
 def create_routine_ddl(routine_id):
 
     # [START bigquery_create_routine_ddl]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Choose a fully-qualified ID for the routine.

--- a/bigquery/samples/create_table.py
+++ b/bigquery/samples/create_table.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def create_table(client, table_id):
+def create_table(table_id):
 
     # [START bigquery_create_table]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to create.
     # table_id = "your-project.your_dataset.your_table_name"

--- a/bigquery/samples/create_table.py
+++ b/bigquery/samples/create_table.py
@@ -18,7 +18,7 @@ def create_table(table_id):
     # [START bigquery_create_table]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to create.

--- a/bigquery/samples/create_table_range_partitioned.py
+++ b/bigquery/samples/create_table_range_partitioned.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def create_table_range_partitioned(client, table_id):
+def create_table_range_partitioned(table_id):
 
     # [START bigquery_create_table_range_partitioned]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to create.
     # table_id = "your-project.your_dataset.your_table_name"

--- a/bigquery/samples/create_table_range_partitioned.py
+++ b/bigquery/samples/create_table_range_partitioned.py
@@ -18,7 +18,7 @@ def create_table_range_partitioned(table_id):
     # [START bigquery_create_table_range_partitioned]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to create.

--- a/bigquery/samples/dataset_exists.py
+++ b/bigquery/samples/dataset_exists.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 
-def dataset_exists(client, dataset_id):
+def dataset_exists(dataset_id):
 
     # [START bigquery_dataset_exists]
+    from google.cloud import bigquery
     from google.cloud.exceptions import NotFound
+
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to determine existence.
     # dataset_id = "your-project.your_dataset"

--- a/bigquery/samples/delete_dataset.py
+++ b/bigquery/samples/delete_dataset.py
@@ -16,10 +16,10 @@
 def delete_dataset(dataset_id):
 
     # [START bigquery_delete_dataset]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set model_id to the ID of the model to fetch.

--- a/bigquery/samples/delete_dataset.py
+++ b/bigquery/samples/delete_dataset.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def delete_dataset(client, dataset_id):
+def delete_dataset(dataset_id):
 
     # [START bigquery_delete_dataset]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set model_id to the ID of the model to fetch.
     # dataset_id = 'your-project.your_dataset'

--- a/bigquery/samples/delete_dataset_labels.py
+++ b/bigquery/samples/delete_dataset_labels.py
@@ -16,10 +16,10 @@
 def delete_dataset_labels(dataset_id):
 
     # [START bigquery_delete_label_dataset]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.

--- a/bigquery/samples/delete_dataset_labels.py
+++ b/bigquery/samples/delete_dataset_labels.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def delete_dataset_labels(client, dataset_id):
+def delete_dataset_labels(dataset_id):
 
     # [START bigquery_delete_label_dataset]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.
     # dataset_id = "your-project.your_dataset"

--- a/bigquery/samples/delete_model.py
+++ b/bigquery/samples/delete_model.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 
-def delete_model(client, model_id):
+def delete_model(model_id):
     """Sample ID: go/samples-tracker/1534"""
 
     # [START bigquery_delete_model]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set model_id to the ID of the model to fetch.
     # model_id = 'your-project.your_dataset.your_model'

--- a/bigquery/samples/delete_model.py
+++ b/bigquery/samples/delete_model.py
@@ -17,10 +17,10 @@ def delete_model(model_id):
     """Sample ID: go/samples-tracker/1534"""
 
     # [START bigquery_delete_model]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set model_id to the ID of the model to fetch.

--- a/bigquery/samples/delete_routine.py
+++ b/bigquery/samples/delete_routine.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def delete_routine(client, routine_id):
+def delete_routine(routine_id):
 
     # [START bigquery_delete_routine]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set the fully-qualified ID for the routine.
     # routine_id = "my-project.my_dataset.my_routine"

--- a/bigquery/samples/delete_routine.py
+++ b/bigquery/samples/delete_routine.py
@@ -16,10 +16,10 @@
 def delete_routine(routine_id):
 
     # [START bigquery_delete_routine]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set the fully-qualified ID for the routine.

--- a/bigquery/samples/delete_table.py
+++ b/bigquery/samples/delete_table.py
@@ -16,10 +16,10 @@
 def delete_table(table_id):
 
     # [START bigquery_delete_table]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to fetch.

--- a/bigquery/samples/delete_table.py
+++ b/bigquery/samples/delete_table.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def delete_table(client, table_id):
+def delete_table(table_id):
 
     # [START bigquery_delete_table]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to fetch.
     # table_id = 'your-project.your_dataset.your_table'

--- a/bigquery/samples/download_public_data.py
+++ b/bigquery/samples/download_public_data.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def download_public_data(client):
+def download_public_data():
 
     # [START bigquery_pandas_public_data]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the fully-qualified table ID in standard
     # SQL format, including the project ID and dataset ID.

--- a/bigquery/samples/download_public_data.py
+++ b/bigquery/samples/download_public_data.py
@@ -16,10 +16,10 @@
 def download_public_data():
 
     # [START bigquery_pandas_public_data]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the fully-qualified table ID in standard

--- a/bigquery/samples/download_public_data_sandbox.py
+++ b/bigquery/samples/download_public_data_sandbox.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def download_public_data_sandbox(client):
+def download_public_data_sandbox():
 
     # [START bigquery_pandas_public_data_sandbox]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # `SELECT *` is an anti-pattern in BigQuery because it is cheaper and
     # faster to use the BigQuery Storage API directly, but BigQuery Sandbox

--- a/bigquery/samples/download_public_data_sandbox.py
+++ b/bigquery/samples/download_public_data_sandbox.py
@@ -16,10 +16,10 @@
 def download_public_data_sandbox():
 
     # [START bigquery_pandas_public_data_sandbox]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # `SELECT *` is an anti-pattern in BigQuery because it is cheaper and

--- a/bigquery/samples/get_dataset.py
+++ b/bigquery/samples/get_dataset.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def get_dataset(client, dataset_id):
+def get_dataset(dataset_id):
 
     # [START bigquery_get_dataset]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.
     # dataset_id = 'your-project.your_dataset'

--- a/bigquery/samples/get_dataset.py
+++ b/bigquery/samples/get_dataset.py
@@ -16,10 +16,10 @@
 def get_dataset(dataset_id):
 
     # [START bigquery_get_dataset]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.

--- a/bigquery/samples/get_dataset_labels.py
+++ b/bigquery/samples/get_dataset_labels.py
@@ -16,10 +16,10 @@
 def get_dataset_labels(dataset_id):
 
     # [START bigquery_get_dataset_labels]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.

--- a/bigquery/samples/get_dataset_labels.py
+++ b/bigquery/samples/get_dataset_labels.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def get_dataset_labels(client, dataset_id):
+def get_dataset_labels(dataset_id):
 
     # [START bigquery_get_dataset_labels]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.
     # dataset_id = "your-project.your_dataset"

--- a/bigquery/samples/get_model.py
+++ b/bigquery/samples/get_model.py
@@ -17,10 +17,10 @@ def get_model(model_id):
     """Sample ID: go/samples-tracker/1510"""
 
     # [START bigquery_get_model]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set model_id to the ID of the model to fetch.

--- a/bigquery/samples/get_model.py
+++ b/bigquery/samples/get_model.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 
-def get_model(client, model_id):
+def get_model(model_id):
     """Sample ID: go/samples-tracker/1510"""
 
     # [START bigquery_get_model]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set model_id to the ID of the model to fetch.
     # model_id = 'your-project.your_dataset.your_model'

--- a/bigquery/samples/get_routine.py
+++ b/bigquery/samples/get_routine.py
@@ -16,10 +16,10 @@
 def get_routine(routine_id):
 
     # [START bigquery_get_routine]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set the fully-qualified ID for the routine.

--- a/bigquery/samples/get_routine.py
+++ b/bigquery/samples/get_routine.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def get_routine(client, routine_id):
+def get_routine(routine_id):
 
     # [START bigquery_get_routine]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set the fully-qualified ID for the routine.
     # routine_id = "my-project.my_dataset.my_routine"

--- a/bigquery/samples/get_table.py
+++ b/bigquery/samples/get_table.py
@@ -16,10 +16,10 @@
 def get_table(table_id):
 
     # [START bigquery_get_table]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the model to fetch.

--- a/bigquery/samples/get_table.py
+++ b/bigquery/samples/get_table.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def get_table(client, table_id):
+def get_table(table_id):
 
     # [START bigquery_get_table]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the model to fetch.
     # table_id = 'your-project.your_dataset.your_table'

--- a/bigquery/samples/label_dataset.py
+++ b/bigquery/samples/label_dataset.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def label_dataset(client, dataset_id):
+def label_dataset(dataset_id):
 
     # [START bigquery_label_dataset]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.
     # dataset_id = "your-project.your_dataset"

--- a/bigquery/samples/label_dataset.py
+++ b/bigquery/samples/label_dataset.py
@@ -16,10 +16,10 @@
 def label_dataset(dataset_id):
 
     # [START bigquery_label_dataset]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.

--- a/bigquery/samples/list_datasets.py
+++ b/bigquery/samples/list_datasets.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def list_datasets(client):
+def list_datasets():
 
     # [START bigquery_list_datasets]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     datasets = list(client.list_datasets())  # Make an API request.
     project = client.project

--- a/bigquery/samples/list_datasets.py
+++ b/bigquery/samples/list_datasets.py
@@ -16,10 +16,10 @@
 def list_datasets():
 
     # [START bigquery_list_datasets]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     datasets = list(client.list_datasets())  # Make an API request.

--- a/bigquery/samples/list_datasets_by_label.py
+++ b/bigquery/samples/list_datasets_by_label.py
@@ -16,10 +16,10 @@
 def list_datasets_by_label():
 
     # [START bigquery_list_datasets_by_label]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     label_filter = "labels.color:green"

--- a/bigquery/samples/list_datasets_by_label.py
+++ b/bigquery/samples/list_datasets_by_label.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def list_datasets_by_label(client):
+def list_datasets_by_label():
 
     # [START bigquery_list_datasets_by_label]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     label_filter = "labels.color:green"
     datasets = list(client.list_datasets(filter=label_filter))  # Make an API request.

--- a/bigquery/samples/list_models.py
+++ b/bigquery/samples/list_models.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 
-def list_models(client, dataset_id):
+def list_models(dataset_id):
     """Sample ID: go/samples-tracker/1512"""
 
     # [START bigquery_list_models]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset that contains
     #                  the models you are listing.

--- a/bigquery/samples/list_models.py
+++ b/bigquery/samples/list_models.py
@@ -17,10 +17,10 @@ def list_models(dataset_id):
     """Sample ID: go/samples-tracker/1512"""
 
     # [START bigquery_list_models]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset that contains

--- a/bigquery/samples/list_routines.py
+++ b/bigquery/samples/list_routines.py
@@ -16,10 +16,10 @@
 def list_routines(dataset_id):
 
     # [START bigquery_list_routines]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset that contains

--- a/bigquery/samples/list_routines.py
+++ b/bigquery/samples/list_routines.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def list_routines(client, dataset_id):
+def list_routines(dataset_id):
 
     # [START bigquery_list_routines]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset that contains
     #                  the routines you are listing.

--- a/bigquery/samples/list_tables.py
+++ b/bigquery/samples/list_tables.py
@@ -16,10 +16,10 @@
 def list_tables(dataset_id):
 
     # [START bigquery_list_tables]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset that contains

--- a/bigquery/samples/list_tables.py
+++ b/bigquery/samples/list_tables.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def list_tables(client, dataset_id):
+def list_tables(dataset_id):
 
     # [START bigquery_list_tables]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset that contains
     #                  the tables you are listing.

--- a/bigquery/samples/load_table_dataframe.py
+++ b/bigquery/samples/load_table_dataframe.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-def load_table_dataframe(client, table_id):
+def load_table_dataframe(table_id):
 
     # [START bigquery_load_table_dataframe]
     from google.cloud import bigquery
@@ -21,7 +21,7 @@ def load_table_dataframe(client, table_id):
     import pandas
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to create.
     # table_id = "your-project.your_dataset.your_table_name"

--- a/bigquery/samples/load_table_dataframe.py
+++ b/bigquery/samples/load_table_dataframe.py
@@ -20,7 +20,7 @@ def load_table_dataframe(table_id):
 
     import pandas
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to create.

--- a/bigquery/samples/query_external_gcs_temporary_table.py
+++ b/bigquery/samples/query_external_gcs_temporary_table.py
@@ -18,7 +18,7 @@ def query_external_gcs_temporary_table():
     # [START bigquery_query_external_gcs_temp]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # Configure the external data source and query job.

--- a/bigquery/samples/query_external_gcs_temporary_table.py
+++ b/bigquery/samples/query_external_gcs_temporary_table.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def query_external_gcs_temporary_table(client):
+def query_external_gcs_temporary_table():
 
     # [START bigquery_query_external_gcs_temp]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # Configure the external data source and query job.
     external_config = bigquery.ExternalConfig("CSV")

--- a/bigquery/samples/query_external_sheets_permanent_table.py
+++ b/bigquery/samples/query_external_sheets_permanent_table.py
@@ -28,7 +28,7 @@ def query_external_sheets_permanent_table(dataset_id):
         ]
     )
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client(credentials=credentials, project=project)
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.

--- a/bigquery/samples/query_external_sheets_temporary_table.py
+++ b/bigquery/samples/query_external_sheets_temporary_table.py
@@ -29,7 +29,7 @@ def query_external_sheets_temporary_table():
         ]
     )
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client(credentials=credentials, project=project)
     # [END bigquery_auth_drive_scope]
 

--- a/bigquery/samples/query_no_cache.py
+++ b/bigquery/samples/query_no_cache.py
@@ -18,7 +18,7 @@ def query_no_cache():
     # [START bigquery_query_no_cache]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     job_config = bigquery.QueryJobConfig(use_query_cache=False)

--- a/bigquery/samples/query_no_cache.py
+++ b/bigquery/samples/query_no_cache.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def query_no_cache(client):
+def query_no_cache():
 
     # [START bigquery_query_no_cache]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     job_config = bigquery.QueryJobConfig(use_query_cache=False)
     sql = """

--- a/bigquery/samples/query_pagination.py
+++ b/bigquery/samples/query_pagination.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def query_pagination(client):
+def query_pagination():
 
     # [START bigquery_query_pagination]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     query = """
         SELECT name, SUM(number) as total_people

--- a/bigquery/samples/query_pagination.py
+++ b/bigquery/samples/query_pagination.py
@@ -16,10 +16,10 @@
 def query_pagination():
 
     # [START bigquery_query_pagination]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     query = """

--- a/bigquery/samples/query_script.py
+++ b/bigquery/samples/query_script.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def query_script(client):
+def query_script():
     # [START bigquery_query_script]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # Run a SQL script.
     sql_script = """

--- a/bigquery/samples/query_script.py
+++ b/bigquery/samples/query_script.py
@@ -15,10 +15,10 @@
 
 def query_script():
     # [START bigquery_query_script]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # Run a SQL script.

--- a/bigquery/samples/query_to_arrow.py
+++ b/bigquery/samples/query_to_arrow.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def query_to_arrow(client):
+def query_to_arrow():
 
     # [START bigquery_query_to_arrow]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     sql = """
     WITH races AS (

--- a/bigquery/samples/query_to_arrow.py
+++ b/bigquery/samples/query_to_arrow.py
@@ -16,10 +16,10 @@
 def query_to_arrow():
 
     # [START bigquery_query_to_arrow]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     sql = """

--- a/bigquery/samples/table_exists.py
+++ b/bigquery/samples/table_exists.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 
-def table_exists(client, table_id):
+def table_exists(table_id):
 
     # [START bigquery_table_exists]
+    from google.cloud import bigquery
     from google.cloud.exceptions import NotFound
+
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the table to determine existence.
     # table_id = "your-project.your_dataset.your_table"

--- a/bigquery/samples/table_insert_rows.py
+++ b/bigquery/samples/table_insert_rows.py
@@ -16,10 +16,10 @@
 def table_insert_rows(table_id):
 
     # [START bigquery_table_insert_rows]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the model to fetch.

--- a/bigquery/samples/table_insert_rows.py
+++ b/bigquery/samples/table_insert_rows.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def table_insert_rows(client, table_id):
+def table_insert_rows(table_id):
 
     # [START bigquery_table_insert_rows]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the model to fetch.
     # table_id = "your-project.your_dataset.your_table"

--- a/bigquery/samples/table_insert_rows_explicit_none_insert_ids.py
+++ b/bigquery/samples/table_insert_rows_explicit_none_insert_ids.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def table_insert_rows_explicit_none_insert_ids(client, table_id):
+def table_insert_rows_explicit_none_insert_ids(table_id):
 
     # [START bigquery_table_insert_rows_explicit_none_insert_ids]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the model to fetch.
     # table_id = "your-project.your_dataset.your_table"

--- a/bigquery/samples/table_insert_rows_explicit_none_insert_ids.py
+++ b/bigquery/samples/table_insert_rows_explicit_none_insert_ids.py
@@ -16,10 +16,10 @@
 def table_insert_rows_explicit_none_insert_ids(table_id):
 
     # [START bigquery_table_insert_rows_explicit_none_insert_ids]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the model to fetch.

--- a/bigquery/samples/tests/conftest.py
+++ b/bigquery/samples/tests/conftest.py
@@ -15,19 +15,24 @@
 import datetime
 import uuid
 
+import mock
 import pytest
 
 from google.cloud import bigquery
 from google.cloud import bigquery_v2
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session", autouse=True)
 def client():
-    return bigquery.Client()
+    real_client = bigquery.Client()
+    mock_client = mock.create_autospec(bigquery.Client)
+    mock_client.return_value = real_client
+    bigquery.Client = mock_client
+    return real_client
 
 
 @pytest.fixture
-def random_table_id(client, dataset_id):
+def random_table_id(dataset_id):
     now = datetime.datetime.now()
     random_table_id = "example_table_{}_{}".format(
         now.strftime("%Y%m%d%H%M%S"), uuid.uuid4().hex[:8]
@@ -46,7 +51,7 @@ def random_dataset_id(client):
 
 
 @pytest.fixture
-def random_routine_id(client, dataset_id):
+def random_routine_id(dataset_id):
     now = datetime.datetime.now()
     random_routine_id = "example_routine_{}_{}".format(
         now.strftime("%Y%m%d%H%M%S"), uuid.uuid4().hex[:8]
@@ -95,7 +100,7 @@ def table_with_schema_id(client, dataset_id):
 
 
 @pytest.fixture
-def table_with_data_id(client):
+def table_with_data_id():
     return "bigquery-public-data.samples.shakespeare"
 
 

--- a/bigquery/samples/tests/conftest.py
+++ b/bigquery/samples/tests/conftest.py
@@ -15,6 +15,7 @@
 import datetime
 import uuid
 
+import google.auth
 import mock
 import pytest
 
@@ -24,7 +25,13 @@ from google.cloud import bigquery_v2
 
 @pytest.fixture(scope="session", autouse=True)
 def client():
-    real_client = bigquery.Client()
+    credentials, project = google.auth.default(
+        scopes=[
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/bigquery",
+        ]
+    )
+    real_client = bigquery.Client(credentials=credentials, project=project)
     mock_client = mock.create_autospec(bigquery.Client)
     mock_client.return_value = real_client
     bigquery.Client = mock_client

--- a/bigquery/samples/tests/test_add_empty_column.py
+++ b/bigquery/samples/tests/test_add_empty_column.py
@@ -15,8 +15,8 @@
 from .. import add_empty_column
 
 
-def test_add_empty_column(capsys, client, table_id):
+def test_add_empty_column(capsys, table_id):
 
-    add_empty_column.add_empty_column(client, table_id)
+    add_empty_column.add_empty_column(table_id)
     out, err = capsys.readouterr()
     assert "A new column has been added." in out

--- a/bigquery/samples/tests/test_browse_table_data.py
+++ b/bigquery/samples/tests/test_browse_table_data.py
@@ -15,9 +15,9 @@
 from .. import browse_table_data
 
 
-def test_browse_table_data(capsys, client, table_with_data_id):
+def test_browse_table_data(capsys, table_with_data_id):
 
-    browse_table_data.browse_table_data(client, table_with_data_id)
+    browse_table_data.browse_table_data(table_with_data_id)
     out, err = capsys.readouterr()
     assert "Downloaded 164656 rows from table {}".format(table_with_data_id) in out
     assert "Downloaded 10 rows from table {}".format(table_with_data_id) in out

--- a/bigquery/samples/tests/test_client_list_jobs.py
+++ b/bigquery/samples/tests/test_client_list_jobs.py
@@ -18,10 +18,10 @@ from .. import create_job
 
 def test_client_list_jobs(capsys, client):
 
-    job = create_job.create_job(client)
+    job = create_job.create_job()
     client.cancel_job(job.job_id)
     job.cancel()
-    client_list_jobs.client_list_jobs(client)
+    client_list_jobs.client_list_jobs()
     out, err = capsys.readouterr()
     assert "Started job: {}".format(job.job_id) in out
     assert "Last 10 jobs:" in out

--- a/bigquery/samples/tests/test_client_load_partitioned_table.py
+++ b/bigquery/samples/tests/test_client_load_partitioned_table.py
@@ -15,8 +15,8 @@
 from .. import client_load_partitioned_table
 
 
-def test_client_load_partitioned_table(capsys, client, random_table_id):
+def test_client_load_partitioned_table(capsys, random_table_id):
 
-    client_load_partitioned_table.client_load_partitioned_table(client, random_table_id)
+    client_load_partitioned_table.client_load_partitioned_table(random_table_id)
     out, err = capsys.readouterr()
     assert "Loaded 50 rows to table {}".format(random_table_id) in out

--- a/bigquery/samples/tests/test_client_query.py
+++ b/bigquery/samples/tests/test_client_query.py
@@ -15,9 +15,9 @@
 from .. import client_query
 
 
-def test_client_query(capsys, client):
+def test_client_query(capsys,):
 
-    client_query.client_query(client)
+    client_query.client_query()
     out, err = capsys.readouterr()
     assert "The query data:" in out
     assert "name=James, count=272793" in out

--- a/bigquery/samples/tests/test_client_query_add_column.py
+++ b/bigquery/samples/tests/test_client_query_add_column.py
@@ -17,7 +17,7 @@ from google.cloud import bigquery
 from .. import client_query_add_column
 
 
-def test_client_query_add_column(capsys, client, random_table_id):
+def test_client_query_add_column(capsys, random_table_id, client):
 
     schema = [
         bigquery.SchemaField("full_name", "STRING", mode="REQUIRED"),
@@ -26,7 +26,7 @@ def test_client_query_add_column(capsys, client, random_table_id):
 
     client.create_table(bigquery.Table(random_table_id, schema=schema))
 
-    client_query_add_column.client_query_add_column(client, random_table_id)
+    client_query_add_column.client_query_add_column(random_table_id)
     out, err = capsys.readouterr()
     assert "Table {} contains 2 columns".format(random_table_id) in out
     assert "Table {} now contains 3 columns".format(random_table_id) in out

--- a/bigquery/samples/tests/test_client_query_batch.py
+++ b/bigquery/samples/tests/test_client_query_batch.py
@@ -15,8 +15,8 @@
 from .. import client_query_batch
 
 
-def test_client_query_batch(capsys, client):
+def test_client_query_batch(capsys,):
 
-    job = client_query_batch.client_query_batch(client)
+    job = client_query_batch.client_query_batch()
     out, err = capsys.readouterr()
     assert "Job {} is currently in state {}".format(job.job_id, job.state) in out

--- a/bigquery/samples/tests/test_client_query_destination_table.py
+++ b/bigquery/samples/tests/test_client_query_destination_table.py
@@ -15,8 +15,8 @@
 from .. import client_query_destination_table
 
 
-def test_client_query_destination_table(capsys, client, table_id):
+def test_client_query_destination_table(capsys, table_id):
 
-    client_query_destination_table.client_query_destination_table(client, table_id)
+    client_query_destination_table.client_query_destination_table(table_id)
     out, err = capsys.readouterr()
     assert "Query results loaded to the table {}".format(table_id) in out

--- a/bigquery/samples/tests/test_client_query_destination_table_cmek.py
+++ b/bigquery/samples/tests/test_client_query_destination_table_cmek.py
@@ -15,12 +15,10 @@
 from .. import client_query_destination_table_cmek
 
 
-def test_client_query_destination_table_cmek(
-    capsys, client, random_table_id, kms_key_name
-):
+def test_client_query_destination_table_cmek(capsys, random_table_id, kms_key_name):
 
     client_query_destination_table_cmek.client_query_destination_table_cmek(
-        client, random_table_id, kms_key_name
+        random_table_id, kms_key_name
     )
     out, err = capsys.readouterr()
     assert "The destination table is written using the encryption configuration" in out

--- a/bigquery/samples/tests/test_client_query_destination_table_legacy.py
+++ b/bigquery/samples/tests/test_client_query_destination_table_legacy.py
@@ -15,10 +15,10 @@
 from .. import client_query_destination_table_legacy
 
 
-def test_client_query_destination_table_legacy(capsys, client, random_table_id):
+def test_client_query_destination_table_legacy(capsys, random_table_id):
 
     client_query_destination_table_legacy.client_query_destination_table_legacy(
-        client, random_table_id
+        random_table_id
     )
     out, err = capsys.readouterr()
     assert "Query results loaded to the table {}".format(random_table_id) in out

--- a/bigquery/samples/tests/test_client_query_dry_run.py
+++ b/bigquery/samples/tests/test_client_query_dry_run.py
@@ -15,9 +15,9 @@
 from .. import client_query_dry_run
 
 
-def test_client_query_dry_run(capsys, client):
+def test_client_query_dry_run(capsys,):
 
-    query_job = client_query_dry_run.client_query_dry_run(client)
+    query_job = client_query_dry_run.client_query_dry_run()
     out, err = capsys.readouterr()
     assert "This query will process" in out
     assert query_job.state == "DONE"

--- a/bigquery/samples/tests/test_client_query_legacy_sql.py
+++ b/bigquery/samples/tests/test_client_query_legacy_sql.py
@@ -17,8 +17,8 @@ import re
 from .. import client_query_legacy_sql
 
 
-def test_client_query_legacy_sql(capsys, client):
+def test_client_query_legacy_sql(capsys,):
 
-    client_query_legacy_sql.client_query_legacy_sql(client)
+    client_query_legacy_sql.client_query_legacy_sql()
     out, err = capsys.readouterr()
     assert re.search(r"(Row[\w(){}:', ]+)$", out)

--- a/bigquery/samples/tests/test_client_query_relax_column.py
+++ b/bigquery/samples/tests/test_client_query_relax_column.py
@@ -17,7 +17,7 @@ from google.cloud import bigquery
 from .. import client_query_relax_column
 
 
-def test_client_query_relax_column(capsys, client, random_table_id):
+def test_client_query_relax_column(capsys, random_table_id, client):
 
     schema = [
         bigquery.SchemaField("full_name", "STRING", mode="REQUIRED"),
@@ -26,7 +26,7 @@ def test_client_query_relax_column(capsys, client, random_table_id):
 
     client.create_table(bigquery.Table(random_table_id, schema=schema))
 
-    client_query_relax_column.client_query_relax_column(client, random_table_id)
+    client_query_relax_column.client_query_relax_column(random_table_id)
     out, err = capsys.readouterr()
     assert "2 fields in the schema are required." in out
     assert "0 fields in the schema are now required." in out

--- a/bigquery/samples/tests/test_client_query_w_array_params.py
+++ b/bigquery/samples/tests/test_client_query_w_array_params.py
@@ -15,8 +15,8 @@
 from .. import client_query_w_array_params
 
 
-def test_client_query_w_array_params(capsys, client):
+def test_client_query_w_array_params(capsys,):
 
-    client_query_w_array_params.client_query_w_array_params(client)
+    client_query_w_array_params.client_query_w_array_params()
     out, err = capsys.readouterr()
     assert "James" in out

--- a/bigquery/samples/tests/test_client_query_w_named_params.py
+++ b/bigquery/samples/tests/test_client_query_w_named_params.py
@@ -15,8 +15,8 @@
 from .. import client_query_w_named_params
 
 
-def test_client_query_w_named_params(capsys, client):
+def test_client_query_w_named_params(capsys,):
 
-    client_query_w_named_params.client_query_w_named_params(client)
+    client_query_w_named_params.client_query_w_named_params()
     out, err = capsys.readouterr()
     assert "the" in out

--- a/bigquery/samples/tests/test_client_query_w_positional_params.py
+++ b/bigquery/samples/tests/test_client_query_w_positional_params.py
@@ -15,8 +15,8 @@
 from .. import client_query_w_positional_params
 
 
-def test_client_query_w_positional_params(capsys, client):
+def test_client_query_w_positional_params(capsys,):
 
-    client_query_w_positional_params.client_query_w_positional_params(client)
+    client_query_w_positional_params.client_query_w_positional_params()
     out, err = capsys.readouterr()
     assert "the" in out

--- a/bigquery/samples/tests/test_client_query_w_struct_params.py
+++ b/bigquery/samples/tests/test_client_query_w_struct_params.py
@@ -15,9 +15,9 @@
 from .. import client_query_w_struct_params
 
 
-def test_client_query_w_struct_params(capsys, client):
+def test_client_query_w_struct_params(capsys,):
 
-    client_query_w_struct_params.client_query_w_struct_params(client)
+    client_query_w_struct_params.client_query_w_struct_params()
     out, err = capsys.readouterr()
     assert "1" in out
     assert "foo" in out

--- a/bigquery/samples/tests/test_client_query_w_timestamp_params.py
+++ b/bigquery/samples/tests/test_client_query_w_timestamp_params.py
@@ -15,8 +15,8 @@
 from .. import client_query_w_timestamp_params
 
 
-def test_client_query_w_timestamp_params(capsys, client):
+def test_client_query_w_timestamp_params(capsys,):
 
-    client_query_w_timestamp_params.client_query_w_timestamp_params(client)
+    client_query_w_timestamp_params.client_query_w_timestamp_params()
     out, err = capsys.readouterr()
     assert "2016, 12, 7, 9, 0" in out

--- a/bigquery/samples/tests/test_copy_table.py
+++ b/bigquery/samples/tests/test_copy_table.py
@@ -15,9 +15,9 @@
 from .. import copy_table
 
 
-def test_copy_table(capsys, client, table_with_data_id, random_table_id):
+def test_copy_table(capsys, table_with_data_id, random_table_id, client):
 
-    copy_table.copy_table(client, table_with_data_id, random_table_id)
+    copy_table.copy_table(table_with_data_id, random_table_id)
     out, err = capsys.readouterr()
     assert "A copy of the table created." in out
     assert (

--- a/bigquery/samples/tests/test_copy_table_cmek.py
+++ b/bigquery/samples/tests/test_copy_table_cmek.py
@@ -15,12 +15,8 @@
 from .. import copy_table_cmek
 
 
-def test_copy_table_cmek(
-    capsys, client, random_table_id, table_with_data_id, kms_key_name
-):
+def test_copy_table_cmek(capsys, random_table_id, table_with_data_id, kms_key_name):
 
-    copy_table_cmek.copy_table_cmek(
-        client, random_table_id, table_with_data_id, kms_key_name
-    )
+    copy_table_cmek.copy_table_cmek(random_table_id, table_with_data_id, kms_key_name)
     out, err = capsys.readouterr()
     assert "A copy of the table created" in out

--- a/bigquery/samples/tests/test_copy_table_multiple_source.py
+++ b/bigquery/samples/tests/test_copy_table_multiple_source.py
@@ -18,7 +18,7 @@ from google.cloud import bigquery
 from .. import copy_table_multiple_source
 
 
-def test_copy_table_multiple_source(capsys, client, random_table_id, random_dataset_id):
+def test_copy_table_multiple_source(capsys, random_table_id, random_dataset_id, client):
 
     dataset = bigquery.Dataset(random_dataset_id)
     dataset.location = "US"
@@ -42,9 +42,7 @@ def test_copy_table_multiple_source(capsys, client, random_table_id, random_data
         "{}.table2".format(random_dataset_id),
     ]
 
-    copy_table_multiple_source.copy_table_multiple_source(
-        client, random_table_id, table_ids
-    )
+    copy_table_multiple_source.copy_table_multiple_source(random_table_id, table_ids)
     dest_table = client.get_table(random_table_id)
     out, err = capsys.readouterr()
     assert (

--- a/bigquery/samples/tests/test_create_dataset.py
+++ b/bigquery/samples/tests/test_create_dataset.py
@@ -15,8 +15,8 @@
 from .. import create_dataset
 
 
-def test_create_dataset(capsys, client, random_dataset_id):
+def test_create_dataset(capsys, random_dataset_id):
 
-    create_dataset.create_dataset(client, random_dataset_id)
+    create_dataset.create_dataset(random_dataset_id)
     out, err = capsys.readouterr()
     assert "Created dataset {}".format(random_dataset_id) in out

--- a/bigquery/samples/tests/test_create_job.py
+++ b/bigquery/samples/tests/test_create_job.py
@@ -16,8 +16,7 @@ from .. import create_job
 
 
 def test_create_job(capsys, client):
-
-    query_job = create_job.create_job(client)
+    query_job = create_job.create_job()
     client.cancel_job(query_job.job_id, location=query_job.location)
     out, err = capsys.readouterr()
     assert "Started job: {}".format(query_job.job_id) in out

--- a/bigquery/samples/tests/test_create_table.py
+++ b/bigquery/samples/tests/test_create_table.py
@@ -15,7 +15,7 @@
 from .. import create_table
 
 
-def test_create_table(capsys, client, random_table_id):
-    create_table.create_table(client, random_table_id)
+def test_create_table(capsys, random_table_id):
+    create_table.create_table(random_table_id)
     out, err = capsys.readouterr()
     assert "Created table {}".format(random_table_id) in out

--- a/bigquery/samples/tests/test_create_table_range_partitioned.py
+++ b/bigquery/samples/tests/test_create_table_range_partitioned.py
@@ -15,9 +15,9 @@
 from .. import create_table_range_partitioned
 
 
-def test_create_table_range_partitioned(capsys, client, random_table_id):
+def test_create_table_range_partitioned(capsys, random_table_id):
     table = create_table_range_partitioned.create_table_range_partitioned(
-        client, random_table_id
+        random_table_id
     )
     out, _ = capsys.readouterr()
     assert "Created table {}".format(random_table_id) in out

--- a/bigquery/samples/tests/test_dataset_exists.py
+++ b/bigquery/samples/tests/test_dataset_exists.py
@@ -17,13 +17,13 @@ from google.cloud import bigquery
 from .. import dataset_exists
 
 
-def test_dataset_exists(capsys, client, random_dataset_id):
+def test_dataset_exists(capsys, random_dataset_id, client):
 
-    dataset_exists.dataset_exists(client, random_dataset_id)
+    dataset_exists.dataset_exists(random_dataset_id)
     out, err = capsys.readouterr()
     assert "Dataset {} is not found".format(random_dataset_id) in out
     dataset = bigquery.Dataset(random_dataset_id)
     dataset = client.create_dataset(dataset)
-    dataset_exists.dataset_exists(client, random_dataset_id)
+    dataset_exists.dataset_exists(random_dataset_id)
     out, err = capsys.readouterr()
     assert "Dataset {} already exists".format(random_dataset_id) in out

--- a/bigquery/samples/tests/test_dataset_label_samples.py
+++ b/bigquery/samples/tests/test_dataset_label_samples.py
@@ -17,17 +17,17 @@ from .. import get_dataset_labels
 from .. import label_dataset
 
 
-def test_dataset_label_samples(capsys, client, dataset_id):
+def test_dataset_label_samples(capsys, dataset_id):
 
-    label_dataset.label_dataset(client, dataset_id)
+    label_dataset.label_dataset(dataset_id)
     out, err = capsys.readouterr()
     assert "Labels added to {}".format(dataset_id) in out
 
-    get_dataset_labels.get_dataset_labels(client, dataset_id)
+    get_dataset_labels.get_dataset_labels(dataset_id)
     out, err = capsys.readouterr()
     assert "color: green" in out
 
-    dataset = delete_dataset_labels.delete_dataset_labels(client, dataset_id)
+    dataset = delete_dataset_labels.delete_dataset_labels(dataset_id)
     out, err = capsys.readouterr()
     assert "Labels deleted from {}".format(dataset_id) in out
     assert dataset.labels.get("color") is None

--- a/bigquery/samples/tests/test_delete_dataset.py
+++ b/bigquery/samples/tests/test_delete_dataset.py
@@ -15,8 +15,8 @@
 from .. import delete_dataset
 
 
-def test_delete_dataset(capsys, client, dataset_id):
+def test_delete_dataset(capsys, dataset_id):
 
-    delete_dataset.delete_dataset(client, dataset_id)
+    delete_dataset.delete_dataset(dataset_id)
     out, err = capsys.readouterr()
     assert "Deleted dataset '{}'.".format(dataset_id) in out

--- a/bigquery/samples/tests/test_delete_table.py
+++ b/bigquery/samples/tests/test_delete_table.py
@@ -15,8 +15,8 @@
 from .. import delete_table
 
 
-def test_delete_table(capsys, client, table_id):
+def test_delete_table(capsys, table_id):
 
-    delete_table.delete_table(client, table_id)
+    delete_table.delete_table(table_id)
     out, err = capsys.readouterr()
     assert "Deleted table '{}'.".format(table_id) in out

--- a/bigquery/samples/tests/test_download_public_data.py
+++ b/bigquery/samples/tests/test_download_public_data.py
@@ -17,11 +17,11 @@ import logging
 from .. import download_public_data
 
 
-def test_download_public_data(caplog, capsys, client):
+def test_download_public_data(caplog, capsys):
     # Enable debug-level logging to verify the BigQuery Storage API is used.
     caplog.set_level(logging.DEBUG)
 
-    download_public_data.download_public_data(client)
+    download_public_data.download_public_data()
     out, _ = capsys.readouterr()
     assert "year" in out
     assert "gender" in out

--- a/bigquery/samples/tests/test_download_public_data_sandbox.py
+++ b/bigquery/samples/tests/test_download_public_data_sandbox.py
@@ -17,11 +17,11 @@ import logging
 from .. import download_public_data_sandbox
 
 
-def test_download_public_data_sandbox(caplog, capsys, client):
+def test_download_public_data_sandbox(caplog, capsys):
     # Enable debug-level logging to verify the BigQuery Storage API is used.
     caplog.set_level(logging.DEBUG)
 
-    download_public_data_sandbox.download_public_data_sandbox(client)
+    download_public_data_sandbox.download_public_data_sandbox()
     out, err = capsys.readouterr()
     assert "year" in out
     assert "gender" in out

--- a/bigquery/samples/tests/test_get_dataset.py
+++ b/bigquery/samples/tests/test_get_dataset.py
@@ -15,8 +15,8 @@
 from .. import get_dataset
 
 
-def test_get_dataset(capsys, client, dataset_id):
+def test_get_dataset(capsys, dataset_id):
 
-    get_dataset.get_dataset(client, dataset_id)
+    get_dataset.get_dataset(dataset_id)
     out, err = capsys.readouterr()
     assert dataset_id in out

--- a/bigquery/samples/tests/test_get_table.py
+++ b/bigquery/samples/tests/test_get_table.py
@@ -17,7 +17,7 @@ from google.cloud import bigquery
 from .. import get_table
 
 
-def test_get_table(capsys, client, random_table_id):
+def test_get_table(capsys, random_table_id, client):
 
     schema = [
         bigquery.SchemaField("full_name", "STRING", mode="REQUIRED"),
@@ -28,7 +28,7 @@ def test_get_table(capsys, client, random_table_id):
     table.description = "Sample Table"
     table = client.create_table(table)
 
-    get_table.get_table(client, random_table_id)
+    get_table.get_table(random_table_id)
     out, err = capsys.readouterr()
     assert "Got table '{}'.".format(random_table_id) in out
     assert "full_name" in out

--- a/bigquery/samples/tests/test_list_datasets.py
+++ b/bigquery/samples/tests/test_list_datasets.py
@@ -15,8 +15,7 @@
 from .. import list_datasets
 
 
-def test_list_datasets(capsys, client, dataset_id):
-
-    list_datasets.list_datasets(client)
+def test_list_datasets(capsys, dataset_id, client):
+    list_datasets.list_datasets()
     out, err = capsys.readouterr()
     assert "Datasets in project {}:".format(client.project) in out

--- a/bigquery/samples/tests/test_list_datasets_by_label.py
+++ b/bigquery/samples/tests/test_list_datasets_by_label.py
@@ -15,11 +15,10 @@
 from .. import list_datasets_by_label
 
 
-def test_list_datasets_by_label(capsys, client, dataset_id):
-
+def test_list_datasets_by_label(capsys, dataset_id, client):
     dataset = client.get_dataset(dataset_id)
     dataset.labels = {"color": "green"}
     dataset = client.update_dataset(dataset, ["labels"])
-    list_datasets_by_label.list_datasets_by_label(client)
+    list_datasets_by_label.list_datasets_by_label()
     out, err = capsys.readouterr()
     assert dataset_id in out

--- a/bigquery/samples/tests/test_list_tables.py
+++ b/bigquery/samples/tests/test_list_tables.py
@@ -15,9 +15,9 @@
 from .. import list_tables
 
 
-def test_list_tables(capsys, client, dataset_id, table_id):
+def test_list_tables(capsys, dataset_id, table_id):
 
-    list_tables.list_tables(client, dataset_id)
+    list_tables.list_tables(dataset_id)
     out, err = capsys.readouterr()
     assert "Tables contained in '{}':".format(dataset_id) in out
     assert table_id in out

--- a/bigquery/samples/tests/test_load_table_dataframe.py
+++ b/bigquery/samples/tests/test_load_table_dataframe.py
@@ -21,9 +21,9 @@ pandas = pytest.importorskip("pandas")
 pyarrow = pytest.importorskip("pyarrow")
 
 
-def test_load_table_dataframe(capsys, client, random_table_id):
+def test_load_table_dataframe(capsys, random_table_id):
 
-    table = load_table_dataframe.load_table_dataframe(client, random_table_id)
+    table = load_table_dataframe.load_table_dataframe(random_table_id)
     out, _ = capsys.readouterr()
     assert "Loaded 4 rows and 3 columns" in out
 

--- a/bigquery/samples/tests/test_model_samples.py
+++ b/bigquery/samples/tests/test_model_samples.py
@@ -18,22 +18,22 @@ from .. import list_models
 from .. import update_model
 
 
-def test_model_samples(capsys, client, dataset_id, model_id):
+def test_model_samples(capsys, dataset_id, model_id):
     """Since creating a model is a long operation, test all model samples in
     the same test, following a typical end-to-end flow.
     """
-    get_model.get_model(client, model_id)
+    get_model.get_model(model_id)
     out, err = capsys.readouterr()
     assert model_id in out
 
-    list_models.list_models(client, dataset_id)
+    list_models.list_models(dataset_id)
     out, err = capsys.readouterr()
     assert "Models contained in '{}':".format(dataset_id) in out
 
-    update_model.update_model(client, model_id)
+    update_model.update_model(model_id)
     out, err = capsys.readouterr()
     assert "This model was modified from a Python program." in out
 
-    delete_model.delete_model(client, model_id)
+    delete_model.delete_model(model_id)
     out, err = capsys.readouterr()
     assert "Deleted model '{}'.".format(model_id) in out

--- a/bigquery/samples/tests/test_query_external_gcs_temporary_table.py
+++ b/bigquery/samples/tests/test_query_external_gcs_temporary_table.py
@@ -15,8 +15,8 @@
 from .. import query_external_gcs_temporary_table
 
 
-def test_query_external_gcs_temporary_table(capsys, client):
+def test_query_external_gcs_temporary_table(capsys,):
 
-    query_external_gcs_temporary_table.query_external_gcs_temporary_table(client)
+    query_external_gcs_temporary_table.query_external_gcs_temporary_table()
     out, err = capsys.readouterr()
     assert "There are 4 states with names starting with W." in out

--- a/bigquery/samples/tests/test_query_no_cache.py
+++ b/bigquery/samples/tests/test_query_no_cache.py
@@ -17,8 +17,8 @@ import re
 from .. import query_no_cache
 
 
-def test_query_no_cache(capsys, client):
+def test_query_no_cache(capsys,):
 
-    query_no_cache.query_no_cache(client)
+    query_no_cache.query_no_cache()
     out, err = capsys.readouterr()
     assert re.search(r"(Row[\w(){}:', ]+)$", out)

--- a/bigquery/samples/tests/test_query_pagination.py
+++ b/bigquery/samples/tests/test_query_pagination.py
@@ -15,9 +15,9 @@
 from .. import query_pagination
 
 
-def test_query_pagination(capsys, client):
+def test_query_pagination(capsys,):
 
-    query_pagination.query_pagination(client)
+    query_pagination.query_pagination()
     out, _ = capsys.readouterr()
     assert "The query data:" in out
     assert "name=James, count=4942431" in out

--- a/bigquery/samples/tests/test_query_script.py
+++ b/bigquery/samples/tests/test_query_script.py
@@ -15,9 +15,9 @@
 from .. import query_script
 
 
-def test_query_script(capsys, client):
+def test_query_script(capsys,):
 
-    query_script.query_script(client)
+    query_script.query_script()
     out, _ = capsys.readouterr()
     assert "Script created 2 child jobs." in out
     assert (

--- a/bigquery/samples/tests/test_query_to_arrow.py
+++ b/bigquery/samples/tests/test_query_to_arrow.py
@@ -17,9 +17,9 @@ import pyarrow
 from .. import query_to_arrow
 
 
-def test_query_to_arrow(capsys, client):
+def test_query_to_arrow(capsys,):
 
-    arrow_table = query_to_arrow.query_to_arrow(client)
+    arrow_table = query_to_arrow.query_to_arrow()
     out, err = capsys.readouterr()
     assert "Downloaded 8 rows, 2 columns." in out
     arrow_schema = arrow_table.schema

--- a/bigquery/samples/tests/test_routine_samples.py
+++ b/bigquery/samples/tests/test_routine_samples.py
@@ -16,18 +16,18 @@ from google.cloud import bigquery
 from google.cloud import bigquery_v2
 
 
-def test_create_routine(capsys, client, random_routine_id):
+def test_create_routine(capsys, random_routine_id):
     from .. import create_routine
 
-    create_routine.create_routine(client, random_routine_id)
+    create_routine.create_routine(random_routine_id)
     out, err = capsys.readouterr()
     assert "Created routine {}".format(random_routine_id) in out
 
 
-def test_create_routine_ddl(capsys, client, random_routine_id):
+def test_create_routine_ddl(capsys, random_routine_id, client):
     from .. import create_routine_ddl
 
-    create_routine_ddl.create_routine_ddl(client, random_routine_id)
+    create_routine_ddl.create_routine_ddl(random_routine_id)
     routine = client.get_routine(random_routine_id)
     out, err = capsys.readouterr()
 
@@ -65,19 +65,19 @@ def test_create_routine_ddl(capsys, client, random_routine_id):
     assert routine.arguments == expected_arguments
 
 
-def test_list_routines(capsys, client, dataset_id, routine_id):
+def test_list_routines(capsys, dataset_id, routine_id):
     from .. import list_routines
 
-    list_routines.list_routines(client, dataset_id)
+    list_routines.list_routines(dataset_id)
     out, err = capsys.readouterr()
     assert "Routines contained in dataset {}:".format(dataset_id) in out
     assert routine_id in out
 
 
-def test_get_routine(capsys, client, routine_id):
+def test_get_routine(capsys, routine_id):
     from .. import get_routine
 
-    get_routine.get_routine(client, routine_id)
+    get_routine.get_routine(routine_id)
     out, err = capsys.readouterr()
     assert "Routine '{}':".format(routine_id) in out
     assert "Type: 'SCALAR_FUNCTION'" in out
@@ -86,16 +86,16 @@ def test_get_routine(capsys, client, routine_id):
     assert "Type: 'type_kind: INT64\n'" in out
 
 
-def test_delete_routine(capsys, client, routine_id):
+def test_delete_routine(capsys, routine_id):
     from .. import delete_routine
 
-    delete_routine.delete_routine(client, routine_id)
+    delete_routine.delete_routine(routine_id)
     out, err = capsys.readouterr()
     assert "Deleted routine {}.".format(routine_id) in out
 
 
-def test_update_routine(client, routine_id):
+def test_update_routine(routine_id):
     from .. import update_routine
 
-    routine = update_routine.update_routine(client, routine_id)
+    routine = update_routine.update_routine(routine_id)
     assert routine.body == "x * 4"

--- a/bigquery/samples/tests/test_table_exists.py
+++ b/bigquery/samples/tests/test_table_exists.py
@@ -17,13 +17,13 @@ from google.cloud import bigquery
 from .. import table_exists
 
 
-def test_table_exists(capsys, client, random_table_id):
+def test_table_exists(capsys, random_table_id, client):
 
-    table_exists.table_exists(client, random_table_id)
+    table_exists.table_exists(random_table_id)
     out, err = capsys.readouterr()
     assert "Table {} is not found.".format(random_table_id) in out
     table = bigquery.Table(random_table_id)
     table = client.create_table(table)
-    table_exists.table_exists(client, random_table_id)
+    table_exists.table_exists(random_table_id)
     out, err = capsys.readouterr()
     assert "Table {} already exists.".format(random_table_id) in out

--- a/bigquery/samples/tests/test_table_insert_rows.py
+++ b/bigquery/samples/tests/test_table_insert_rows.py
@@ -17,7 +17,7 @@ from google.cloud import bigquery
 from .. import table_insert_rows
 
 
-def test_table_insert_rows(capsys, client, random_table_id):
+def test_table_insert_rows(capsys, random_table_id, client):
 
     schema = [
         bigquery.SchemaField("full_name", "STRING", mode="REQUIRED"),
@@ -27,6 +27,6 @@ def test_table_insert_rows(capsys, client, random_table_id):
     table = bigquery.Table(random_table_id, schema=schema)
     table = client.create_table(table)
 
-    table_insert_rows.table_insert_rows(client, random_table_id)
+    table_insert_rows.table_insert_rows(random_table_id)
     out, err = capsys.readouterr()
     assert "New rows have been added." in out

--- a/bigquery/samples/tests/test_table_insert_rows_explicit_none_insert_ids.py
+++ b/bigquery/samples/tests/test_table_insert_rows_explicit_none_insert_ids.py
@@ -17,7 +17,7 @@ from google.cloud import bigquery
 from .. import table_insert_rows_explicit_none_insert_ids as mut
 
 
-def test_table_insert_rows_explicit_none_insert_ids(capsys, client, random_table_id):
+def test_table_insert_rows_explicit_none_insert_ids(capsys, random_table_id, client):
 
     schema = [
         bigquery.SchemaField("full_name", "STRING", mode="REQUIRED"),
@@ -27,6 +27,6 @@ def test_table_insert_rows_explicit_none_insert_ids(capsys, client, random_table
     table = bigquery.Table(random_table_id, schema=schema)
     table = client.create_table(table)
 
-    mut.table_insert_rows_explicit_none_insert_ids(client, random_table_id)
+    mut.table_insert_rows_explicit_none_insert_ids(random_table_id)
     out, err = capsys.readouterr()
     assert "New rows have been added." in out

--- a/bigquery/samples/tests/test_undelete_table.py
+++ b/bigquery/samples/tests/test_undelete_table.py
@@ -15,8 +15,8 @@
 from .. import undelete_table
 
 
-def test_undelete_table(capsys, client, table_with_schema_id, random_table_id):
-    undelete_table.undelete_table(client, table_with_schema_id, random_table_id)
+def test_undelete_table(capsys, table_with_schema_id, random_table_id):
+    undelete_table.undelete_table(table_with_schema_id, random_table_id)
     out, _ = capsys.readouterr()
     assert (
         "Copied data from deleted table {} to {}".format(

--- a/bigquery/samples/tests/test_update_dataset_access.py
+++ b/bigquery/samples/tests/test_update_dataset_access.py
@@ -15,9 +15,9 @@
 from .. import update_dataset_access
 
 
-def test_update_dataset_access(capsys, client, dataset_id):
+def test_update_dataset_access(capsys, dataset_id):
 
-    update_dataset_access.update_dataset_access(client, dataset_id)
+    update_dataset_access.update_dataset_access(dataset_id)
     out, err = capsys.readouterr()
     assert (
         "Updated dataset '{}' with modified user permissions.".format(dataset_id) in out

--- a/bigquery/samples/tests/test_update_dataset_default_partition_expiration.py
+++ b/bigquery/samples/tests/test_update_dataset_default_partition_expiration.py
@@ -15,12 +15,12 @@
 from .. import update_dataset_default_partition_expiration
 
 
-def test_update_dataset_default_partition_expiration(capsys, client, dataset_id):
+def test_update_dataset_default_partition_expiration(capsys, dataset_id):
 
     ninety_days_ms = 90 * 24 * 60 * 60 * 1000  # in milliseconds
 
     update_dataset_default_partition_expiration.update_dataset_default_partition_expiration(
-        client, dataset_id
+        dataset_id
     )
     out, _ = capsys.readouterr()
     assert (

--- a/bigquery/samples/tests/test_update_dataset_default_table_expiration.py
+++ b/bigquery/samples/tests/test_update_dataset_default_table_expiration.py
@@ -15,12 +15,12 @@
 from .. import update_dataset_default_table_expiration
 
 
-def test_update_dataset_default_table_expiration(capsys, client, dataset_id):
+def test_update_dataset_default_table_expiration(capsys, dataset_id):
 
     one_day_ms = 24 * 60 * 60 * 1000  # in milliseconds
 
     update_dataset_default_table_expiration.update_dataset_default_table_expiration(
-        client, dataset_id
+        dataset_id
     )
     out, err = capsys.readouterr()
     assert (

--- a/bigquery/samples/tests/test_update_dataset_description.py
+++ b/bigquery/samples/tests/test_update_dataset_description.py
@@ -15,8 +15,8 @@
 from .. import update_dataset_description
 
 
-def test_update_dataset_description(capsys, client, dataset_id):
+def test_update_dataset_description(capsys, dataset_id):
 
-    update_dataset_description.update_dataset_description(client, dataset_id)
+    update_dataset_description.update_dataset_description(dataset_id)
     out, err = capsys.readouterr()
     assert "Updated description." in out

--- a/bigquery/samples/tests/test_update_table_require_partition_filter.py
+++ b/bigquery/samples/tests/test_update_table_require_partition_filter.py
@@ -17,7 +17,7 @@ from google.cloud import bigquery
 from .. import update_table_require_partition_filter
 
 
-def test_update_table_require_partition_filter(capsys, client, random_table_id):
+def test_update_table_require_partition_filter(capsys, random_table_id, client):
 
     # Make a partitioned table.
     schema = [bigquery.SchemaField("transaction_timestamp", "TIMESTAMP")]
@@ -26,7 +26,7 @@ def test_update_table_require_partition_filter(capsys, client, random_table_id):
     table = client.create_table(table)
 
     update_table_require_partition_filter.update_table_require_partition_filter(
-        client, random_table_id
+        random_table_id
     )
     out, _ = capsys.readouterr()
     assert (

--- a/bigquery/samples/undelete_table.py
+++ b/bigquery/samples/undelete_table.py
@@ -15,15 +15,15 @@
 from google.api_core import datetime_helpers
 
 
-def undelete_table(client, table_id, recovered_table_id):
+def undelete_table(table_id, recovered_table_id):
     # [START bigquery_undelete_table]
     import time
 
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Choose a table to recover.
     # table_id = "your-project.your_dataset.your_table"

--- a/bigquery/samples/undelete_table.py
+++ b/bigquery/samples/undelete_table.py
@@ -19,10 +19,9 @@ def undelete_table(table_id, recovered_table_id):
     # [START bigquery_undelete_table]
     import time
 
-    # TODO(developer): Import the client library.
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Choose a table to recover.

--- a/bigquery/samples/update_dataset_access.py
+++ b/bigquery/samples/update_dataset_access.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def update_dataset_access(client, dataset_id):
+def update_dataset_access(dataset_id):
 
     # [START bigquery_update_dataset_access]
     from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.
     # dataset_id = 'your-project.your_dataset'

--- a/bigquery/samples/update_dataset_access.py
+++ b/bigquery/samples/update_dataset_access.py
@@ -18,7 +18,7 @@ def update_dataset_access(dataset_id):
     # [START bigquery_update_dataset_access]
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.

--- a/bigquery/samples/update_dataset_default_partition_expiration.py
+++ b/bigquery/samples/update_dataset_default_partition_expiration.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def update_dataset_default_partition_expiration(client, dataset_id):
+def update_dataset_default_partition_expiration(dataset_id):
 
     # [START bigquery_update_dataset_partition_expiration]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.
     # dataset_id = 'your-project.your_dataset'

--- a/bigquery/samples/update_dataset_default_partition_expiration.py
+++ b/bigquery/samples/update_dataset_default_partition_expiration.py
@@ -16,10 +16,10 @@
 def update_dataset_default_partition_expiration(dataset_id):
 
     # [START bigquery_update_dataset_partition_expiration]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.

--- a/bigquery/samples/update_dataset_default_table_expiration.py
+++ b/bigquery/samples/update_dataset_default_table_expiration.py
@@ -16,10 +16,10 @@
 def update_dataset_default_table_expiration(dataset_id):
 
     # [START bigquery_update_dataset_expiration]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.

--- a/bigquery/samples/update_dataset_default_table_expiration.py
+++ b/bigquery/samples/update_dataset_default_table_expiration.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def update_dataset_default_table_expiration(client, dataset_id):
+def update_dataset_default_table_expiration(dataset_id):
 
     # [START bigquery_update_dataset_expiration]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.
     # dataset_id = 'your-project.your_dataset'

--- a/bigquery/samples/update_dataset_description.py
+++ b/bigquery/samples/update_dataset_description.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def update_dataset_description(client, dataset_id):
+def update_dataset_description(dataset_id):
 
     # [START bigquery_update_dataset_description]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.
     # dataset_id = 'your-project.your_dataset'

--- a/bigquery/samples/update_dataset_description.py
+++ b/bigquery/samples/update_dataset_description.py
@@ -16,10 +16,10 @@
 def update_dataset_description(dataset_id):
 
     # [START bigquery_update_dataset_description]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set dataset_id to the ID of the dataset to fetch.

--- a/bigquery/samples/update_model.py
+++ b/bigquery/samples/update_model.py
@@ -17,10 +17,10 @@ def update_model(model_id):
     """Sample ID: go/samples-tracker/1533"""
 
     # [START bigquery_update_model_description]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set model_id to the ID of the model to fetch.

--- a/bigquery/samples/update_model.py
+++ b/bigquery/samples/update_model.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 
-def update_model(client, model_id):
+def update_model(model_id):
     """Sample ID: go/samples-tracker/1533"""
 
     # [START bigquery_update_model_description]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set model_id to the ID of the model to fetch.
     # model_id = 'your-project.your_dataset.your_model'

--- a/bigquery/samples/update_routine.py
+++ b/bigquery/samples/update_routine.py
@@ -16,10 +16,10 @@
 def update_routine(routine_id):
 
     # [START bigquery_update_routine]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set the fully-qualified ID for the routine.

--- a/bigquery/samples/update_routine.py
+++ b/bigquery/samples/update_routine.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def update_routine(client, routine_id):
+def update_routine(routine_id):
 
     # [START bigquery_update_routine]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set the fully-qualified ID for the routine.
     # routine_id = "my-project.my_dataset.my_routine"

--- a/bigquery/samples/update_table_require_partition_filter.py
+++ b/bigquery/samples/update_table_require_partition_filter.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-def update_table_require_partition_filter(client, table_id):
+def update_table_require_partition_filter(table_id):
 
     # [START bigquery_update_table_require_partition_filter]
     # TODO(developer): Import the client library.
-    # from google.cloud import bigquery
+    from google.cloud import bigquery
 
     # TODO(developer): Construct a BigQuery client object.
-    # client = bigquery.Client()
+    client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the model to fetch.
     # table_id = 'your-project.your_dataset.your_table'

--- a/bigquery/samples/update_table_require_partition_filter.py
+++ b/bigquery/samples/update_table_require_partition_filter.py
@@ -16,10 +16,10 @@
 def update_table_require_partition_filter(table_id):
 
     # [START bigquery_update_table_require_partition_filter]
-    # TODO(developer): Import the client library.
+
     from google.cloud import bigquery
 
-    # TODO(developer): Construct a BigQuery client object.
+    # Construct a BigQuery client object.
     client = bigquery.Client()
 
     # TODO(developer): Set table_id to the ID of the model to fetch.


### PR DESCRIPTION
Use a session-scope filter to ensure that a client is only constructed once per test run, saving time on authentication.

We received customer feedback (internal issue 144569827) pointing out that the `Client` constructor and `from google.cloud import bigquery` lines shouldn't be commented-out. Leaving these uncommented also better matches the latest code sample best practices. To ensure this is net-neutral in terms of test time, I update the client fixture to ensure that `bigquery.Client()` in the code samples doesn't redo the slow authentication logic.