### PR TITLE
chore(migration): allow system tests to be migrated

### DIFF
--- a/scripts/split_repo_migration/single-library.post-process.api-files.sh
+++ b/scripts/split_repo_migration/single-library.post-process.api-files.sh
@@ -127,22 +127,6 @@ EOF
 
 pushd "${PATH_MONOREPO}" >& /dev/null
 
-## START system tests check ########################################
-# variable prefix: TST_*
-
-# If there are integration tests, do not proceed with the script.
-
-TST_MONO_TESTDIR="${MONOREPO_PATH_PACKAGE}/tests/"
-TST_MONO_SYSTEM_DIR="${TST_MONO_TESTDIR}system"
-TST_MONO_SYSTEM_FILE="${TST_MONO_TESTDIR}system.py"
-echo "Checking for system tests in ${TST_MONO_TESTDIR}"
-
-[[ ! -f ${TST_MONO_SYSTEM_FILE} ]] || \
-  { echo "ERROR: ${TST_MONO_SYSTEM_FILE} exists. Need to manually deal with that." ; return -10 ; }
-[[ ! -d ${TST_MONO_SYSTEM_DIR} ]] || \
-  { echo "ERROR: ${TST_MONO_SYSTEM_DIR} exists. Need to manually deal with that." ; return -11 ; }
-## END system tests check
-
 ## START owlbot.yaml migration ########################################
 # variable prefix: OWY_*
 # FIXME: KEEP?

--- a/scripts/split_repo_migration/single-library.post-process.common-files.sh
+++ b/scripts/split_repo_migration/single-library.post-process.common-files.sh
@@ -132,22 +132,6 @@ EOF
 
 pushd "${PATH_MONOREPO}" >& /dev/null
 
-## START system tests check ########################################
-# variable prefix: TST_*
-
-# If there are integration tests, do not proceed with the script.
-
-TST_MONO_TESTDIR="${MONOREPO_PATH_PACKAGE}/tests/"
-TST_MONO_SYSTEM_DIR="${TST_MONO_TESTDIR}system"
-TST_MONO_SYSTEM_FILE="${TST_MONO_TESTDIR}system.py"
-echo "Checking for system tests in ${TST_MONO_TESTDIR}"
-
-[[ ! -f ${TST_MONO_SYSTEM_FILE} ]] || \
-  { echo "ERROR: ${TST_MONO_SYSTEM_FILE} exists. Need to manually deal with that." ; return -10 ; }
-[[ ! -d ${TST_MONO_SYSTEM_DIR} ]] || \
-  { echo "ERROR: ${TST_MONO_SYSTEM_DIR} exists. Need to manually deal with that." ; return -11 ; }
-## END system tests check
-
 ## START release-please config migration ########################################
 # variable prefix: RPC_*
 


### PR DESCRIPTION
Internally, we recently decided to allow migration of a few system tests into this repository, until we have a better overall testing infrastructure in place.