### PR TITLE
chore: fix docs build in google-cloud-datacatalog 

### DIFF
--- a/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/usage.py
+++ b/packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/usage.py
@@ -37,7 +37,7 @@ class UsageStats(proto.Message):
     - The usage stats only include BigQuery query jobs
     - The usage stats might be underestimated, e.g. wildcard table
       references are not yet counted in usage computation
-    https://cloud.google.com/bigquery/docs/querying-wildcard-tables
+      https://cloud.google.com/bigquery/docs/querying-wildcard-tables
 
     Attributes:
         total_completions (float):


### PR DESCRIPTION
Towards https://github.com/googleapis/google-cloud-python/issues/12326 🦕

See https://github.com/googleapis/gapic-generator-python/issues/1776