### PR TITLE
docs(storage): update README code snippet to clarify that download_as_string() returns bytes

### DIFF
--- a/storage/README.rst
+++ b/storage/README.rst
@@ -98,6 +98,7 @@ how to create a bucket.
     bucket = client.get_bucket('bucket-id-here')
     # Then do other things...
     blob = bucket.get_blob('remote/path/to/file.txt')
+    #   download_as_string() returns bytes not a string
     print(blob.download_as_string())
     blob.upload_from_string('New contents!')
     blob2 = bucket.blob('remote/path/storage.txt')


### PR DESCRIPTION
…urns byte array
I now know that download_as_string() returns a byte object.  I think it needs to be more obvious in the places where new users might encounter it.  I add this as an additional fix to the previous documentation fix.

Fixes #9290 🦕