### PR TITLE
chore(bigquery): adjust test assertions to new default timeout

### DIFF
--- a/bigquery/tests/unit/test__http.py
+++ b/bigquery/tests/unit/test__http.py
@@ -20,6 +20,12 @@ import requests
 
 class TestConnection(unittest.TestCase):
     @staticmethod
+    def _get_default_timeout():
+        from google.cloud.bigquery._http import _http
+
+        return _http._DEFAULT_TIMEOUT
+
+    @staticmethod
     def _get_target_class():
         from google.cloud.bigquery._http import Connection
 
@@ -79,7 +85,7 @@ class TestConnection(unittest.TestCase):
             headers=expected_headers,
             method="GET",
             url=expected_uri,
-            timeout=None,
+            timeout=self._get_default_timeout(),
         )
         self.assertIn("my-application/1.2.3", conn.user_agent)
 
@@ -112,5 +118,5 @@ class TestConnection(unittest.TestCase):
             headers=expected_headers,
             method="GET",
             url=expected_uri,
-            timeout=None,
+            timeout=self._get_default_timeout(),
         )


### PR DESCRIPTION
Fixes #10221.

This PR adjusts a few unit test assertions to the new default timeout in `core`.

### How to test
- Run unit tests on the latest `master` branch.

**Actual result** (before the fix):
A few tests fail due to the `timeout` argument mismatch.

**Expected result** (after the fix):
All tests pass as they should.

### PR checklist:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

