### PR TITLE
fix: consume part of StreamingResponseIterator to support failure while under a retry context

### DIFF
--- a/api_core/google/api_core/grpc_helpers.py
+++ b/api_core/google/api_core/grpc_helpers.py
@@ -66,7 +66,7 @@ class _StreamingResponseIterator(grpc.Call):
         self._wrapped = wrapped
 
         # This iterator is used in a retry context, and returned outside after init.
-        # gRPC will not throw an exception until the stream is consumed, so we need 
+        # gRPC will not throw an exception until the stream is consumed, so we need
         # to retrieve the first result, in order to fail, in order to trigger a retry.
         try:
             self._stored_first_result = six.next(self._wrapped)
@@ -77,7 +77,6 @@ class _StreamingResponseIterator(grpc.Call):
         except StopIteration:
             # ignore stop iteration at this time. This should be handled outside of retry.
             pass
-
 
     def __iter__(self):
         """This iterator is also an iterable that returns itself."""
@@ -96,7 +95,7 @@ class _StreamingResponseIterator(grpc.Call):
                 return result
             return six.next(self._wrapped)
         except grpc.RpcError as exc:
-            # If the stream has already returned data, we cannot recover here. 
+            # If the stream has already returned data, we cannot recover here.
             six.raise_from(exceptions.from_grpc_error(exc), exc)
 
     # Alias needed for Python 2/3 support.

--- a/api_core/google/api_core/grpc_helpers.py
+++ b/api_core/google/api_core/grpc_helpers.py
@@ -70,6 +70,10 @@ class _StreamingResponseIterator(grpc.Call):
         # to retrieve the first result, in order to fail, in order to trigger a retry.
         try:
             self._stored_first_result = six.next(self._wrapped)
+        except TypeError:
+            # It is possible the wrappe method isn't an iterable (a grpc.Call
+            # for instance). If this happens don't store the first result.
+            pass
         except StopIteration:
             # ignore stop iteration at this time. This should be handled outside of retry.
             pass
@@ -86,7 +90,7 @@ class _StreamingResponseIterator(grpc.Call):
             protobuf.Message: A single response from the stream.
         """
         try:
-            if hasattr(self._stored_first_result):
+            if hasattr(self, "_stored_first_result"):
                 result = self._stored_first_result
                 del self._stored_first_result
                 return result

--- a/api_core/google/api_core/grpc_helpers.py
+++ b/api_core/google/api_core/grpc_helpers.py
@@ -71,7 +71,7 @@ class _StreamingResponseIterator(grpc.Call):
         try:
             self._stored_first_result = six.next(self._wrapped)
         except TypeError:
-            # It is possible the wrappe method isn't an iterable (a grpc.Call
+            # It is possible the wrapped method isn't an iterable (a grpc.Call
             # for instance). If this happens don't store the first result.
             pass
         except StopIteration:

--- a/api_core/google/api_core/grpc_helpers.py
+++ b/api_core/google/api_core/grpc_helpers.py
@@ -64,6 +64,18 @@ def _wrap_unary_errors(callable_):
 class _StreamingResponseIterator(grpc.Call):
     def __init__(self, wrapped):
         self._wrapped = wrapped
+        self._stored_first_result = False
+
+        # This iterator is used in a retry context, and returned outside after init.
+        # gRPC will not throw an exception until the stream is consumed, so we need 
+        # to retrieve the first result, in order to fail, in order to trigger a retry.
+        try:
+            self._first_result = six.next(self._wrapped)
+            self._stored_first_result = True
+        except StopIteration:
+            # ignore stop iteration at this time. This should be handled outside of retry.
+            pass
+
 
     def __iter__(self):
         """This iterator is also an iterable that returns itself."""
@@ -76,8 +88,12 @@ class _StreamingResponseIterator(grpc.Call):
             protobuf.Message: A single response from the stream.
         """
         try:
-            return six.next(self._wrapped)
+            if self._stored_first_result:
+                self._stored_first_result = False
+                return self._first_result
+           return six.next(self._wrapped)
         except grpc.RpcError as exc:
+            # If the stream has already returned data, we cannot recover here. 
             six.raise_from(exceptions.from_grpc_error(exc), exc)
 
     # Alias needed for Python 2/3 support.

--- a/api_core/tests/unit/test_grpc_helpers.py
+++ b/api_core/tests/unit/test_grpc_helpers.py
@@ -88,7 +88,6 @@ def test_wrap_stream_iterable_iterface():
 
     got_iterator = wrapped_callable()
 
-
     callable_.assert_called_once_with()
 
     # Check each aliased method in the grpc.Call interface
