### PR TITLE
fix: replace unsafe six.PY3 with PY2 for better future compatibility with Python 4

### DIFF
--- a/logging/tests/unit/handlers/test__helpers.py
+++ b/logging/tests/unit/handlers/test__helpers.py
@@ -77,7 +77,7 @@ class _GetTraceId(RequestHandler):
         self.response.out.write(json.dumps(trace_id))
 
 
-@unittest.skipIf(six.PY3, "webapp2 is Python 2 only")
+@unittest.skipIf(not six.PY2, "webapp2 is Python 2 only")
 class Test_get_trace_id_from_webapp2(unittest.TestCase):
     @staticmethod
     def create_app():

--- a/pubsub/synth.py
+++ b/pubsub/synth.py
@@ -127,10 +127,10 @@ s.replace(
     "google/cloud/pubsub_v1/gapic/publisher_client.py",
     "class PublisherClient",
     """# TODO: remove conditional import after Python 2 support is dropped
-if six.PY3:
-    from collections.abc import Mapping
-else:
+if six.PY2:
     from collections import Mapping
+else:
+    from collections.abc import Mapping
     
 
 def _merge_dict(d1, d2):

--- a/storage/google/cloud/storage/batch.py
+++ b/storage/google/cloud/storage/batch.py
@@ -214,10 +214,10 @@ class Batch(Connection):
             timeout = _timeout
 
         # The `email` package expects to deal with "native" strings
-        if six.PY3:  # pragma: NO COVER  Python3
-            buf = io.StringIO()
-        else:
+        if six.PY2:  # pragma: NO COVER  Python3
             buf = io.BytesIO()
+        else:
+            buf = io.StringIO()
         generator = Generator(buf, False, 0)
         generator.flatten(multi)
         payload = buf.getvalue()

--- a/storage/tests/unit/test__signing.py
+++ b/storage/tests/unit/test__signing.py
@@ -70,7 +70,7 @@ class Test_get_expiration_seconds_v2(unittest.TestCase):
 
     def test_w_expiration_long(self):
         if not six.PY2:
-            raise unittest.SkipTest("No long on Python 3")
+            raise unittest.SkipTest("No long on Python 3+")
 
         self.assertEqual(self._call_fut(long(123)), 123)  # noqa: F821
 

--- a/storage/tests/unit/test__signing.py
+++ b/storage/tests/unit/test__signing.py
@@ -69,7 +69,7 @@ class Test_get_expiration_seconds_v2(unittest.TestCase):
         self.assertEqual(self._call_fut(123), 123)
 
     def test_w_expiration_long(self):
-        if six.PY3:
+        if not six.PY2:
             raise unittest.SkipTest("No long on Python 3")
 
         self.assertEqual(self._call_fut(long(123)), 123)  # noqa: F821


### PR DESCRIPTION
Fixes #10158.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [trivial] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
(edit by @plamut: opened the [issue](https://github.com/googleapis/google-cloud-python/issues/10158) for better traceability)
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [n/a] Appropriate docs were updated (if necessary)

---

We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

There's some code which uses `six.PY3`:

```python
if six.PY3:
    print("Python 3+ code")
else:
    print "Python 2 code"
```

Where:

```python
PY3 = sys.version_info[0] == 3
```

When run on Python 4, this will run the Python 2 code!

Instead, use `six.PY2`.

Found using https://github.com/asottile/flake8-2020.


