### PR TITLE
feat(storage): add timeout parameter to public methods

### DIFF
--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -21,6 +21,9 @@ import base64
 from hashlib import md5
 import os
 
+from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+
+
 STORAGE_EMULATOR_ENV_VAR = "STORAGE_EMULATOR_HOST"
 """Environment variable defining host for Storage emulator."""
 
@@ -117,7 +120,7 @@ class _PropertyMixin(object):
             params["userProject"] = self.user_project
         return params
 
-    def reload(self, client=None):
+    def reload(self, client=None, timeout=_DEFAULT_TIMEOUT):
         """Reload properties from Cloud Storage.
 
         If :attr:`user_project` is set, bills the API request to that project.
@@ -126,6 +129,12 @@ class _PropertyMixin(object):
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current object.
+        :type timeout: float or tuple
+        :param timeout: (optional) The amount of time, in seconds, to wait
+            for the server response.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
         """
         client = self._require_client(client)
         query_params = self._query_params
@@ -138,6 +147,7 @@ class _PropertyMixin(object):
             query_params=query_params,
             headers=self._encryption_headers(),
             _target_object=self,
+            timeout=timeout,
         )
         self._set_properties(api_response)
 
@@ -169,7 +179,7 @@ class _PropertyMixin(object):
         # If the values are reset, the changes must as well.
         self._changes = set()
 
-    def patch(self, client=None):
+    def patch(self, client=None, timeout=_DEFAULT_TIMEOUT):
         """Sends all changed properties in a PATCH request.
 
         Updates the ``_properties`` with the response from the backend.
@@ -180,6 +190,12 @@ class _PropertyMixin(object):
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current object.
+        :type timeout: float or tuple
+        :param timeout: (optional) The amount of time, in seconds, to wait
+            for the server response.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
         """
         client = self._require_client(client)
         query_params = self._query_params
@@ -195,10 +211,11 @@ class _PropertyMixin(object):
             data=update_properties,
             query_params=query_params,
             _target_object=self,
+            timeout=timeout,
         )
         self._set_properties(api_response)
 
-    def update(self, client=None):
+    def update(self, client=None, timeout=_DEFAULT_TIMEOUT):
         """Sends all properties in a PUT request.
 
         Updates the ``_properties`` with the response from the backend.
@@ -209,6 +226,12 @@ class _PropertyMixin(object):
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current object.
+        :type timeout: float or tuple
+        :param timeout: (optional) The amount of time, in seconds, to wait
+            for the server response.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
         """
         client = self._require_client(client)
         query_params = self._query_params
@@ -219,6 +242,7 @@ class _PropertyMixin(object):
             data=self._properties,
             query_params=query_params,
             _target_object=self,
+            timeout=timeout,
         )
         self._set_properties(api_response)
 

--- a/storage/google/cloud/storage/batch.py
+++ b/storage/google/cloud/storage/batch.py
@@ -29,6 +29,7 @@ import six
 from google.cloud import _helpers
 from google.cloud import exceptions
 from google.cloud.storage._http import Connection
+from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 
 
 class MIMEApplicationHTTP(MIMEApplication):
@@ -150,7 +151,9 @@ class Batch(Connection):
         self._requests = []
         self._target_objects = []
 
-    def _do_request(self, method, url, headers, data, target_object, timeout=None):
+    def _do_request(
+        self, method, url, headers, data, target_object, timeout=_DEFAULT_TIMEOUT
+    ):
         """Override Connection:  defer actual HTTP request.
 
         Only allow up to ``_MAX_BATCH_SIZE`` requests to be deferred.
@@ -175,7 +178,8 @@ class Batch(Connection):
 
         :type timeout: float or tuple
         :param timeout: (optional) The amount of time, in seconds, to wait
-            for the server response. By default, the method waits indefinitely.
+            for the server response.
+
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
 
@@ -206,8 +210,8 @@ class Batch(Connection):
 
         multi = MIMEMultipart()
 
-        # Use timeout of last request, default to None (indefinite)
-        timeout = None
+        # Use timeout of last request, default to _DEFAULT_TIMEOUT
+        timeout = _DEFAULT_TIMEOUT
         for method, uri, headers, body, _timeout in self._requests:
             subrequest = MIMEApplicationHTTP(method, uri, headers, body)
             multi.attach(subrequest)

--- a/storage/google/cloud/storage/constants.py
+++ b/storage/google/cloud/storage/constants.py
@@ -89,3 +89,10 @@ DUAL_REGION_LOCATION_TYPE = "dual-region"
 
 Provides high availability and low latency across two regions.
 """
+
+
+# Internal constants
+
+_DEFAULT_TIMEOUT = 60  # in seconds
+"""The default request timeout in seconds if a timeout is not explicitly given.
+"""

--- a/storage/google/cloud/storage/hmac_key.py
+++ b/storage/google/cloud/storage/hmac_key.py
@@ -15,6 +15,8 @@
 from google.cloud.exceptions import NotFound
 from google.cloud._helpers import _rfc3339_to_datetime
 
+from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+
 
 class HMACKeyMetadata(object):
     """Metadata about an HMAC service account key withn Cloud Storage.
@@ -185,8 +187,15 @@ class HMACKeyMetadata(object):
         """
         return self._user_project
 
-    def exists(self):
+    def exists(self, timeout=_DEFAULT_TIMEOUT):
         """Determine whether or not the key for this metadata exists.
+
+        :type timeout: float or tuple
+        :param timeout: (optional) The amount of time, in seconds, to wait
+            for the server response.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
 
         :rtype: bool
         :returns: True if the key exists in Cloud Storage.
@@ -198,15 +207,22 @@ class HMACKeyMetadata(object):
                 qs_params["userProject"] = self.user_project
 
             self._client._connection.api_request(
-                method="GET", path=self.path, query_params=qs_params
+                method="GET", path=self.path, query_params=qs_params, timeout=timeout
             )
         except NotFound:
             return False
         else:
             return True
 
-    def reload(self):
+    def reload(self, timeout=_DEFAULT_TIMEOUT):
         """Reload properties from Cloud Storage.
+
+        :type timeout: float or tuple
+        :param timeout: (optional) The amount of time, in seconds, to wait
+            for the server response.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
 
         :raises :class:`~google.api_core.exceptions.NotFound`:
             if the key does not exist on the back-end.
@@ -217,11 +233,18 @@ class HMACKeyMetadata(object):
             qs_params["userProject"] = self.user_project
 
         self._properties = self._client._connection.api_request(
-            method="GET", path=self.path, query_params=qs_params
+            method="GET", path=self.path, query_params=qs_params, timeout=timeout
         )
 
-    def update(self):
+    def update(self, timeout=_DEFAULT_TIMEOUT):
         """Save writable properties to Cloud Storage.
+
+        :type timeout: float or tuple
+        :param timeout: (optional) The amount of time, in seconds, to wait
+            for the server response.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
 
         :raises :class:`~google.api_core.exceptions.NotFound`:
             if the key does not exist on the back-end.
@@ -232,11 +255,22 @@ class HMACKeyMetadata(object):
 
         payload = {"state": self.state}
         self._properties = self._client._connection.api_request(
-            method="PUT", path=self.path, data=payload, query_params=qs_params
+            method="PUT",
+            path=self.path,
+            data=payload,
+            query_params=qs_params,
+            timeout=timeout,
         )
 
-    def delete(self):
+    def delete(self, timeout=_DEFAULT_TIMEOUT):
         """Delete the key from Cloud Storage.
+
+        :type timeout: float or tuple
+        :param timeout: (optional) The amount of time, in seconds, to wait
+            for the server response.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
 
         :raises :class:`~google.api_core.exceptions.NotFound`:
             if the key does not exist on the back-end.
@@ -249,5 +283,5 @@ class HMACKeyMetadata(object):
             qs_params["userProject"] = self.user_project
 
         self._client._connection.api_request(
-            method="DELETE", path=self.path, query_params=qs_params
+            method="DELETE", path=self.path, query_params=qs_params, timeout=timeout
         )

--- a/storage/google/cloud/storage/notification.py
+++ b/storage/google/cloud/storage/notification.py
@@ -18,6 +18,8 @@ import re
 
 from google.api_core.exceptions import NotFound
 
+from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+
 
 OBJECT_FINALIZE_EVENT_TYPE = "OBJECT_FINALIZE"
 OBJECT_METADATA_UPDATE_EVENT_TYPE = "OBJECT_METADATA_UPDATE"
@@ -221,7 +223,7 @@ class BucketNotification(object):
         self._properties.clear()
         self._properties.update(response)
 
