### PR TITLE
fix: make google-cloud-monitoring tests work without `mock`

### DIFF
--- a/packages/google-cloud-monitoring/tests/unit/test_query.py
+++ b/packages/google-cloud-monitoring/tests/unit/test_query.py
@@ -16,13 +16,7 @@ from __future__ import absolute_import
 
 import datetime
 import unittest
-
-# try/except added for compatibility with python < 3.8
-try:
-    from unittest import mock
-    from unittest.mock import AsyncMock  # pragma: NO COVER
-except ImportError:  # pragma: NO COVER
-    import mock
+from unittest import mock
 
 from google.cloud import monitoring_v3 as monitoring_v3
 from google.cloud.monitoring_v3 import MetricServiceClient

--- a/packages/google-cloud-monitoring/tests/unit/test_query.py
+++ b/packages/google-cloud-monitoring/tests/unit/test_query.py
@@ -17,7 +17,12 @@ from __future__ import absolute_import
 import datetime
 import unittest
 
-import mock
+# try/except added for compatibility with python < 3.8
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    import mock
 
 from google.cloud import monitoring_v3 as monitoring_v3
 from google.cloud.monitoring_v3 import MetricServiceClient


### PR DESCRIPTION
https://pypi.org/project/mock/ library is not needed anymore on modern
Python installation, since it is now part of the Python standard
library, available as `unittest.mock`.

Reuse approach used in generated `tests/unit/gapic/monitoring_v3/` for
manually written `tests/unit/test_query.py`.

This issue and solution was found as a part of packaging the library for
Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=2263960.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #12316 🦕
