### PR TITLE
chore: update post processor image

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:11c56ce03d0ada22086790a5f4a3b552b304a1d71554cfeda3372885d390984a
+  digest: sha256:2425930c45520a5acb255bd2876c078681f90e6e259dee2739e86d60a94a2a10

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel
@@ -25,7 +25,7 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: docs
-        PY_VERSION: "3.9"
+        PY_VERSION: "3.10"
       run: |
         ci/run_conditional_tests.sh
   docfx:
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel
@@ -45,6 +45,6 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: docfx
-        PY_VERSION: "3.9"
+        PY_VERSION: "3.10"
       run: |
         ci/run_conditional_tests.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel
@@ -25,13 +25,13 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: lint
-        PY_VERSION: "3.9"
+        PY_VERSION: "3.10"
       run: |
         ci/run_conditional_tests.sh
     - name: Run lint_setup_py
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: lint_setup_py
-        PY_VERSION: "3.9"
+        PY_VERSION: "3.10"
       run: |
         ci/run_conditional_tests.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,10 @@ jobs:
         id: date
         run: echo "::set-output name=current_date::$(date +'%Y-%m-%d')"
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install script dependencies
         run: pip3 install -r requirements.txt
         working-directory: ./scripts

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install pytest
       run: |
         python -m pip install pytest


### PR DESCRIPTION
This PR updates the post processor image to the latest one which is `gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:2425930c45520a5acb255bd2876c078681f90e6e259dee2739e86d60a94a2a10`.

The latest image includes the following fix to update the default python version to 3.10 in `noxfile.py`:
https://github.com/googleapis/synthtool/pull/1891

Run the following commands to obtain the latest sha256
```
docker pull gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
```

```
partheniou@partheniou-vm-3:~/git/google-cloud-python$ docker inspect --format='{{.RepoDigests}}' gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
[gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:2425930c45520a5acb255bd2876c078681f90e6e259dee2739e86d60a94a2a10]
```