-    def create(self, client=None):
+    def create(self, client=None, timeout=_DEFAULT_TIMEOUT):
         """API wrapper: create the notification.
 
         See:
@@ -233,6 +235,12 @@ class BucketNotification(object):
         :type client: :class:`~google.cloud.storage.client.Client`
         :param client: (Optional) the client to use.  If not passed, falls back
                        to the ``client`` stored on the notification's bucket.
+        :type timeout: float or tuple
+        :param timeout: (optional) The amount of time, in seconds, to wait
+            for the server response.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
         """
         if self.notification_id is not None:
             raise ValueError(
@@ -249,10 +257,14 @@ class BucketNotification(object):
         properties = self._properties.copy()
         properties["topic"] = _TOPIC_REF_FMT.format(self.topic_project, self.topic_name)
         self._properties = client._connection.api_request(
-            method="POST", path=path, query_params=query_params, data=properties
+            method="POST",
+            path=path,
+            query_params=query_params,
+            data=properties,
+            timeout=timeout,
         )
 
-    def exists(self, client=None):
+    def exists(self, client=None, timeout=_DEFAULT_TIMEOUT):
         """Test whether this notification exists.
 
         See:
@@ -265,6 +277,12 @@ class BucketNotification(object):
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the current bucket.
+        :type timeout: float or tuple
+        :param timeout: (optional) The amount of time, in seconds, to wait
+            for the server response.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
 
         :rtype: bool
         :returns: True, if the notification exists, else False.
@@ -281,14 +299,14 @@ class BucketNotification(object):
 
         try:
             client._connection.api_request(
-                method="GET", path=self.path, query_params=query_params
+                method="GET", path=self.path, query_params=query_params, timeout=timeout
             )
         except NotFound:
             return False
         else:
             return True
 
-    def reload(self, client=None):
+    def reload(self, client=None, timeout=_DEFAULT_TIMEOUT):
         """Update this notification from the server configuration.
 
         See:
@@ -301,6 +319,12 @@ class BucketNotification(object):
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the current bucket.
+        :type timeout: float or tuple
+        :param timeout: (optional) The amount of time, in seconds, to wait
+            for the server response.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
 
         :rtype: bool
         :returns: True, if the notification exists, else False.
@@ -316,11 +340,11 @@ class BucketNotification(object):
             query_params["userProject"] = self.bucket.user_project
 
         response = client._connection.api_request(
-            method="GET", path=self.path, query_params=query_params
+            method="GET", path=self.path, query_params=query_params, timeout=timeout
         )
         self._set_properties(response)
 
-    def delete(self, client=None):
+    def delete(self, client=None, timeout=_DEFAULT_TIMEOUT):
         """Delete this notification.
 
         See:
@@ -333,6 +357,12 @@ class BucketNotification(object):
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the current bucket.
+        :type timeout: float or tuple
+        :param timeout: (optional) The amount of time, in seconds, to wait
+            for the server response.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
 
         :raises: :class:`google.api_core.exceptions.NotFound`:
             if the notification does not exist.
@@ -348,7 +378,7 @@ class BucketNotification(object):
             query_params["userProject"] = self.bucket.user_project
 
         client._connection.api_request(
-            method="DELETE", path=self.path, query_params=query_params
+            method="DELETE", path=self.path, query_params=query_params, timeout=timeout
         )
 
 

--- a/storage/tests/unit/test__http.py
+++ b/storage/tests/unit/test__http.py
@@ -30,6 +30,7 @@ class TestConnection(unittest.TestCase):
     def test_extra_headers(self):
         import requests
         from google.cloud import _http as base_http
+        from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 
         http = mock.create_autospec(requests.Session, instance=True)
         response = requests.Response()
@@ -55,7 +56,7 @@ class TestConnection(unittest.TestCase):
             headers=expected_headers,
             method="GET",
             url=expected_uri,
-            timeout=None,
+            timeout=_DEFAULT_TIMEOUT,
         )
 
     def test_build_api_url_no_extra_query_params(self):

--- a/storage/tests/unit/test_batch.py
+++ b/storage/tests/unit/test_batch.py
@@ -91,6 +91,12 @@ class TestMIMEApplicationHTTP(unittest.TestCase):
 
 class TestBatch(unittest.TestCase):
     @staticmethod
+    def _get_default_timeout():
+        from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+
+        return _DEFAULT_TIMEOUT
+
+    @staticmethod
     def _get_target_class():
         from google.cloud.storage.batch import Batch
 
@@ -344,7 +350,7 @@ class TestBatch(unittest.TestCase):
             url=expected_url,
             headers=mock.ANY,
             data=mock.ANY,
-            timeout=mock.ANY,
+            timeout=self._get_default_timeout(),
         )
 
         request_info = self._get_mutlipart_request(http)
@@ -393,8 +399,8 @@ class TestBatch(unittest.TestCase):
         target1 = _MockObject()
         target2 = _MockObject()
 
-        batch._do_request("GET", url, {}, None, target1)
-        batch._do_request("GET", url, {}, None, target2)
+        batch._do_request("GET", url, {}, None, target1, timeout=42)
+        batch._do_request("GET", url, {}, None, target2, timeout=420)
 
         # Make sure futures are not populated.
         self.assertEqual(
@@ -414,7 +420,7 @@ class TestBatch(unittest.TestCase):
             url=expected_url,
             headers=mock.ANY,
             data=mock.ANY,
-            timeout=mock.ANY,
+            timeout=420,  # the last request timeout prevails
         )
 
         _, request_body, _, boundary = self._get_mutlipart_request(http)

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -43,6 +43,12 @@ class Test_Blob(unittest.TestCase):
         blob._properties.update(properties)
         return blob
 
+    @staticmethod
+    def _get_default_timeout():
+        from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+
+        return _DEFAULT_TIMEOUT
+
     def test_ctor_wo_encryption_key(self):
         BLOB_NAME = "blob-name"
         bucket = _Bucket()
@@ -603,7 +609,7 @@ class Test_Blob(unittest.TestCase):
         client = _Client(connection)
         bucket = _Bucket(client)
         blob = self._make_one(NONESUCH, bucket=bucket)
-        self.assertFalse(blob.exists())
+        self.assertFalse(blob.exists(timeout=42))
         self.assertEqual(len(connection._requested), 1)
         self.assertEqual(
             connection._requested[0],
@@ -612,6 +618,7 @@ class Test_Blob(unittest.TestCase):
                 "path": "/b/name/o/{}".format(NONESUCH),
                 "query_params": {"fields": "name"},
                 "_target_object": None,
+                "timeout": 42,
             },
         )
 
@@ -633,6 +640,7 @@ class Test_Blob(unittest.TestCase):
                 "path": "/b/name/o/{}".format(BLOB_NAME),
                 "query_params": {"fields": "name", "userProject": USER_PROJECT},
                 "_target_object": None,
+                "timeout": self._get_default_timeout(),
             },
         )
 
@@ -654,6 +662,7 @@ class Test_Blob(unittest.TestCase):
                 "path": "/b/name/o/{}".format(BLOB_NAME),
                 "query_params": {"fields": "name", "generation": GENERATION},
                 "_target_object": None,
+                "timeout": self._get_default_timeout(),
             },
         )
 
@@ -667,7 +676,9 @@ class Test_Blob(unittest.TestCase):
         bucket._blobs[BLOB_NAME] = 1
         blob.delete()
         self.assertFalse(blob.exists())
-        self.assertEqual(bucket._deleted, [(BLOB_NAME, None, None)])
+        self.assertEqual(
+            bucket._deleted, [(BLOB_NAME, None, None, self._get_default_timeout())]
+        )
 
     def test_delete_w_generation(self):
         BLOB_NAME = "blob-name"
@@ -678,9 +689,9 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket(client)
         blob = self._make_one(BLOB_NAME, bucket=bucket, generation=GENERATION)
         bucket._blobs[BLOB_NAME] = 1
-        blob.delete()
+        blob.delete(timeout=42)
         self.assertFalse(blob.exists())
-        self.assertEqual(bucket._deleted, [(BLOB_NAME, None, GENERATION)])
+        self.assertEqual(bucket._deleted, [(BLOB_NAME, None, GENERATION, 42)])
 
     def test__get_transport(self):
         client = mock.Mock(spec=[u"_credentials", "_http"])
@@ -1954,7 +1965,7 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket(client=client)
         blob = self._make_one(BLOB_NAME, bucket=bucket)
 
-        policy = blob.get_iam_policy()
+        policy = blob.get_iam_policy(timeout=42)
 
         self.assertIsInstance(policy, Policy)
         self.assertEqual(policy.etag, RETURNED["etag"])
@@ -1970,6 +1981,7 @@ class Test_Blob(unittest.TestCase):
                 "path": "%s/iam" % (PATH,),
                 "query_params": {},
                 "_target_object": None,
+                "timeout": 42,
             },
         )
 
@@ -2005,6 +2017,7 @@ class Test_Blob(unittest.TestCase):
                 "path": "%s/iam" % (PATH,),
                 "query_params": {"optionsRequestedPolicyVersion": 3},
                 "_target_object": None,
+                "timeout": self._get_default_timeout(),
             },
         )
 
@@ -2045,6 +2058,7 @@ class Test_Blob(unittest.TestCase):
                 "path": "%s/iam" % (PATH,),
                 "query_params": {"userProject": USER_PROJECT},
                 "_target_object": None,
+                "timeout": self._get_default_timeout(),
             },
         )
 
@@ -2081,7 +2095,7 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket(client=client)
         blob = self._make_one(BLOB_NAME, bucket=bucket)
 
-        returned = blob.set_iam_policy(policy)
+        returned = blob.set_iam_policy(policy, timeout=42)
 
         self.assertEqual(returned.etag, ETAG)
         self.assertEqual(returned.version, VERSION)
@@ -2092,6 +2106,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]["method"], "PUT")
         self.assertEqual(kw[0]["path"], "%s/iam" % (PATH,))
         self.assertEqual(kw[0]["query_params"], {})
+        self.assertEqual(kw[0]["timeout"], 42)
         sent = kw[0]["data"]
         self.assertEqual(sent["resourceId"], PATH)
         self.assertEqual(len(sent["bindings"]), len(BINDINGS))
@@ -2153,7 +2168,7 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket(client=client)
         blob = self._make_one(BLOB_NAME, bucket=bucket)
 
-        allowed = blob.test_iam_permissions(PERMISSIONS)
+        allowed = blob.test_iam_permissions(PERMISSIONS, timeout=42)
 
         self.assertEqual(allowed, ALLOWED)
 
@@ -2162,6 +2177,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]["method"], "GET")
         self.assertEqual(kw[0]["path"], "%s/iam/testPermissions" % (PATH,))
         self.assertEqual(kw[0]["query_params"], {"permissions": PERMISSIONS})
+        self.assertEqual(kw[0]["timeout"], 42)
 
     def test_test_iam_permissions_w_user_project(self):
         from google.cloud.storage.iam import STORAGE_OBJECTS_LIST
@@ -2196,6 +2212,7 @@ class Test_Blob(unittest.TestCase):
             kw[0]["query_params"],
             {"permissions": PERMISSIONS, "userProject": USER_PROJECT},
         )
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
 
     def test_make_public(self):
         from google.cloud.storage.acl import _ACLEntity
@@ -2266,6 +2283,7 @@ class Test_Blob(unittest.TestCase):
                     "destination": {},
                 },
                 "_target_object": destination,
+                "timeout": self._get_default_timeout(),
             },
         )
 
@@ -2284,7 +2302,7 @@ class Test_Blob(unittest.TestCase):
         destination = self._make_one(DESTINATION, bucket=bucket)
         destination.content_type = "text/plain"
 
-        destination.compose(sources=[source_1, source_2])
+        destination.compose(sources=[source_1, source_2], timeout=42)
 
         self.assertEqual(destination.etag, "DEADBEEF")
 
@@ -2301,6 +2319,7 @@ class Test_Blob(unittest.TestCase):
                     "destination": {"contentType": "text/plain"},
                 },
                 "_target_object": destination,
+                "timeout": 42,
             },
         )
 
@@ -2341,6 +2360,7 @@ class Test_Blob(unittest.TestCase):
                     },
                 },
                 "_target_object": destination,
+                "timeout": self._get_default_timeout(),
             },
         )
 
@@ -2394,7 +2414,7 @@ class Test_Blob(unittest.TestCase):
             DEST_BLOB, bucket=dest_bucket, generation=DEST_GENERATION
         )
 
-        token, rewritten, size = dest_blob.rewrite(source_blob)
+        token, rewritten, size = dest_blob.rewrite(source_blob, timeout=42)
 
         self.assertEqual(token, TOKEN)
         self.assertEqual(rewritten, 33)
@@ -2410,6 +2430,7 @@ class Test_Blob(unittest.TestCase):
             ),
         )
         self.assertEqual(kw["query_params"], {"sourceGeneration": SOURCE_GENERATION})
+        self.assertEqual(kw["timeout"], 42)
 
     def test_rewrite_other_bucket_other_name_no_encryption_partial(self):
         SOURCE_BLOB = "source"
@@ -2449,6 +2470,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]["query_params"], {})
         SENT = {}
         self.assertEqual(kw[0]["data"], SENT)
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
 
         headers = {key.title(): str(value) for key, value in kw[0]["headers"].items()}
         self.assertNotIn("X-Goog-Copy-Source-Encryption-Algorithm", headers)
@@ -2492,6 +2514,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]["query_params"], {"userProject": USER_PROJECT})
         SENT = {}
         self.assertEqual(kw[0]["data"], SENT)
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
 
         headers = {key.title(): str(value) for key, value in kw[0]["headers"].items()}
         self.assertNotIn("X-Goog-Copy-Source-Encryption-Algorithm", headers)
@@ -2539,6 +2562,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]["query_params"], {"rewriteToken": TOKEN})
         SENT = {}
         self.assertEqual(kw[0]["data"], SENT)
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
 
         headers = {key.title(): str(value) for key, value in kw[0]["headers"].items()}
         self.assertEqual(headers["X-Goog-Copy-Source-Encryption-Algorithm"], "AES256")
@@ -2589,6 +2613,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(
             kw[0]["query_params"], {"destinationKmsKeyName": DEST_KMS_RESOURCE}
         )
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
         SENT = {"kmsKeyName": DEST_KMS_RESOURCE}
         self.assertEqual(kw[0]["data"], SENT)
 
@@ -3339,9 +3364,9 @@ class _Bucket(object):
         self.path = "/b/" + name
         self.user_project = user_project
 
-    def delete_blob(self, blob_name, client=None, generation=None):
+    def delete_blob(self, blob_name, client=None, generation=None, timeout=None):
         del self._blobs[blob_name]
-        self._deleted.append((blob_name, client, generation))
+        self._deleted.append((blob_name, client, generation, timeout))
 
 
 class _Client(object):

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -361,6 +361,12 @@ class Test_Bucket(unittest.TestCase):
 
         return Bucket
 
+    @staticmethod
+    def _get_default_timeout():
+        from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+
+        return _DEFAULT_TIMEOUT
+
     def _make_one(self, client=None, name=None, properties=None, user_project=None):
         if client is None:
             connection = _Connection()
@@ -571,12 +577,13 @@ class Test_Bucket(unittest.TestCase):
         BUCKET_NAME = "bucket-name"
         bucket = self._make_one(name=BUCKET_NAME)
         client = _Client(_FakeConnection)
-        self.assertFalse(bucket.exists(client=client))
+        self.assertFalse(bucket.exists(client=client, timeout=42))
         expected_called_kwargs = {
             "method": "GET",
             "path": bucket.path,
             "query_params": {"fields": "name"},
             "_target_object": None,
+            "timeout": 42,
         }
         expected_cw = [((), expected_called_kwargs)]
         self.assertEqual(_FakeConnection._called_with, expected_cw)
@@ -603,6 +610,7 @@ class Test_Bucket(unittest.TestCase):
             "path": bucket.path,
             "query_params": {"fields": "name", "userProject": USER_PROJECT},
             "_target_object": None,
+            "timeout": self._get_default_timeout(),
         }
         expected_cw = [((), expected_called_kwargs)]
         self.assertEqual(_FakeConnection._called_with, expected_cw)
@@ -653,6 +661,7 @@ class Test_Bucket(unittest.TestCase):
             query_params={"project": OTHER_PROJECT},
             data=DATA,
             _target_object=bucket,
+            timeout=self._get_default_timeout(),
         )
 
     def test_create_w_explicit_location(self):
@@ -679,6 +688,7 @@ class Test_Bucket(unittest.TestCase):
             data=DATA,
             _target_object=bucket,
             query_params={"project": "PROJECT"},
+            timeout=self._get_default_timeout(),
         )
         self.assertEqual(bucket.location, LOCATION)
 
@@ -693,7 +703,7 @@ class Test_Bucket(unittest.TestCase):
         client._base_connection = connection
 
         bucket = self._make_one(client=client, name=BUCKET_NAME)
-        bucket.create()
+        bucket.create(timeout=42)
 
         connection.api_request.assert_called_once_with(
             method="POST",
@@ -701,6 +711,7 @@ class Test_Bucket(unittest.TestCase):
             query_params={"project": PROJECT},
             data=DATA,
             _target_object=bucket,
+            timeout=42,
         )
 
     def test_create_w_extra_properties(self):
@@ -750,6 +761,7 @@ class Test_Bucket(unittest.TestCase):
             query_params={"project": PROJECT},
             data=DATA,
             _target_object=bucket,
+            timeout=self._get_default_timeout(),
         )
 
     def test_create_w_predefined_acl_invalid(self):
@@ -784,6 +796,7 @@ class Test_Bucket(unittest.TestCase):
         expected_qp = {"project": PROJECT, "predefinedAcl": "publicRead"}
         self.assertEqual(kw["query_params"], expected_qp)
         self.assertEqual(kw["data"], DATA)
+        self.assertEqual(kw["timeout"], self._get_default_timeout())
 
     def test_create_w_predefined_default_object_acl_invalid(self):
         from google.cloud.storage.client import Client
@@ -817,6 +830,7 @@ class Test_Bucket(unittest.TestCase):
         expected_qp = {"project": PROJECT, "predefinedDefaultObjectAcl": "publicRead"}
         self.assertEqual(kw["query_params"], expected_qp)
         self.assertEqual(kw["data"], DATA)
+        self.assertEqual(kw["timeout"], self._get_default_timeout())
 
     def test_acl_property(self):
         from google.cloud.storage.acl import BucketACL
@@ -849,11 +863,12 @@ class Test_Bucket(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         bucket = self._make_one(name=NAME)
-        result = bucket.get_blob(NONESUCH, client=client)
+        result = bucket.get_blob(NONESUCH, client=client, timeout=42)
         self.assertIsNone(result)
         kw, = connection._requested
         self.assertEqual(kw["method"], "GET")
         self.assertEqual(kw["path"], "/b/%s/o/%s" % (NAME, NONESUCH))
+        self.assertEqual(kw["timeout"], 42)
 
     def test_get_blob_hit_w_user_project(self):
         NAME = "name"
@@ -870,6 +885,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "GET")
         self.assertEqual(kw["path"], "/b/%s/o/%s" % (NAME, BLOB_NAME))
         self.assertEqual(kw["query_params"], expected_qp)
+        self.assertEqual(kw["timeout"], self._get_default_timeout())
 
     def test_get_blob_hit_w_generation(self):
         NAME = "name"
@@ -887,6 +903,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "GET")
         self.assertEqual(kw["path"], "/b/%s/o/%s" % (NAME, BLOB_NAME))
         self.assertEqual(kw["query_params"], expected_qp)
+        self.assertEqual(kw["timeout"], self._get_default_timeout())
 
     def test_get_blob_hit_with_kwargs(self):
         from google.cloud.storage.blob import _get_encryption_headers
@@ -908,6 +925,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "GET")
         self.assertEqual(kw["path"], "/b/%s/o/%s" % (NAME, BLOB_NAME))
         self.assertEqual(kw["headers"], _get_encryption_headers(KEY))
+        self.assertEqual(kw["timeout"], self._get_default_timeout())
         self.assertEqual(blob.chunk_size, CHUNK_SIZE)
         self.assertEqual(blob._encryption_key, KEY)
 
@@ -923,6 +941,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "GET")
         self.assertEqual(kw["path"], "/b/%s/o" % NAME)
         self.assertEqual(kw["query_params"], {"projection": "noAcl"})
+        self.assertEqual(kw["timeout"], self._get_default_timeout())
 
     def test_list_blobs_w_all_arguments_and_user_project(self):
         NAME = "name"
@@ -956,6 +975,7 @@ class Test_Bucket(unittest.TestCase):
             projection=PROJECTION,
             fields=FIELDS,
             client=client,
+            timeout=42,
         )
         blobs = list(iterator)
         self.assertEqual(blobs, [])
@@ -963,6 +983,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "GET")
         self.assertEqual(kw["path"], "/b/%s/o" % NAME)
         self.assertEqual(kw["query_params"], EXPECTED)
+        self.assertEqual(kw["timeout"], 42)
 
     def test_list_notifications(self):
         from google.cloud.storage.notification import BucketNotification
@@ -996,7 +1017,10 @@ class Test_Bucket(unittest.TestCase):
         client = _Client(connection)
         bucket = self._make_one(client=client, name=NAME)
 
-        notifications = list(bucket.list_notifications())
+        notifications = list(bucket.list_notifications(timeout=42))
+
+        req_args = client._connection._requested[0]
+        self.assertEqual(req_args.get("timeout"), 42)
 
         self.assertEqual(len(notifications), len(resources))
         for notification, resource, topic_ref in zip(
@@ -1033,6 +1057,7 @@ class Test_Bucket(unittest.TestCase):
                 "path": bucket.path,
                 "query_params": {},
                 "_target_object": None,
+                "timeout": self._get_default_timeout(),
             }
         ]
         self.assertEqual(connection._deleted_buckets, expected_cw)
@@ -1045,7 +1070,7 @@ class Test_Bucket(unittest.TestCase):
         connection._delete_bucket = True
         client = _Client(connection)
         bucket = self._make_one(client=client, name=NAME, user_project=USER_PROJECT)
-        result = bucket.delete(force=True)
+        result = bucket.delete(force=True, timeout=42)
         self.assertIsNone(result)
         expected_cw = [
             {
@@ -1053,6 +1078,7 @@ class Test_Bucket(unittest.TestCase):
                 "path": bucket.path,
                 "_target_object": None,
                 "query_params": {"userProject": USER_PROJECT},
+                "timeout": 42,
             }
         ]
         self.assertEqual(connection._deleted_buckets, expected_cw)
@@ -1075,6 +1101,7 @@ class Test_Bucket(unittest.TestCase):
                 "path": bucket.path,
                 "query_params": {},
                 "_target_object": None,
+                "timeout": self._get_default_timeout(),
             }
         ]
         self.assertEqual(connection._deleted_buckets, expected_cw)
@@ -1096,6 +1123,7 @@ class Test_Bucket(unittest.TestCase):
                 "path": bucket.path,
                 "query_params": {},
                 "_target_object": None,
+                "timeout": self._get_default_timeout(),
             }
         ]
         self.assertEqual(connection._deleted_buckets, expected_cw)
@@ -1128,6 +1156,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "DELETE")
         self.assertEqual(kw["path"], "/b/%s/o/%s" % (NAME, NONESUCH))
         self.assertEqual(kw["query_params"], {})
+        self.assertEqual(kw["timeout"], self._get_default_timeout())
 
     def test_delete_blob_hit_with_user_project(self):
         NAME = "name"
@@ -1136,12 +1165,13 @@ class Test_Bucket(unittest.TestCase):
         connection = _Connection({})
         client = _Client(connection)
         bucket = self._make_one(client=client, name=NAME, user_project=USER_PROJECT)
-        result = bucket.delete_blob(BLOB_NAME)
+        result = bucket.delete_blob(BLOB_NAME, timeout=42)
         self.assertIsNone(result)
         kw, = connection._requested
         self.assertEqual(kw["method"], "DELETE")
         self.assertEqual(kw["path"], "/b/%s/o/%s" % (NAME, BLOB_NAME))
         self.assertEqual(kw["query_params"], {"userProject": USER_PROJECT})
+        self.assertEqual(kw["timeout"], 42)
 
     def test_delete_blob_hit_with_generation(self):
         NAME = "name"
@@ -1156,6 +1186,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "DELETE")
         self.assertEqual(kw["path"], "/b/%s/o/%s" % (NAME, BLOB_NAME))
         self.assertEqual(kw["query_params"], {"generation": GENERATION})
+        self.assertEqual(kw["timeout"], self._get_default_timeout())
 
     def test_delete_blobs_empty(self):
         NAME = "name"
@@ -1172,12 +1203,13 @@ class Test_Bucket(unittest.TestCase):
         connection = _Connection({})
         client = _Client(connection)
         bucket = self._make_one(client=client, name=NAME, user_project=USER_PROJECT)
-        bucket.delete_blobs([BLOB_NAME])
+        bucket.delete_blobs([BLOB_NAME], timeout=42)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]["method"], "DELETE")
         self.assertEqual(kw[0]["path"], "/b/%s/o/%s" % (NAME, BLOB_NAME))
         self.assertEqual(kw[0]["query_params"], {"userProject": USER_PROJECT})
+        self.assertEqual(kw[0]["timeout"], 42)
 
     def test_delete_blobs_miss_no_on_error(self):
         from google.cloud.exceptions import NotFound
@@ -1193,8 +1225,10 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(len(kw), 2)
         self.assertEqual(kw[0]["method"], "DELETE")
         self.assertEqual(kw[0]["path"], "/b/%s/o/%s" % (NAME, BLOB_NAME))
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
         self.assertEqual(kw[1]["method"], "DELETE")
         self.assertEqual(kw[1]["path"], "/b/%s/o/%s" % (NAME, NONESUCH))
+        self.assertEqual(kw[1]["timeout"], self._get_default_timeout())
 
     def test_delete_blobs_miss_w_on_error(self):
         NAME = "name"
@@ -1210,8 +1244,10 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(len(kw), 2)
         self.assertEqual(kw[0]["method"], "DELETE")
         self.assertEqual(kw[0]["path"], "/b/%s/o/%s" % (NAME, BLOB_NAME))
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
         self.assertEqual(kw[1]["method"], "DELETE")
         self.assertEqual(kw[1]["path"], "/b/%s/o/%s" % (NAME, NONESUCH))
+        self.assertEqual(kw[1]["timeout"], self._get_default_timeout())
 
     @staticmethod
     def _make_blob(bucket_name, blob_name):
@@ -1232,7 +1268,7 @@ class Test_Bucket(unittest.TestCase):
         dest = self._make_one(client=client, name=DEST)
         blob = self._make_blob(SOURCE, BLOB_NAME)
 
-        new_blob = source.copy_blob(blob, dest)
+        new_blob = source.copy_blob(blob, dest, timeout=42)
 
         self.assertIs(new_blob.bucket, dest)
         self.assertEqual(new_blob.name, BLOB_NAME)
@@ -1244,6 +1280,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "POST")
         self.assertEqual(kw["path"], COPY_PATH)
         self.assertEqual(kw["query_params"], {})
+        self.assertEqual(kw["timeout"], 42)
 
     def test_copy_blobs_source_generation(self):
         SOURCE = "source"
@@ -1269,6 +1306,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "POST")
         self.assertEqual(kw["path"], COPY_PATH)
         self.assertEqual(kw["query_params"], {"sourceGeneration": GENERATION})
+        self.assertEqual(kw["timeout"], self._get_default_timeout())
 
     def test_copy_blobs_preserve_acl(self):
         from google.cloud.storage.acl import ObjectACL
@@ -1301,10 +1339,12 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw1["method"], "POST")
         self.assertEqual(kw1["path"], COPY_PATH)
         self.assertEqual(kw1["query_params"], {})
+        self.assertEqual(kw1["timeout"], self._get_default_timeout())
 
         self.assertEqual(kw2["method"], "PATCH")
         self.assertEqual(kw2["path"], NEW_BLOB_PATH)
         self.assertEqual(kw2["query_params"], {"projection": "full"})
+        self.assertEqual(kw2["timeout"], self._get_default_timeout())
 
     def test_copy_blobs_w_name_and_user_project(self):
         SOURCE = "source"
@@ -1330,6 +1370,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "POST")
         self.assertEqual(kw["path"], COPY_PATH)
         self.assertEqual(kw["query_params"], {"userProject": USER_PROJECT})
+        self.assertEqual(kw["timeout"], self._get_default_timeout())
 
     def test_rename_blob(self):
         BUCKET_NAME = "BUCKET_NAME"
@@ -1341,7 +1382,9 @@ class Test_Bucket(unittest.TestCase):
         bucket = self._make_one(client=client, name=BUCKET_NAME)
         blob = self._make_blob(BUCKET_NAME, BLOB_NAME)
 
-        renamed_blob = bucket.rename_blob(blob, NEW_BLOB_NAME, client=client)
+        renamed_blob = bucket.rename_blob(
+            blob, NEW_BLOB_NAME, client=client, timeout=42
+        )
 
         self.assertIs(renamed_blob.bucket, bucket)
         self.assertEqual(renamed_blob.name, NEW_BLOB_NAME)
@@ -1353,8 +1396,9 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "POST")
         self.assertEqual(kw["path"], COPY_PATH)
         self.assertEqual(kw["query_params"], {})
+        self.assertEqual(kw["timeout"], 42)
 
-        blob.delete.assert_called_once_with(client)
+        blob.delete.assert_called_once_with(client=client, timeout=42)
 
     def test_rename_blob_to_itself(self):
         BUCKET_NAME = "BUCKET_NAME"
@@ -1377,6 +1421,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw["method"], "POST")
         self.assertEqual(kw["path"], COPY_PATH)
         self.assertEqual(kw["query_params"], {})
+        self.assertEqual(kw["timeout"], self._get_default_timeout())
 
         blob.delete.assert_not_called()
 
@@ -1680,13 +1725,15 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(len(kwargs["data"]["labels"]), 2)
         self.assertEqual(kwargs["data"]["labels"]["color"], "red")
         self.assertIsNone(kwargs["data"]["labels"]["flavor"])
+        self.assertEqual(kwargs["timeout"], self._get_default_timeout())
 
         # A second patch call should be a no-op for labels.
         client._connection.api_request.reset_mock()
-        bucket.patch(client=client)
+        bucket.patch(client=client, timeout=42)
         client._connection.api_request.assert_called()
         _, _, kwargs = client._connection.api_request.mock_calls[0]
         self.assertNotIn("labels", kwargs["data"])
+        self.assertEqual(kwargs["timeout"], 42)
 
     def test_location_type_getter_unset(self):
         bucket = self._make_one()
@@ -2047,7 +2094,7 @@ class Test_Bucket(unittest.TestCase):
         client = _Client(connection, None)
         bucket = self._make_one(client=client, name=NAME)
 
-        policy = bucket.get_iam_policy()
+        policy = bucket.get_iam_policy(timeout=42)
 
         self.assertIsInstance(policy, Policy)
         self.assertEqual(policy.etag, RETURNED["etag"])
@@ -2059,6 +2106,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[0]["method"], "GET")
         self.assertEqual(kw[0]["path"], "%s/iam" % (PATH,))
         self.assertEqual(kw[0]["query_params"], {})
+        self.assertEqual(kw[0]["timeout"], 42)
 
     def test_get_iam_policy_w_user_project(self):
         from google.api_core.iam import Policy
@@ -2091,6 +2139,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[0]["method"], "GET")
         self.assertEqual(kw[0]["path"], "%s/iam" % (PATH,))
         self.assertEqual(kw[0]["query_params"], {"userProject": USER_PROJECT})
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
 
     def test_get_iam_policy_w_requested_policy_version(self):
         from google.cloud.storage.iam import STORAGE_OWNER_ROLE
@@ -2120,6 +2169,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[0]["method"], "GET")
         self.assertEqual(kw[0]["path"], "%s/iam" % (PATH,))
         self.assertEqual(kw[0]["query_params"], {"optionsRequestedPolicyVersion": 3})
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
 
     def test_set_iam_policy(self):
         import operator
@@ -2152,7 +2202,7 @@ class Test_Bucket(unittest.TestCase):
         client = _Client(connection, None)
         bucket = self._make_one(client=client, name=NAME)
 
-        returned = bucket.set_iam_policy(policy)
+        returned = bucket.set_iam_policy(policy, timeout=42)
 
         self.assertEqual(returned.etag, ETAG)
         self.assertEqual(returned.version, VERSION)
@@ -2163,6 +2213,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[0]["method"], "PUT")
         self.assertEqual(kw[0]["path"], "%s/iam" % (PATH,))
         self.assertEqual(kw[0]["query_params"], {})
+        self.assertEqual(kw[0]["timeout"], 42)
         sent = kw[0]["data"]
         self.assertEqual(sent["resourceId"], PATH)
         self.assertEqual(len(sent["bindings"]), len(BINDINGS))
@@ -2216,6 +2267,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[0]["method"], "PUT")
         self.assertEqual(kw[0]["path"], "%s/iam" % (PATH,))
         self.assertEqual(kw[0]["query_params"], {"userProject": USER_PROJECT})
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
         sent = kw[0]["data"]
         self.assertEqual(sent["resourceId"], PATH)
         self.assertEqual(len(sent["bindings"]), len(BINDINGS))
@@ -2244,7 +2296,7 @@ class Test_Bucket(unittest.TestCase):
         client = _Client(connection, None)
         bucket = self._make_one(client=client, name=NAME)
 
-        allowed = bucket.test_iam_permissions(PERMISSIONS)
+        allowed = bucket.test_iam_permissions(PERMISSIONS, timeout=42)
 
         self.assertEqual(allowed, ALLOWED)
 
@@ -2253,6 +2305,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[0]["method"], "GET")
         self.assertEqual(kw[0]["path"], "%s/iam/testPermissions" % (PATH,))
         self.assertEqual(kw[0]["query_params"], {"permissions": PERMISSIONS})
+        self.assertEqual(kw[0]["timeout"], 42)
 
     def test_test_iam_permissions_w_user_project(self):
         from google.cloud.storage.iam import STORAGE_OBJECTS_LIST
@@ -2285,6 +2338,7 @@ class Test_Bucket(unittest.TestCase):
             kw[0]["query_params"],
             {"permissions": PERMISSIONS, "userProject": USER_PROJECT},
         )
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
 
     def test_make_public_defaults(self):
         from google.cloud.storage.acl import _ACLEntity
@@ -2306,6 +2360,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[0]["path"], "/b/%s" % NAME)
         self.assertEqual(kw[0]["data"], {"acl": after["acl"]})
         self.assertEqual(kw[0]["query_params"], {"projection": "full"})
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
 
     def _make_public_w_future_helper(self, default_object_acl_loaded=True):
         from google.cloud.storage.acl import _ACLEntity
@@ -2335,6 +2390,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[0]["path"], "/b/%s" % NAME)
         self.assertEqual(kw[0]["data"], {"acl": permissive})
         self.assertEqual(kw[0]["query_params"], {"projection": "full"})
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
         if not default_object_acl_loaded:
             self.assertEqual(kw[1]["method"], "GET")
             self.assertEqual(kw[1]["path"], "/b/%s/defaultObjectAcl" % NAME)
@@ -2343,6 +2399,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[-1]["path"], "/b/%s" % NAME)
         self.assertEqual(kw[-1]["data"], {"defaultObjectAcl": permissive})
         self.assertEqual(kw[-1]["query_params"], {"projection": "full"})
+        self.assertEqual(kw[-1]["timeout"], self._get_default_timeout())
 
     def test_make_public_w_future(self):
         self._make_public_w_future_helper(default_object_acl_loaded=True)
@@ -2373,8 +2430,10 @@ class Test_Bucket(unittest.TestCase):
             def grant_read(self):
                 self._granted = True
 
-            def save(self, client=None):
-                _saved.append((self._bucket, self._name, self._granted, client))
+            def save(self, client=None, timeout=None):
+                _saved.append(
+                    (self._bucket, self._name, self._granted, client, timeout)
+                )
 
         def item_to_blob(self, item):
             return _Blob(self.bucket, item["name"])
@@ -2390,22 +2449,24 @@ class Test_Bucket(unittest.TestCase):
         bucket.default_object_acl.loaded = True
 
         with mock.patch("google.cloud.storage.bucket._item_to_blob", new=item_to_blob):
-            bucket.make_public(recursive=True)
+            bucket.make_public(recursive=True, timeout=42)
         self.assertEqual(list(bucket.acl), permissive)
         self.assertEqual(list(bucket.default_object_acl), [])
-        self.assertEqual(_saved, [(bucket, BLOB_NAME, True, None)])
+        self.assertEqual(_saved, [(bucket, BLOB_NAME, True, None, 42)])
         kw = connection._requested
         self.assertEqual(len(kw), 2)
         self.assertEqual(kw[0]["method"], "PATCH")
         self.assertEqual(kw[0]["path"], "/b/%s" % NAME)
         self.assertEqual(kw[0]["data"], {"acl": permissive})
         self.assertEqual(kw[0]["query_params"], {"projection": "full"})
+        self.assertEqual(kw[0]["timeout"], 42)
         self.assertEqual(kw[1]["method"], "GET")
         self.assertEqual(kw[1]["path"], "/b/%s/o" % NAME)
         max_results = bucket._MAX_OBJECTS_FOR_ITERATION + 1
         self.assertEqual(
             kw[1]["query_params"], {"maxResults": max_results, "projection": "full"}
         )
+        self.assertEqual(kw[1]["timeout"], 42)
 
     def test_make_public_recursive_too_many(self):
         from google.cloud.storage.acl import _ACLEntity
@@ -2445,6 +2506,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[0]["path"], "/b/%s" % NAME)
         self.assertEqual(kw[0]["data"], {"acl": after["acl"]})
         self.assertEqual(kw[0]["query_params"], {"projection": "full"})
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
 
     def _make_private_w_future_helper(self, default_object_acl_loaded=True):
         NAME = "name"
@@ -2472,6 +2534,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[0]["path"], "/b/%s" % NAME)
         self.assertEqual(kw[0]["data"], {"acl": no_permissions})
         self.assertEqual(kw[0]["query_params"], {"projection": "full"})
+        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
         if not default_object_acl_loaded:
             self.assertEqual(kw[1]["method"], "GET")
             self.assertEqual(kw[1]["path"], "/b/%s/defaultObjectAcl" % NAME)
@@ -2480,6 +2543,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[-1]["path"], "/b/%s" % NAME)
         self.assertEqual(kw[-1]["data"], {"defaultObjectAcl": no_permissions})
         self.assertEqual(kw[-1]["query_params"], {"projection": "full"})
+        self.assertEqual(kw[-1]["timeout"], self._get_default_timeout())
 
     def test_make_private_w_future(self):
         self._make_private_w_future_helper(default_object_acl_loaded=True)
@@ -2508,8 +2572,10 @@ class Test_Bucket(unittest.TestCase):
             def revoke_read(self):
                 self._granted = False
 
-            def save(self, client=None):
-                _saved.append((self._bucket, self._name, self._granted, client))
+            def save(self, client=None, timeout=None):
+                _saved.append(
+                    (self._bucket, self._name, self._granted, client, timeout)
+                )
 
         def item_to_blob(self, item):
             return _Blob(self.bucket, item["name"])
@@ -2525,22 +2591,24 @@ class Test_Bucket(unittest.TestCase):
         bucket.default_object_acl.loaded = True
 
         with mock.patch("google.cloud.storage.bucket._item_to_blob", new=item_to_blob):
-            bucket.make_private(recursive=True)
+            bucket.make_private(recursive=True, timeout=42)
         self.assertEqual(list(bucket.acl), no_permissions)
         self.assertEqual(list(bucket.default_object_acl), [])
-        self.assertEqual(_saved, [(bucket, BLOB_NAME, False, None)])
+        self.assertEqual(_saved, [(bucket, BLOB_NAME, False, None, 42)])
         kw = connection._requested
         self.assertEqual(len(kw), 2)
         self.assertEqual(kw[0]["method"], "PATCH")
         self.assertEqual(kw[0]["path"], "/b/%s" % NAME)
         self.assertEqual(kw[0]["data"], {"acl": no_permissions})
         self.assertEqual(kw[0]["query_params"], {"projection": "full"})
+        self.assertEqual(kw[0]["timeout"], 42)
         self.assertEqual(kw[1]["method"], "GET")
         self.assertEqual(kw[1]["path"], "/b/%s/o" % NAME)
         max_results = bucket._MAX_OBJECTS_FOR_ITERATION + 1
         self.assertEqual(
             kw[1]["query_params"], {"maxResults": max_results, "projection": "full"}
         )
+        self.assertEqual(kw[1]["timeout"], 42)
 
     def test_make_private_recursive_too_many(self):
         NO_PERMISSIONS = []
@@ -2778,12 +2846,13 @@ class Test_Bucket(unittest.TestCase):
             "retentionPeriod": 86400 * 100,  # 100 days
         }
 
-        bucket.lock_retention_policy()
+        bucket.lock_retention_policy(timeout=42)
 
         kw, = connection._requested
         self.assertEqual(kw["method"], "POST")
         self.assertEqual(kw["path"], "/b/{}/lockRetentionPolicy".format(name))
         self.assertEqual(kw["query_params"], {"ifMetagenerationMatch": 1234})
+        self.assertEqual(kw["timeout"], 42)
 
     def test_lock_retention_policy_w_user_project(self):
         name = "name"
@@ -2817,6 +2886,7 @@ class Test_Bucket(unittest.TestCase):
             kw["query_params"],
             {"ifMetagenerationMatch": 1234, "userProject": user_project},
         )
+        self.assertEqual(kw["timeout"], self._get_default_timeout())
 
     def test_generate_signed_url_w_invalid_version(self):
         expiration = "2014-10-16T20:34:37.000Z"

--- a/storage/tests/unit/test_client.py
+++ b/storage/tests/unit/test_client.py
@@ -265,7 +265,7 @@ class TestClient(unittest.TestCase):
         http = _make_requests_session([_make_json_response(RESOURCE)])
         client._http_internal = http
 
-        service_account_email = client.get_service_account_email()
+        service_account_email = client.get_service_account_email(timeout=42)
 
         self.assertEqual(service_account_email, EMAIL)
         URI = "/".join(
@@ -277,7 +277,7 @@ class TestClient(unittest.TestCase):
             ]
         )
         http.request.assert_called_once_with(
-            method="GET", url=URI, data=None, headers=mock.ANY, timeout=mock.ANY
+            method="GET", url=URI, data=None, headers=mock.ANY, timeout=42
         )
 
     def test_get_service_account_email_w_project(self):
@@ -303,7 +303,11 @@ class TestClient(unittest.TestCase):
             ]
         )
         http.request.assert_called_once_with(
-            method="GET", url=URI, data=None, headers=mock.ANY, timeout=mock.ANY
+            method="GET",
+            url=URI,
+            data=None,
+            headers=mock.ANY,
+            timeout=self._get_default_timeout(),
         )
 
     def test_bucket(self):
@@ -369,10 +373,10 @@ class TestClient(unittest.TestCase):
         client._http_internal = http
 
         with self.assertRaises(NotFound):
-            client.get_bucket(NONESUCH)
+            client.get_bucket(NONESUCH, timeout=42)
 
         http.request.assert_called_once_with(
-            method="GET", url=URI, data=mock.ANY, headers=mock.ANY, timeout=mock.ANY
+            method="GET", url=URI, data=mock.ANY, headers=mock.ANY, timeout=42
         )
 
     def test_get_bucket_with_string_hit(self):
@@ -402,7 +406,11 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(bucket, Bucket)
         self.assertEqual(bucket.name, BUCKET_NAME)
         http.request.assert_called_once_with(
-            method="GET", url=URI, data=mock.ANY, headers=mock.ANY, timeout=mock.ANY
+            method="GET",
+            url=URI,
+            data=mock.ANY,
+            headers=mock.ANY,
+            timeout=self._get_default_timeout(),
         )
 
     def test_get_bucket_with_object_miss(self):
@@ -433,7 +441,11 @@ class TestClient(unittest.TestCase):
             client.get_bucket(bucket_obj)
 
         http.request.assert_called_once_with(
-            method="GET", url=URI, data=mock.ANY, headers=mock.ANY, timeout=mock.ANY
+            method="GET",
+            url=URI,
+            data=mock.ANY,
+            headers=mock.ANY,
+            timeout=self._get_default_timeout(),
         )
 
     def test_get_bucket_with_object_hit(self):
@@ -464,7 +476,11 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(bucket, Bucket)
         self.assertEqual(bucket.name, bucket_name)
         http.request.assert_called_once_with(
-            method="GET", url=URI, data=mock.ANY, headers=mock.ANY, timeout=mock.ANY
+            method="GET",
+            url=URI,
+            data=mock.ANY,
+            headers=mock.ANY,
+            timeout=self._get_default_timeout(),
         )
 
     def test_lookup_bucket_miss(self):
@@ -487,11 +503,11 @@ class TestClient(unittest.TestCase):
         )
         client._http_internal = http
 
-        bucket = client.lookup_bucket(NONESUCH)
+        bucket = client.lookup_bucket(NONESUCH, timeout=42)
 
         self.assertIsNone(bucket)
         http.request.assert_called_once_with(
-            method="GET", url=URI, data=mock.ANY, headers=mock.ANY, timeout=mock.ANY
+            method="GET", url=URI, data=mock.ANY, headers=mock.ANY, timeout=42
         )
 
     def test_lookup_bucket_hit(self):
@@ -520,7 +536,11 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(bucket, Bucket)
         self.assertEqual(bucket.name, BUCKET_NAME)
         http.request.assert_called_once_with(
-            method="GET", url=URI, data=mock.ANY, headers=mock.ANY, timeout=mock.ANY
+            method="GET",
+            url=URI,
+            data=mock.ANY,
+            headers=mock.ANY,
+            timeout=self._get_default_timeout(),
         )
 
     def test_create_bucket_w_missing_client_project(self):
@@ -556,6 +576,7 @@ class TestClient(unittest.TestCase):
             query_params={"project": other_project, "userProject": user_project},
             data=data,
             _target_object=mock.ANY,
+            timeout=self._get_default_timeout(),
         )
 
     def test_create_bucket_w_predefined_acl_invalid(self):
@@ -576,7 +597,9 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=project, credentials=credentials)
         connection = _make_connection(data)
         client._base_connection = connection
-        bucket = client.create_bucket(bucket_name, predefined_acl="publicRead")
+        bucket = client.create_bucket(
+            bucket_name, predefined_acl="publicRead", timeout=42
+        )
 
         connection.api_request.assert_called_once_with(
             method="POST",
@@ -584,6 +607,7 @@ class TestClient(unittest.TestCase):
             query_params={"project": project, "predefinedAcl": "publicRead"},
             data=data,
             _target_object=bucket,
+            timeout=42,
         )
 
     def test_create_bucket_w_predefined_default_object_acl_invalid(self):
@@ -618,6 +642,7 @@ class TestClient(unittest.TestCase):
             },
             data=data,
             _target_object=bucket,
+            timeout=self._get_default_timeout(),
         )
 
     def test_create_bucket_w_explicit_location(self):
@@ -642,6 +667,7 @@ class TestClient(unittest.TestCase):
             data=data,
             _target_object=bucket,
             query_params={"project": project},
+            timeout=self._get_default_timeout(),
         )
         self.assertEqual(bucket.location, location)
 
@@ -824,6 +850,7 @@ class TestClient(unittest.TestCase):
                 versions=VERSIONS,
                 projection=PROJECTION,
                 fields=FIELDS,
+                timeout=42,
             )
             blobs = list(iterator)
 
@@ -832,7 +859,7 @@ class TestClient(unittest.TestCase):
                 method="GET",
                 path="/b/%s/o" % BUCKET_NAME,
                 query_params=EXPECTED,
-                timeout=self._get_default_timeout(),
+                timeout=42,
             )
 
     def test_list_buckets_wo_project(self):
@@ -940,7 +967,7 @@ class TestClient(unittest.TestCase):
             url=mock.ANY,
             data=mock.ANY,
             headers=mock.ANY,
-            timeout=mock.ANY,
+            timeout=self._get_default_timeout(),
         )
 
     def test_list_buckets_all_arguments(self):
@@ -966,15 +993,12 @@ class TestClient(unittest.TestCase):
             prefix=PREFIX,
             projection=PROJECTION,
             fields=FIELDS,
+            timeout=42,
         )
         buckets = list(iterator)
         self.assertEqual(buckets, [])
         http.request.assert_called_once_with(
-            method="GET",
-            url=mock.ANY,
-            data=mock.ANY,
-            headers=mock.ANY,
-            timeout=mock.ANY,
+            method="GET", url=mock.ANY, data=mock.ANY, headers=mock.ANY, timeout=42
         )
 
         requested_url = http.request.mock_calls[0][2]["url"]
@@ -1034,7 +1058,9 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(bucket, Bucket)
         self.assertEqual(bucket.name, blob_name)
 
-    def _create_hmac_key_helper(self, explicit_project=None, user_project=None):
+    def _create_hmac_key_helper(
+        self, explicit_project=None, user_project=None, timeout=None
+    ):
         import datetime
         from pytz import UTC
         from six.moves.urllib.parse import urlencode
@@ -1079,6 +1105,10 @@ class TestClient(unittest.TestCase):
         if user_project is not None:
             kwargs["user_project"] = user_project
 
+        if timeout is None:
+            timeout = self._get_default_timeout()
+        kwargs["timeout"] = timeout
+
         metadata, secret = client.create_hmac_key(service_account_email=EMAIL, **kwargs)
 
         self.assertIsInstance(metadata, HMACKeyMetadata)
@@ -1103,7 +1133,7 @@ class TestClient(unittest.TestCase):
 
         FULL_URI = "{}?{}".format(URI, urlencode(qs_params))
         http.request.assert_called_once_with(
-            method="POST", url=FULL_URI, data=None, headers=mock.ANY, timeout=mock.ANY
+            method="POST", url=FULL_URI, data=None, headers=mock.ANY, timeout=timeout
         )
 
     def test_create_hmac_key_defaults(self):
@@ -1113,7 +1143,7 @@ class TestClient(unittest.TestCase):
         self._create_hmac_key_helper(explicit_project="other-project-456")
 
     def test_create_hmac_key_user_project(self):
-        self._create_hmac_key_helper(user_project="billed-project")
+        self._create_hmac_key_helper(user_project="billed-project", timeout=42)
 
     def test_list_hmac_keys_defaults_empty(self):
         PROJECT = "PROJECT"
@@ -1138,7 +1168,11 @@ class TestClient(unittest.TestCase):
             ]
         )
         http.request.assert_called_once_with(
-            method="GET", url=URI, data=None, headers=mock.ANY, timeout=mock.ANY
+            method="GET",
+            url=URI,
+            data=None,
+            headers=mock.ANY,
+            timeout=self._get_default_timeout(),
         )
 
     def test_list_hmac_keys_explicit_non_empty(self):
@@ -1175,6 +1209,7 @@ class TestClient(unittest.TestCase):
                 show_deleted_keys=True,
                 project_id=OTHER_PROJECT,
                 user_project=USER_PROJECT,
+                timeout=42,
             )
         )
 
@@ -1202,7 +1237,7 @@ class TestClient(unittest.TestCase):
             "userProject": USER_PROJECT,
         }
         http.request.assert_called_once_with(
-            method="GET", url=mock.ANY, data=None, headers=mock.ANY, timeout=mock.ANY
+            method="GET", url=mock.ANY, data=None, headers=mock.ANY, timeout=42
         )
         kwargs = http.request.mock_calls[0].kwargs
         uri = kwargs["url"]
@@ -1230,7 +1265,7 @@ class TestClient(unittest.TestCase):
         http = _make_requests_session([_make_json_response(resource)])
         client._http_internal = http
 
-        metadata = client.get_hmac_key_metadata(ACCESS_ID)
+        metadata = client.get_hmac_key_metadata(ACCESS_ID, timeout=42)
 
         self.assertIsInstance(metadata, HMACKeyMetadata)
         self.assertIs(metadata._client, client)
@@ -1249,7 +1284,7 @@ class TestClient(unittest.TestCase):
             ]
         )
         http.request.assert_called_once_with(
-            method="GET", url=URI, data=None, headers=mock.ANY, timeout=mock.ANY
+            method="GET", url=URI, data=None, headers=mock.ANY, timeout=42
         )
 
     def test_get_hmac_key_metadata_w_project(self):
@@ -1299,5 +1334,9 @@ class TestClient(unittest.TestCase):
         FULL_URI = "{}?{}".format(URI, urlencode(qs_params))
 
         http.request.assert_called_once_with(
-            method="GET", url=FULL_URI, data=None, headers=mock.ANY, timeout=mock.ANY
+            method="GET",
+            url=FULL_URI,
+            data=None,
+            headers=mock.ANY,
+            timeout=self._get_default_timeout(),
         )

--- a/storage/tests/unit/test_client.py
+++ b/storage/tests/unit/test_client.py
@@ -68,6 +68,12 @@ class TestClient(unittest.TestCase):
 
         return Client
 
+    @staticmethod
+    def _get_default_timeout():
+        from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+
+        return _DEFAULT_TIMEOUT
+
     def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
@@ -772,6 +778,7 @@ class TestClient(unittest.TestCase):
                 method="GET",
                 path="/b/%s/o" % BUCKET_NAME,
                 query_params={"projection": "noAcl"},
+                timeout=self._get_default_timeout(),
             )
 
     def test_list_blobs_w_all_arguments_and_user_project(self):
@@ -822,7 +829,10 @@ class TestClient(unittest.TestCase):
 
             self.assertEqual(blobs, [])
             connection.api_request.assert_called_once_with(
-                method="GET", path="/b/%s/o" % BUCKET_NAME, query_params=EXPECTED
+                method="GET",
+                path="/b/%s/o" % BUCKET_NAME,
+                query_params=EXPECTED,
+                timeout=self._get_default_timeout(),
             )
 
     def test_list_buckets_wo_project(self):

--- a/storage/tests/unit/test_hmac_key.py
+++ b/storage/tests/unit/test_hmac_key.py
@@ -19,6 +19,12 @@ import mock
 
 class TestHMACKeyMetadata(unittest.TestCase):
     @staticmethod
+    def _get_default_timeout():
+        from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+
+        return _DEFAULT_TIMEOUT
+
+    @staticmethod
     def _get_target_class():
         from google.cloud.storage.hmac_key import HMACKeyMetadata
 
@@ -219,12 +225,17 @@ class TestHMACKeyMetadata(unittest.TestCase):
         metadata = self._make_one(client)
         metadata._properties["accessId"] = access_id
 
-        self.assertFalse(metadata.exists())
+        self.assertFalse(metadata.exists(timeout=42))
 
         expected_path = "/projects/{}/hmacKeys/{}".format(
             client.DEFAULT_PROJECT, access_id
         )
-        expected_kwargs = {"method": "GET", "path": expected_path, "query_params": {}}
+        expected_kwargs = {
+            "method": "GET",
+            "path": expected_path,
+            "query_params": {},
+            "timeout": 42,
+        }
         connection.api_request.assert_called_once_with(**expected_kwargs)
 
     def test_exists_hit_w_project_set(self):
@@ -251,6 +262,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
             "method": "GET",
             "path": expected_path,
             "query_params": {"userProject": user_project},
+            "timeout": self._get_default_timeout(),
         }
         connection.api_request.assert_called_once_with(**expected_kwargs)
 
@@ -265,12 +277,17 @@ class TestHMACKeyMetadata(unittest.TestCase):
         metadata._properties["accessId"] = access_id
 
         with self.assertRaises(NotFound):
-            metadata.reload()
+            metadata.reload(timeout=42)
 
         expected_path = "/projects/{}/hmacKeys/{}".format(
             client.DEFAULT_PROJECT, access_id
         )
-        expected_kwargs = {"method": "GET", "path": expected_path, "query_params": {}}
+        expected_kwargs = {
+            "method": "GET",
+            "path": expected_path,
+            "query_params": {},
+            "timeout": 42,
+        }
         connection.api_request.assert_called_once_with(**expected_kwargs)
 
     def test_reload_hit_w_project_set(self):
@@ -299,6 +316,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
             "method": "GET",
             "path": expected_path,
             "query_params": {"userProject": user_project},
+            "timeout": self._get_default_timeout(),
         }
         connection.api_request.assert_called_once_with(**expected_kwargs)
 
@@ -314,7 +332,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
         metadata.state = "INACTIVE"
 
         with self.assertRaises(NotFound):
-            metadata.update()
+            metadata.update(timeout=42)
 
         expected_path = "/projects/{}/hmacKeys/{}".format(
             client.DEFAULT_PROJECT, access_id
@@ -324,6 +342,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
             "path": expected_path,
             "data": {"state": "INACTIVE"},
             "query_params": {},
+            "timeout": 42,
         }
         connection.api_request.assert_called_once_with(**expected_kwargs)
 
@@ -356,6 +375,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
             "path": expected_path,
             "data": {"state": "ACTIVE"},
             "query_params": {"userProject": user_project},
+            "timeout": self._get_default_timeout(),
         }
         connection.api_request.assert_called_once_with(**expected_kwargs)
 
@@ -379,7 +399,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
         metadata.state = "INACTIVE"
 
         with self.assertRaises(NotFound):
-            metadata.delete()
+            metadata.delete(timeout=42)
 
         expected_path = "/projects/{}/hmacKeys/{}".format(
             client.DEFAULT_PROJECT, access_id
@@ -388,6 +408,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
             "method": "DELETE",
             "path": expected_path,
             "query_params": {},
+            "timeout": 42,
         }
         connection.api_request.assert_called_once_with(**expected_kwargs)
 
@@ -410,6 +431,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
             "method": "DELETE",
             "path": expected_path,
             "query_params": {"userProject": user_project},
+            "timeout": self._get_default_timeout(),
         }
         connection.api_request.assert_called_once_with(**expected_kwargs)
 

--- a/storage/tests/unit/test_notification.py
+++ b/storage/tests/unit/test_notification.py
@@ -52,6 +52,12 @@ class TestBucketNotification(unittest.TestCase):
         return JSON_API_V1_PAYLOAD_FORMAT
 
     @staticmethod
+    def _get_default_timeout():
+        from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+
+        return _DEFAULT_TIMEOUT
+
+    @staticmethod
     def _get_target_class():
         from google.cloud.storage.notification import BucketNotification
 
@@ -258,7 +264,11 @@ class TestBucketNotification(unittest.TestCase):
 
         data = {"topic": self.TOPIC_REF, "payload_format": NONE_PAYLOAD_FORMAT}
         api_request.assert_called_once_with(
-            method="POST", path=self.CREATE_PATH, query_params={}, data=data
+            method="POST",
+            path=self.CREATE_PATH,
+            query_params={},
+            data=data,
+            timeout=self._get_default_timeout(),
         )
 
     def test_create_w_explicit_client(self):
@@ -287,7 +297,7 @@ class TestBucketNotification(unittest.TestCase):
             "selfLink": self.SELF_LINK,
         }
 
-        notification.create(client=alt_client)
+        notification.create(client=alt_client, timeout=42)
 
         self.assertEqual(notification.custom_attributes, self.CUSTOM_ATTRIBUTES)
         self.assertEqual(notification.event_types, self.event_types())
@@ -309,6 +319,7 @@ class TestBucketNotification(unittest.TestCase):
             path=self.CREATE_PATH,
             query_params={"userProject": USER_PROJECT},
             data=data,
+            timeout=42,
         )
 
     def test_exists_wo_notification_id(self):
@@ -329,10 +340,10 @@ class TestBucketNotification(unittest.TestCase):
         api_request = client._connection.api_request
         api_request.side_effect = NotFound("testing")
 
-        self.assertFalse(notification.exists())
+        self.assertFalse(notification.exists(timeout=42))
 
         api_request.assert_called_once_with(
-            method="GET", path=self.NOTIFICATION_PATH, query_params={}
+            method="GET", path=self.NOTIFICATION_PATH, query_params={}, timeout=42
         )
 
     def test_exists_hit(self):
@@ -355,6 +366,7 @@ class TestBucketNotification(unittest.TestCase):
             method="GET",
             path=self.NOTIFICATION_PATH,
             query_params={"userProject": USER_PROJECT},
+            timeout=self._get_default_timeout(),
         )
 
     def test_reload_wo_notification_id(self):
@@ -376,10 +388,10 @@ class TestBucketNotification(unittest.TestCase):
         api_request.side_effect = NotFound("testing")
 
         with self.assertRaises(NotFound):
-            notification.reload()
+            notification.reload(timeout=42)
 
         api_request.assert_called_once_with(
-            method="GET", path=self.NOTIFICATION_PATH, query_params={}
+            method="GET", path=self.NOTIFICATION_PATH, query_params={}, timeout=42
         )
 
     def test_reload_hit(self):
@@ -412,6 +424,7 @@ class TestBucketNotification(unittest.TestCase):
             method="GET",
             path=self.NOTIFICATION_PATH,
             query_params={"userProject": USER_PROJECT},
+            timeout=self._get_default_timeout(),
         )
 
     def test_delete_wo_notification_id(self):
@@ -433,10 +446,10 @@ class TestBucketNotification(unittest.TestCase):
         api_request.side_effect = NotFound("testing")
 
         with self.assertRaises(NotFound):
-            notification.delete()
+            notification.delete(timeout=42)
 
         api_request.assert_called_once_with(
-            method="DELETE", path=self.NOTIFICATION_PATH, query_params={}
+            method="DELETE", path=self.NOTIFICATION_PATH, query_params={}, timeout=42
         )
 
     def test_delete_hit(self):
@@ -454,6 +467,7 @@ class TestBucketNotification(unittest.TestCase):
             method="DELETE",
             path=self.NOTIFICATION_PATH,
             query_params={"userProject": USER_PROJECT},
+            timeout=self._get_default_timeout(),
         )
 
 


### PR DESCRIPTION
Closes #10199.
Towards #10182.

Preview only for now to show the direction this is going. There are still quite a few potentially blocking code paths that are not covered yet.

#### Notes
 - `ACL._ensure_loaded()` has a default timeout, but not all internal calls to it can be made that configurable, such as in `ACL.__iter__()`. I thus left that part to use a default timeout.
 - `Blob.download_to_file()`,  `Blob.upload_from_file()`, and the methods that rely on these two do not expose timeouts, because the underlying `resumable-media` logic applies its own default timeout to `transport.request()`, which would override user timeouts.
Getting around that would first require adding configurable timeouts to the `resumable-media` dependency (there is a PR [#116](https://github.com/googleapis/google-resumable-media-python/pull/116) that adds these, but only for uploads and it's not merged yet)   .



#### Things still to do/check:

- [x] Add `timeout` to the remaining methods that use `client._connection.api_request()` (read: helpers)
- [x] Add `timeout` to any methods that use `_connection._make_request()` directly, i.e. bypassing the `api_request()` method.
- [x]  Add `timeout` to public methods that interact with methods using the `timeout` (to pass the timeout through).

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
