### PR TITLE
chore(docs): Update .repo-metadata.json for backupdr

### DIFF
--- a/packages/google-cloud-backupdr/.repo-metadata.json
+++ b/packages/google-cloud-backupdr/.repo-metadata.json
@@ -3,7 +3,7 @@
     "name_pretty": "Backup and DR Service API",
     "api_description": "Backup and DR Service ensures that your data is managed, protected, and accessible using both hybrid and cloud-based backup/recovery appliances that are managed using the Backup and DR management console.",
     "product_documentation": "https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr",
-    "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-backupdr/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/backupdr/latest",
     "issue_tracker": "https://issuetracker.google.com/issues/new?component=966572",
     "release_level": "preview",
     "language": "python",


### PR DESCRIPTION
Updating the repo.metadata.json for documentation path: https://cloud.google.com/python/docs/reference/backupdr/latest

The current link doesn't work.

Please let me know if this can be manually fixed or if it needs to be updated from the serviceconfigs.