### PR TITLE
chore(migration): allow git tags to be force created when running the migration script

### DIFF
--- a/scripts/split_repo_migration/single-library.post-process.common-files.sh
+++ b/scripts/split_repo_migration/single-library.post-process.common-files.sh
@@ -189,7 +189,7 @@ LRT_VERSION="${RPM_VERSION//\"/}"
 # any of the gapic_version.py files will do: they all match
 LRT_VERSION_FILE="$(find ${MONOREPO_PATH_PACKAGE} -name "gapic_version.py" | head -n 1)"
 LRT_SHA=$(git log --format=oneline ${LRT_VERSION_FILE} | grep release | head -n 1 | awk '{ print $1 }')
-$GIT tag ${MONOREPO_PACKAGE_NAME}-v${LRT_VERSION} ${LRT_SHA}
+$GIT tag -f ${MONOREPO_PACKAGE_NAME}-v${LRT_VERSION} ${LRT_SHA}
 $GIT push --tags
 ## END migrate release tags
 


### PR DESCRIPTION
This PR modifies `scripts/split_repo_migration/single-library.post-process.common-files.sh` to allow git tags to be force created so that the script can be run more than once, in case of failure. 

Another alternative is to move the `git tag` command outside of the `scripts/split_repo_migration/single-library.post-process.common-files.sh` script so that the script can be run more than once if required.