### PR TITLE
chore: add migration scripts

### DIFF
--- a/scripts/main_migration/migratemain.sh
+++ b/scripts/main_migration/migratemain.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Run this script in the root of the repo. Warning this bash script will wipe out any uncommitted work.
+# This script also requires the following file migratemainowlbot be placed in the same directory
+git reset --hard
+git clean -dfx
+git checkout master
+git pull
+git pull origin master
+git checkout -b migrate-default-branch-to-main
+sed -i -e 's/master/main/g' .kokoro/*.sh
+sed -i -e 's/blob\/master\/CONTRIBUTING.rst/blob\/main\/CONTRIBUTING.rst/g' CONTRIBUTING.rst
+sed -i -e 's/blob\/master\/noxfile.py/blob\/main\/noxfile.py/g' CONTRIBUTING.rst
+sed -i -e 's/GOOGLE_CLOUD_TESTING_BRANCH="master"/GOOGLE_CLOUD_TESTING_BRANCH="main"/g' CONTRIBUTING.rst
+sed -i -e 's/``master``/``main``/g' CONTRIBUTING.rst
+sed -i -e 's/upstream into master/upstream into main/g' CONTRIBUTING.rst
+sed -i -e 's/upstream\/master/upstream\/main/g' CONTRIBUTING.rst
+curl https://raw.githubusercontent.com/googleapis/google-cloud-python/main-migration/scripts/main_migration/migratemainowlbot -o migratemainowlbot
+sed -i '/the microgenerator has a good coveragerc file/r migratemainowlbot' owlbot.py
+rm migratemainowlbot
+git commit -a -m "docs: migrate default branch from master to main"
+git push origin migrate-default-branch-to-main
+
+

--- a/scripts/main_migration/migratemainowlbot
+++ b/scripts/main_migration/migratemainowlbot
@@ -1,0 +1,53 @@
+# Remove the replacements below once https://github.com/googleapis/synthtool/pull/1188 is merged
+
+# Update googleapis/repo-automation-bots repo to main in .kokoro/*.sh files
+s.replace(".kokoro/*.sh", "repo-automation-bots/tree/master", "repo-automation-bots/tree/main")
+
+# Customize CONTRIBUTING.rst to replace master with main
+s.replace(
+    "CONTRIBUTING.rst",
+    "fetch and merge changes from upstream into master",
+    "fetch and merge changes from upstream into main",
+)
+
+s.replace(
+    "CONTRIBUTING.rst",
+    "git merge upstream/master",
+    "git merge upstream/main",
+)
+
+s.replace(
+    "CONTRIBUTING.rst",
+    """export GOOGLE_CLOUD_TESTING_BRANCH=\"master\"""",
+    """export GOOGLE_CLOUD_TESTING_BRANCH=\"main\"""",
+)
+
+s.replace(
+    "CONTRIBUTING.rst",
+    "remote \(``master``\)",
+    "remote (``main``)",
+)
+
+s.replace(
+    "CONTRIBUTING.rst",
+    "blob/master/CONTRIBUTING.rst",
+    "blob/main/CONTRIBUTING.rst",
+)
+
+s.replace(
+    "CONTRIBUTING.rst",
+    "blob/master/noxfile.py",
+    "blob/main/noxfile.py",
+)
+
+s.replace(
+    "docs/conf.py",
+    "master_doc",
+    "root_doc",
+)
+
+s.replace(
+    "docs/conf.py",
+    "# The master toctree document.",
+    "# The root toctree document.",
+)


### PR DESCRIPTION
Adding migration scripts to a special migration branch.

`scripts/main_migration/migratemain.sh references the URI of `scripts/main_migration/migratemainowlbot`, so that no unzipping is necessary to drive the migration.

To migrate a repo, run:
```bash
curl https://raw.githubusercontent.com/nicain/google-cloud-python/main-migration/scripts/main_migration/migratemain.sh -o migratemain.sh && chmod +x migratemain.sh && migratemain.sh
```
