### PR TITLE
build: update post processor image

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:2504e243aeb46a96e5012409500fd35b01b86855bc4b916646d8b179b2908741
+  digest: sha256:590e38040466dced83fa3f0817b8b79723ca3a55ce8c61243d911fe253662f04


### PR DESCRIPTION
This PR updates the post processor image to the latest one which is `gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:590e38040466dced83fa3f0817b8b79723ca3a55ce8c61243d911fe253662f04`.

The latest image includes the following fixes:
https://github.com/googleapis/synthtool/pull/1856
https://github.com/googleapis/synthtool/pull/1881

Run the following commands to obtain the latest sha256
```
docker pull gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
```

```
partheniou@partheniou-vm-3:~$ docker inspect --format='{{.RepoDigests}}' gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
[gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:590e38040466dced83fa3f0817b8b79723ca3a55ce8c61243d911fe253662f04]
```