### PR TITLE
docs: automate library list generation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,40 +4,6 @@ about: Create a report to help us improve
 
 ---
 
-Thanks for stopping by to let us know something could be better!
+**NOTE**: [Google Cloud Python](https://cloud.google.com/python/docs/reference) client libraries are no longer maintained inside this repository. Please visit the python-API repository (e.g., https://github.com/googleapis/python-pubsub/issues) for faster response times.
 
-**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
-
-Please run down the following list and make sure you've tried the usual "quick fixes":
-
-  - Search the issues already opened: https://github.com/googleapis/google-cloud-python/issues
-  - Check for answers on StackOverflow: http://stackoverflow.com/questions/tagged/google-cloud-python
-
-If you are still having issues, please be sure to include as much information as possible:
-
-#### Environment details
-
-1. Specify the API at the beginning of the title (for example, "BigQuery: ...")
-   General, Core, and Other are also allowed as types
-2. OS type and version
-3. Python version and virtual environment information: `python --version`
-4. google-cloud-<service> version:  `pip show google-<service>` or `pip freeze`
-
-#### Steps to reproduce
-
-  1. ?
-
-#### Code example
-
-```python
-# example
-```
-
-#### Stack trace
-```
-# example
-```
-
-Making sure to follow these steps will guarantee the quickest resolution possible.
-
-Thanks!
+See all published libraries at https://cloud.google.com/python/docs/reference.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,4 +8,4 @@ about: Create a report to help us improve
 
 **NOTE**: [Google Cloud Python](https://cloud.google.com/python/docs/reference) client libraries are no longer maintained inside this repository. Please visit the python-API repository (e.g., https://github.com/googleapis/python-pubsub/issues) for faster response times.
 
-See all published libraries at https://cloud.google.com/python/docs/reference.
+See all published libraries in the [README](https://github.com/googleapis/google-cloud-python/blob/master/README.rst).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,8 @@ about: Create a report to help us improve
 
 ---
 
+**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
+
 **NOTE**: [Google Cloud Python](https://cloud.google.com/python/docs/reference) client libraries are no longer maintained inside this repository. Please visit the python-API repository (e.g., https://github.com/googleapis/python-pubsub/issues) for faster response times.
 
 See all published libraries at https://cloud.google.com/python/docs/reference.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,4 +8,4 @@ about: Suggest an idea for this library
 
 **NOTE**: [Google Cloud Python](https://cloud.google.com/python/docs/reference) client libraries are no longer maintained inside this repository. Please visit the python-API repository (e.g., https://github.com/googleapis/python-pubsub/issues) for faster response times.
 
-See all published libraries at https://cloud.google.com/python/docs/reference.
+See all published libraries in the [README](https://github.com/googleapis/google-cloud-python/blob/master/README.rst).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,15 +4,6 @@ about: Suggest an idea for this library
 
 ---
 
-Thanks for stopping by to let us know something could be better!
+**NOTE**: [Google Cloud Python](https://cloud.google.com/python/docs/reference) client libraries are no longer maintained inside this repository. Please visit the python-API repository (e.g., https://github.com/googleapis/python-pubsub/issues) for faster response times.
 
-**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
-
- **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
- **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
- **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
- **Additional context**
-Add any other context or screenshots about the feature request here.
+See all published libraries at https://cloud.google.com/python/docs/reference.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,8 @@ about: Suggest an idea for this library
 
 ---
 
+**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
+
 **NOTE**: [Google Cloud Python](https://cloud.google.com/python/docs/reference) client libraries are no longer maintained inside this repository. Please visit the python-API repository (e.g., https://github.com/googleapis/python-pubsub/issues) for faster response times.
 
 See all published libraries at https://cloud.google.com/python/docs/reference.

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -5,3 +5,7 @@ about: If you have a support contract with Google, please create an issue in the
 ---
 
 **PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
+
+**NOTE**: [Google Cloud Python](https://cloud.google.com/python/docs/reference) client libraries are no longer maintained inside this repository. Please visit the python-API repository (e.g., https://github.com/googleapis/python-pubsub/issues) for faster response times.
+
+See all published libraries at https://cloud.google.com/python/docs/reference.

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -8,4 +8,4 @@ about: If you have a support contract with Google, please create an issue in the
 
 **NOTE**: [Google Cloud Python](https://cloud.google.com/python/docs/reference) client libraries are no longer maintained inside this repository. Please visit the python-API repository (e.g., https://github.com/googleapis/python-pubsub/issues) for faster response times.
 
-See all published libraries at https://cloud.google.com/python/docs/reference.
+See all published libraries in the [README](https://github.com/googleapis/google-cloud-python/blob/master/README.rst).

--- a/README.rst
+++ b/README.rst
@@ -295,155 +295,155 @@ Libraries
      - |alpha|
      - |PyPI-google-cloud-webrisk|
 
-.. |PyPI-google-cloud-asset| image:: https://img.shields.io/pypi/v/google-cloud-asset.svg)
+.. |PyPI-google-cloud-asset| image:: https://img.shields.io/pypi/v/google-cloud-asset.svg
      :target: https://pypi.org/project/google-cloud-asset
-.. |PyPI-google-cloud-automl| image:: https://img.shields.io/pypi/v/google-cloud-automl.svg)
+.. |PyPI-google-cloud-automl| image:: https://img.shields.io/pypi/v/google-cloud-automl.svg
      :target: https://pypi.org/project/google-cloud-automl
-.. |PyPI-google-cloud-bigquery| image:: https://img.shields.io/pypi/v/google-cloud-bigquery.svg)
+.. |PyPI-google-cloud-bigquery| image:: https://img.shields.io/pypi/v/google-cloud-bigquery.svg
      :target: https://pypi.org/project/google-cloud-bigquery
-.. |PyPI-google-cloud-bigquery-connection| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-connection.svg)
+.. |PyPI-google-cloud-bigquery-connection| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-connection.svg
      :target: https://pypi.org/project/google-cloud-bigquery-connection
-.. |PyPI-google-cloud-bigquery-datatransfer| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-datatransfer.svg)
+.. |PyPI-google-cloud-bigquery-datatransfer| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-datatransfer.svg
      :target: https://pypi.org/project/google-cloud-bigquery-datatransfer
-.. |PyPI-google-cloud-bigquery-reservation| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-reservation.svg)
+.. |PyPI-google-cloud-bigquery-reservation| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-reservation.svg
      :target: https://pypi.org/project/google-cloud-bigquery-reservation
-.. |PyPI-google-cloud-bigquery-storage| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-storage.svg)
+.. |PyPI-google-cloud-bigquery-storage| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-storage.svg
      :target: https://pypi.org/project/google-cloud-bigquery-storage
-.. |PyPI-google-cloud-bigtable| image:: https://img.shields.io/pypi/v/google-cloud-bigtable.svg)
+.. |PyPI-google-cloud-bigtable| image:: https://img.shields.io/pypi/v/google-cloud-bigtable.svg
      :target: https://pypi.org/project/google-cloud-bigtable
-.. |PyPI-google-cloud-billing| image:: https://img.shields.io/pypi/v/google-cloud-billing.svg)
+.. |PyPI-google-cloud-billing| image:: https://img.shields.io/pypi/v/google-cloud-billing.svg
      :target: https://pypi.org/project/google-cloud-billing
-.. |PyPI-google-cloud-build| image:: https://img.shields.io/pypi/v/google-cloud-build.svg)
+.. |PyPI-google-cloud-build| image:: https://img.shields.io/pypi/v/google-cloud-build.svg
      :target: https://pypi.org/project/google-cloud-build
-.. |PyPI-google-cloud-containeranalysis| image:: https://img.shields.io/pypi/v/google-cloud-containeranalysis.svg)
+.. |PyPI-google-cloud-containeranalysis| image:: https://img.shields.io/pypi/v/google-cloud-containeranalysis.svg
      :target: https://pypi.org/project/google-cloud-containeranalysis
-.. |PyPI-google-cloud-datacatalog| image:: https://img.shields.io/pypi/v/google-cloud-datacatalog.svg)
+.. |PyPI-google-cloud-datacatalog| image:: https://img.shields.io/pypi/v/google-cloud-datacatalog.svg
      :target: https://pypi.org/project/google-cloud-datacatalog
-.. |PyPI-google-cloud-dlp| image:: https://img.shields.io/pypi/v/google-cloud-dlp.svg)
+.. |PyPI-google-cloud-dlp| image:: https://img.shields.io/pypi/v/google-cloud-dlp.svg
      :target: https://pypi.org/project/google-cloud-dlp
-.. |PyPI-google-cloud-dataproc| image:: https://img.shields.io/pypi/v/google-cloud-dataproc.svg)
+.. |PyPI-google-cloud-dataproc| image:: https://img.shields.io/pypi/v/google-cloud-dataproc.svg
      :target: https://pypi.org/project/google-cloud-dataproc
-.. |PyPI-google-cloud-datastore| image:: https://img.shields.io/pypi/v/google-cloud-datastore.svg)
+.. |PyPI-google-cloud-datastore| image:: https://img.shields.io/pypi/v/google-cloud-datastore.svg
      :target: https://pypi.org/project/google-cloud-datastore
-.. |PyPI-google-cloud-firestore| image:: https://img.shields.io/pypi/v/google-cloud-firestore.svg)
+.. |PyPI-google-cloud-firestore| image:: https://img.shields.io/pypi/v/google-cloud-firestore.svg
      :target: https://pypi.org/project/google-cloud-firestore
-.. |PyPI-google-cloud-iam| image:: https://img.shields.io/pypi/v/google-cloud-iam.svg)
+.. |PyPI-google-cloud-iam| image:: https://img.shields.io/pypi/v/google-cloud-iam.svg
      :target: https://pypi.org/project/google-cloud-iam
-.. |PyPI-google-cloud-iot| image:: https://img.shields.io/pypi/v/google-cloud-iot.svg)
+.. |PyPI-google-cloud-iot| image:: https://img.shields.io/pypi/v/google-cloud-iot.svg
      :target: https://pypi.org/project/google-cloud-iot
-.. |PyPI-google-cloud-kms| image:: https://img.shields.io/pypi/v/google-cloud-kms.svg)
+.. |PyPI-google-cloud-kms| image:: https://img.shields.io/pypi/v/google-cloud-kms.svg
      :target: https://pypi.org/project/google-cloud-kms
-.. |PyPI-google-cloud-container| image:: https://img.shields.io/pypi/v/google-cloud-container.svg)
+.. |PyPI-google-cloud-container| image:: https://img.shields.io/pypi/v/google-cloud-container.svg
      :target: https://pypi.org/project/google-cloud-container
-.. |PyPI-google-cloud-logging| image:: https://img.shields.io/pypi/v/google-cloud-logging.svg)
+.. |PyPI-google-cloud-logging| image:: https://img.shields.io/pypi/v/google-cloud-logging.svg
      :target: https://pypi.org/project/google-cloud-logging
-.. |PyPI-google-cloud-monitoring-dashboards| image:: https://img.shields.io/pypi/v/google-cloud-monitoring-dashboards.svg)
+.. |PyPI-google-cloud-monitoring-dashboards| image:: https://img.shields.io/pypi/v/google-cloud-monitoring-dashboards.svg
      :target: https://pypi.org/project/google-cloud-monitoring-dashboards
-.. |PyPI-google-cloud-ndb| image:: https://img.shields.io/pypi/v/google-cloud-ndb.svg)
+.. |PyPI-google-cloud-ndb| image:: https://img.shields.io/pypi/v/google-cloud-ndb.svg
      :target: https://pypi.org/project/google-cloud-ndb
-.. |PyPI-google-cloud-language| image:: https://img.shields.io/pypi/v/google-cloud-language.svg)
+.. |PyPI-google-cloud-language| image:: https://img.shields.io/pypi/v/google-cloud-language.svg
      :target: https://pypi.org/project/google-cloud-language
-.. |PyPI-google-cloud-os-login| image:: https://img.shields.io/pypi/v/google-cloud-os-login.svg)
+.. |PyPI-google-cloud-os-login| image:: https://img.shields.io/pypi/v/google-cloud-os-login.svg
      :target: https://pypi.org/project/google-cloud-os-login
-.. |PyPI-google-cloud-pubsub| image:: https://img.shields.io/pypi/v/google-cloud-pubsub.svg)
+.. |PyPI-google-cloud-pubsub| image:: https://img.shields.io/pypi/v/google-cloud-pubsub.svg
      :target: https://pypi.org/project/google-cloud-pubsub
-.. |PyPI-google-cloud-recommender| image:: https://img.shields.io/pypi/v/google-cloud-recommender.svg)
+.. |PyPI-google-cloud-recommender| image:: https://img.shields.io/pypi/v/google-cloud-recommender.svg
      :target: https://pypi.org/project/google-cloud-recommender
-.. |PyPI-google-cloud-redis| image:: https://img.shields.io/pypi/v/google-cloud-redis.svg)
+.. |PyPI-google-cloud-redis| image:: https://img.shields.io/pypi/v/google-cloud-redis.svg
      :target: https://pypi.org/project/google-cloud-redis
-.. |PyPI-google-cloud-scheduler| image:: https://img.shields.io/pypi/v/google-cloud-scheduler.svg)
+.. |PyPI-google-cloud-scheduler| image:: https://img.shields.io/pypi/v/google-cloud-scheduler.svg
      :target: https://pypi.org/project/google-cloud-scheduler
-.. |PyPI-google-cloud-secret-manager| image:: https://img.shields.io/pypi/v/google-cloud-secret-manager.svg)
+.. |PyPI-google-cloud-secret-manager| image:: https://img.shields.io/pypi/v/google-cloud-secret-manager.svg
      :target: https://pypi.org/project/google-cloud-secret-manager
-.. |PyPI-google-cloud-spanner| image:: https://img.shields.io/pypi/v/google-cloud-spanner.svg)
+.. |PyPI-google-cloud-spanner| image:: https://img.shields.io/pypi/v/google-cloud-spanner.svg
      :target: https://pypi.org/project/google-cloud-spanner
-.. |PyPI-google-cloud-speech| image:: https://img.shields.io/pypi/v/google-cloud-speech.svg)
+.. |PyPI-google-cloud-speech| image:: https://img.shields.io/pypi/v/google-cloud-speech.svg
      :target: https://pypi.org/project/google-cloud-speech
-.. |PyPI-google-cloud-monitoring| image:: https://img.shields.io/pypi/v/google-cloud-monitoring.svg)
+.. |PyPI-google-cloud-monitoring| image:: https://img.shields.io/pypi/v/google-cloud-monitoring.svg
      :target: https://pypi.org/project/google-cloud-monitoring
-.. |PyPI-google-cloud-storage| image:: https://img.shields.io/pypi/v/google-cloud-storage.svg)
+.. |PyPI-google-cloud-storage| image:: https://img.shields.io/pypi/v/google-cloud-storage.svg
      :target: https://pypi.org/project/google-cloud-storage
-.. |PyPI-google-cloud-tasks| image:: https://img.shields.io/pypi/v/google-cloud-tasks.svg)
+.. |PyPI-google-cloud-tasks| image:: https://img.shields.io/pypi/v/google-cloud-tasks.svg
      :target: https://pypi.org/project/google-cloud-tasks
-.. |PyPI-google-cloud-texttospeech| image:: https://img.shields.io/pypi/v/google-cloud-texttospeech.svg)
+.. |PyPI-google-cloud-texttospeech| image:: https://img.shields.io/pypi/v/google-cloud-texttospeech.svg
      :target: https://pypi.org/project/google-cloud-texttospeech
-.. |PyPI-google-cloud-trace| image:: https://img.shields.io/pypi/v/google-cloud-trace.svg)
+.. |PyPI-google-cloud-trace| image:: https://img.shields.io/pypi/v/google-cloud-trace.svg
      :target: https://pypi.org/project/google-cloud-trace
-.. |PyPI-google-cloud-translate| image:: https://img.shields.io/pypi/v/google-cloud-translate.svg)
+.. |PyPI-google-cloud-translate| image:: https://img.shields.io/pypi/v/google-cloud-translate.svg
      :target: https://pypi.org/project/google-cloud-translate
-.. |PyPI-google-cloud-videointelligence| image:: https://img.shields.io/pypi/v/google-cloud-videointelligence.svg)
+.. |PyPI-google-cloud-videointelligence| image:: https://img.shields.io/pypi/v/google-cloud-videointelligence.svg
      :target: https://pypi.org/project/google-cloud-videointelligence
-.. |PyPI-google-cloud-vision| image:: https://img.shields.io/pypi/v/google-cloud-vision.svg)
+.. |PyPI-google-cloud-vision| image:: https://img.shields.io/pypi/v/google-cloud-vision.svg
      :target: https://pypi.org/project/google-cloud-vision
-.. |PyPI-google-cloud-notebooks| image:: https://img.shields.io/pypi/v/google-cloud-notebooks.svg)
+.. |PyPI-google-cloud-notebooks| image:: https://img.shields.io/pypi/v/google-cloud-notebooks.svg
      :target: https://pypi.org/project/google-cloud-notebooks
-.. |PyPI-google-cloud-access-approval| image:: https://img.shields.io/pypi/v/google-cloud-access-approval.svg)
+.. |PyPI-google-cloud-access-approval| image:: https://img.shields.io/pypi/v/google-cloud-access-approval.svg
      :target: https://pypi.org/project/google-cloud-access-approval
-.. |PyPI-google-cloud-assured-workflows| image:: https://img.shields.io/pypi/v/google-cloud-assured-workflows.svg)
+.. |PyPI-google-cloud-assured-workflows| image:: https://img.shields.io/pypi/v/google-cloud-assured-workflows.svg
      :target: https://pypi.org/project/google-cloud-assured-workflows
-.. |PyPI-google-cloud-audit-log| image:: https://img.shields.io/pypi/v/google-cloud-audit-log.svg)
+.. |PyPI-google-cloud-audit-log| image:: https://img.shields.io/pypi/v/google-cloud-audit-log.svg
      :target: https://pypi.org/project/google-cloud-audit-log
-.. |PyPI-google-cloud-billing-budgets| image:: https://img.shields.io/pypi/v/google-cloud-billing-budgets.svg)
+.. |PyPI-google-cloud-billing-budgets| image:: https://img.shields.io/pypi/v/google-cloud-billing-budgets.svg
      :target: https://pypi.org/project/google-cloud-billing-budgets
-.. |PyPI-google-cloud-binary-authorization| image:: https://img.shields.io/pypi/v/google-cloud-binary-authorization.svg)
+.. |PyPI-google-cloud-binary-authorization| image:: https://img.shields.io/pypi/v/google-cloud-binary-authorization.svg
      :target: https://pypi.org/project/google-cloud-binary-authorization
-.. |PyPI-google-cloud-compute| image:: https://img.shields.io/pypi/v/google-cloud-compute.svg)
+.. |PyPI-google-cloud-compute| image:: https://img.shields.io/pypi/v/google-cloud-compute.svg
      :target: https://pypi.org/project/google-cloud-compute
-.. |PyPI-google-cloud-datalabeling| image:: https://img.shields.io/pypi/v/google-cloud-datalabeling.svg)
+.. |PyPI-google-cloud-datalabeling| image:: https://img.shields.io/pypi/v/google-cloud-datalabeling.svg
      :target: https://pypi.org/project/google-cloud-datalabeling
-.. |PyPI-google-cloud-dialogflow-cx| image:: https://img.shields.io/pypi/v/google-cloud-dialogflow-cx.svg)
+.. |PyPI-google-cloud-dialogflow-cx| image:: https://img.shields.io/pypi/v/google-cloud-dialogflow-cx.svg
      :target: https://pypi.org/project/google-cloud-dialogflow-cx
-.. |PyPI-google-cloud-documentai| image:: https://img.shields.io/pypi/v/google-cloud-documentai.svg)
+.. |PyPI-google-cloud-documentai| image:: https://img.shields.io/pypi/v/google-cloud-documentai.svg
      :target: https://pypi.org/project/google-cloud-documentai
-.. |PyPI-google-cloud-error-reporting| image:: https://img.shields.io/pypi/v/google-cloud-error-reporting.svg)
+.. |PyPI-google-cloud-error-reporting| image:: https://img.shields.io/pypi/v/google-cloud-error-reporting.svg
      :target: https://pypi.org/project/google-cloud-error-reporting
-.. |PyPI-google-cloud-functions| image:: https://img.shields.io/pypi/v/google-cloud-functions.svg)
+.. |PyPI-google-cloud-functions| image:: https://img.shields.io/pypi/v/google-cloud-functions.svg
      :target: https://pypi.org/project/google-cloud-functions
-.. |PyPI-google-cloud-game-servers| image:: https://img.shields.io/pypi/v/google-cloud-game-servers.svg)
+.. |PyPI-google-cloud-game-servers| image:: https://img.shields.io/pypi/v/google-cloud-game-servers.svg
      :target: https://pypi.org/project/google-cloud-game-servers
-.. |PyPI-google-cloud-media-translation| image:: https://img.shields.io/pypi/v/google-cloud-media-translation.svg)
+.. |PyPI-google-cloud-media-translation| image:: https://img.shields.io/pypi/v/google-cloud-media-translation.svg
      :target: https://pypi.org/project/google-cloud-media-translation
-.. |PyPI-google-cloud-memcache| image:: https://img.shields.io/pypi/v/google-cloud-memcache.svg)
+.. |PyPI-google-cloud-memcache| image:: https://img.shields.io/pypi/v/google-cloud-memcache.svg
      :target: https://pypi.org/project/google-cloud-memcache
-.. |PyPI-google-cloud-phishingprotection| image:: https://img.shields.io/pypi/v/google-cloud-phishingprotection.svg)
+.. |PyPI-google-cloud-phishingprotection| image:: https://img.shields.io/pypi/v/google-cloud-phishingprotection.svg
      :target: https://pypi.org/project/google-cloud-phishingprotection
-.. |PyPI-google-cloud-security-private-ca| image:: https://img.shields.io/pypi/v/google-cloud-security-private-ca.svg)
+.. |PyPI-google-cloud-security-private-ca| image:: https://img.shields.io/pypi/v/google-cloud-security-private-ca.svg
      :target: https://pypi.org/project/google-cloud-security-private-ca
-.. |PyPI-google-cloud-pubsublite| image:: https://img.shields.io/pypi/v/google-cloud-pubsublite.svg)
+.. |PyPI-google-cloud-pubsublite| image:: https://img.shields.io/pypi/v/google-cloud-pubsublite.svg
      :target: https://pypi.org/project/google-cloud-pubsublite
-.. |PyPI-google-cloud-recommendations-ai| image:: https://img.shields.io/pypi/v/google-cloud-recommendations-ai.svg)
+.. |PyPI-google-cloud-recommendations-ai| image:: https://img.shields.io/pypi/v/google-cloud-recommendations-ai.svg
      :target: https://pypi.org/project/google-cloud-recommendations-ai
-.. |PyPI-google-cloud-runtimeconfig| image:: https://img.shields.io/pypi/v/google-cloud-runtimeconfig.svg)
+.. |PyPI-google-cloud-runtimeconfig| image:: https://img.shields.io/pypi/v/google-cloud-runtimeconfig.svg
      :target: https://pypi.org/project/google-cloud-runtimeconfig
-.. |PyPI-google-cloud-service-directory| image:: https://img.shields.io/pypi/v/google-cloud-service-directory.svg)
+.. |PyPI-google-cloud-service-directory| image:: https://img.shields.io/pypi/v/google-cloud-service-directory.svg
      :target: https://pypi.org/project/google-cloud-service-directory
-.. |PyPI-google-cloud-talent| image:: https://img.shields.io/pypi/v/google-cloud-talent.svg)
+.. |PyPI-google-cloud-talent| image:: https://img.shields.io/pypi/v/google-cloud-talent.svg
      :target: https://pypi.org/project/google-cloud-talent
-.. |PyPI-google-cloud-video-transcoder| image:: https://img.shields.io/pypi/v/google-cloud-video-transcoder.svg)
+.. |PyPI-google-cloud-video-transcoder| image:: https://img.shields.io/pypi/v/google-cloud-video-transcoder.svg
      :target: https://pypi.org/project/google-cloud-video-transcoder
-.. |PyPI-google-cloud-workflows| image:: https://img.shields.io/pypi/v/google-cloud-workflows.svg)
+.. |PyPI-google-cloud-workflows| image:: https://img.shields.io/pypi/v/google-cloud-workflows.svg
      :target: https://pypi.org/project/google-cloud-workflows
-.. |PyPI-google-cloud-recpatcha-enterprise| image:: https://img.shields.io/pypi/v/google-cloud-recpatcha-enterprise.svg)
+.. |PyPI-google-cloud-recpatcha-enterprise| image:: https://img.shields.io/pypi/v/google-cloud-recpatcha-enterprise.svg
      :target: https://pypi.org/project/google-cloud-recpatcha-enterprise
-.. |PyPI-google-analytics-admin| image:: https://img.shields.io/pypi/v/google-analytics-admin.svg)
+.. |PyPI-google-analytics-admin| image:: https://img.shields.io/pypi/v/google-analytics-admin.svg
      :target: https://pypi.org/project/google-analytics-admin
-.. |PyPI-google-analytics-data| image:: https://img.shields.io/pypi/v/google-analytics-data.svg)
+.. |PyPI-google-analytics-data| image:: https://img.shields.io/pypi/v/google-analytics-data.svg
      :target: https://pypi.org/project/google-analytics-data
-.. |PyPI-google-area120-tables| image:: https://img.shields.io/pypi/v/google-area120-tables.svg)
+.. |PyPI-google-area120-tables| image:: https://img.shields.io/pypi/v/google-area120-tables.svg
      :target: https://pypi.org/project/google-area120-tables
-.. |PyPI-google-cloud-dns| image:: https://img.shields.io/pypi/v/google-cloud-dns.svg)
+.. |PyPI-google-cloud-dns| image:: https://img.shields.io/pypi/v/google-cloud-dns.svg
      :target: https://pypi.org/project/google-cloud-dns
-.. |PyPI-google-cloud-data-qna| image:: https://img.shields.io/pypi/v/google-cloud-data-qna.svg)
+.. |PyPI-google-cloud-data-qna| image:: https://img.shields.io/pypi/v/google-cloud-data-qna.svg
      :target: https://pypi.org/project/google-cloud-data-qna
-.. |PyPI-grafeas| image:: https://img.shields.io/pypi/v/grafeas.svg)
+.. |PyPI-grafeas| image:: https://img.shields.io/pypi/v/grafeas.svg
      :target: https://pypi.org/project/grafeas
-.. |PyPI-google-cloud-resource-manager| image:: https://img.shields.io/pypi/v/google-cloud-resource-manager.svg)
+.. |PyPI-google-cloud-resource-manager| image:: https://img.shields.io/pypi/v/google-cloud-resource-manager.svg
      :target: https://pypi.org/project/google-cloud-resource-manager
-.. |PyPI-google-cloud-securitycenter| image:: https://img.shields.io/pypi/v/google-cloud-securitycenter.svg)
+.. |PyPI-google-cloud-securitycenter| image:: https://img.shields.io/pypi/v/google-cloud-securitycenter.svg
      :target: https://pypi.org/project/google-cloud-securitycenter
-.. |PyPI-google-cloud-websecurityscanner| image:: https://img.shields.io/pypi/v/google-cloud-websecurityscanner.svg)
+.. |PyPI-google-cloud-websecurityscanner| image:: https://img.shields.io/pypi/v/google-cloud-websecurityscanner.svg
      :target: https://pypi.org/project/google-cloud-websecurityscanner
-.. |PyPI-google-cloud-webrisk| image:: https://img.shields.io/pypi/v/google-cloud-webrisk.svg)
+.. |PyPI-google-cloud-webrisk| image:: https://img.shields.io/pypi/v/google-cloud-webrisk.svg
      :target: https://pypi.org/project/google-cloud-webrisk
 
 .. API_TABLE_END

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Libraries
 
 .. API_TABLE_START
 
-.. list-table:: Libraries
+.. list-table::
    :header-rows: 1
 
    * - Client

--- a/README.rst
+++ b/README.rst
@@ -68,318 +68,328 @@ If you need support for other Google APIs, check out the
      - Version
    * - `API client core library <https://github.com/googleapis/python-api-core>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-api-core.svg)
+     - .. |PyPI-google-api-core| image:: https://img.shields.io/pypi/v/google-api-core.svg)
         :target: https://pypi.org/project/google-api-core
    * - `API client core library <https://github.com/googleapis/python-cloud-core>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-core.svg)
+     - .. |PyPI-google-cloud-core| image:: https://img.shields.io/pypi/v/google-cloud-core.svg)
         :target: https://pypi.org/project/google-cloud-core
    * - `Asset Inventory <https://github.com/googleapis/python-asset>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-asset.svg)
+     - .. |PyPI-google-cloud-asset| image:: https://img.shields.io/pypi/v/google-cloud-asset.svg)
         :target: https://pypi.org/project/google-cloud-asset
    * - `AutoML <https://github.com/googleapis/python-automl>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-automl.svg)
+     - .. |PyPI-google-cloud-automl| image:: https://img.shields.io/pypi/v/google-cloud-automl.svg)
         :target: https://pypi.org/project/google-cloud-automl
    * - `BigQuery <https://github.com/googleapis/python-bigquery>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-bigquery.svg)
+     - .. |PyPI-google-cloud-bigquery| image:: https://img.shields.io/pypi/v/google-cloud-bigquery.svg)
         :target: https://pypi.org/project/google-cloud-bigquery
    * - `BigQuery Connection <https://github.com/googleapis/python-bigquery-connection>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-connection.svg)
+     - .. |PyPI-google-cloud-bigquery-connection| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-connection.svg)
         :target: https://pypi.org/project/google-cloud-bigquery-connection
    * - `BigQuery Data Transfer Service <https://github.com/googleapis/python-bigquery-datatransfer>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-datatransfer.svg)
+     - .. |PyPI-google-cloud-bigquery-datatransfer| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-datatransfer.svg)
         :target: https://pypi.org/project/google-cloud-bigquery-datatransfer
    * - `BigQuery Reservation <https://github.com/googleapis/python-bigquery-reservation>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-reservation.svg)
+     - .. |PyPI-google-cloud-bigquery-reservation| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-reservation.svg)
         :target: https://pypi.org/project/google-cloud-bigquery-reservation
    * - `BigQuery Storage <https://github.com/googleapis/python-bigquery-storage>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-storage.svg)
+     - .. |PyPI-google-cloud-bigquery-storage| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-storage.svg)
         :target: https://pypi.org/project/google-cloud-bigquery-storage
    * - `Bigtable <https://github.com/googleapis/python-bigtable>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-bigtable.svg)
+     - .. |PyPI-google-cloud-bigtable| image:: https://img.shields.io/pypi/v/google-cloud-bigtable.svg)
         :target: https://pypi.org/project/google-cloud-bigtable
    * - `Billing <https://github.com/googleapis/python-billing>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-billing.svg)
+     - .. |PyPI-google-cloud-billing| image:: https://img.shields.io/pypi/v/google-cloud-billing.svg)
         :target: https://pypi.org/project/google-cloud-billing
    * - `Build <https://github.com/googleapis/python-cloudbuild>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-build.svg)
+     - .. |PyPI-google-cloud-build| image:: https://img.shields.io/pypi/v/google-cloud-build.svg)
         :target: https://pypi.org/project/google-cloud-build
    * - `Container Analysis <https://github.com/googleapis/python-containeranalysis>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-containeranalysis.svg)
+     - .. |PyPI-google-cloud-containeranalysis| image:: https://img.shields.io/pypi/v/google-cloud-containeranalysis.svg)
         :target: https://pypi.org/project/google-cloud-containeranalysis
    * - `Data Catalog <https://github.com/googleapis/python-datacatalog>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-datacatalog.svg)
+     - .. |PyPI-google-cloud-datacatalog| image:: https://img.shields.io/pypi/v/google-cloud-datacatalog.svg)
         :target: https://pypi.org/project/google-cloud-datacatalog
    * - `Data Loss Prevention <https://github.com/googleapis/python-dlp>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-dlp.svg)
+     - .. |PyPI-google-cloud-dlp| image:: https://img.shields.io/pypi/v/google-cloud-dlp.svg)
         :target: https://pypi.org/project/google-cloud-dlp
    * - `Dataproc <https://github.com/googleapis/python-dataproc>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-dataproc.svg)
+     - .. |PyPI-google-cloud-dataproc| image:: https://img.shields.io/pypi/v/google-cloud-dataproc.svg)
         :target: https://pypi.org/project/google-cloud-dataproc
    * - `Datastore <https://github.com/googleapis/python-datastore>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-datastore.svg)
+     - .. |PyPI-google-cloud-datastore| image:: https://img.shields.io/pypi/v/google-cloud-datastore.svg)
         :target: https://pypi.org/project/google-cloud-datastore
    * - `Firestore <https://github.com/googleapis/python-firestore>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-firestore.svg)
+     - .. |PyPI-google-cloud-firestore| image:: https://img.shields.io/pypi/v/google-cloud-firestore.svg)
         :target: https://pypi.org/project/google-cloud-firestore
    * - `Identity and Access Management <https://github.com/googleapis/python-iam>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-iam.svg)
+     - .. |PyPI-google-cloud-iam| image:: https://img.shields.io/pypi/v/google-cloud-iam.svg)
         :target: https://pypi.org/project/google-cloud-iam
    * - `Internet of Things (IoT) Core <https://github.com/googleapis/python-iot>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-iot.svg)
+     - .. |PyPI-google-cloud-iot| image:: https://img.shields.io/pypi/v/google-cloud-iot.svg)
         :target: https://pypi.org/project/google-cloud-iot
    * - `Key Management Service <https://github.com/googleapis/python-kms>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-kms.svg)
+     - .. |PyPI-google-cloud-kms| image:: https://img.shields.io/pypi/v/google-cloud-kms.svg)
         :target: https://pypi.org/project/google-cloud-kms
    * - `Kubernetes Engine <https://github.com/googleapis/python-container>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-container.svg)
+     - .. |PyPI-google-cloud-container| image:: https://img.shields.io/pypi/v/google-cloud-container.svg)
         :target: https://pypi.org/project/google-cloud-container
    * - `Logging <https://github.com/googleapis/python-logging>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-logging.svg)
+     - .. |PyPI-google-cloud-logging| image:: https://img.shields.io/pypi/v/google-cloud-logging.svg)
         :target: https://pypi.org/project/google-cloud-logging
    * - `Monitoring Dashboards <https://github.com/googleapis/python-monitoring-dashboards>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-monitoring-dashboards.svg)
+     - .. |PyPI-google-cloud-monitoring-dashboards| image:: https://img.shields.io/pypi/v/google-cloud-monitoring-dashboards.svg)
         :target: https://pypi.org/project/google-cloud-monitoring-dashboards
    * - `NDB Client Library for Datastore <https://github.com/googleapis/python-ndb>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-ndb.svg)
+     - .. |PyPI-google-cloud-ndb| image:: https://img.shields.io/pypi/v/google-cloud-ndb.svg)
         :target: https://pypi.org/project/google-cloud-ndb
    * - `Natural Language <https://github.com/googleapis/python-language>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-language.svg)
+     - .. |PyPI-google-cloud-language| image:: https://img.shields.io/pypi/v/google-cloud-language.svg)
         :target: https://pypi.org/project/google-cloud-language
    * - `OS Login <https://github.com/googleapis/python-oslogin>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-os-login.svg)
+     - .. |PyPI-google-cloud-os-login| image:: https://img.shields.io/pypi/v/google-cloud-os-login.svg)
         :target: https://pypi.org/project/google-cloud-os-login
    * - `Pub/Sub <https://github.com/googleapis/python-pubsub>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-pubsub.svg)
+     - .. |PyPI-google-cloud-pubsub| image:: https://img.shields.io/pypi/v/google-cloud-pubsub.svg)
         :target: https://pypi.org/project/google-cloud-pubsub
    * - `Recommender API <https://github.com/googleapis/python-recommender>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-recommender.svg)
+     - .. |PyPI-google-cloud-recommender| image:: https://img.shields.io/pypi/v/google-cloud-recommender.svg)
         :target: https://pypi.org/project/google-cloud-recommender
    * - `Redis <https://github.com/googleapis/python-redis>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-redis.svg)
+     - .. |PyPI-google-cloud-redis| image:: https://img.shields.io/pypi/v/google-cloud-redis.svg)
         :target: https://pypi.org/project/google-cloud-redis
    * - `Scheduler <https://github.com/googleapis/python-scheduler>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-scheduler.svg)
+     - .. |PyPI-google-cloud-scheduler| image:: https://img.shields.io/pypi/v/google-cloud-scheduler.svg)
         :target: https://pypi.org/project/google-cloud-scheduler
    * - `Secret Manager <https://github.com/googleapis/python-secret-manager>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-secret-manager.svg)
+     - .. |PyPI-google-cloud-secret-manager| image:: https://img.shields.io/pypi/v/google-cloud-secret-manager.svg)
         :target: https://pypi.org/project/google-cloud-secret-manager
    * - `Spanner <https://github.com/googleapis/python-spanner>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-spanner.svg)
+     - .. |PyPI-google-cloud-spanner| image:: https://img.shields.io/pypi/v/google-cloud-spanner.svg)
         :target: https://pypi.org/project/google-cloud-spanner
    * - `Speech <https://github.com/googleapis/python-speech>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-speech.svg)
+     - .. |PyPI-google-cloud-speech| image:: https://img.shields.io/pypi/v/google-cloud-speech.svg)
         :target: https://pypi.org/project/google-cloud-speech
    * - `Stackdriver Monitoring <https://github.com/googleapis/python-monitoring>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-monitoring.svg)
+     - .. |PyPI-google-cloud-monitoring| image:: https://img.shields.io/pypi/v/google-cloud-monitoring.svg)
         :target: https://pypi.org/project/google-cloud-monitoring
    * - `Storage <https://github.com/googleapis/python-storage>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-storage.svg)
+     - .. |PyPI-google-cloud-storage| image:: https://img.shields.io/pypi/v/google-cloud-storage.svg)
         :target: https://pypi.org/project/google-cloud-storage
    * - `Tasks <https://github.com/googleapis/python-tasks>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-tasks.svg)
+     - .. |PyPI-google-cloud-tasks| image:: https://img.shields.io/pypi/v/google-cloud-tasks.svg)
         :target: https://pypi.org/project/google-cloud-tasks
    * - `Text-to-Speech <https://github.com/googleapis/python-texttospeech>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-texttospeech.svg)
+     - .. |PyPI-google-cloud-texttospeech| image:: https://img.shields.io/pypi/v/google-cloud-texttospeech.svg)
         :target: https://pypi.org/project/google-cloud-texttospeech
    * - `Trace <https://github.com/googleapis/python-trace>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-trace.svg)
+     - .. |PyPI-google-cloud-trace| image:: https://img.shields.io/pypi/v/google-cloud-trace.svg)
         :target: https://pypi.org/project/google-cloud-trace
    * - `Translation <https://github.com/googleapis/python-translate>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-translate.svg)
+     - .. |PyPI-google-cloud-translate| image:: https://img.shields.io/pypi/v/google-cloud-translate.svg)
         :target: https://pypi.org/project/google-cloud-translate
    * - `Video Intelligence <https://github.com/googleapis/python-videointelligence>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-videointelligence.svg)
+     - .. |PyPI-google-cloud-videointelligence| image:: https://img.shields.io/pypi/v/google-cloud-videointelligence.svg)
         :target: https://pypi.org/project/google-cloud-videointelligence
    * - `Vision <https://github.com/googleapis/python-vision>`_
      - |ga|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-vision.svg)
+     - .. |PyPI-google-cloud-vision| image:: https://img.shields.io/pypi/v/google-cloud-vision.svg)
         :target: https://pypi.org/project/google-cloud-vision
    * - `AI Platform Notebooks <https://github.com/googleapis/python-notebooks>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-notebooks.svg)
+     - .. |PyPI-google-cloud-notebooks| image:: https://img.shields.io/pypi/v/google-cloud-notebooks.svg)
         :target: https://pypi.org/project/google-cloud-notebooks
    * - `Access Approval <https://github.com/googleapis/python-access-approval>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-access-approval.svg)
+     - .. |PyPI-google-cloud-access-approval| image:: https://img.shields.io/pypi/v/google-cloud-access-approval.svg)
         :target: https://pypi.org/project/google-cloud-access-approval
    * - `Assured Workloads for Government <https://github.com/googleapis/python-assured-workloads>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-assured-workflows.svg)
+     - .. |PyPI-google-cloud-assured-workflows| image:: https://img.shields.io/pypi/v/google-cloud-assured-workflows.svg)
         :target: https://pypi.org/project/google-cloud-assured-workflows
    * - `Audit Log <https://github.com/googleapis/python-audit-log>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-audit-log.svg)
+     - .. |PyPI-google-cloud-audit-log| image:: https://img.shields.io/pypi/v/google-cloud-audit-log.svg)
         :target: https://pypi.org/project/google-cloud-audit-log
    * - `Billing Budget <https://github.com/googleapis/python-billingbudgets>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-billing-budgets.svg)
+     - .. |PyPI-google-cloud-billing-budgets| image:: https://img.shields.io/pypi/v/google-cloud-billing-budgets.svg)
         :target: https://pypi.org/project/google-cloud-billing-budgets
    * - `Binary Authorization <https://github.com/googleapis/python-binary-authorization>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-binary-authorization.svg)
+     - .. |PyPI-google-cloud-binary-authorization| image:: https://img.shields.io/pypi/v/google-cloud-binary-authorization.svg)
         :target: https://pypi.org/project/google-cloud-binary-authorization
    * - `Compute Engine <https://github.com/googleapis/python-compute>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-compute.svg)
+     - .. |PyPI-google-cloud-compute| image:: https://img.shields.io/pypi/v/google-cloud-compute.svg)
         :target: https://pypi.org/project/google-cloud-compute
    * - `Data Labeling <https://github.com/googleapis/python-datalabeling>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-datalabeling.svg)
+     - .. |PyPI-google-cloud-datalabeling| image:: https://img.shields.io/pypi/v/google-cloud-datalabeling.svg)
         :target: https://pypi.org/project/google-cloud-datalabeling
    * - `Dialogflow CX <https://github.com/googleapis/python-dialogflow-cx>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-dialogflow-cx.svg)
+     - .. |PyPI-google-cloud-dialogflow-cx| image:: https://img.shields.io/pypi/v/google-cloud-dialogflow-cx.svg)
         :target: https://pypi.org/project/google-cloud-dialogflow-cx
    * - `Document Understanding API <https://github.com/googleapis/python-documentai>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-documentai.svg)
+     - .. |PyPI-google-cloud-documentai| image:: https://img.shields.io/pypi/v/google-cloud-documentai.svg)
         :target: https://pypi.org/project/google-cloud-documentai
    * - `Error Reporting <https://github.com/googleapis/python-error-reporting>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-error-reporting.svg)
+     - .. |PyPI-google-cloud-error-reporting| image:: https://img.shields.io/pypi/v/google-cloud-error-reporting.svg)
         :target: https://pypi.org/project/google-cloud-error-reporting
    * - `Functions <https://github.com/googleapis/python-functions>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-functions.svg)
+     - .. |PyPI-google-cloud-functions| image:: https://img.shields.io/pypi/v/google-cloud-functions.svg)
         :target: https://pypi.org/project/google-cloud-functions
    * - `Game Servers <https://github.com/googleapis/python-game-servers>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-game-servers.svg)
+     - .. |PyPI-google-cloud-game-servers| image:: https://img.shields.io/pypi/v/google-cloud-game-servers.svg)
         :target: https://pypi.org/project/google-cloud-game-servers
    * - `Media Translation <https://github.com/googleapis/python-media-translation>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-media-translation.svg)
+     - .. |PyPI-google-cloud-media-translation| image:: https://img.shields.io/pypi/v/google-cloud-media-translation.svg)
         :target: https://pypi.org/project/google-cloud-media-translation
    * - `Memorystore for Memcached <https://github.com/googleapis/python-memcache>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-memcache.svg)
+     - .. |PyPI-google-cloud-memcache| image:: https://img.shields.io/pypi/v/google-cloud-memcache.svg)
         :target: https://pypi.org/project/google-cloud-memcache
    * - `Phishing Protection <https://github.com/googleapis/python-phishingprotection>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-phishingprotection.svg)
+     - .. |PyPI-google-cloud-phishingprotection| image:: https://img.shields.io/pypi/v/google-cloud-phishingprotection.svg)
         :target: https://pypi.org/project/google-cloud-phishingprotection
    * - `Private Certificate Authority <https://github.com/googleapis/python-security-private-ca>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-security-private-ca.svg)
+     - .. |PyPI-google-cloud-security-private-ca| image:: https://img.shields.io/pypi/v/google-cloud-security-private-ca.svg)
         :target: https://pypi.org/project/google-cloud-security-private-ca
    * - `Pub/Sub Lite <https://github.com/googleapis/python-pubsublite>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-pubsublite.svg)
+     - .. |PyPI-google-cloud-pubsublite| image:: https://img.shields.io/pypi/v/google-cloud-pubsublite.svg)
         :target: https://pypi.org/project/google-cloud-pubsublite
    * - `Python Test Utils for Cloud <https://github.com/googleapis/python-test-utils>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-testutils.svg)
+     - .. |PyPI-google-cloud-testutils| image:: https://img.shields.io/pypi/v/google-cloud-testutils.svg)
         :target: https://pypi.org/project/google-cloud-testutils
    * - `Recommendations AI <https://github.com/googleapis/python-recommendations-ai>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-recommendations-ai.svg)
+     - .. |PyPI-google-cloud-recommendations-ai| image:: https://img.shields.io/pypi/v/google-cloud-recommendations-ai.svg)
         :target: https://pypi.org/project/google-cloud-recommendations-ai
    * - `Runtime Configurator <https://github.com/googleapis/python-runtimeconfig>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-runtimeconfig.svg)
+     - .. |PyPI-google-cloud-runtimeconfig| image:: https://img.shields.io/pypi/v/google-cloud-runtimeconfig.svg)
         :target: https://pypi.org/project/google-cloud-runtimeconfig
    * - `Service Directory <https://github.com/googleapis/python-service-directory>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-service-directory.svg)
+     - .. |PyPI-google-cloud-service-directory| image:: https://img.shields.io/pypi/v/google-cloud-service-directory.svg)
         :target: https://pypi.org/project/google-cloud-service-directory
    * - `Talent Solution <https://github.com/googleapis/python-talent>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-talent.svg)
+     - .. |PyPI-google-cloud-talent| image:: https://img.shields.io/pypi/v/google-cloud-talent.svg)
         :target: https://pypi.org/project/google-cloud-talent
    * - `Transcoder <https://github.com/googleapis/python-video-transcoder>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-video-transcoder.svg)
+     - .. |PyPI-google-cloud-video-transcoder| image:: https://img.shields.io/pypi/v/google-cloud-video-transcoder.svg)
         :target: https://pypi.org/project/google-cloud-video-transcoder
    * - `Workflows <https://github.com/googleapis/python-workflows>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-workflows.svg)
+     - .. |PyPI-google-cloud-workflows| image:: https://img.shields.io/pypi/v/google-cloud-workflows.svg)
         :target: https://pypi.org/project/google-cloud-workflows
    * - `reCAPTCHA Enterprise <https://github.com/googleapis/python-recaptcha-enterprise>`_
      - |beta|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-recpatcha-enterprise.svg)
+     - .. |PyPI-google-cloud-recpatcha-enterprise| image:: https://img.shields.io/pypi/v/google-cloud-recpatcha-enterprise.svg)
         :target: https://pypi.org/project/google-cloud-recpatcha-enterprise
    * - `Analytics Admin <https://github.com/googleapis/python-analytics-admin>`_
      - |alpha|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-analytics-admin.svg)
+     - .. |PyPI-google-analytics-admin| image:: https://img.shields.io/pypi/v/google-analytics-admin.svg)
         :target: https://pypi.org/project/google-analytics-admin
    * - `Analytics Data API <https://github.com/googleapis/python-analytics-data>`_
      - |alpha|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-analytics-data.svg)
+     - .. |PyPI-google-analytics-data| image:: https://img.shields.io/pypi/v/google-analytics-data.svg)
         :target: https://pypi.org/project/google-analytics-data
    * - `Area 120 Tables API <https://github.com/googleapis/python-area120-tables>`_
      - |alpha|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-area120-tables.svg)
