### PR TITLE
fix(bigquery): fix inserting missing repeated fields

### DIFF
--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -422,13 +422,16 @@ def _record_field_to_json(fields, row_value):
     record = {}
     isdict = isinstance(row_value, dict)
 
+    MISSING = object()  # a sentinel to distinguish from None values
+
     for subindex, subfield in enumerate(fields):
         subname = subfield.name
-        if isdict:
-            subvalue = row_value.get(subname)
-        else:
-            subvalue = row_value[subindex]
-        record[subname] = _field_to_json(subfield, subvalue)
+        subvalue = row_value.get(subname, MISSING) if isdict else row_value[subindex]
+
+        # we should not convert missing values to an explicit None
+        if subvalue is not MISSING:
+            record[subname] = _field_to_json(subfield, subvalue)
+
     return record
 
 

--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -422,14 +422,12 @@ def _record_field_to_json(fields, row_value):
     record = {}
     isdict = isinstance(row_value, dict)
 
-    MISSING = object()  # a sentinel to distinguish from None values
-
     for subindex, subfield in enumerate(fields):
         subname = subfield.name
-        subvalue = row_value.get(subname, MISSING) if isdict else row_value[subindex]
+        subvalue = row_value.get(subname) if isdict else row_value[subindex]
 
-        # we should not convert missing values to an explicit None
-        if subvalue is not MISSING:
+        # None values are unconditionally omitted
+        if subvalue is not None:
             record[subname] = _field_to_json(subfield, subvalue)
 
     return record

--- a/bigquery/tests/unit/test__helpers.py
+++ b/bigquery/tests/unit/test__helpers.py
@@ -863,7 +863,9 @@ class Test_record_field_to_json(unittest.TestCase):
         ]
         original = {"one": 42}
         converted = self._call_fut(fields, original)
-        self.assertEqual(converted, {"one": "42", "two": None})
+
+        # missing fields should not be converted to an explicit None
+        self.assertEqual(converted, {"one": "42"})
 
 
 class Test_field_to_json(unittest.TestCase):

--- a/bigquery/tests/unit/test__helpers.py
+++ b/bigquery/tests/unit/test__helpers.py
@@ -867,6 +867,18 @@ class Test_record_field_to_json(unittest.TestCase):
         # missing fields should not be converted to an explicit None
         self.assertEqual(converted, {"one": "42"})
 
+    def test_w_explicit_none_value(self):
+        fields = [
+            _make_field("INT64", name="one", mode="NULLABLE"),
+            _make_field("STRING", name="two", mode="NULLABLE"),
+            _make_field("BOOL", name="three", mode="REPEATED"),
+        ]
+        original = {"three": None, "one": 42, "two": None}
+        converted = self._call_fut(fields, original)
+
+        # None values should be dropped regardless of the field type
+        self.assertEqual(converted, {"one": "42"})
+
 
 class Test_field_to_json(unittest.TestCase):
     def _call_fut(self, field, value):

--- a/bigquery/tests/unit/test__helpers.py
+++ b/bigquery/tests/unit/test__helpers.py
@@ -856,7 +856,7 @@ class Test_record_field_to_json(unittest.TestCase):
         converted = self._call_fut(fields, original)
         self.assertEqual(converted, {"one": "42", "two": "two"})
 
-    def test_w_missing_nullable(self):
+    def test_w_some_missing_nullables(self):
         fields = [
             _make_field("INT64", name="one", mode="NULLABLE"),
             _make_field("STRING", name="two", mode="NULLABLE"),
@@ -866,6 +866,17 @@ class Test_record_field_to_json(unittest.TestCase):
 
         # missing fields should not be converted to an explicit None
         self.assertEqual(converted, {"one": "42"})
+
+    def test_w_all_missing_nullables(self):
+        fields = [
+            _make_field("INT64", name="one", mode="NULLABLE"),
+            _make_field("STRING", name="two", mode="NULLABLE"),
+        ]
+        original = {}
+        converted = self._call_fut(fields, original)
+
+        # we should get an empty dict, not None
+        self.assertEqual(converted, {})
 
     def test_w_explicit_none_value(self):
         fields = [

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -4636,10 +4636,13 @@ class TestClient(unittest.TestCase):
         ]
 
         def _row_data(row):
+            result = {"full_name": row[0], "age": str(row[1])}
             joined = row[2]
-            if isinstance(row[2], datetime.datetime):
-                joined = _microseconds_from_datetime(joined) * 1e-6
-            return {"full_name": row[0], "age": str(row[1]), "joined": joined}
+            if joined is not None:
+                if isinstance(joined, datetime.datetime):
+                    joined = _microseconds_from_datetime(joined) * 1e-6
+                result["joined"] = joined
+            return result
 
         SENT = {
             "rows": [
@@ -4708,7 +4711,10 @@ class TestClient(unittest.TestCase):
 
         def _row_data(row):
             joined = row["joined"]
-            if isinstance(joined, datetime.datetime):
+            if joined is None:
+                row = copy.deepcopy(row)
+                del row["joined"]
+            elif isinstance(joined, datetime.datetime):
                 row["joined"] = _microseconds_from_datetime(joined) * 1e-6
             row["age"] = str(row["age"])
             return row
@@ -4927,9 +4933,8 @@ class TestClient(unittest.TestCase):
                 },
                 {
                     "json": {
-                        "color": None,
                         "items": [],
-                        "structs": [{"score": None, "times": [], "distances": [3.5]}],
+                        "structs": [{"times": [], "distances": [3.5]}],
                     },
                     "insertId": "1",
                 },
@@ -4996,10 +5001,7 @@ class TestClient(unittest.TestCase):
                     },
                     "insertId": "1",
                 },
-                {
-                    "json": {"full_name": "Wylma Phlyntstone", "phone": None},
-                    "insertId": "2",
-                },
+                {"json": {"full_name": "Wylma Phlyntstone"}, "insertId": "2"},
             ]
         }
 

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -4638,9 +4638,9 @@ class TestClient(unittest.TestCase):
         def _row_data(row):
             result = {"full_name": row[0], "age": str(row[1])}
             joined = row[2]
+            if isinstance(joined, datetime.datetime):
+                joined = _microseconds_from_datetime(joined) * 1e-6
             if joined is not None:
-                if isinstance(joined, datetime.datetime):
-                    joined = _microseconds_from_datetime(joined) * 1e-6
                 result["joined"] = joined
             return result
 


### PR DESCRIPTION
Fixes #9602.

This PR fixes the issue when inserting rows with missing REPEATED fields. Omitting a REPEATED field from the request does not result in an error anymore.

### How to test
Best to run the ready-made script from one of the [issue comments](https://github.com/googleapis/google-cloud-python/issues/9602#issuecomment-572259971).

**MIND:**
Omitting `None` values only happens when the code needs to convert the data to JSON by itself, i.e. in `insert_rows()`. The following thus still fails when `insert_rows_json()` is used:
```py
rows = [{"int_col": 9, "repeated_col": None}
errors = client.insert_rows_json(TABLE_PATH, rows)
```

If this inconsistency is not desired, we need to sync the logic in these two methods.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

