### PR TITLE
test(bigquery): fix snippet test for loading partitioned tables

### DIFF
--- a/bigquery/samples/tests/test_client_load_partitioned_table.py
+++ b/bigquery/samples/tests/test_client_load_partitioned_table.py
@@ -16,7 +16,6 @@ from .. import client_load_partitioned_table
 
 
 def test_client_load_partitioned_table(capsys, random_table_id):
-
     client_load_partitioned_table.client_load_partitioned_table(random_table_id)
     out, err = capsys.readouterr()
-    assert "Loaded 50 rows to table {}".format(random_table_id) in out
+    assert "Loaded 49 rows to table {}".format(random_table_id) in out


### PR DESCRIPTION
Fixes #10194.

For some reason the number of rows in the public test file `us-states-by-date.csv` has changed from 50 to 49. This PR adjusts the affected test.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)