### PR TITLE
chore(storage): adjust test assertions to new default timeout

### DIFF
--- a/storage/tests/unit/test__http.py
+++ b/storage/tests/unit/test__http.py
@@ -55,7 +55,7 @@ class TestConnection(unittest.TestCase):
             headers=expected_headers,
             method="GET",
             url=expected_uri,
-            timeout=None,
+            timeout=base_http._DEFAULT_TIMEOUT,
         )
 
     def test_build_api_url_no_extra_query_params(self):


### PR DESCRIPTION
Fixes #10250 

This PR adjusts a few unit test assertions to the new default timeout in core.

### How to test

- Run unit tests on the latest master branch.

**Actual result (before the fix):**
One test failed due to the timeout argument mismatch.

**Expected result (after the fix):**
All tests pass.