### PR TITLE
build: clean up __pycache__ directories

### DIFF
--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -57,7 +57,6 @@ case ${TEST_TYPE} in
         # `[Errno 28] No space left on device`
         # See https://github.com/googleapis/google-cloud-python/issues/12271
         rm -rf docs/_build
-        find . | grep -E "(__pycache__)" | xargs rm -rf
         ;;
     docfx)
         nox -s docfx
@@ -68,7 +67,6 @@ case ${TEST_TYPE} in
         # `[Errno 28] No space left on device`
         # See https://github.com/googleapis/google-cloud-python/issues/12271
         rm -rf docs/_build
-        find . | grep -E "(__pycache__)" | xargs rm -rf
         ;;
     prerelease)
         nox -s prerelease_deps-3.12
@@ -104,5 +102,9 @@ case ${TEST_TYPE} in
             ;;
         esac
 esac
+
+# Clean up `__pycache__` directories to avoid error `No space left on device`
+# seen when running tests in Github Actions
+find . | grep -E "(__pycache__)" | xargs rm -rf
 
 exit ${retval}


### PR DESCRIPTION
This PR fixes the `No space left on device` error seen in presubmits in https://github.com/googleapis/google-cloud-python/pull/12860 

The specific failure can be seen in [this presubmit run](https://github.com/googleapis/google-cloud-python/actions/runs/9797847588?pr=12860)

I tested the fix in https://github.com/googleapis/google-cloud-python/pull/12875
