### PR TITLE
chore: fix path to .OwlBot.yaml

### DIFF
--- a/containers/python-bootstrap-container/entrypoint.sh
+++ b/containers/python-bootstrap-container/entrypoint.sh
@@ -40,7 +40,7 @@ mkdir -p "$WORKSPACE_DIR/$MONO_REPO_NAME/packages/$FOLDER_NAME"
 
 # This is the path to the .OwlBot.yaml that will 
 # be used by the bootstrapping container
-PATH_TO_YAML="packages/$FOLDER_NAME/.github/.OwlBot.yaml"
+PATH_TO_YAML="packages/$FOLDER_NAME/.OwlBot.yaml"
 
 # Write the Path to .OwlBot.yaml in the interContainerVars.json folder
 jq --arg PATH_TO_YAML "$PATH_TO_YAML" '. += {"owlbotYamlPath": $PATH_TO_YAML}' $PATH_TO_CONTAINER_VARS | save_to_temp_then_file $PATH_TO_CONTAINER_VARS


### PR DESCRIPTION
In PR https://github.com/googleapis/google-cloud-python/pull/10682, the owlbot bootstrapper failed to generate a client library because the path to `.OwlBot.yaml` was incorrect. The `.OwlBot.yaml` file is in the root of the directory which contains the package. For example, `packages/google-cloud-discoveryengine/.OwlBot.yaml` not `packages/google-cloud-discoveryengine/.github/.OwlBot.yaml`