### PR TITLE
chore(migration): permit non-zero exit codes when nothing to commit

### DIFF
--- a/scripts/split_repo_migration/single-library.post-process.api-files.sh
+++ b/scripts/split_repo_migration/single-library.post-process.api-files.sh
@@ -208,7 +208,8 @@ ${RM} -f "${PATH_PACKAGE}/${MONOREPO_PACKAGE_NAME}.txt"
 ## START commit changes #############################################
 echo "Committing changes locally"
 ${GIT} add .
-${GIT} commit -am "build: ${MONOREPO_PACKAGE_NAME} migration: adjust owlbot-related files"
+${GIT} commit -am "build: ${MONOREPO_PACKAGE_NAME} migration: adjust owlbot-related files" || \
+  echo "No changes to commit"
 ## END commit changes
 
 popd >& /dev/null # "${PATH_MONOREPO}"


### PR DESCRIPTION
Previously, attempting to commit with no changes, which returns a non-zero code, was causing the script to abort early.
