### PR TITLE
chore: populate default_version in .repo-metadata.json

### DIFF
--- a/containers/python-bootstrap-container/.repo-metadata.json
+++ b/containers/python-bootstrap-container/.repo-metadata.json
@@ -11,7 +11,7 @@
     "repo": "googleapis/google-cloud-python",
     "distribution_name": "apiPackage",
     "api_id": "apiName.googleapis.com",
-    "default_version": "",
+    "default_version": "apiVersion",
     "codeowner_team": "",
     "api_shortname": "apiName"
 }

--- a/containers/python-bootstrap-container/entrypoint.sh
+++ b/containers/python-bootstrap-container/entrypoint.sh
@@ -33,7 +33,7 @@ cd "$WORKSPACE_DIR/$MONO_REPO_NAME/containers/python-bootstrap-container"
 # Get the version of the API (the value after the last `.`)
 # For example, the `API_VERSION` for `google.cloud.workflows.v1`
 # will be `v1`
-API_VERSION = "$(echo $API_ID | sed 's/.*\.//')"
+API_VERSION="$(echo $API_ID | sed 's/.*\.//')"
 
 # API_ID has the form google.cloud.*.vX or `google.*.*.vX`
 # Replace `.`` with `-` and remove the trailing version

--- a/containers/python-bootstrap-container/entrypoint.sh
+++ b/containers/python-bootstrap-container/entrypoint.sh
@@ -30,8 +30,14 @@ PATH_TO_CONTAINER_VARS="$WORKSPACE_DIR/interContainerVars.json"
 cd "$WORKSPACE_DIR/$MONO_REPO_NAME/containers/python-bootstrap-container"
 
 # API_ID has the form google.cloud.*.vX or `google.*.*.vX`
+# Get the version of the API (the value after the last `.`)
+# For example, the `API_VERSION` for `google.cloud.workflows.v1`
+# will be `v1`
+API_VERSION = "$(echo $API_ID | sed 's/.*\.//')"
+
+# API_ID has the form google.cloud.*.vX or `google.*.*.vX`
 # Replace `.`` with `-` and remove the trailing version
-# For example, the `FOLDER_NAME`` for `google.cloud.workflows.v1`
+# For example, the `FOLDER_NAME` for `google.cloud.workflows.v1`
 # should be `google-cloud-workflows`
 FOLDER_NAME="$(echo $API_ID | sed -E 's/\./-/g' | sed 's/-[^-]*$//')"
 
@@ -81,6 +87,8 @@ DOCS_ROOT_URL=$(jq --arg API_SHORTNAME "$API_SHORTNAME" -r '.apis | to_entries[]
 # Update apiProductDocumentation in .repo-metadata.json
 sed -i -e "s|apiProductDocumentation|$DOCS_ROOT_URL|" "${WORKSPACE_DIR}/${MONO_REPO_NAME}/packages/${FOLDER_NAME}/.repo-metadata.json"
 
-# Update distribution_name in .repo-metadata.json
+# Update apiPackage in .repo-metadata.json
 sed -i -e "s|apiPackage|$FOLDER_NAME|" "${WORKSPACE_DIR}/${MONO_REPO_NAME}/packages/${FOLDER_NAME}/.repo-metadata.json"
 
+# Update apiVersion in .repo-metadata.json
+sed -i -e "s|apiVersion|$API_VERSION|" "${WORKSPACE_DIR}/${MONO_REPO_NAME}/packages/${FOLDER_NAME}/.repo-metadata.json"


### PR DESCRIPTION
This PR fixes an issue where the owlbot post processor fails to run on PRs created by the owlbot bootstrapper. The reason is that `default_version` is not set in `.repo-metadata.json` in those PRs. The `default_version` needs to be set for the post processor to run. The issue can be seen in https://github.com/googleapis/google-cloud-python/pull/10685. I was able to resolve the issue by setting the `default_version` in [this commit](https://github.com/googleapis/google-cloud-python/pull/10685/commits/d449124de3b430b4a87f811820d805c1a0d95840).