### PR TITLE
feat(spanner): add resource based routing implementation

### DIFF
--- a/spanner/google/cloud/spanner_v1/client.py
+++ b/spanner/google/cloud/spanner_v1/client.py
@@ -26,6 +26,7 @@ In the hierarchy of API concepts
 import warnings
 
 from google.api_core.gapic_v1 import client_info
+import google.api_core.client_options
 
 # pylint: disable=line-too-long
 from google.cloud.spanner_admin_database_v1.gapic.database_admin_client import (  # noqa
@@ -122,6 +123,7 @@ class Client(ClientWithProject):
 
     _instance_admin_api = None
     _database_admin_api = None
+    _endpoint_cache = {}
     user_agent = None
     _SET_PROJECT = True  # Used by from_service_account_json()
 
@@ -143,7 +145,12 @@ class Client(ClientWithProject):
             project=project, credentials=credentials, _http=None
         )
         self._client_info = client_info
-        self._client_options = client_options
+        if client_options and type(client_options) == dict:
+            self._client_options = google.api_core.client_options.from_dict(
+                client_options
+            )
+        else:
+            self._client_options = client_options
 
         if user_agent is not None:
             warnings.warn(_USER_AGENT_DEPRECATED, DeprecationWarning, stacklevel=2)

--- a/spanner/google/cloud/spanner_v1/database.py
+++ b/spanner/google/cloud/spanner_v1/database.py
@@ -60,7 +60,7 @@ _DATABASE_NAME_RE = re.compile(
 
 _RESOURCE_ROUTING_PERMISSIONS_WARNING = (
     "The client library attempted to connect to an endpoint closer to your Cloud Spanner data "
-    "but was unable to do so. The client library will fallback and route requests to the endpoint "
+    "but was unable to do so. The client library will fall back and route requests to the endpoint "
     "given in the client options which may result in increased latency. "
     "We recommend including the scope https://www.googleapis.com/auth/spanner.admin so that the "
     "client library can get an instance-specific endpoint and efficiently route requests."

--- a/spanner/google/cloud/spanner_v1/database.py
+++ b/spanner/google/cloud/spanner_v1/database.py
@@ -61,7 +61,7 @@ _DATABASE_NAME_RE = re.compile(
 _RESOURCE_ROUTING_PERMISSIONS_WARNING = (
     "The client library attempted to connect to an endpoint closer to your Cloud Spanner data "
     "but was unable to do so. The client library will fall back and route requests to the endpoint "
-    "given in the client options which may result in increased latency. "
+    "given in the client options, which may result in increased latency. "
     "We recommend including the scope https://www.googleapis.com/auth/spanner.admin so that the "
     "client library can get an instance-specific endpoint and efficiently route requests."
 )

--- a/spanner/google/cloud/spanner_v1/database.py
+++ b/spanner/google/cloud/spanner_v1/database.py
@@ -16,12 +16,16 @@
 
 import copy
 import functools
+import os
 import re
 import threading
+import warnings
 
+from google.api_core.client_options import ClientOptions
 import google.auth.credentials
 from google.protobuf.struct_pb2 import Struct
 from google.cloud.exceptions import NotFound
+from google.api_core.exceptions import PermissionDenied
 import six
 
 # pylint: disable=ungrouped-imports
@@ -52,6 +56,19 @@ _DATABASE_NAME_RE = re.compile(
     r"instances/(?P<instance_id>[a-z][-a-z0-9]*)/"
     r"databases/(?P<database_id>[a-z][a-z0-9_\-]*[a-z0-9])$"
 )
+
+
+_RESOURCE_ROUTING_PERMISSIONS_WARNING = (
+    "The client library attempted to connect to an endpoint closer to your Cloud Spanner data "
+    "but was unable to do so. The client library will fallback and route requests to the endpoint "
+    "given in the client options which may result in increased latency. "
+    "We recommend including the scope https://www.googleapis.com/auth/spanner.admin so that the "
+    "client library can get an instance-specific endpoint and efficiently route requests."
+)
+
+
+class ResourceRoutingPermissionsWarning(Warning):
+    pass
 
 
 class Database(object):
@@ -178,6 +195,36 @@ class Database(object):
                 credentials = credentials.with_scopes((SPANNER_DATA_SCOPE,))
             client_info = self._instance._client._client_info
             client_options = self._instance._client._client_options
+            if (
+                os.getenv("GOOGLE_CLOUD_SPANNER_ENABLE_RESOURCE_BASED_ROUTING")
+                == "true"
+            ):
+                endpoint_cache = self._instance._client._endpoint_cache
+                if self._instance.name in endpoint_cache:
+                    client_options = ClientOptions(
+                        api_endpoint=endpoint_cache[self._instance.name]
+                    )
+                else:
+                    try:
+                        api = self._instance._client.instance_admin_api
+                        resp = api.get_instance(
+                            self._instance.name,
+                            field_mask={"paths": ["endpoint_uris"]},
+                            metadata=_metadata_with_prefix(self.name),
+                        )
+                        endpoints = resp.endpoint_uris
+                        if endpoints:
+                            endpoint_cache[self._instance.name] = list(endpoints)[0]
+                            client_options = ClientOptions(
+                                api_endpoint=endpoint_cache[self._instance.name]
+                            )
+                        # If there are no endpoints, use default endpoint.
+                    except PermissionDenied:
+                        warnings.warn(
+                            _RESOURCE_ROUTING_PERMISSIONS_WARNING,
+                            ResourceRoutingPermissionsWarning,
+                            stacklevel=2,
+                        )
             self._spanner_api = SpannerClient(
                 credentials=credentials,
                 client_info=client_info,


### PR DESCRIPTION
Implement resource based routing.

When creating a SpannerClient, check for suggested endpoints. 
If endpoints are returned, use the first one. 
If no endpoints are returned, use default endpoint (either global endpoint or user-specified endpoint).

Endpoints are cached per instance on the Client.

This feature is disabled by default and is enabled by setting the environment variable to true.

To enable:
export GOOGLE_CLOUD_SPANNER_ENABLE_RESOURCE_BASED_ROUTING=true