### PR TITLE
build: update to the latest post processor image

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:75836d6965f6e772ae0e7bdece6781ffab91bda27392909be4a5acb954de2cfc
+  digest: sha256:93fe03a099be9aa70157b95f5600473602d53b34983488ccdcd37cecb6a9ba3e

--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:1f42c1d6b70210540f55110662ae80e22b03dfb897782b09e546148599d3336c
+  digest: sha256:75836d6965f6e772ae0e7bdece6781ffab91bda27392909be4a5acb954de2cfc


### PR DESCRIPTION
This PR updates the post processor image to the latest one which is `gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:93fe03a099be9aa70157b95f5600473602d53b34983488ccdcd37cecb6a9ba3e`.

The latest image updates `noxfile.py` to test all 3 protobuf implementations `upb`, `python` and `cpp`. See https://github.com/googleapis/synthtool/pull/1974

Run the following commands to obtain the latest sha256
```
docker pull gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
```

```
docker inspect --format='{{.RepoDigests}}' gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
[gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:93fe03a099be9aa70157b95f5600473602d53b34983488ccdcd37cecb6a9ba3e]
```