+     - .. |PyPI-google-area120-tables| image:: https://img.shields.io/pypi/v/google-area120-tables.svg)
         :target: https://pypi.org/project/google-area120-tables
    * - `DNS <https://github.com/googleapis/python-dns>`_
      - |alpha|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-dns.svg)
+     - .. |PyPI-google-cloud-dns| image:: https://img.shields.io/pypi/v/google-cloud-dns.svg)
         :target: https://pypi.org/project/google-cloud-dns
    * - `Data QnA <https://github.com/googleapis/python-data-qna>`_
      - |alpha|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-data-qna.svg)
+     - .. |PyPI-google-cloud-data-qna| image:: https://img.shields.io/pypi/v/google-cloud-data-qna.svg)
         :target: https://pypi.org/project/google-cloud-data-qna
    * - `Grafeas <https://github.com/googleapis/python-grafeas>`_
      - |alpha|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/grafeas.svg)
+     - .. |PyPI-grafeas| image:: https://img.shields.io/pypi/v/grafeas.svg)
         :target: https://pypi.org/project/grafeas
    * - `Resource Manager API <https://github.com/googleapis/python-resource-manager>`_
      - |alpha|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-resource-manager.svg)
+     - .. |PyPI-google-cloud-resource-manager| image:: https://img.shields.io/pypi/v/google-cloud-resource-manager.svg)
         :target: https://pypi.org/project/google-cloud-resource-manager
    * - `Security Command Center <https://github.com/googleapis/python-securitycenter>`_
      - |alpha|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-securitycenter.svg)
