### PR TITLE
chore(migration): help remember/automate merge-commits of git history

### DIFF
--- a/scripts/split_repo_migration/single-library.git-migrate-history.sh
+++ b/scripts/split_repo_migration/single-library.git-migrate-history.sh
@@ -160,7 +160,7 @@ else
   $EXIT 1
 fi
 
-pushd "${TARGET_REPO}"  # To target repo
+pushd "${TARGET_REPO}" >& /dev/null  # To target repo
 
 # For postprocessing of the batch migration script.
 mkdir -p owl-bot-staging/${DISTRIBUTION_NAME}/${DISTRIBUTION_NAME}
@@ -171,14 +171,14 @@ git commit -m "Trigger owlbot post-processor"
 git push -u origin "${BRANCH}" --force
 
 # create pull request
-if gh --help > /dev/null
+if which gh > /dev/null
 then
-  gh pr create --title "chore(migration): Migrate code from ${SOURCE_REPO} into ${TARGET_PATH}" --body "See #${ISSUE_NUMBER}."
+  gh pr create --title "chore(migration): Migrate code from ${SOURCE_REPO} into ${TARGET_PATH}" --body "See #${ISSUE_NUMBER}. $(echo '\n\nThis PR should be merged with a merge-commit, not a squash-commit, in order to preserve the git history.')"
 else
   hub pull-request -m "migrate code from ${SOURCE_REPO}"
 fi
 
-popd
+popd >& /dev/null
 
 # Some of the post-processing scripts require the ${DISTRIBUTION_NAME}. We
 # output it here so they can use the same value we derived, rather than risking


### PR DESCRIPTION
1. We add a note in the PR body that the PR should be merged and not squashed.
2. We simplify the trailing out put so that we can more easily use the PR URL outputby the `gh` command to scriptify CLI-based merge-commit commands.
