### PR TITLE
build: Trigger presubmit workflows on GitHub merge queue events

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - main
   # Trigger workflow on GitHub merge queue events
-  # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository
+  # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
   merge_group:
     types: [checks_requested]
 name: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,10 @@ on:
   pull_request:
     branches:
       - main
+  # Trigger workflow on GitHub merge queue events
+  # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository
+  merge_group:
+    types: [checks_requested]
 name: docs
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - main
   # Trigger workflow on GitHub merge queue events
-  # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository
+  # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
   merge_group:
     types: [checks_requested]
 name: lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ on:
   pull_request:
     branches:
       - main
+  # Trigger workflow on GitHub merge queue events
+  # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository
+  merge_group:
+    types: [checks_requested]
 name: lint
 
 permissions:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - main
   # Trigger workflow on GitHub merge queue events
-  # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository
+  # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
   merge_group:
     types: [checks_requested]
 name: unittest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -2,6 +2,10 @@ on:
   pull_request:
     branches:
       - main
+  # Trigger workflow on GitHub merge queue events
+  # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository
+  merge_group:
+    types: [checks_requested]
 name: unittest
 
 permissions:


### PR DESCRIPTION
Googlers see approved doc in b/300959810

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group which mentions the following:

>More than one activity type triggers this event. Although only the checks_requested activity type is supported, specifying the activity type will keep your workflow specific if more activity types are added in the future. 

>If your repository uses GitHub Actions to perform required checks on pull requests in your repository, you need to update the workflows to include the merge_group event as an additional trigger. Otherwise, status checks will not be triggered when you add a pull request to a merge queue. The merge will fail as the required status check will not be reported. The merge_group event is separate from the pull_request and push events.