+     - .. |PyPI-google-cloud-securitycenter| image:: https://img.shields.io/pypi/v/google-cloud-securitycenter.svg)
         :target: https://pypi.org/project/google-cloud-securitycenter
    * - `Security Scanner <https://github.com/googleapis/python-websecurityscanner>`_
      - |alpha|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-websecurityscanner.svg)
+     - .. |PyPI-google-cloud-websecurityscanner| image:: https://img.shields.io/pypi/v/google-cloud-websecurityscanner.svg)
         :target: https://pypi.org/project/google-cloud-websecurityscanner
    * - `Web Risk <https://github.com/googleapis/python-webrisk>`_
      - |alpha|
-     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-webrisk.svg)
+     - .. |PyPI-google-cloud-webrisk| image:: https://img.shields.io/pypi/v/google-cloud-webrisk.svg)
         :target: https://pypi.org/project/google-cloud-webrisk
 
 .. API_TABLE_END
+
+.. |ga| image:: https://img.shields.io/badge/support-GA-gold.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+
+.. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+
+
+.. |alpha| image:: https://img.shields.io/badge/support-alpha-orange.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#alpha-support
 
 
 Example Applications

--- a/README.rst
+++ b/README.rst
@@ -60,10 +60,11 @@ If you need support for other Google APIs, check out the
 Libraries
 *********
 
