### PR TITLE
chore(pubsub): declaratively drop Python 3.4 support

### DIFF
--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -84,7 +84,7 @@ setuptools.setup(
     namespace_packages=namespaces,
     install_requires=dependencies,
     extras_require=extras,
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
Fixes #10167.

This PR declaratively drops Python 3.4 support by constraining installation on Python 3.4 with the corresponding option in `setup.py`.

### PR checklist:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

