### PR TITLE
Fixes typo in Natural Language samples

### DIFF
--- a/language/samples/v1/language_syntax_gcs.py
+++ b/language/samples/v1/language_syntax_gcs.py
@@ -64,7 +64,7 @@ def sample_analyze_syntax(gcs_content_uri):
             u"Location of this token in overall document: {}".format(text.begin_offset)
         )
         # Get the part of speech information for this token.
-        # Parts of spech are as defined in:
+        # Parts of speech are as defined in:
         # http://www.lrec-conf.org/proceedings/lrec2012/pdf/274_Paper.pdf
         part_of_speech = token.part_of_speech
         # Get the tag, e.g. NOUN, ADJ for Adjective, et al.

--- a/language/samples/v1/language_syntax_text.py
+++ b/language/samples/v1/language_syntax_text.py
@@ -63,7 +63,7 @@ def sample_analyze_syntax(text_content):
             u"Location of this token in overall document: {}".format(text.begin_offset)
         )
         # Get the part of speech information for this token.
-        # Parts of spech are as defined in:
+        # Parts of speech are as defined in:
         # http://www.lrec-conf.org/proceedings/lrec2012/pdf/274_Paper.pdf
         part_of_speech = token.part_of_speech
         # Get the tag, e.g. NOUN, ADJ for Adjective, et al.


### PR DESCRIPTION
Fixes a typo ("speech" instead of "spech") in Natural Languages samples.

Fixes #10133 🦕