+.. This table is generated, see synth.py for details.
+
 .. API_TABLE_START
 
 .. list-table:: Libraries
-   :widths: 25 25 50
    :header-rows: 1
 
    * - Client

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,9 @@ If you need support for other Google APIs, check out the
 .. _Google APIs Python Client library: https://github.com/google/google-api-python-client
 
 
+Libraries
+*********
+
 .. API_TABLE_START
 
 .. list-table:: Libraries
@@ -66,318 +69,382 @@ If you need support for other Google APIs, check out the
    * - Client
      - Release Level
      - Version
-   * - `API client core library <https://github.com/googleapis/python-api-core>`_
-     - |ga|
-     - .. |PyPI-google-api-core| image:: https://img.shields.io/pypi/v/google-api-core.svg)
-        :target: https://pypi.org/project/google-api-core
-   * - `API client core library <https://github.com/googleapis/python-cloud-core>`_
-     - |ga|
-     - .. |PyPI-google-cloud-core| image:: https://img.shields.io/pypi/v/google-cloud-core.svg)
-        :target: https://pypi.org/project/google-cloud-core
    * - `Asset Inventory <https://github.com/googleapis/python-asset>`_
      - |ga|
-     - .. |PyPI-google-cloud-asset| image:: https://img.shields.io/pypi/v/google-cloud-asset.svg)
-        :target: https://pypi.org/project/google-cloud-asset
+     - |PyPI-google-cloud-asset|
    * - `AutoML <https://github.com/googleapis/python-automl>`_
      - |ga|
-     - .. |PyPI-google-cloud-automl| image:: https://img.shields.io/pypi/v/google-cloud-automl.svg)
-        :target: https://pypi.org/project/google-cloud-automl
+     - |PyPI-google-cloud-automl|
    * - `BigQuery <https://github.com/googleapis/python-bigquery>`_
      - |ga|
-     - .. |PyPI-google-cloud-bigquery| image:: https://img.shields.io/pypi/v/google-cloud-bigquery.svg)
-        :target: https://pypi.org/project/google-cloud-bigquery
+     - |PyPI-google-cloud-bigquery|
    * - `BigQuery Connection <https://github.com/googleapis/python-bigquery-connection>`_
      - |ga|
-     - .. |PyPI-google-cloud-bigquery-connection| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-connection.svg)
-        :target: https://pypi.org/project/google-cloud-bigquery-connection
+     - |PyPI-google-cloud-bigquery-connection|
    * - `BigQuery Data Transfer Service <https://github.com/googleapis/python-bigquery-datatransfer>`_
      - |ga|
-     - .. |PyPI-google-cloud-bigquery-datatransfer| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-datatransfer.svg)
-        :target: https://pypi.org/project/google-cloud-bigquery-datatransfer
+     - |PyPI-google-cloud-bigquery-datatransfer|
    * - `BigQuery Reservation <https://github.com/googleapis/python-bigquery-reservation>`_
      - |ga|
-     - .. |PyPI-google-cloud-bigquery-reservation| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-reservation.svg)
-        :target: https://pypi.org/project/google-cloud-bigquery-reservation
+     - |PyPI-google-cloud-bigquery-reservation|
    * - `BigQuery Storage <https://github.com/googleapis/python-bigquery-storage>`_
      - |ga|
-     - .. |PyPI-google-cloud-bigquery-storage| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-storage.svg)
-        :target: https://pypi.org/project/google-cloud-bigquery-storage
+     - |PyPI-google-cloud-bigquery-storage|
    * - `Bigtable <https://github.com/googleapis/python-bigtable>`_
      - |ga|
-     - .. |PyPI-google-cloud-bigtable| image:: https://img.shields.io/pypi/v/google-cloud-bigtable.svg)
-        :target: https://pypi.org/project/google-cloud-bigtable
+     - |PyPI-google-cloud-bigtable|
    * - `Billing <https://github.com/googleapis/python-billing>`_
      - |ga|
-     - .. |PyPI-google-cloud-billing| image:: https://img.shields.io/pypi/v/google-cloud-billing.svg)
-        :target: https://pypi.org/project/google-cloud-billing
+     - |PyPI-google-cloud-billing|
    * - `Build <https://github.com/googleapis/python-cloudbuild>`_
      - |ga|
-     - .. |PyPI-google-cloud-build| image:: https://img.shields.io/pypi/v/google-cloud-build.svg)
-        :target: https://pypi.org/project/google-cloud-build
+     - |PyPI-google-cloud-build|
    * - `Container Analysis <https://github.com/googleapis/python-containeranalysis>`_
      - |ga|
-     - .. |PyPI-google-cloud-containeranalysis| image:: https://img.shields.io/pypi/v/google-cloud-containeranalysis.svg)
-        :target: https://pypi.org/project/google-cloud-containeranalysis
+     - |PyPI-google-cloud-containeranalysis|
    * - `Data Catalog <https://github.com/googleapis/python-datacatalog>`_
      - |ga|
-     - .. |PyPI-google-cloud-datacatalog| image:: https://img.shields.io/pypi/v/google-cloud-datacatalog.svg)
-        :target: https://pypi.org/project/google-cloud-datacatalog
+     - |PyPI-google-cloud-datacatalog|
    * - `Data Loss Prevention <https://github.com/googleapis/python-dlp>`_
      - |ga|
-     - .. |PyPI-google-cloud-dlp| image:: https://img.shields.io/pypi/v/google-cloud-dlp.svg)
-        :target: https://pypi.org/project/google-cloud-dlp
+     - |PyPI-google-cloud-dlp|
    * - `Dataproc <https://github.com/googleapis/python-dataproc>`_
      - |ga|
-     - .. |PyPI-google-cloud-dataproc| image:: https://img.shields.io/pypi/v/google-cloud-dataproc.svg)
-        :target: https://pypi.org/project/google-cloud-dataproc
+     - |PyPI-google-cloud-dataproc|
    * - `Datastore <https://github.com/googleapis/python-datastore>`_
      - |ga|
-     - .. |PyPI-google-cloud-datastore| image:: https://img.shields.io/pypi/v/google-cloud-datastore.svg)
-        :target: https://pypi.org/project/google-cloud-datastore
+     - |PyPI-google-cloud-datastore|
    * - `Firestore <https://github.com/googleapis/python-firestore>`_
      - |ga|
-     - .. |PyPI-google-cloud-firestore| image:: https://img.shields.io/pypi/v/google-cloud-firestore.svg)
-        :target: https://pypi.org/project/google-cloud-firestore
+     - |PyPI-google-cloud-firestore|
    * - `Identity and Access Management <https://github.com/googleapis/python-iam>`_
      - |ga|
-     - .. |PyPI-google-cloud-iam| image:: https://img.shields.io/pypi/v/google-cloud-iam.svg)
-        :target: https://pypi.org/project/google-cloud-iam
+     - |PyPI-google-cloud-iam|
    * - `Internet of Things (IoT) Core <https://github.com/googleapis/python-iot>`_
      - |ga|
-     - .. |PyPI-google-cloud-iot| image:: https://img.shields.io/pypi/v/google-cloud-iot.svg)
-        :target: https://pypi.org/project/google-cloud-iot
+     - |PyPI-google-cloud-iot|
    * - `Key Management Service <https://github.com/googleapis/python-kms>`_
      - |ga|
-     - .. |PyPI-google-cloud-kms| image:: https://img.shields.io/pypi/v/google-cloud-kms.svg)
-        :target: https://pypi.org/project/google-cloud-kms
+     - |PyPI-google-cloud-kms|
    * - `Kubernetes Engine <https://github.com/googleapis/python-container>`_
      - |ga|
-     - .. |PyPI-google-cloud-container| image:: https://img.shields.io/pypi/v/google-cloud-container.svg)
-        :target: https://pypi.org/project/google-cloud-container
+     - |PyPI-google-cloud-container|
    * - `Logging <https://github.com/googleapis/python-logging>`_
      - |ga|
-     - .. |PyPI-google-cloud-logging| image:: https://img.shields.io/pypi/v/google-cloud-logging.svg)
-        :target: https://pypi.org/project/google-cloud-logging
+     - |PyPI-google-cloud-logging|
    * - `Monitoring Dashboards <https://github.com/googleapis/python-monitoring-dashboards>`_
      - |ga|
-     - .. |PyPI-google-cloud-monitoring-dashboards| image:: https://img.shields.io/pypi/v/google-cloud-monitoring-dashboards.svg)
-        :target: https://pypi.org/project/google-cloud-monitoring-dashboards
+     - |PyPI-google-cloud-monitoring-dashboards|
    * - `NDB Client Library for Datastore <https://github.com/googleapis/python-ndb>`_
      - |ga|
-     - .. |PyPI-google-cloud-ndb| image:: https://img.shields.io/pypi/v/google-cloud-ndb.svg)
-        :target: https://pypi.org/project/google-cloud-ndb
+     - |PyPI-google-cloud-ndb|
    * - `Natural Language <https://github.com/googleapis/python-language>`_
      - |ga|
-     - .. |PyPI-google-cloud-language| image:: https://img.shields.io/pypi/v/google-cloud-language.svg)
-        :target: https://pypi.org/project/google-cloud-language
+     - |PyPI-google-cloud-language|
    * - `OS Login <https://github.com/googleapis/python-oslogin>`_
      - |ga|
-     - .. |PyPI-google-cloud-os-login| image:: https://img.shields.io/pypi/v/google-cloud-os-login.svg)
-        :target: https://pypi.org/project/google-cloud-os-login
+     - |PyPI-google-cloud-os-login|
    * - `Pub/Sub <https://github.com/googleapis/python-pubsub>`_
      - |ga|
-     - .. |PyPI-google-cloud-pubsub| image:: https://img.shields.io/pypi/v/google-cloud-pubsub.svg)
-        :target: https://pypi.org/project/google-cloud-pubsub
+     - |PyPI-google-cloud-pubsub|
    * - `Recommender API <https://github.com/googleapis/python-recommender>`_
      - |ga|
-     - .. |PyPI-google-cloud-recommender| image:: https://img.shields.io/pypi/v/google-cloud-recommender.svg)
-        :target: https://pypi.org/project/google-cloud-recommender
+     - |PyPI-google-cloud-recommender|
    * - `Redis <https://github.com/googleapis/python-redis>`_
      - |ga|
-     - .. |PyPI-google-cloud-redis| image:: https://img.shields.io/pypi/v/google-cloud-redis.svg)
-        :target: https://pypi.org/project/google-cloud-redis
+     - |PyPI-google-cloud-redis|
    * - `Scheduler <https://github.com/googleapis/python-scheduler>`_
      - |ga|
-     - .. |PyPI-google-cloud-scheduler| image:: https://img.shields.io/pypi/v/google-cloud-scheduler.svg)
-        :target: https://pypi.org/project/google-cloud-scheduler
+     - |PyPI-google-cloud-scheduler|
    * - `Secret Manager <https://github.com/googleapis/python-secret-manager>`_
      - |ga|
-     - .. |PyPI-google-cloud-secret-manager| image:: https://img.shields.io/pypi/v/google-cloud-secret-manager.svg)
-        :target: https://pypi.org/project/google-cloud-secret-manager
+     - |PyPI-google-cloud-secret-manager|
    * - `Spanner <https://github.com/googleapis/python-spanner>`_
      - |ga|
-     - .. |PyPI-google-cloud-spanner| image:: https://img.shields.io/pypi/v/google-cloud-spanner.svg)
-        :target: https://pypi.org/project/google-cloud-spanner
+     - |PyPI-google-cloud-spanner|
    * - `Speech <https://github.com/googleapis/python-speech>`_
      - |ga|
-     - .. |PyPI-google-cloud-speech| image:: https://img.shields.io/pypi/v/google-cloud-speech.svg)
-        :target: https://pypi.org/project/google-cloud-speech
+     - |PyPI-google-cloud-speech|
    * - `Stackdriver Monitoring <https://github.com/googleapis/python-monitoring>`_
      - |ga|
-     - .. |PyPI-google-cloud-monitoring| image:: https://img.shields.io/pypi/v/google-cloud-monitoring.svg)
-        :target: https://pypi.org/project/google-cloud-monitoring
+     - |PyPI-google-cloud-monitoring|
    * - `Storage <https://github.com/googleapis/python-storage>`_
      - |ga|
-     - .. |PyPI-google-cloud-storage| image:: https://img.shields.io/pypi/v/google-cloud-storage.svg)
-        :target: https://pypi.org/project/google-cloud-storage
+     - |PyPI-google-cloud-storage|
    * - `Tasks <https://github.com/googleapis/python-tasks>`_
      - |ga|
-     - .. |PyPI-google-cloud-tasks| image:: https://img.shields.io/pypi/v/google-cloud-tasks.svg)
-        :target: https://pypi.org/project/google-cloud-tasks
+     - |PyPI-google-cloud-tasks|
    * - `Text-to-Speech <https://github.com/googleapis/python-texttospeech>`_
      - |ga|
-     - .. |PyPI-google-cloud-texttospeech| image:: https://img.shields.io/pypi/v/google-cloud-texttospeech.svg)
-        :target: https://pypi.org/project/google-cloud-texttospeech
+     - |PyPI-google-cloud-texttospeech|
    * - `Trace <https://github.com/googleapis/python-trace>`_
      - |ga|
-     - .. |PyPI-google-cloud-trace| image:: https://img.shields.io/pypi/v/google-cloud-trace.svg)
-        :target: https://pypi.org/project/google-cloud-trace
+     - |PyPI-google-cloud-trace|
    * - `Translation <https://github.com/googleapis/python-translate>`_
      - |ga|
-     - .. |PyPI-google-cloud-translate| image:: https://img.shields.io/pypi/v/google-cloud-translate.svg)
-        :target: https://pypi.org/project/google-cloud-translate
+     - |PyPI-google-cloud-translate|
    * - `Video Intelligence <https://github.com/googleapis/python-videointelligence>`_
      - |ga|
-     - .. |PyPI-google-cloud-videointelligence| image:: https://img.shields.io/pypi/v/google-cloud-videointelligence.svg)
-        :target: https://pypi.org/project/google-cloud-videointelligence
+     - |PyPI-google-cloud-videointelligence|
    * - `Vision <https://github.com/googleapis/python-vision>`_
      - |ga|
-     - .. |PyPI-google-cloud-vision| image:: https://img.shields.io/pypi/v/google-cloud-vision.svg)
-        :target: https://pypi.org/project/google-cloud-vision
+     - |PyPI-google-cloud-vision|
    * - `AI Platform Notebooks <https://github.com/googleapis/python-notebooks>`_
      - |beta|
-     - .. |PyPI-google-cloud-notebooks| image:: https://img.shields.io/pypi/v/google-cloud-notebooks.svg)
-        :target: https://pypi.org/project/google-cloud-notebooks
+     - |PyPI-google-cloud-notebooks|
    * - `Access Approval <https://github.com/googleapis/python-access-approval>`_
      - |beta|
-     - .. |PyPI-google-cloud-access-approval| image:: https://img.shields.io/pypi/v/google-cloud-access-approval.svg)
-        :target: https://pypi.org/project/google-cloud-access-approval
+     - |PyPI-google-cloud-access-approval|
    * - `Assured Workloads for Government <https://github.com/googleapis/python-assured-workloads>`_
      - |beta|
-     - .. |PyPI-google-cloud-assured-workflows| image:: https://img.shields.io/pypi/v/google-cloud-assured-workflows.svg)
-        :target: https://pypi.org/project/google-cloud-assured-workflows
+     - |PyPI-google-cloud-assured-workflows|
    * - `Audit Log <https://github.com/googleapis/python-audit-log>`_
      - |beta|
-     - .. |PyPI-google-cloud-audit-log| image:: https://img.shields.io/pypi/v/google-cloud-audit-log.svg)
-        :target: https://pypi.org/project/google-cloud-audit-log
+     - |PyPI-google-cloud-audit-log|
    * - `Billing Budget <https://github.com/googleapis/python-billingbudgets>`_
      - |beta|
-     - .. |PyPI-google-cloud-billing-budgets| image:: https://img.shields.io/pypi/v/google-cloud-billing-budgets.svg)
-        :target: https://pypi.org/project/google-cloud-billing-budgets
+     - |PyPI-google-cloud-billing-budgets|
    * - `Binary Authorization <https://github.com/googleapis/python-binary-authorization>`_
      - |beta|
-     - .. |PyPI-google-cloud-binary-authorization| image:: https://img.shields.io/pypi/v/google-cloud-binary-authorization.svg)
-        :target: https://pypi.org/project/google-cloud-binary-authorization
+     - |PyPI-google-cloud-binary-authorization|
    * - `Compute Engine <https://github.com/googleapis/python-compute>`_
      - |beta|