@@ -148,7 +147,7 @@ def test_wrap_stream_errors_iterator():
     wrapped_callable = grpc_helpers._wrap_stream_errors(callable_)
 
     with pytest.raises(exceptions.ServiceUnavailable) as exc_info:
-        got_iterator = wrapped_callable(1, 2, three="four")
+        wrapped_callable(1, 2, three="four")
 
     callable_.assert_called_once_with(1, 2, three="four")
     assert exc_info.value.response == grpc_error

--- a/api_core/tests/unit/test_grpc_helpers.py
+++ b/api_core/tests/unit/test_grpc_helpers.py
@@ -144,24 +144,43 @@ def test_wrap_stream_empty_iterator():
 
 
 class RpcResponseIteratorImpl(object):
-    def __init__(self, exception):
-        self._exception = exception
+    def __init__(self, iterable):
+        self._iterable = iter(iterable)
 
     def next(self):
-        raise self._exception
+        next_item = next(self._iterable)
+        if isinstance(next_item, RpcErrorImpl):
+            raise next_item
+        return next_item
 
     __next__ = next
 
 
-def test_wrap_stream_errors_iterator():
+def test_wrap_stream_errors_iterator_initialization():
     grpc_error = RpcErrorImpl(grpc.StatusCode.UNAVAILABLE)
-    response_iter = RpcResponseIteratorImpl(grpc_error)
+    response_iter = RpcResponseIteratorImpl([grpc_error])
     callable_ = mock.Mock(spec=["__call__"], return_value=response_iter)
 
     wrapped_callable = grpc_helpers._wrap_stream_errors(callable_)
 
     with pytest.raises(exceptions.ServiceUnavailable) as exc_info:
         wrapped_callable(1, 2, three="four")
+
+    callable_.assert_called_once_with(1, 2, three="four")
+    assert exc_info.value.response == grpc_error
+
+
+def test_wrap_stream_errors_during_iteration():
+    grpc_error = RpcErrorImpl(grpc.StatusCode.UNAVAILABLE)
+    response_iter = RpcResponseIteratorImpl([1, grpc_error])
+    callable_ = mock.Mock(spec=["__call__"], return_value=response_iter)
+
+    wrapped_callable = grpc_helpers._wrap_stream_errors(callable_)
+    got_iterator = wrapped_callable(1, 2, three="four")
+    next(got_iterator)
+
+    with pytest.raises(exceptions.ServiceUnavailable) as exc_info:
+        next(got_iterator)
 
     callable_.assert_called_once_with(1, 2, three="four")
     assert exc_info.value.response == grpc_error

--- a/api_core/tests/unit/test_grpc_helpers.py
+++ b/api_core/tests/unit/test_grpc_helpers.py
@@ -129,6 +129,20 @@ def test_wrap_stream_errors_invocation():
     assert exc_info.value.response == grpc_error
 
 
+def test_wrap_stream_empty_iterator():
+    expected_responses = []
+    callable_ = mock.Mock(spec=["__call__"], return_value=iter(expected_responses))
+
+    wrapped_callable = grpc_helpers._wrap_stream_errors(callable_)
+
+    got_iterator = wrapped_callable()
+
+    responses = list(got_iterator)
+
+    callable_.assert_called_once_with()
+    assert responses == expected_responses
+
+
 class RpcResponseIteratorImpl(object):
     def __init__(self, exception):
         self._exception = exception

--- a/api_core/tests/unit/test_grpc_helpers.py
+++ b/api_core/tests/unit/test_grpc_helpers.py
@@ -88,6 +88,7 @@ def test_wrap_stream_iterable_iterface():
 
     got_iterator = wrapped_callable()
 
+
     callable_.assert_called_once_with()
 
     # Check each aliased method in the grpc.Call interface
@@ -146,10 +147,8 @@ def test_wrap_stream_errors_iterator():
 
     wrapped_callable = grpc_helpers._wrap_stream_errors(callable_)
 
-    got_iterator = wrapped_callable(1, 2, three="four")
-
     with pytest.raises(exceptions.ServiceUnavailable) as exc_info:
-        next(got_iterator)
+        got_iterator = wrapped_callable(1, 2, three="four")
 
     callable_.assert_called_once_with(1, 2, three="four")
     assert exc_info.value.response == grpc_error


### PR DESCRIPTION
In the Node.js SDK, there's code that explicitly waits until at least one result has been observed and retries the underlying stream until then. This doesn't handle the case where the connection is interrupted mid-stream but has been good enough to resolve this class of issues. https://github.com/googleapis/nodejs-firestore/blob/master/dev/src/index.ts#L1127

The Firestore Python SDK needs equivalent code to make it resilient to this class of failure.

This PR causes init of the streaming response iterator to consume the first result immediately which will cause the error to occur while under the retry context. Once the iterator is created it is returned and future access is no longer in a retry context.

