### PR TITLE
ci: free up resources in docfx build

### DIFF
--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -59,6 +59,11 @@ case ${TEST_TYPE} in
         ;;
     docfx)
         nox -s docfx
+        # Clean up built docs and python cache after the build process to avoid
+        # `[Errno 28] No space left on device`
+        # See https://github.com/googleapis/google-cloud-python/issues/12271
+        rm -rf docs/_build
+        find . | grep -E "(__pycache__)" | xargs rm -rf
         retval=$?
         ;;
     prerelease)


### PR DESCRIPTION
Similar to https://github.com/googleapis/google-cloud-python/pull/12273, we also need to free up resources in the docfx build.