### PR TITLE
perf(bigquery): remove redundant array deepcopy

### DIFF
--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -15,7 +15,6 @@
 """Shared helper functions for BigQuery API classes."""
 
 import base64
-import copy
 import datetime
 import decimal
 import re

--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -396,13 +396,9 @@ def _repeated_field_to_json(field, row_value):
     Returns:
         List[Any]: A list of JSON-serializable objects.
     """
-    # Remove the REPEATED, but keep the other fields. This allows us to process
-    # each item as if it were a top-level field.
-    item_field = copy.deepcopy(field)
-    item_field._mode = "NULLABLE"
     values = []
     for item in row_value:
-        values.append(_field_to_json(item_field, item))
+        values.append(_single_field_to_json(field, item))
     return values
 
 
@@ -432,6 +428,29 @@ def _record_field_to_json(fields, row_value):
     return record
 
 
+def _single_field_to_json(field, row_value):
+    """Convert a single (non-repeating) field into JSON-serializable values.
+
+    Args:
+        field (google.cloud.bigquery.schema.SchemaField):
+            The SchemaField to use for type conversion and field name.
+
+        row_value (Any):
+            Scalar or Struct to be inserted. The type
+            is inferred from the SchemaField's field_type.
+
+    Returns:
+        Any: A JSON-serializable object.
+    """
+    if row_value is None:
+        return None
+
+    if field.field_type == "RECORD":
+        return _record_field_to_json(field.fields, row_value)
+
+    return _scalar_field_to_json(field, row_value)
+
+
 def _field_to_json(field, row_value):
     """Convert a field into JSON-serializable values.
 
@@ -453,10 +472,7 @@ def _field_to_json(field, row_value):
     if field.mode == "REPEATED":
         return _repeated_field_to_json(field, row_value)
 
-    if field.field_type == "RECORD":
-        return _record_field_to_json(field.fields, row_value)
-
-    return _scalar_field_to_json(field, row_value)
+    return _single_field_to_json(field, row_value)
 
 
 def _snake_to_camel_case(value):

--- a/bigquery/tests/unit/test__helpers.py
+++ b/bigquery/tests/unit/test__helpers.py
@@ -805,6 +805,35 @@ class Test_scalar_field_to_json(unittest.TestCase):
         self.assertEqual(converted, str(original))
 
 
+class Test_single_field_to_json(unittest.TestCase):
+    def _call_fut(self, field, value):
+        from google.cloud.bigquery._helpers import _single_field_to_json
+
+        return _single_field_to_json(field, value)
+
+    def test_w_none(self):
+        field = _make_field("INT64")
+        original = None
+        converted = self._call_fut(field, original)
+        self.assertIsNone(converted)
+
+    def test_w_record(self):
+        subfields = [
+            _make_field("INT64", name="one"),
+            _make_field("STRING", name="two"),
+        ]
+        field = _make_field("RECORD", fields=subfields)
+        original = {"one": 42, "two": "two"}
+        converted = self._call_fut(field, original)
+        self.assertEqual(converted, {"one": "42", "two": "two"})
+
+    def test_w_scalar(self):
+        field = _make_field("INT64")
+        original = 42
+        converted = self._call_fut(field, original)
+        self.assertEqual(converted, str(original))
+
+
 class Test_repeated_field_to_json(unittest.TestCase):
     def _call_fut(self, field, value):
         from google.cloud.bigquery._helpers import _repeated_field_to_json


### PR DESCRIPTION
Deepcopy can be a very costly operation when considering large arrays with complex nested objects.
Refactor helpers to allow recursive conversion without copying arrays.

Fixes #10138  🦕