### PR TITLE
fix: set google.ai.generativelanguage_v1beta3 as the default import

### DIFF
--- a/packages/google-ai-generativelanguage/.repo-metadata.json
+++ b/packages/google-ai-generativelanguage/.repo-metadata.json
@@ -11,7 +11,7 @@
   "repo": "googleapis/google-cloud-python",
   "distribution_name": "google-ai-generativelanguage",
   "api_id": "generativelanguage.googleapis.com",
-  "default_version": "v1beta2",
+  "default_version": "v1beta3",
   "codeowner_team": "",
   "api_shortname": "generativelanguage"
 }

--- a/packages/google-ai-generativelanguage/docs/index.rst
+++ b/packages/google-ai-generativelanguage/docs/index.rst
@@ -3,16 +3,8 @@
 .. include:: multiprocessing.rst
 
 This package includes clients for multiple versions of Generative Language API.
-By default, you will get version ``generativelanguage_v1beta2``.
+By default, you will get version ``generativelanguage_v1beta3``.
 
-
-API Reference
--------------
-.. toctree::
-    :maxdepth: 2
-
-    generativelanguage_v1beta2/services
-    generativelanguage_v1beta2/types
 
 API Reference
 -------------
@@ -21,6 +13,14 @@ API Reference
 
     generativelanguage_v1beta3/services
     generativelanguage_v1beta3/types
+
+API Reference
+-------------
+.. toctree::
+    :maxdepth: 2
+
+    generativelanguage_v1beta2/services
+    generativelanguage_v1beta2/types
 
 
 Changelog

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage/__init__.py
@@ -18,29 +18,35 @@ from google.ai.generativelanguage import gapic_version as package_version
 __version__ = package_version.__version__
 
 
