### PR TITLE
ci: resolve issue where docs failures do not appear in presubmits

### DIFF
--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -50,6 +50,8 @@ case ${TEST_TYPE} in
         ;;
     docs)
         nox -s docs
+        # This line needs to be directly after `nox -s docs` in order
+        # for the failure to appear in Github presubmits
         retval=$?
         # Clean up built docs and python cache after the build process to avoid
         # `[Errno 28] No space left on device`
@@ -59,6 +61,8 @@ case ${TEST_TYPE} in
         ;;
     docfx)
         nox -s docfx
+        # This line needs to be directly after `nox -s docfx` in order
+        # for the failure to appear in Github presubmits
         retval=$?
         # Clean up built docs and python cache after the build process to avoid
         # `[Errno 28] No space left on device`

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -50,21 +50,21 @@ case ${TEST_TYPE} in
         ;;
     docs)
         nox -s docs
+        retval=$?
         # Clean up built docs and python cache after the build process to avoid
         # `[Errno 28] No space left on device`
         # See https://github.com/googleapis/google-cloud-python/issues/12271
         rm -rf docs/_build
         find . | grep -E "(__pycache__)" | xargs rm -rf
-        retval=$?
         ;;
     docfx)
         nox -s docfx
+        retval=$?
         # Clean up built docs and python cache after the build process to avoid
         # `[Errno 28] No space left on device`
         # See https://github.com/googleapis/google-cloud-python/issues/12271
         rm -rf docs/_build
         find . | grep -E "(__pycache__)" | xargs rm -rf
-        retval=$?
         ;;
     prerelease)
         nox -s prerelease_deps-3.12


### PR DESCRIPTION
A bug was introduced in https://github.com/googleapis/google-cloud-python/pull/12273 and https://github.com/googleapis/google-cloud-python/pull/12274 which prevents docs failures from appearing in presubmits