### PR TITLE
build: clean up .nox directory

### DIFF
--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -103,8 +103,9 @@ case ${TEST_TYPE} in
         esac
 esac
 
-# Clean up `__pycache__` directories to avoid error `No space left on device`
-# seen when running tests in Github Actions
+# Clean up `__pycache__` and `.nox` directories to avoid error
+# `No space left on device` seen when running tests in Github Actions
 find . | grep -E "(__pycache__)" | xargs rm -rf
+rm -rf .nox
 
 exit ${retval}


### PR DESCRIPTION
The `.nox` directory is created when `nox` is run and is more than 100MB for some packages. This PR removes the `.nox` directory after presubmit tests run to free up disk space.

As an example,
1. cd to `packages/google-cloud-access-approval`
2. run `nox -s unit-3.9`
3. run `du -sh .nox` which shows the directory is 152 MB