-     - .. |PyPI-google-cloud-compute| image:: https://img.shields.io/pypi/v/google-cloud-compute.svg)
-        :target: https://pypi.org/project/google-cloud-compute
+     - |PyPI-google-cloud-compute|
    * - `Data Labeling <https://github.com/googleapis/python-datalabeling>`_
      - |beta|
-     - .. |PyPI-google-cloud-datalabeling| image:: https://img.shields.io/pypi/v/google-cloud-datalabeling.svg)
-        :target: https://pypi.org/project/google-cloud-datalabeling
+     - |PyPI-google-cloud-datalabeling|
    * - `Dialogflow CX <https://github.com/googleapis/python-dialogflow-cx>`_
      - |beta|
-     - .. |PyPI-google-cloud-dialogflow-cx| image:: https://img.shields.io/pypi/v/google-cloud-dialogflow-cx.svg)
-        :target: https://pypi.org/project/google-cloud-dialogflow-cx
+     - |PyPI-google-cloud-dialogflow-cx|
    * - `Document Understanding API <https://github.com/googleapis/python-documentai>`_
      - |beta|
-     - .. |PyPI-google-cloud-documentai| image:: https://img.shields.io/pypi/v/google-cloud-documentai.svg)
-        :target: https://pypi.org/project/google-cloud-documentai
+     - |PyPI-google-cloud-documentai|
    * - `Error Reporting <https://github.com/googleapis/python-error-reporting>`_
      - |beta|
-     - .. |PyPI-google-cloud-error-reporting| image:: https://img.shields.io/pypi/v/google-cloud-error-reporting.svg)
-        :target: https://pypi.org/project/google-cloud-error-reporting
+     - |PyPI-google-cloud-error-reporting|
    * - `Functions <https://github.com/googleapis/python-functions>`_
      - |beta|
-     - .. |PyPI-google-cloud-functions| image:: https://img.shields.io/pypi/v/google-cloud-functions.svg)
-        :target: https://pypi.org/project/google-cloud-functions
+     - |PyPI-google-cloud-functions|
    * - `Game Servers <https://github.com/googleapis/python-game-servers>`_
      - |beta|
-     - .. |PyPI-google-cloud-game-servers| image:: https://img.shields.io/pypi/v/google-cloud-game-servers.svg)
-        :target: https://pypi.org/project/google-cloud-game-servers
+     - |PyPI-google-cloud-game-servers|
    * - `Media Translation <https://github.com/googleapis/python-media-translation>`_
      - |beta|
-     - .. |PyPI-google-cloud-media-translation| image:: https://img.shields.io/pypi/v/google-cloud-media-translation.svg)
-        :target: https://pypi.org/project/google-cloud-media-translation
+     - |PyPI-google-cloud-media-translation|
    * - `Memorystore for Memcached <https://github.com/googleapis/python-memcache>`_
      - |beta|
-     - .. |PyPI-google-cloud-memcache| image:: https://img.shields.io/pypi/v/google-cloud-memcache.svg)
-        :target: https://pypi.org/project/google-cloud-memcache
+     - |PyPI-google-cloud-memcache|
    * - `Phishing Protection <https://github.com/googleapis/python-phishingprotection>`_
      - |beta|
-     - .. |PyPI-google-cloud-phishingprotection| image:: https://img.shields.io/pypi/v/google-cloud-phishingprotection.svg)
-        :target: https://pypi.org/project/google-cloud-phishingprotection
+     - |PyPI-google-cloud-phishingprotection|
    * - `Private Certificate Authority <https://github.com/googleapis/python-security-private-ca>`_
      - |beta|
-     - .. |PyPI-google-cloud-security-private-ca| image:: https://img.shields.io/pypi/v/google-cloud-security-private-ca.svg)
-        :target: https://pypi.org/project/google-cloud-security-private-ca
+     - |PyPI-google-cloud-security-private-ca|
    * - `Pub/Sub Lite <https://github.com/googleapis/python-pubsublite>`_
      - |beta|
-     - .. |PyPI-google-cloud-pubsublite| image:: https://img.shields.io/pypi/v/google-cloud-pubsublite.svg)
-        :target: https://pypi.org/project/google-cloud-pubsublite
-   * - `Python Test Utils for Cloud <https://github.com/googleapis/python-test-utils>`_
-     - |beta|
-     - .. |PyPI-google-cloud-testutils| image:: https://img.shields.io/pypi/v/google-cloud-testutils.svg)
-        :target: https://pypi.org/project/google-cloud-testutils
+     - |PyPI-google-cloud-pubsublite|
    * - `Recommendations AI <https://github.com/googleapis/python-recommendations-ai>`_
      - |beta|
-     - .. |PyPI-google-cloud-recommendations-ai| image:: https://img.shields.io/pypi/v/google-cloud-recommendations-ai.svg)
-        :target: https://pypi.org/project/google-cloud-recommendations-ai
+     - |PyPI-google-cloud-recommendations-ai|
    * - `Runtime Configurator <https://github.com/googleapis/python-runtimeconfig>`_
      - |beta|
-     - .. |PyPI-google-cloud-runtimeconfig| image:: https://img.shields.io/pypi/v/google-cloud-runtimeconfig.svg)
-        :target: https://pypi.org/project/google-cloud-runtimeconfig
+     - |PyPI-google-cloud-runtimeconfig|
    * - `Service Directory <https://github.com/googleapis/python-service-directory>`_
      - |beta|
-     - .. |PyPI-google-cloud-service-directory| image:: https://img.shields.io/pypi/v/google-cloud-service-directory.svg)
-        :target: https://pypi.org/project/google-cloud-service-directory
+     - |PyPI-google-cloud-service-directory|
    * - `Talent Solution <https://github.com/googleapis/python-talent>`_
      - |beta|
-     - .. |PyPI-google-cloud-talent| image:: https://img.shields.io/pypi/v/google-cloud-talent.svg)
-        :target: https://pypi.org/project/google-cloud-talent
+     - |PyPI-google-cloud-talent|
    * - `Transcoder <https://github.com/googleapis/python-video-transcoder>`_
      - |beta|
-     - .. |PyPI-google-cloud-video-transcoder| image:: https://img.shields.io/pypi/v/google-cloud-video-transcoder.svg)
-        :target: https://pypi.org/project/google-cloud-video-transcoder
+     - |PyPI-google-cloud-video-transcoder|
    * - `Workflows <https://github.com/googleapis/python-workflows>`_
      - |beta|
-     - .. |PyPI-google-cloud-workflows| image:: https://img.shields.io/pypi/v/google-cloud-workflows.svg)
-        :target: https://pypi.org/project/google-cloud-workflows
+     - |PyPI-google-cloud-workflows|
    * - `reCAPTCHA Enterprise <https://github.com/googleapis/python-recaptcha-enterprise>`_
      - |beta|
-     - .. |PyPI-google-cloud-recpatcha-enterprise| image:: https://img.shields.io/pypi/v/google-cloud-recpatcha-enterprise.svg)
-        :target: https://pypi.org/project/google-cloud-recpatcha-enterprise
+     - |PyPI-google-cloud-recpatcha-enterprise|
    * - `Analytics Admin <https://github.com/googleapis/python-analytics-admin>`_
      - |alpha|
-     - .. |PyPI-google-analytics-admin| image:: https://img.shields.io/pypi/v/google-analytics-admin.svg)
-        :target: https://pypi.org/project/google-analytics-admin
+     - |PyPI-google-analytics-admin|
    * - `Analytics Data API <https://github.com/googleapis/python-analytics-data>`_
      - |alpha|
-     - .. |PyPI-google-analytics-data| image:: https://img.shields.io/pypi/v/google-analytics-data.svg)
-        :target: https://pypi.org/project/google-analytics-data
+     - |PyPI-google-analytics-data|
    * - `Area 120 Tables API <https://github.com/googleapis/python-area120-tables>`_
      - |alpha|
-     - .. |PyPI-google-area120-tables| image:: https://img.shields.io/pypi/v/google-area120-tables.svg)
-        :target: https://pypi.org/project/google-area120-tables
+     - |PyPI-google-area120-tables|
    * - `DNS <https://github.com/googleapis/python-dns>`_
      - |alpha|
-     - .. |PyPI-google-cloud-dns| image:: https://img.shields.io/pypi/v/google-cloud-dns.svg)
-        :target: https://pypi.org/project/google-cloud-dns
+     - |PyPI-google-cloud-dns|
    * - `Data QnA <https://github.com/googleapis/python-data-qna>`_
      - |alpha|
-     - .. |PyPI-google-cloud-data-qna| image:: https://img.shields.io/pypi/v/google-cloud-data-qna.svg)
-        :target: https://pypi.org/project/google-cloud-data-qna
+     - |PyPI-google-cloud-data-qna|
    * - `Grafeas <https://github.com/googleapis/python-grafeas>`_
      - |alpha|
-     - .. |PyPI-grafeas| image:: https://img.shields.io/pypi/v/grafeas.svg)
-        :target: https://pypi.org/project/grafeas
+     - |PyPI-grafeas|
    * - `Resource Manager API <https://github.com/googleapis/python-resource-manager>`_
      - |alpha|
-     - .. |PyPI-google-cloud-resource-manager| image:: https://img.shields.io/pypi/v/google-cloud-resource-manager.svg)
-        :target: https://pypi.org/project/google-cloud-resource-manager
+     - |PyPI-google-cloud-resource-manager|
    * - `Security Command Center <https://github.com/googleapis/python-securitycenter>`_
      - |alpha|
-     - .. |PyPI-google-cloud-securitycenter| image:: https://img.shields.io/pypi/v/google-cloud-securitycenter.svg)
-        :target: https://pypi.org/project/google-cloud-securitycenter
+     - |PyPI-google-cloud-securitycenter|
    * - `Security Scanner <https://github.com/googleapis/python-websecurityscanner>`_
      - |alpha|
-     - .. |PyPI-google-cloud-websecurityscanner| image:: https://img.shields.io/pypi/v/google-cloud-websecurityscanner.svg)
-        :target: https://pypi.org/project/google-cloud-websecurityscanner
+     - |PyPI-google-cloud-websecurityscanner|
    * - `Web Risk <https://github.com/googleapis/python-webrisk>`_
      - |alpha|
