### PR TITLE
build: Update common.cfg

### DIFF
--- a/.kokoro/docs/common.cfg
+++ b/.kokoro/docs/common.cfg
@@ -1,5 +1,8 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
+# Build timeout set for 24 hours.
+timeout_mins: 1440
+
 # Build logs will be here
 action {
   define_artifacts {


### PR DESCRIPTION
The default timeout for Kokoro jobs is 3 hours. Specifying the timeout will help increase it to 24 hours.

24 should be good for all latest versions for the foreseeable future. We can increase it now, or try to optimize it in the future if we run into the problem again.

Fixes #12084 🦕