### PR TITLE
Pin grpcio and grpcio-tools versions

### DIFF
--- a/Makefile.bigtable_v2
+++ b/Makefile.bigtable_v2
@@ -14,7 +14,7 @@ help:
 generate:
 	# Ensure we have a virtualenv w/ up-to-date grpcio/grpcio-tools
 	[ -d $(GRPCIO_VIRTUALENV) ] || python2.7 -m virtualenv $(GRPCIO_VIRTUALENV)
-	$(GRPCIO_VIRTUALENV)/bin/pip install --upgrade grpcio grpcio-tools
+	$(GRPCIO_VIRTUALENV)/bin/pip install grpcio==1.27.2 grpcio-tools==1.27.2
 	# Retrieve git repos that have our *.proto files.
 	[ -d googleapis-pb ] || git clone https://github.com/googleapis/googleapis googleapis-pb --depth=1
 	cd googleapis-pb && git pull origin master


### PR DESCRIPTION
Pinned the version to the latest one to avoid install irreproducibility and save users with grpcio-tools==1.27.0 and grpcio==1.27.0 installed.

See https://github.com/grpc/grpc/issues/21922

Fixes #10377 🦕