### PR TITLE
chore: update default template

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:893a171e2e7f634eb3dc1f61730507ba199d83012c234568531541a2005a6d41
+  digest: sha256:c1a7cf36e5949106e7772393804ea1e19e38c691c8ad4d3af3faa13c3aedda73


### PR DESCRIPTION
Updating the default template version based on https://github.com/googleapis/synthtool/pull/1832.

Towards b/291087837 🦕