-from google.ai.generativelanguage_v1beta2.services.discuss_service.async_client import (
+from google.ai.generativelanguage_v1beta3.services.discuss_service.async_client import (
     DiscussServiceAsyncClient,
 )
-from google.ai.generativelanguage_v1beta2.services.discuss_service.client import (
+from google.ai.generativelanguage_v1beta3.services.discuss_service.client import (
     DiscussServiceClient,
 )
-from google.ai.generativelanguage_v1beta2.services.model_service.async_client import (
+from google.ai.generativelanguage_v1beta3.services.model_service.async_client import (
     ModelServiceAsyncClient,
 )
-from google.ai.generativelanguage_v1beta2.services.model_service.client import (
+from google.ai.generativelanguage_v1beta3.services.model_service.client import (
     ModelServiceClient,
 )
-from google.ai.generativelanguage_v1beta2.services.text_service.async_client import (
+from google.ai.generativelanguage_v1beta3.services.permission_service.async_client import (
+    PermissionServiceAsyncClient,
+)
+from google.ai.generativelanguage_v1beta3.services.permission_service.client import (
+    PermissionServiceClient,
+)
+from google.ai.generativelanguage_v1beta3.services.text_service.async_client import (
     TextServiceAsyncClient,
 )
-from google.ai.generativelanguage_v1beta2.services.text_service.client import (
+from google.ai.generativelanguage_v1beta3.services.text_service.client import (
     TextServiceClient,
 )
-from google.ai.generativelanguage_v1beta2.types.citation import (
+from google.ai.generativelanguage_v1beta3.types.citation import (
     CitationMetadata,
     CitationSource,
 )
-from google.ai.generativelanguage_v1beta2.types.discuss_service import (
+from google.ai.generativelanguage_v1beta3.types.discuss_service import (
     CountMessageTokensRequest,
     CountMessageTokensResponse,
     Example,
@@ -49,20 +55,42 @@ from google.ai.generativelanguage_v1beta2.types.discuss_service import (
     Message,
     MessagePrompt,
 )
-from google.ai.generativelanguage_v1beta2.types.model import Model
-from google.ai.generativelanguage_v1beta2.types.model_service import (
+from google.ai.generativelanguage_v1beta3.types.model import Model
+from google.ai.generativelanguage_v1beta3.types.model_service import (
+    CreateTunedModelMetadata,
+    CreateTunedModelRequest,
+    DeleteTunedModelRequest,
     GetModelRequest,
+    GetTunedModelRequest,
     ListModelsRequest,
     ListModelsResponse,
+    ListTunedModelsRequest,
+    ListTunedModelsResponse,
+    UpdateTunedModelRequest,
 )
-from google.ai.generativelanguage_v1beta2.types.safety import (
+from google.ai.generativelanguage_v1beta3.types.permission import Permission
+from google.ai.generativelanguage_v1beta3.types.permission_service import (
+    CreatePermissionRequest,
+    DeletePermissionRequest,
+    GetPermissionRequest,
+    ListPermissionsRequest,
+    ListPermissionsResponse,
+    TransferOwnershipRequest,
+    TransferOwnershipResponse,
+    UpdatePermissionRequest,
+)
+from google.ai.generativelanguage_v1beta3.types.safety import (
     ContentFilter,
     HarmCategory,
     SafetyFeedback,
     SafetyRating,
     SafetySetting,
 )
-from google.ai.generativelanguage_v1beta2.types.text_service import (
+from google.ai.generativelanguage_v1beta3.types.text_service import (
+    BatchEmbedTextRequest,
+    BatchEmbedTextResponse,
+    CountTextTokensRequest,
+    CountTextTokensResponse,
     Embedding,
     EmbedTextRequest,
     EmbedTextResponse,
@@ -71,12 +99,24 @@ from google.ai.generativelanguage_v1beta2.types.text_service import (
     TextCompletion,
     TextPrompt,
 )
+from google.ai.generativelanguage_v1beta3.types.tuned_model import (
+    Dataset,
+    Hyperparameters,
+    TunedModel,
+    TunedModelSource,
+    TuningExample,
+    TuningExamples,
+    TuningSnapshot,
+    TuningTask,
+)
 
 __all__ = (
     "DiscussServiceClient",
     "DiscussServiceAsyncClient",
     "ModelServiceClient",
     "ModelServiceAsyncClient",
+    "PermissionServiceClient",
+    "PermissionServiceAsyncClient",
     "TextServiceClient",
     "TextServiceAsyncClient",
     "CitationMetadata",
@@ -89,14 +129,34 @@ __all__ = (
     "Message",
     "MessagePrompt",
     "Model",
+    "CreateTunedModelMetadata",
+    "CreateTunedModelRequest",
+    "DeleteTunedModelRequest",
     "GetModelRequest",
+    "GetTunedModelRequest",
     "ListModelsRequest",
     "ListModelsResponse",
+    "ListTunedModelsRequest",
+    "ListTunedModelsResponse",
+    "UpdateTunedModelRequest",
+    "Permission",
+    "CreatePermissionRequest",
+    "DeletePermissionRequest",
+    "GetPermissionRequest",
+    "ListPermissionsRequest",
+    "ListPermissionsResponse",
+    "TransferOwnershipRequest",
+    "TransferOwnershipResponse",
+    "UpdatePermissionRequest",
     "ContentFilter",
     "SafetyFeedback",
     "SafetyRating",
     "SafetySetting",
     "HarmCategory",
+    "BatchEmbedTextRequest",
+    "BatchEmbedTextResponse",
+    "CountTextTokensRequest",
+    "CountTextTokensResponse",
     "Embedding",
     "EmbedTextRequest",
     "EmbedTextResponse",
@@ -104,4 +164,12 @@ __all__ = (
     "GenerateTextResponse",
     "TextCompletion",
     "TextPrompt",
+    "Dataset",
+    "Hyperparameters",
+    "TunedModel",
+    "TunedModelSource",
+    "TuningExample",
+    "TuningExamples",
+    "TuningSnapshot",
+    "TuningTask",
 )

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.3.2"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.3.2"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/rest.py
@@ -395,11 +395,11 @@ class PermissionServiceRestTransport(PermissionServiceTransport):
                 role is a superset of the previous
                 role's permitted operations:
 
-                 - reader can use the resource (e.g.
+                - reader can use the resource (e.g.
                   tuned model) for inference
-                 - writer has reader's permissions and
+                - writer has reader's permissions and
                   additionally can edit and share
-                 - owner has writer's permissions and
+                - owner has writer's permissions and
                   additionally can delete
 
             """
@@ -592,11 +592,11 @@ class PermissionServiceRestTransport(PermissionServiceTransport):
                 role is a superset of the previous
                 role's permitted operations:
 
-                 - reader can use the resource (e.g.
+                - reader can use the resource (e.g.
                   tuned model) for inference
-                 - writer has reader's permissions and
+                - writer has reader's permissions and
                   additionally can edit and share
-                 - owner has writer's permissions and
+                - owner has writer's permissions and
                   additionally can delete
 
             """
@@ -891,11 +891,11 @@ class PermissionServiceRestTransport(PermissionServiceTransport):
                 role is a superset of the previous
                 role's permitted operations:
 
-                 - reader can use the resource (e.g.
+                - reader can use the resource (e.g.
                   tuned model) for inference
-                 - writer has reader's permissions and
+                - writer has reader's permissions and
                   additionally can edit and share
-                 - owner has writer's permissions and
+                - owner has writer's permissions and
                   additionally can delete
 
             """

--- a/packages/google-ai-generativelanguage/samples/generated_samples/snippet_metadata_google.ai.generativelanguage.v1beta2.json
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/snippet_metadata_google.ai.generativelanguage.v1beta2.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-ai-generativelanguage",
-    "version": "0.3.2"
+    "version": "0.1.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
Here are the steps that I followed to generate this PR

- Update the `default_version` in `.repo-metadata.json` here
 https://github.com/googleapis/google-cloud-python/blob/eca60c3027820c97fc12590d0709b8fe3eb54034/packages/google-ai-generativelanguage/.repo-metadata.json#L14
- Work around the docs issue mentioned in https://github.com/googleapis/gapic-generator-python/issues/1776 by applying this change locally
- Build the `v1beta2` and `v1beta3` clients locally in a clone of [googleapis/googleapis](https://github.com/googleapis/googleapis) using `bazel build //google/ai/generativelanguage/v1beta3:ai-generativelanguage-v1beta2-py` and `bazel build //google/ai/generativelanguage/v1beta3:ai-generativelanguage-v1beta3-py`
- Run the docker containers for the owlbot copy-code and owlbot post processor
```
 docker run --rm --user $(id -u):$(id -g)   -v $(pwd):/repo   -v /usr/local/google/home/partheniou/git/googleapis/bazel-bin:/bazel-bin   gcr.io/cloud-devrel-public-resources/owlbot-cli:latest copy-bazel-bin   --config-file=packages/google-apps-script-type/.OwlBot.yaml   --source-dir /bazel-bin --dest /repo
 ```
 
```
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
```

I also had to fix a bug in synthtool for the owlbot post processing: https://github.com/googleapis/synthtool/pull/1861. Without this fix, the [docs/index.rst](https://github.com/googleapis/google-cloud-python/blob/main/packages/google-ai-generativelanguage/docs/index.rst) file would list `v1beta2` as the default import instead of `v1beta3`.

Fixes #11676 🦕