-     - .. |PyPI-google-cloud-webrisk| image:: https://img.shields.io/pypi/v/google-cloud-webrisk.svg)
-        :target: https://pypi.org/project/google-cloud-webrisk
+     - |PyPI-google-cloud-webrisk|
+
+.. |PyPI-google-cloud-asset| image:: https://img.shields.io/pypi/v/google-cloud-asset.svg)
+     :target: https://pypi.org/project/google-cloud-asset
+.. |PyPI-google-cloud-automl| image:: https://img.shields.io/pypi/v/google-cloud-automl.svg)
+     :target: https://pypi.org/project/google-cloud-automl
+.. |PyPI-google-cloud-bigquery| image:: https://img.shields.io/pypi/v/google-cloud-bigquery.svg)
+     :target: https://pypi.org/project/google-cloud-bigquery
+.. |PyPI-google-cloud-bigquery-connection| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-connection.svg)
+     :target: https://pypi.org/project/google-cloud-bigquery-connection
+.. |PyPI-google-cloud-bigquery-datatransfer| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-datatransfer.svg)
+     :target: https://pypi.org/project/google-cloud-bigquery-datatransfer
+.. |PyPI-google-cloud-bigquery-reservation| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-reservation.svg)
+     :target: https://pypi.org/project/google-cloud-bigquery-reservation
+.. |PyPI-google-cloud-bigquery-storage| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-storage.svg)
+     :target: https://pypi.org/project/google-cloud-bigquery-storage
+.. |PyPI-google-cloud-bigtable| image:: https://img.shields.io/pypi/v/google-cloud-bigtable.svg)
+     :target: https://pypi.org/project/google-cloud-bigtable
+.. |PyPI-google-cloud-billing| image:: https://img.shields.io/pypi/v/google-cloud-billing.svg)
+     :target: https://pypi.org/project/google-cloud-billing
+.. |PyPI-google-cloud-build| image:: https://img.shields.io/pypi/v/google-cloud-build.svg)
+     :target: https://pypi.org/project/google-cloud-build
+.. |PyPI-google-cloud-containeranalysis| image:: https://img.shields.io/pypi/v/google-cloud-containeranalysis.svg)
+     :target: https://pypi.org/project/google-cloud-containeranalysis
+.. |PyPI-google-cloud-datacatalog| image:: https://img.shields.io/pypi/v/google-cloud-datacatalog.svg)
+     :target: https://pypi.org/project/google-cloud-datacatalog
+.. |PyPI-google-cloud-dlp| image:: https://img.shields.io/pypi/v/google-cloud-dlp.svg)
+     :target: https://pypi.org/project/google-cloud-dlp
+.. |PyPI-google-cloud-dataproc| image:: https://img.shields.io/pypi/v/google-cloud-dataproc.svg)
+     :target: https://pypi.org/project/google-cloud-dataproc
+.. |PyPI-google-cloud-datastore| image:: https://img.shields.io/pypi/v/google-cloud-datastore.svg)
+     :target: https://pypi.org/project/google-cloud-datastore
+.. |PyPI-google-cloud-firestore| image:: https://img.shields.io/pypi/v/google-cloud-firestore.svg)
+     :target: https://pypi.org/project/google-cloud-firestore
+.. |PyPI-google-cloud-iam| image:: https://img.shields.io/pypi/v/google-cloud-iam.svg)
+     :target: https://pypi.org/project/google-cloud-iam
+.. |PyPI-google-cloud-iot| image:: https://img.shields.io/pypi/v/google-cloud-iot.svg)
+     :target: https://pypi.org/project/google-cloud-iot
+.. |PyPI-google-cloud-kms| image:: https://img.shields.io/pypi/v/google-cloud-kms.svg)
+     :target: https://pypi.org/project/google-cloud-kms
+.. |PyPI-google-cloud-container| image:: https://img.shields.io/pypi/v/google-cloud-container.svg)
+     :target: https://pypi.org/project/google-cloud-container
+.. |PyPI-google-cloud-logging| image:: https://img.shields.io/pypi/v/google-cloud-logging.svg)
+     :target: https://pypi.org/project/google-cloud-logging
+.. |PyPI-google-cloud-monitoring-dashboards| image:: https://img.shields.io/pypi/v/google-cloud-monitoring-dashboards.svg)
+     :target: https://pypi.org/project/google-cloud-monitoring-dashboards
+.. |PyPI-google-cloud-ndb| image:: https://img.shields.io/pypi/v/google-cloud-ndb.svg)
+     :target: https://pypi.org/project/google-cloud-ndb
+.. |PyPI-google-cloud-language| image:: https://img.shields.io/pypi/v/google-cloud-language.svg)
+     :target: https://pypi.org/project/google-cloud-language
+.. |PyPI-google-cloud-os-login| image:: https://img.shields.io/pypi/v/google-cloud-os-login.svg)
+     :target: https://pypi.org/project/google-cloud-os-login
+.. |PyPI-google-cloud-pubsub| image:: https://img.shields.io/pypi/v/google-cloud-pubsub.svg)
+     :target: https://pypi.org/project/google-cloud-pubsub
+.. |PyPI-google-cloud-recommender| image:: https://img.shields.io/pypi/v/google-cloud-recommender.svg)
+     :target: https://pypi.org/project/google-cloud-recommender
+.. |PyPI-google-cloud-redis| image:: https://img.shields.io/pypi/v/google-cloud-redis.svg)
+     :target: https://pypi.org/project/google-cloud-redis
+.. |PyPI-google-cloud-scheduler| image:: https://img.shields.io/pypi/v/google-cloud-scheduler.svg)
+     :target: https://pypi.org/project/google-cloud-scheduler
+.. |PyPI-google-cloud-secret-manager| image:: https://img.shields.io/pypi/v/google-cloud-secret-manager.svg)
+     :target: https://pypi.org/project/google-cloud-secret-manager
+.. |PyPI-google-cloud-spanner| image:: https://img.shields.io/pypi/v/google-cloud-spanner.svg)
+     :target: https://pypi.org/project/google-cloud-spanner
+.. |PyPI-google-cloud-speech| image:: https://img.shields.io/pypi/v/google-cloud-speech.svg)
+     :target: https://pypi.org/project/google-cloud-speech
+.. |PyPI-google-cloud-monitoring| image:: https://img.shields.io/pypi/v/google-cloud-monitoring.svg)
+     :target: https://pypi.org/project/google-cloud-monitoring
+.. |PyPI-google-cloud-storage| image:: https://img.shields.io/pypi/v/google-cloud-storage.svg)
+     :target: https://pypi.org/project/google-cloud-storage
+.. |PyPI-google-cloud-tasks| image:: https://img.shields.io/pypi/v/google-cloud-tasks.svg)
+     :target: https://pypi.org/project/google-cloud-tasks
+.. |PyPI-google-cloud-texttospeech| image:: https://img.shields.io/pypi/v/google-cloud-texttospeech.svg)
+     :target: https://pypi.org/project/google-cloud-texttospeech
+.. |PyPI-google-cloud-trace| image:: https://img.shields.io/pypi/v/google-cloud-trace.svg)
+     :target: https://pypi.org/project/google-cloud-trace
+.. |PyPI-google-cloud-translate| image:: https://img.shields.io/pypi/v/google-cloud-translate.svg)
+     :target: https://pypi.org/project/google-cloud-translate
+.. |PyPI-google-cloud-videointelligence| image:: https://img.shields.io/pypi/v/google-cloud-videointelligence.svg)
+     :target: https://pypi.org/project/google-cloud-videointelligence
+.. |PyPI-google-cloud-vision| image:: https://img.shields.io/pypi/v/google-cloud-vision.svg)
+     :target: https://pypi.org/project/google-cloud-vision
+.. |PyPI-google-cloud-notebooks| image:: https://img.shields.io/pypi/v/google-cloud-notebooks.svg)
+     :target: https://pypi.org/project/google-cloud-notebooks
+.. |PyPI-google-cloud-access-approval| image:: https://img.shields.io/pypi/v/google-cloud-access-approval.svg)
+     :target: https://pypi.org/project/google-cloud-access-approval
+.. |PyPI-google-cloud-assured-workflows| image:: https://img.shields.io/pypi/v/google-cloud-assured-workflows.svg)
+     :target: https://pypi.org/project/google-cloud-assured-workflows
+.. |PyPI-google-cloud-audit-log| image:: https://img.shields.io/pypi/v/google-cloud-audit-log.svg)
+     :target: https://pypi.org/project/google-cloud-audit-log
+.. |PyPI-google-cloud-billing-budgets| image:: https://img.shields.io/pypi/v/google-cloud-billing-budgets.svg)
+     :target: https://pypi.org/project/google-cloud-billing-budgets
+.. |PyPI-google-cloud-binary-authorization| image:: https://img.shields.io/pypi/v/google-cloud-binary-authorization.svg)
+     :target: https://pypi.org/project/google-cloud-binary-authorization
+.. |PyPI-google-cloud-compute| image:: https://img.shields.io/pypi/v/google-cloud-compute.svg)
+     :target: https://pypi.org/project/google-cloud-compute
+.. |PyPI-google-cloud-datalabeling| image:: https://img.shields.io/pypi/v/google-cloud-datalabeling.svg)
+     :target: https://pypi.org/project/google-cloud-datalabeling
+.. |PyPI-google-cloud-dialogflow-cx| image:: https://img.shields.io/pypi/v/google-cloud-dialogflow-cx.svg)
+     :target: https://pypi.org/project/google-cloud-dialogflow-cx
+.. |PyPI-google-cloud-documentai| image:: https://img.shields.io/pypi/v/google-cloud-documentai.svg)
+     :target: https://pypi.org/project/google-cloud-documentai
+.. |PyPI-google-cloud-error-reporting| image:: https://img.shields.io/pypi/v/google-cloud-error-reporting.svg)
+     :target: https://pypi.org/project/google-cloud-error-reporting
+.. |PyPI-google-cloud-functions| image:: https://img.shields.io/pypi/v/google-cloud-functions.svg)
+     :target: https://pypi.org/project/google-cloud-functions
+.. |PyPI-google-cloud-game-servers| image:: https://img.shields.io/pypi/v/google-cloud-game-servers.svg)
+     :target: https://pypi.org/project/google-cloud-game-servers
+.. |PyPI-google-cloud-media-translation| image:: https://img.shields.io/pypi/v/google-cloud-media-translation.svg)
+     :target: https://pypi.org/project/google-cloud-media-translation
+.. |PyPI-google-cloud-memcache| image:: https://img.shields.io/pypi/v/google-cloud-memcache.svg)
+     :target: https://pypi.org/project/google-cloud-memcache
+.. |PyPI-google-cloud-phishingprotection| image:: https://img.shields.io/pypi/v/google-cloud-phishingprotection.svg)
+     :target: https://pypi.org/project/google-cloud-phishingprotection
+.. |PyPI-google-cloud-security-private-ca| image:: https://img.shields.io/pypi/v/google-cloud-security-private-ca.svg)
+     :target: https://pypi.org/project/google-cloud-security-private-ca
+.. |PyPI-google-cloud-pubsublite| image:: https://img.shields.io/pypi/v/google-cloud-pubsublite.svg)
+     :target: https://pypi.org/project/google-cloud-pubsublite
+.. |PyPI-google-cloud-recommendations-ai| image:: https://img.shields.io/pypi/v/google-cloud-recommendations-ai.svg)
+     :target: https://pypi.org/project/google-cloud-recommendations-ai
+.. |PyPI-google-cloud-runtimeconfig| image:: https://img.shields.io/pypi/v/google-cloud-runtimeconfig.svg)
+     :target: https://pypi.org/project/google-cloud-runtimeconfig
+.. |PyPI-google-cloud-service-directory| image:: https://img.shields.io/pypi/v/google-cloud-service-directory.svg)
+     :target: https://pypi.org/project/google-cloud-service-directory
+.. |PyPI-google-cloud-talent| image:: https://img.shields.io/pypi/v/google-cloud-talent.svg)
+     :target: https://pypi.org/project/google-cloud-talent
+.. |PyPI-google-cloud-video-transcoder| image:: https://img.shields.io/pypi/v/google-cloud-video-transcoder.svg)
+     :target: https://pypi.org/project/google-cloud-video-transcoder
+.. |PyPI-google-cloud-workflows| image:: https://img.shields.io/pypi/v/google-cloud-workflows.svg)
+     :target: https://pypi.org/project/google-cloud-workflows
+.. |PyPI-google-cloud-recpatcha-enterprise| image:: https://img.shields.io/pypi/v/google-cloud-recpatcha-enterprise.svg)
+     :target: https://pypi.org/project/google-cloud-recpatcha-enterprise
+.. |PyPI-google-analytics-admin| image:: https://img.shields.io/pypi/v/google-analytics-admin.svg)
+     :target: https://pypi.org/project/google-analytics-admin
+.. |PyPI-google-analytics-data| image:: https://img.shields.io/pypi/v/google-analytics-data.svg)
+     :target: https://pypi.org/project/google-analytics-data
+.. |PyPI-google-area120-tables| image:: https://img.shields.io/pypi/v/google-area120-tables.svg)
+     :target: https://pypi.org/project/google-area120-tables
+.. |PyPI-google-cloud-dns| image:: https://img.shields.io/pypi/v/google-cloud-dns.svg)
+     :target: https://pypi.org/project/google-cloud-dns
+.. |PyPI-google-cloud-data-qna| image:: https://img.shields.io/pypi/v/google-cloud-data-qna.svg)
+     :target: https://pypi.org/project/google-cloud-data-qna
+.. |PyPI-grafeas| image:: https://img.shields.io/pypi/v/grafeas.svg)
+     :target: https://pypi.org/project/grafeas
+.. |PyPI-google-cloud-resource-manager| image:: https://img.shields.io/pypi/v/google-cloud-resource-manager.svg)
+     :target: https://pypi.org/project/google-cloud-resource-manager
+.. |PyPI-google-cloud-securitycenter| image:: https://img.shields.io/pypi/v/google-cloud-securitycenter.svg)
+     :target: https://pypi.org/project/google-cloud-securitycenter
+.. |PyPI-google-cloud-websecurityscanner| image:: https://img.shields.io/pypi/v/google-cloud-websecurityscanner.svg)
+     :target: https://pypi.org/project/google-cloud-websecurityscanner
+.. |PyPI-google-cloud-webrisk| image:: https://img.shields.io/pypi/v/google-cloud-webrisk.svg)
+     :target: https://pypi.org/project/google-cloud-webrisk
 
 .. API_TABLE_END
 

--- a/README.rst
+++ b/README.rst
@@ -5,10 +5,17 @@ Python idiomatic clients for `Google Cloud Platform`_ services.
 
 .. _Google Cloud Platform: https://cloud.google.com/
 
-**Heads up**! These libraries are supported on App Engine standard's `Python 3 runtime`_ but are *not* supported on App Engine's `Python 2 runtime`_.
 
-.. _Python 3 runtime: https://cloud.google.com/appengine/docs/standard/python3
-.. _Python 2 runtime: https://cloud.google.com/appengine/docs/standard/python
+See a full list of published libraries at https://cloud.google.com/python/docs/reference.
+
+
+Stability levels
+*******************
+
+The `development status classifier`_ on PyPI indicates the current stability
+of a package. 
+
+.. _development status classifier: https://pypi.org/classifiers/
 
 General Availability
 --------------------
@@ -20,190 +27,13 @@ of critical security issues) or with an extensive deprecation period.
 Issues and requests against GA libraries are addressed with the highest
 priority.
 
+GA libraries have development status classifier ``Development Status :: 5 - Production/Stable``.
+
 .. note::
 
     Sub-components of GA libraries explicitly marked as beta in the
     import path (e.g. ``google.cloud.language_v1beta2``) should be considered
     to be beta.
-
-The following client libraries have **GA** support:
-
--  `Google Cloud Asset`_ (`Asset README`_, `Asset Documentation`_)
--  `Google Cloud AutoML`_ (`AutoML README`_, `AutoML Documentation`_)
--  `Google BigQuery`_ (`BigQuery README`_, `BigQuery Documentation`_)
--  `Google BigQuery Data Transfer`_ (`BigQuery Data Transfer README`_, `BigQuery Data Transfer Documentation`_)
--  `Google BigQuery Storage`_ (`BigQuery Storage README`_, `BigQuery Storage Documentation`_)
--  `Google Cloud Bigtable`_ (`Bigtable README`_, `Bigtable Documentation`_)
--  `Google Cloud Billing`_ (`Billing README`_, `Billing Documentation`_)
--  `Google Cloud Build`_ (`Cloud Build README`_, `Cloud Build Documentation`_)
--  `Google Cloud Container`_ (`Container README`_, `Container Documentation`_)
--  `Google Cloud Container Analysis`_ (`Container Analysis README`_, `Container Analysis Documentation`_)
--  `Google Cloud Dataproc`_ (`Dataproc README`_, `Dataproc Documentation`_)
--  `Google Cloud Datastore`_ (`Datastore README`_, `Datastore Documentation`_)
--  `Google Cloud DLP`_ (`DLP README`_, `DLP Documentation`_)
--  `Google Cloud Firestore`_ (`Firestore README`_, `Firestore Documentation`_)
--  `Google Cloud IAM Credentials`_ (`IAM Credentials README`_, `IAM Credentials Documentation`_)
--  `Google Cloud IoT`_ (`IoT README`_, `IoT Documentation`_)
--  `Google Cloud KMS`_ (`KMS README`_, `KMS Documentation`_)
--  `Google Cloud Memorystore for Redis`_ (`Redis README`_, `Redis Documentation`_)
--  `Google Cloud Monitoring Dashboards`_ (`Monitoring Dashboards README`_, `Monitoring Dashboards Documentation`_)
--  `Google Cloud Natural Language`_ (`Natural Language README`_, `Natural Language Documentation`_)
--  `Google Cloud OS Login`_ (`OS Login README`_, `OS Login Documentation`_)
--  `Google Cloud Pub/Sub`_ (`Pub/Sub README`_, `Pub/Sub Documentation`_)
--  `Google Cloud Recommender`_ (`Recommender README`_, `Recommender Documentation`_)
--  `Google Cloud Scheduler`_ (`Scheduler README`_, `Scheduler Documentation`_)
--  `Google Cloud Secret Manager`_ (`Secret Manager README`_, `Secret Manager Documentation`_)
--  `Google Cloud Spanner`_ (`Spanner README`_, `Spanner Documentation`_)
--  `Google Cloud Speech to Text`_ (`Speech to Text README`_, `Speech to Text Documentation`_)
--  `Google Cloud Storage`_ (`Storage README`_, `Storage Documentation`_)
--  `Google Cloud Tasks`_ (`Tasks README`_, `Tasks Documentation`_)
--  `Google Cloud Text-to-Speech`_ (`Text-to-Speech README`_, `Text-to-Speech Documentation`_)
--  `Google Cloud Translation`_ (`Translation README`_, `Translation Documentation`_)
--  `Google Cloud Video Intelligence`_ (`Video Intelligence README`_, `Video Intelligence Documentation`_)
--  `Google Cloud Vision`_ (`Vision README`_, `Vision Documentation`_)
--  `Stackdriver Logging`_ (`Logging README`_, `Logging Documentation`_)
--  `Stackdriver Monitoring`_ (`Monitoring README`_, `Monitoring Documentation`_)
-
-.. _Google Cloud Asset: https://pypi.org/project/google-cloud-asset/
-.. _Asset README: https://github.com/googleapis/python-asset
-.. _Asset Documentation: https://googleapis.dev/python/cloudasset/latest
-
-.. _Google Cloud AutoML: https://pypi.org/project/google-cloud-automl/
-.. _AutoML README: https://github.com/googleapis/python-automl
-.. _AutoML Documentation: https://googleapis.dev/python/automl/latest
-
-.. _Google BigQuery: https://pypi.org/project/google-cloud-bigquery/
-.. _BigQuery README: https://github.com/googleapis/python-bigquery#python-client-for-google-bigquery
-.. _BigQuery Documentation: https://googleapis.dev/python/bigquery/latest
-
-.. _Google BigQuery Data Transfer: https://pypi.org/project/google-cloud-bigquery-datatransfer/
-.. _BigQuery Data Transfer README: https://github.com/googleapis/python-bigquery-datatransfer
-.. _BigQuery Data Transfer Documentation: https://googleapis.dev/python/bigquerydatatransfer/latest/index.html
-
-.. _Google BigQuery Storage: https://pypi.org/project/google-cloud-bigquery-storage/
-.. _BigQuery Storage README: https://github.com/googleapis/python-bigquery-storage/
-.. _BigQuery Storage Documentation: https://googleapis.dev/python/bigquerystorage/latest/index.html
-
-.. _Google Cloud Bigtable: https://pypi.org/project/google-cloud-bigtable/
-.. _Bigtable README: https://github.com/googleapis/python-bigtable
-.. _Bigtable Documentation: https://googleapis.dev/python/bigtable/latest
-
-.. _Google Cloud Billing: https://pypi.org/project/google-cloud-billing/
-.. _Billing README: https://github.com/googleapis/python-billing
-.. _Billing Documentation: https://googleapis.dev/python/cloudbilling/latest
-
-.. _Google Cloud Build: https://pypi.org/project/google-cloud-build/
-.. _Cloud Build README: https://github.com/googleapis/python-cloudbuild
-.. _Cloud Build Documentation: https://googleapis.dev/python/cloudbuild/latest
-
-.. _Google Cloud Container: https://pypi.org/project/google-cloud-container/
-.. _Container README: https://github.com/googleapis/python-container
-.. _Container Documentation: https://googleapis.dev/python/container/latest
-
-.. _Google Cloud Container Analysis: https://pypi.org/project/google-cloud-containeranalysis/
-.. _Container Analysis README: https://github.com/googleapis/python-containeranalysis
-.. _Container Analysis Documentation: https://googleapis.dev/python/containeranalysis/latest
-
-.. _Google Cloud Dataproc: https://pypi.org/project/google-cloud-dataproc/
-.. _Dataproc README: https://github.com/googleapis/python-dataproc
-.. _Dataproc Documentation: https://googleapis.dev/python/dataproc/latest
-
-.. _Google Cloud Datastore: https://pypi.org/project/google-cloud-datastore/
-.. _Datastore README: https://github.com/googleapis/python-datastore
-.. _Datastore Documentation: https://googleapis.dev/python/datastore/latest
-
-.. _Google Cloud DLP: https://pypi.org/project/google-cloud-dlp/
-.. _DLP README: https://github.com/googleapis/python-dlp#python-client-for-cloud-data-loss-prevention-dlp-api
-.. _DLP Documentation: https://googleapis.dev/python/dlp/latest
-
-.. _Google Cloud Firestore: https://pypi.org/project/google-cloud-firestore/
-.. _Firestore README: https://github.com/googleapis/python-firestore
-.. _Firestore Documentation: https://googleapis.dev/python/firestore/latest
-
-.. _Google Cloud IAM Credentials: https://pypi.org/project/google-cloud-iam/
-.. _IAM Credentials README: https://github.com/googleapis/python-iam
-.. _IAM Credentials Documentation: https://googleapis.dev/python/iam/latest
-
-.. _Google Cloud IoT: https://pypi.org/project/google-cloud-iot/
-.. _IoT README: https://github.com/googleapis/python-iot/
-.. _IoT Documentation: https://googleapis.dev/python/cloudiot/latest
-
-.. _Google Cloud KMS: https://pypi.org/project/google-cloud-kms/
-.. _KMS README: https://github.com/googleapis/python-kms
-.. _KMS Documentation: https://googleapis.dev/python/cloudkms/latest
-
-.. _Google Cloud Memorystore for Redis: https://pypi.org/project/google-cloud-redis/
-.. _Redis README: https://github.com/googleapis/python-redis
-.. _Redis Documentation: https://googleapis.dev/python/redis/latest
-
-.. _Google Cloud Monitoring Dashboards: https://pypi.org/project/google-cloud-monitoring-dashboards/
-.. _Monitoring Dashboards README: https://github.com/googleapis/python-monitoring-dashboards
-.. _Monitoring Dashboards Documentation: https://googleapis.dev/python/monitoring-dashboards/latest
-
-.. _Google Cloud Natural Language: https://pypi.org/project/google-cloud-language/
-.. _Natural Language README: https://github.com/googleapis/python-language
-.. _Natural Language Documentation: https://googleapis.dev/python/language/latest
-
-.. _Google Cloud OS Login: https://pypi.org/project/google-cloud-os-login/
-.. _OS Login README: https://github.com/googleapis/python-oslogin
-.. _OS Login Documentation: https://googleapis.dev/python/oslogin/latest
-
-.. _Google Cloud Pub/Sub: https://pypi.org/project/google-cloud-pubsub/
-.. _Pub/Sub README: https://github.com/googleapis/python-pubsub
-.. _Pub/Sub Documentation: https://googleapis.dev/python/pubsub/latest
-
-.. _Google Cloud Recommender: https://pypi.org/project/google-cloud-recommender/
-.. _Recommender README: https://github.com/googleapis/python-recommender
-.. _Recommender Documentation: https://googleapis.dev/python/recommender/latest
-
-.. _Google Cloud Scheduler: https://pypi.org/project/google-cloud-scheduler/
-.. _Scheduler README: https://github.com/googleapis/python-scheduler
-.. _Scheduler Documentation: https://googleapis.dev/python/cloudscheduler/latest
-
-.. _Google Cloud Secret Manager: https://pypi.org/project/google-cloud-secret-manager/
-.. _Secret Manager README: https://github.com/googleapis/python-secret-manager
-.. _Secret Manager Documentation: https://googleapis.dev/python/secretmanager/latest
-
-.. _Google Cloud Spanner: https://pypi.org/project/google-cloud-spanner
-.. _Spanner README: https://github.com/googleapis/python-spanner
-.. _Spanner Documentation: https://googleapis.dev/python/spanner/latest
-
-.. _Google Cloud Speech to Text: https://pypi.org/project/google-cloud-speech/
-.. _Speech to Text README: https://github.com/googleapis/python-speech
-.. _Speech to Text Documentation: https://googleapis.dev/python/speech/latest
-
-.. _Google Cloud Storage: https://pypi.org/project/google-cloud-storage/
-.. _Storage README: https://github.com/googleapis/python-storage
-.. _Storage Documentation: https://googleapis.dev/python/storage/latest
-
-.. _Google Cloud Tasks: https://pypi.org/project/google-cloud-tasks/
-.. _Tasks README: https://github.com/googleapis/python-tasks
-.. _Tasks Documentation: https://googleapis.dev/python/cloudtasks/latest
-
-.. _Google Cloud Text-to-Speech: https://pypi.org/project/google-cloud-texttospeech/
-.. _Text-to-Speech README: https://github.com/googleapis/python-texttospeech#python-client-for-cloud-text-to-speech-api
-.. _Text-to-Speech Documentation: https://googleapis.dev/python/texttospeech/latest
-
-.. _Google Cloud Translation: https://pypi.org/project/google-cloud-translate/
-.. _Translation README: https://github.com/googleapis/python-translate#python-client-for-google-cloud-translation
-.. _Translation Documentation: https://googleapis.dev/python/translation/latest
-
-.. _Google Cloud Video Intelligence: https://pypi.org/project/google-cloud-videointelligence
-.. _Video Intelligence README: https://github.com/googleapis/python-videointelligence
-.. _Video Intelligence Documentation: https://googleapis.dev/python/videointelligence/latest
-
-.. _Google Cloud Vision: https://pypi.org/project/google-cloud-vision/
-.. _Vision README: https://github.com/googleapis/python-vision
-.. _Vision Documentation: https://googleapis.dev/python/vision/latest
-
-.. _Stackdriver Logging: https://pypi.org/project/google-cloud-logging/
-.. _Logging README: https://github.com/googleapis/python-logging
-.. _Logging Documentation: https://googleapis.dev/python/logging/latest
-
-.. _Stackdriver Monitoring: https://pypi.org/project/google-cloud-monitoring/
-.. _Monitoring README: https://github.com/googleapis/python-monitoring
-.. _Monitoring Documentation: https://googleapis.dev/python/monitoring/latest
-
 
 Beta Support
 ------------
