### PR TITLE
chore: fix docs build in google-geo-type

### DIFF
--- a/packages/google-geo-type/docs/index.rst
+++ b/packages/google-geo-type/docs/index.rst
@@ -1,7 +1,21 @@
-API Reference
--------------
-.. toctree::
-    :maxdepth: 2
+      .. include:: README.rst
 
-    type/services
-    type/types
+      .. include:: multiprocessing.rst
+
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          type/services_
+          type/types_
+
+      Changelog
+      ---------
+
+      For a list of all ``google-geo-type`` releases:
+
+      .. toctree::
+          :maxdepth: 2
+
+          CHANGELOG

--- a/packages/google-geo-type/docs/index.rst
+++ b/packages/google-geo-type/docs/index.rst
@@ -1,21 +1,21 @@
-      .. include:: README.rst
+.. include:: README.rst
 
-      .. include:: multiprocessing.rst
+.. include:: multiprocessing.rst
 
-      API Reference
-      -------------
-      .. toctree::
-          :maxdepth: 2
+API Reference
+-------------
+.. toctree::
+    :maxdepth: 2
 
-          type/services_
-          type/types_
+    type/services_
+    type/types_
 
-      Changelog
-      ---------
+Changelog
+---------
 
-      For a list of all ``google-geo-type`` releases:
+For a list of all ``google-geo-type`` releases:
 
-      .. toctree::
-          :maxdepth: 2
+.. toctree::
+    :maxdepth: 2
 
-          CHANGELOG
+    CHANGELOG


### PR DESCRIPTION
Towards https://github.com/googleapis/google-cloud-python/issues/12326 🦕

See https://github.com/googleapis/gapic-generator-python/issues/1776