### PR TITLE
Fix reference to SearchCatalogRequest.Scope

### DIFF
--- a/datacatalog/google/cloud/datacatalog_v1beta1/gapic/data_catalog_client.py
+++ b/datacatalog/google/cloud/datacatalog_v1beta1/gapic/data_catalog_client.py
@@ -345,10 +345,10 @@ class DataCatalogClient(object):
             ...         pass
 
         Args:
-            scope (Union[dict, ~google.cloud.datacatalog_v1beta1.types.Scope]): Required. The scope of this search request.
+            scope (Union[dict, ~google.cloud.datacatalog_v1beta1.types.SearchCatalogRequest.Scope]): Required. The scope of this search request.
 
                 If a dict is provided, it must be of the same form as the protobuf
-                message :class:`~google.cloud.datacatalog_v1beta1.types.Scope`
+                message :class:`~google.cloud.datacatalog_v1beta1.types.SearchCatalogRequest.Scope`
             query (str): Required. The query string in search query syntax. The query must be
                 non-empty.
 


### PR DESCRIPTION
Hello,

I would like to correct the incorrect class reference in the documentation:
https://github.com/googleapis/google-cloud-python/issues/10059

Best regards,
Kamil


Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #10059  🦕