@@ -212,59 +42,7 @@ Beta Support
 mostly stable and is being prepared for release. Issues and requests
 against beta libraries are addressed with a higher priority.
 
-The following client libraries have **beta** support:
-
--  `Google Cloud Access Approval`_ (`Access Approval README`_, `Access Approval Documentation`_)
--  `Google Cloud Billing Budgets`_ (`Billing Budgets README`_, `Billing Budgets Documentation`_)
--  `Google Cloud Data Catalog`_ (`Data Catalog README`_, `Data Catalog Documentation`_)
--  `Google Cloud Data Labeling`_ (`Data Labeling README`_, `Data Labeling Documentation`_)
--  `Google Cloud Notebooks`_ (`Notebooks README`_, `Notebooks Documentation`_)
--  `Google Cloud OS Config`_ (`OS Config README`_, `OS Config Documentation`_)
--  `Google Cloud Phishing Protection`_ (`Phishing Protection README`_, `Phishing Protection Documentation`_)
--  `Google Cloud Runtime Configuration`_ (`Runtime Config README`_, `Runtime Config Documentation`_)
--  `Google Cloud Talent`_ (`Talent README`_, `Talent Documentation`_)
--  `Stackdriver Error Reporting`_ (`Error Reporting README`_, `Error Reporting Documentation`_)
-
-.. _Google Cloud Access Approval: https://pypi.org/project/google-cloud-access-approval/
-.. _Access Approval README: https://github.com/googleapis/python-access-approval
-.. _Access Approval Documentation: https://googleapis.dev/python/accessapproval/latest
-
-.. _Google Cloud Billing Budgets: https://pypi.org/project/google-cloud-billing-budgets/
-.. _Billing Budgets README: https://github.com/googleapis/python-billingbudgets
-.. _Billing Budgets Documentation: https://googleapis.dev/python/billingbudgets/latest
-
-.. _Google Cloud Data Catalog: https://pypi.org/project/google-cloud-datacatalog/
-.. _Data Catalog README: https://github.com/googleapis/python-datacatalog
-.. _Data Catalog Documentation: https://googleapis.dev/python/datacatalog/latest
-
-.. _Google Cloud Data Labeling: https://pypi.org/project/google-cloud-datalabeling/
-.. _Data Labeling README: https://github.com/googleapis/python-datalabeling#python-client-for-data-labeling-api-beta
-.. _Data Labeling Documentation: https://googleapis.dev/python/datalabeling/latest
-
-.. _Google Cloud Notebooks: https://pypi.org/project/google-cloud-notebooks/
-.. _Notebooks README: https://github.com/googleapis/python-notebooks
-.. _Notebooks Documentation: https://googleapis.dev/python/notebooks/latest
-
-.. _Google Cloud OS Config: https://pypi.org/project/google-cloud-os-config
-.. _OS Config README: https://github.com/googleapis/python-os-config
-.. _OS Config Documentation: https://googleapis.dev/python/osconfig/latest
-
-.. _Google Cloud Phishing Protection: https://pypi.org/project/google-cloud-phishing-protection/
-.. _Phishing Protection README: https://github.com/googleapis/python-phishingprotection
-.. _Phishing Protection Documentation: https://googleapis.dev/python/phishingprotection/latest
-
-.. _Google Cloud Runtime Configuration: https://pypi.org/project/google-cloud-runtimeconfig/
-.. _Runtime Config README: https://github.com/googleapis/python-runtimeconfig
-.. _Runtime Config Documentation: https://googleapis.dev/python/runtimeconfig/latest
-
-.. _Google Cloud Talent: https://pypi.org/project/google-cloud-talent/
-.. _Talent README: https://github.com/googleapis/python-talent
-.. _Talent Documentation: https://googleapis.dev/python/talent/latest
-
-.. _Stackdriver Error Reporting: https://pypi.org/project/google-cloud-error-reporting/
-.. _Error Reporting README: https://github.com/googleapis/python-error-reporting#python-client-for-stackdriver-error-reporting
-.. _Error Reporting Documentation: https://googleapis.dev/python/clouderrorreporting/latest
-
+Beta libraries have development status classifier ``Development Status :: 4 - Beta``.
 
 Alpha Support
 -------------
@@ -273,50 +51,8 @@ Alpha Support
 still a work-in-progress and is more likely to get backwards-incompatible
 updates. See `versioning`_ for more details.
 
-The following client libraries have **alpha** support:
 
--  `Google Cloud Bigtable - HappyBase`_ (`HappyBase README`_, `HappyBase Documentation`_)
--  `Google Cloud DNS`_ (`DNS README`_, `DNS Documentation`_)
--  `Google Cloud Resource Manager`_ (`Resource Manager README`_, `Resource Manager Documentation`_)
--  `Google Cloud Security Command Center`_ (`Security Center README`_, `Security Center Documentation`_)
--  `Google Cloud Security Scanner`_ (`Security Scanner README`_ , `Security Scanner Documentation`_)
--  `Google Cloud Trace`_ (`Trace README`_, `Trace Documentation`_)
--  `Grafeas`_ (`Grafeas README`_, `Grafeas Documentation`_)
--  `Webrisk`_ (`Webrisk README`_, `Webrisk Documentation`_)
-
-.. _Google Cloud Bigtable - HappyBase: https://pypi.org/project/google-cloud-happybase/
-.. _HappyBase README: https://github.com/googleapis/google-cloud-python-happybase
-.. _HappyBase Documentation: https://google-cloud-python-happybase.readthedocs.io/en/latest/
-
-.. _Google Cloud DNS: https://pypi.org/project/google-cloud-dns/
-.. _DNS README: https://github.com/googleapis/python-dns#python-client-for-google-cloud-dns
-.. _DNS Documentation: https://googleapis.dev/python/dns/latest
-
-.. _Google Cloud Resource Manager: https://pypi.org/project/google-cloud-resource-manager/
-.. _Resource Manager README: https://github.com/googleapis/python-resource-manager
-.. _Resource Manager Documentation: https://googleapis.dev/python/cloudresourcemanager/latest
-
-.. _Google Cloud Security Command Center: https://pypi.org/project/google-cloud-securitycenter/
-.. _Security Center README: https://github.com/googleapis/python-securitycenter
-.. _Security Center Documentation: https://googleapis.dev/python/securitycenter/latest/index.html
-
-.. _Google Cloud Security Scanner: https://pypi.org/project/google-cloud-websecurityscanner/
-.. _Security Scanner README: https://github.com/googleapis/google-cloud-python/blob/master/websecurityscanner
-.. _Security Scanner Documentation: https://googleapis.dev/python/websecurityscanner/latest
-
-.. _Google Cloud Trace: https://pypi.org/project/google-cloud-trace/
-.. _Trace README: https://github.com/googleapis/python-trace
-.. _Trace Documentation: https://googleapis.dev/python/cloudtrace/latest
-
-.. _Grafeas: https://pypi.org/project/grafeas/
-.. _Grafeas README: https://github.com/googleapis/python-grafeas#python-client-for-grafeas-api-alpha
-.. _Grafeas Documentation: https://googleapis.dev/python/grafeas/latest
-
-.. _Webrisk: https://pypi.org/project/google-cloud-webrisk
-.. _Webrisk README: https://github.com/googleapis/python-webrisk#python-client-for-web-risk-api-alpha
-.. _Webrisk Documentation: https://googleapis.dev/python/webrisk/latest
-
-.. _versioning: https://github.com/googleapis/google-cloud-python/blob/master/CONTRIBUTING.rst#versioning
+Alpha libraries have development status classifier ``Development Status :: 3 - Alpha``.
 
 If you need support for other Google APIs, check out the
 `Google APIs Python Client library`_.

--- a/README.rst
+++ b/README.rst
@@ -6,9 +6,6 @@ Python idiomatic clients for `Google Cloud Platform`_ services.
 .. _Google Cloud Platform: https://cloud.google.com/
 
 
-See a full list of published libraries at https://cloud.google.com/python/docs/reference.
-
-
 Stability levels
 *******************
 
@@ -60,8 +57,333 @@ If you need support for other Google APIs, check out the
 .. _Google APIs Python Client library: https://github.com/google/google-api-python-client
 
 
