### PR TITLE
build: update owlbot post processor image

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:c1a7cf36e5949106e7772393804ea1e19e38c691c8ad4d3af3faa13c3aedda73
+  digest: sha256:eeaeabb180cbcf1300469ae7621cc1dd24f06b48e4cd2962008bd5150c5f7c1e


### PR DESCRIPTION
This PR updates the post processor image to the latest one which is `gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:eeaeabb180cbcf1300469ae7621cc1dd24f06b48e4cd2962008bd5150c5f7c1e`.

The latest image includes the following fixes:
https://github.com/googleapis/synthtool/pull/1861
https://github.com/googleapis/synthtool/pull/1867

Run the following commands to obtain the latest sha256
```
docker pull gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
```

```
partheniou@partheniou-vm-3:~/git/google-cloud-python$ docker inspect --format='{{.RepoDigests}}' gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
[gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:eeaeabb180cbcf1300469ae7621cc1dd24f06b48e4cd2962008bd5150c5f7c1e]
```