+.. API_TABLE_START
+
+.. list-table:: Libraries
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Client
+     - Release Level
+     - Version
+   * - `API client core library <https://github.com/googleapis/python-api-core>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-api-core.svg)
+        :target: https://pypi.org/project/google-api-core
+   * - `API client core library <https://github.com/googleapis/python-cloud-core>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-core.svg)
+        :target: https://pypi.org/project/google-cloud-core
+   * - `Asset Inventory <https://github.com/googleapis/python-asset>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-asset.svg)
+        :target: https://pypi.org/project/google-cloud-asset
+   * - `AutoML <https://github.com/googleapis/python-automl>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-automl.svg)
+        :target: https://pypi.org/project/google-cloud-automl
+   * - `BigQuery <https://github.com/googleapis/python-bigquery>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-bigquery.svg)
+        :target: https://pypi.org/project/google-cloud-bigquery
+   * - `BigQuery Connection <https://github.com/googleapis/python-bigquery-connection>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-connection.svg)
+        :target: https://pypi.org/project/google-cloud-bigquery-connection
+   * - `BigQuery Data Transfer Service <https://github.com/googleapis/python-bigquery-datatransfer>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-datatransfer.svg)
+        :target: https://pypi.org/project/google-cloud-bigquery-datatransfer
+   * - `BigQuery Reservation <https://github.com/googleapis/python-bigquery-reservation>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-reservation.svg)
+        :target: https://pypi.org/project/google-cloud-bigquery-reservation
+   * - `BigQuery Storage <https://github.com/googleapis/python-bigquery-storage>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-storage.svg)
+        :target: https://pypi.org/project/google-cloud-bigquery-storage
+   * - `Bigtable <https://github.com/googleapis/python-bigtable>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-bigtable.svg)
+        :target: https://pypi.org/project/google-cloud-bigtable
+   * - `Billing <https://github.com/googleapis/python-billing>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-billing.svg)
+        :target: https://pypi.org/project/google-cloud-billing
+   * - `Build <https://github.com/googleapis/python-cloudbuild>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-build.svg)
+        :target: https://pypi.org/project/google-cloud-build
+   * - `Container Analysis <https://github.com/googleapis/python-containeranalysis>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-containeranalysis.svg)
+        :target: https://pypi.org/project/google-cloud-containeranalysis
+   * - `Data Catalog <https://github.com/googleapis/python-datacatalog>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-datacatalog.svg)
+        :target: https://pypi.org/project/google-cloud-datacatalog
+   * - `Data Loss Prevention <https://github.com/googleapis/python-dlp>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-dlp.svg)
+        :target: https://pypi.org/project/google-cloud-dlp
+   * - `Dataproc <https://github.com/googleapis/python-dataproc>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-dataproc.svg)
+        :target: https://pypi.org/project/google-cloud-dataproc
+   * - `Datastore <https://github.com/googleapis/python-datastore>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-datastore.svg)
+        :target: https://pypi.org/project/google-cloud-datastore
+   * - `Firestore <https://github.com/googleapis/python-firestore>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-firestore.svg)
+        :target: https://pypi.org/project/google-cloud-firestore
+   * - `Identity and Access Management <https://github.com/googleapis/python-iam>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-iam.svg)
+        :target: https://pypi.org/project/google-cloud-iam
+   * - `Internet of Things (IoT) Core <https://github.com/googleapis/python-iot>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-iot.svg)
+        :target: https://pypi.org/project/google-cloud-iot
+   * - `Key Management Service <https://github.com/googleapis/python-kms>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-kms.svg)
+        :target: https://pypi.org/project/google-cloud-kms
+   * - `Kubernetes Engine <https://github.com/googleapis/python-container>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-container.svg)
+        :target: https://pypi.org/project/google-cloud-container
+   * - `Logging <https://github.com/googleapis/python-logging>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-logging.svg)
+        :target: https://pypi.org/project/google-cloud-logging
+   * - `Monitoring Dashboards <https://github.com/googleapis/python-monitoring-dashboards>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-monitoring-dashboards.svg)
+        :target: https://pypi.org/project/google-cloud-monitoring-dashboards
+   * - `NDB Client Library for Datastore <https://github.com/googleapis/python-ndb>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-ndb.svg)
+        :target: https://pypi.org/project/google-cloud-ndb
+   * - `Natural Language <https://github.com/googleapis/python-language>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-language.svg)
+        :target: https://pypi.org/project/google-cloud-language
+   * - `OS Login <https://github.com/googleapis/python-oslogin>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-os-login.svg)
+        :target: https://pypi.org/project/google-cloud-os-login
+   * - `Pub/Sub <https://github.com/googleapis/python-pubsub>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-pubsub.svg)
+        :target: https://pypi.org/project/google-cloud-pubsub
+   * - `Recommender API <https://github.com/googleapis/python-recommender>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-recommender.svg)
+        :target: https://pypi.org/project/google-cloud-recommender
+   * - `Redis <https://github.com/googleapis/python-redis>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-redis.svg)
+        :target: https://pypi.org/project/google-cloud-redis
+   * - `Scheduler <https://github.com/googleapis/python-scheduler>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-scheduler.svg)
+        :target: https://pypi.org/project/google-cloud-scheduler
+   * - `Secret Manager <https://github.com/googleapis/python-secret-manager>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-secret-manager.svg)
+        :target: https://pypi.org/project/google-cloud-secret-manager
+   * - `Spanner <https://github.com/googleapis/python-spanner>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-spanner.svg)
+        :target: https://pypi.org/project/google-cloud-spanner
+   * - `Speech <https://github.com/googleapis/python-speech>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-speech.svg)
+        :target: https://pypi.org/project/google-cloud-speech
+   * - `Stackdriver Monitoring <https://github.com/googleapis/python-monitoring>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-monitoring.svg)
+        :target: https://pypi.org/project/google-cloud-monitoring
+   * - `Storage <https://github.com/googleapis/python-storage>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-storage.svg)
+        :target: https://pypi.org/project/google-cloud-storage
+   * - `Tasks <https://github.com/googleapis/python-tasks>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-tasks.svg)
+        :target: https://pypi.org/project/google-cloud-tasks
+   * - `Text-to-Speech <https://github.com/googleapis/python-texttospeech>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-texttospeech.svg)
+        :target: https://pypi.org/project/google-cloud-texttospeech
+   * - `Trace <https://github.com/googleapis/python-trace>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-trace.svg)
+        :target: https://pypi.org/project/google-cloud-trace
+   * - `Translation <https://github.com/googleapis/python-translate>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-translate.svg)
+        :target: https://pypi.org/project/google-cloud-translate
+   * - `Video Intelligence <https://github.com/googleapis/python-videointelligence>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-videointelligence.svg)
+        :target: https://pypi.org/project/google-cloud-videointelligence
+   * - `Vision <https://github.com/googleapis/python-vision>`_
+     - |ga|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-vision.svg)
+        :target: https://pypi.org/project/google-cloud-vision
+   * - `AI Platform Notebooks <https://github.com/googleapis/python-notebooks>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-notebooks.svg)
+        :target: https://pypi.org/project/google-cloud-notebooks
+   * - `Access Approval <https://github.com/googleapis/python-access-approval>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-access-approval.svg)
+        :target: https://pypi.org/project/google-cloud-access-approval
+   * - `Assured Workloads for Government <https://github.com/googleapis/python-assured-workloads>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-assured-workflows.svg)
+        :target: https://pypi.org/project/google-cloud-assured-workflows
+   * - `Audit Log <https://github.com/googleapis/python-audit-log>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-audit-log.svg)
+        :target: https://pypi.org/project/google-cloud-audit-log
+   * - `Billing Budget <https://github.com/googleapis/python-billingbudgets>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-billing-budgets.svg)
+        :target: https://pypi.org/project/google-cloud-billing-budgets
+   * - `Binary Authorization <https://github.com/googleapis/python-binary-authorization>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-binary-authorization.svg)
+        :target: https://pypi.org/project/google-cloud-binary-authorization
+   * - `Compute Engine <https://github.com/googleapis/python-compute>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-compute.svg)
+        :target: https://pypi.org/project/google-cloud-compute
+   * - `Data Labeling <https://github.com/googleapis/python-datalabeling>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-datalabeling.svg)
+        :target: https://pypi.org/project/google-cloud-datalabeling
+   * - `Dialogflow CX <https://github.com/googleapis/python-dialogflow-cx>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-dialogflow-cx.svg)
+        :target: https://pypi.org/project/google-cloud-dialogflow-cx
+   * - `Document Understanding API <https://github.com/googleapis/python-documentai>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-documentai.svg)
+        :target: https://pypi.org/project/google-cloud-documentai
+   * - `Error Reporting <https://github.com/googleapis/python-error-reporting>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-error-reporting.svg)
+        :target: https://pypi.org/project/google-cloud-error-reporting
+   * - `Functions <https://github.com/googleapis/python-functions>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-functions.svg)
+        :target: https://pypi.org/project/google-cloud-functions
+   * - `Game Servers <https://github.com/googleapis/python-game-servers>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-game-servers.svg)
+        :target: https://pypi.org/project/google-cloud-game-servers
+   * - `Media Translation <https://github.com/googleapis/python-media-translation>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-media-translation.svg)
+        :target: https://pypi.org/project/google-cloud-media-translation
+   * - `Memorystore for Memcached <https://github.com/googleapis/python-memcache>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-memcache.svg)
+        :target: https://pypi.org/project/google-cloud-memcache
+   * - `Phishing Protection <https://github.com/googleapis/python-phishingprotection>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-phishingprotection.svg)
+        :target: https://pypi.org/project/google-cloud-phishingprotection
+   * - `Private Certificate Authority <https://github.com/googleapis/python-security-private-ca>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-security-private-ca.svg)
+        :target: https://pypi.org/project/google-cloud-security-private-ca
+   * - `Pub/Sub Lite <https://github.com/googleapis/python-pubsublite>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-pubsublite.svg)
+        :target: https://pypi.org/project/google-cloud-pubsublite
+   * - `Python Test Utils for Cloud <https://github.com/googleapis/python-test-utils>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-testutils.svg)
+        :target: https://pypi.org/project/google-cloud-testutils
+   * - `Recommendations AI <https://github.com/googleapis/python-recommendations-ai>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-recommendations-ai.svg)
+        :target: https://pypi.org/project/google-cloud-recommendations-ai
+   * - `Runtime Configurator <https://github.com/googleapis/python-runtimeconfig>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-runtimeconfig.svg)
+        :target: https://pypi.org/project/google-cloud-runtimeconfig
+   * - `Service Directory <https://github.com/googleapis/python-service-directory>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-service-directory.svg)
+        :target: https://pypi.org/project/google-cloud-service-directory
+   * - `Talent Solution <https://github.com/googleapis/python-talent>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-talent.svg)
+        :target: https://pypi.org/project/google-cloud-talent
+   * - `Transcoder <https://github.com/googleapis/python-video-transcoder>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-video-transcoder.svg)
+        :target: https://pypi.org/project/google-cloud-video-transcoder
+   * - `Workflows <https://github.com/googleapis/python-workflows>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-workflows.svg)
+        :target: https://pypi.org/project/google-cloud-workflows
+   * - `reCAPTCHA Enterprise <https://github.com/googleapis/python-recaptcha-enterprise>`_
+     - |beta|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-recpatcha-enterprise.svg)
+        :target: https://pypi.org/project/google-cloud-recpatcha-enterprise
+   * - `Analytics Admin <https://github.com/googleapis/python-analytics-admin>`_
+     - |alpha|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-analytics-admin.svg)
+        :target: https://pypi.org/project/google-analytics-admin
+   * - `Analytics Data API <https://github.com/googleapis/python-analytics-data>`_
+     - |alpha|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-analytics-data.svg)
+        :target: https://pypi.org/project/google-analytics-data
+   * - `Area 120 Tables API <https://github.com/googleapis/python-area120-tables>`_
+     - |alpha|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-area120-tables.svg)
+        :target: https://pypi.org/project/google-area120-tables
+   * - `DNS <https://github.com/googleapis/python-dns>`_
+     - |alpha|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-dns.svg)
+        :target: https://pypi.org/project/google-cloud-dns
+   * - `Data QnA <https://github.com/googleapis/python-data-qna>`_
+     - |alpha|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-data-qna.svg)
+        :target: https://pypi.org/project/google-cloud-data-qna
+   * - `Grafeas <https://github.com/googleapis/python-grafeas>`_
+     - |alpha|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/grafeas.svg)
+        :target: https://pypi.org/project/grafeas
+   * - `Resource Manager API <https://github.com/googleapis/python-resource-manager>`_
+     - |alpha|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-resource-manager.svg)
+        :target: https://pypi.org/project/google-cloud-resource-manager
+   * - `Security Command Center <https://github.com/googleapis/python-securitycenter>`_
+     - |alpha|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-securitycenter.svg)
+        :target: https://pypi.org/project/google-cloud-securitycenter
+   * - `Security Scanner <https://github.com/googleapis/python-websecurityscanner>`_
+     - |alpha|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-websecurityscanner.svg)
+        :target: https://pypi.org/project/google-cloud-websecurityscanner
+   * - `Web Risk <https://github.com/googleapis/python-webrisk>`_
+     - |alpha|
+     - .. |PyPI| image:: https://img.shields.io/pypi/v/google-cloud-webrisk.svg)
+        :target: https://pypi.org/project/google-cloud-webrisk
+
+.. API_TABLE_END
+
+
 Example Applications
---------------------
+********************
 
 -  `getting-started-python`_ - A sample and `tutorial`_ that demonstrates how to build a complete web application using Cloud Datastore, Cloud Storage, and Cloud Pub/Sub and deploy it to Google App Engine or Google Compute Engine.
 -  `google-cloud-python-expenses-demo`_ - A sample expenses demo using Cloud Datastore and Cloud Storage
@@ -72,7 +394,8 @@ Example Applications
 
 
 Authentication
---------------
+********************
+
 
 With ``google-cloud-python`` we try to make authentication as painless as possible.
 Check out the `Authentication section`_ in our documentation to learn more.
@@ -85,7 +408,8 @@ You may also find the `authentication document`_ shared by all the
 
 
 License
--------
+********************
+
 
 Apache 2.0 - See `the LICENSE`_ for more information.
 

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,0 +1,11 @@
+{
+  "sources": [
+    {
+      "git": {
+        "name": ".",
+        "remote": "git@github.com:googleapis/google-cloud-python.git",
+        "sha": "d81d6c34073bb280933dd46b36c6902ac09b1ccd"
+      }
+    }
+  ]
+}

--- a/synth.py
+++ b/synth.py
@@ -63,7 +63,7 @@ def replace_content_in_readme(content_rows: List[str]) -> None:
             f.write(line)
 
 def client_row(client: CloudClient) -> str:
-    pypi_badge = f".. |PyPI| image:: https://img.shields.io/pypi/v/{client.distribution_name}.svg)\n        :target: https://pypi.org/project/{client.distribution_name}"
+    pypi_badge = f".. |PyPI-{client.distribution_name}| image:: https://img.shields.io/pypi/v/{client.distribution_name}.svg)\n        :target: https://pypi.org/project/{client.distribution_name}"
 
     return [
         f"   * - `{client.title} <https://github.com/{client.repo}>`_\n",

--- a/synth.py
+++ b/synth.py
@@ -82,7 +82,6 @@ def generate_table_contents(clients: List[CloudClient]) -> List[str]:
     content_rows = [
         "\n",
         ".. list-table:: Libraries\n",
-        "   :widths: 25 25 50\n",
         "   :header-rows: 1\n",
         "\n",
         "   * - Client\n",

--- a/synth.py
+++ b/synth.py
@@ -63,12 +63,15 @@ def replace_content_in_readme(content_rows: List[str]) -> None:
             f.write(line)
 
 def client_row(client: CloudClient) -> str:
-    pypi_badge = f".. |PyPI-{client.distribution_name}| image:: https://img.shields.io/pypi/v/{client.distribution_name}.svg)\n        :target: https://pypi.org/project/{client.distribution_name}"
+    pypi_badge = f""".. |PyPI-{client.distribution_name}| image:: https://img.shields.io/pypi/v/{client.distribution_name}.svg)
+     :target: https://pypi.org/project/{client.distribution_name}\n"""
 
-    return [
+    content_row = [
         f"   * - `{client.title} <https://github.com/{client.repo}>`_\n",
         f"     - " + "|" + client.release_level + "|\n"
-        f"     - {pypi_badge}\n"]
+        f"     - |PyPI-{client.distribution_name}|\n"]
+
+    return (content_row, pypi_badge)
 
 def generate_table_contents(clients: List[CloudClient]) -> List[str]:
     content_rows = [
@@ -82,10 +85,13 @@ def generate_table_contents(clients: List[CloudClient]) -> List[str]:
         "     - Version\n",
     ]
 
+    pypi_links = ["\n"]
     for client in clients:
-        content_rows += client_row(client)
+        content_row, pypi_link = client_row(client)
+        content_rows += content_row
+        pypi_links.append(pypi_link)
 
-    return content_rows
+    return content_rows + pypi_links
 
 
 REPO_METADATA_URL_FORMAT = "https://raw.githubusercontent.com/{repo_slug}/master/.repo-metadata.json"
@@ -101,13 +107,15 @@ def client_for_repo(repo_slug) -> Optional[CloudClient]:
 REPO_LIST_JSON = "https://raw.githubusercontent.com/googleapis/sloth/master/repos.json"
 REPO_EXCLUSION = [
     # core libraries
-    "googleapis/python-api-core"
+    "googleapis/python-api-core",
     "googleapis/python-cloud-core",
     # proto only packages
     "googleapis/python-org-policy",
     "googleapis/python-os-config",
     "googleapis/python-access-context-manager",
     "googleapis/python-api-common-protos",
+    # testing utilities
+    "googleapis/python-test-utils"
 ]
 
 def allowed_repo(repo) -> bool:

--- a/synth.py
+++ b/synth.py
@@ -1,0 +1,126 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This script is used to synthesize generated parts of this library."""
+
+from typing import List, Optional
+import requests
+
+class CloudClient:
+    repo: str = None
+    title: str = None
+    release_level: str = None
+    distribution_name: str = None
+
+    def __init__(self, repo: dict):
+        self.repo = repo['repo']
+        # For now, strip out "Google Cloud" to standardize the titles
+        self.title = repo['name_pretty'].replace("Google ", "").replace("Cloud ", "")
+        self.release_level = repo['release_level']
+        self.distribution_name = repo['distribution_name']
+
+    # For sorting, we want to sort by release level, then API pretty_name
+    def __lt__(self, other):
+        if self.release_level == other.release_level:
+            return self.title < other.title
+        
+        return other.release_level < self.release_level
+    
+    def __repr__(self):
+        return repr((self.release_level, self.title))
+
+def replace_content_in_readme(content_rows: List[str]) -> None:
+    START_MARKER = ".. API_TABLE_START"
+    END_MARKER = ".. API_TABLE_END"
+    newlines = []
+    repl_open = False
+    with open("README.rst", "r") as f:
+        for line in f:
+            if not repl_open:
+                newlines.append(line)
+
+            if line.startswith(START_MARKER):
+                repl_open = True
+                newlines = newlines + content_rows
+            elif line.startswith(END_MARKER):
+                newlines.append("\n")
+                newlines.append(line)
+                repl_open = False
+
+    with open("README.rst", "w") as f:
+        for line in newlines:
+            f.write(line)
+
+def client_row(client: CloudClient) -> str:
+    pypi_badge = f".. |PyPI| image:: https://img.shields.io/pypi/v/{client.distribution_name}.svg)\n        :target: https://pypi.org/project/{client.distribution_name}"
+
+    return [
+        f"   * - `{client.title} <https://github.com/{client.repo}>`_\n",
+        f"     - " + "|" + client.release_level + "|\n"
+        f"     - {pypi_badge}\n"]
+
+def generate_table_contents(clients: List[CloudClient]) -> List[str]:
+    content_rows = [
+        "\n",
+        ".. list-table:: Libraries\n",
+        "   :widths: 25 25 50\n",
+        "   :header-rows: 1\n",
+        "\n",
+        "   * - Client\n",
+        "     - Release Level\n",
+        "     - Version\n",
+    ]
+
+    for client in clients:
+        content_rows += client_row(client)
+
+    return content_rows
+
+
+REPO_METADATA_URL_FORMAT = "https://raw.githubusercontent.com/{repo_slug}/master/.repo-metadata.json"
+
+def client_for_repo(repo_slug) -> Optional[CloudClient]:
+    url = REPO_METADATA_URL_FORMAT.format(repo_slug=repo_slug)
+    response = requests.get(url)
+    if response.status_code != requests.codes.ok:
+        return
+    
+    return CloudClient(response.json())
+
+REPO_LIST_JSON = "https://raw.githubusercontent.com/googleapis/sloth/master/repos.json"
+REPO_EXCLUSION = [
+    # core libraries
+    "googleapis/python-api-core"
+    "googleapis/python-cloud-core",
+    # proto only packages
+    "googleapis/python-org-policy",
+    "googleapis/python-os-config",
+    "googleapis/python-access-context-manager",
+    "googleapis/python-api-common-protos",
+]
+
+def allowed_repo(repo) -> bool:
+    return repo['language'] == 'python' and repo['repo'].startswith('googleapis/python-') and repo['repo'] not in REPO_EXCLUSION
+
+    
+def all_clients() -> List[CloudClient]:
+    response = requests.get(REPO_LIST_JSON)
+    clients = [client_for_repo(repo['repo']) for repo in response.json()['repos'] if allowed_repo(repo)]
+    # remove empty clients
+    return [client for client in clients if client] 
+
+
+clients = sorted(all_clients())
+table_contents = generate_table_contents(clients)
+replace_content_in_readme(table_contents)


### PR DESCRIPTION
- Use a lightly modified version of google-cloud-java's [synth.py](https://github.com/googleapis/google-cloud-java/blob/master/synth.py) to generate a table of libraries 
- Edit issue templates to nudge folks towards the split repos. 