### PR TITLE
chore(docs): add doc formatting post-processing fixes

### DIFF
--- a/packages/google-ai-generativelanguage/scripts/client-post-processing/doc-formatting.yaml
+++ b/packages/google-ai-generativelanguage/scripts/client-post-processing/doc-formatting.yaml
@@ -1,0 +1,1 @@
+../../../../scripts/client-post-processing/doc-formatting.yaml

--- a/packages/google-cloud-datacatalog/scripts/client-post-processing/doc-formatting.yaml
+++ b/packages/google-cloud-datacatalog/scripts/client-post-processing/doc-formatting.yaml
@@ -1,0 +1,1 @@
+../../../../scripts/client-post-processing/doc-formatting.yaml

--- a/packages/google-cloud-edgenetwork/scripts/client-post-processing/doc-formatting.yaml
+++ b/packages/google-cloud-edgenetwork/scripts/client-post-processing/doc-formatting.yaml
@@ -1,0 +1,1 @@
+../../../../scripts/client-post-processing/doc-formatting.yaml

--- a/packages/google-cloud-network-connectivity/scripts/client-post-processing/doc-formatting.yaml
+++ b/packages/google-cloud-network-connectivity/scripts/client-post-processing/doc-formatting.yaml
@@ -1,0 +1,1 @@
+../../../../scripts/client-post-processing/doc-formatting.yaml

--- a/packages/google-cloud-retail/scripts/client-post-processing/doc-formatting.yaml
+++ b/packages/google-cloud-retail/scripts/client-post-processing/doc-formatting.yaml
@@ -1,0 +1,1 @@
+../../../../scripts/client-post-processing/doc-formatting.yaml

--- a/packages/google-cloud-securitycentermanagement/scripts/client-post-processing/doc-formatting.yaml
+++ b/packages/google-cloud-securitycentermanagement/scripts/client-post-processing/doc-formatting.yaml
@@ -1,0 +1,1 @@
+../../../../scripts/client-post-processing/doc-formatting.yaml

--- a/packages/google-cloud-visionai/scripts/client-post-processing/doc-formatting.yaml
+++ b/packages/google-cloud-visionai/scripts/client-post-processing/doc-formatting.yaml
@@ -1,0 +1,1 @@
+../../../../scripts/client-post-processing/doc-formatting.yaml

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -58,8 +58,9 @@ replacements:
   - paths: [
       packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/resources.py,
     ]
-    before: " 14 years, 51 weeks, 6 days, 23 hours, 59"
-    after:  "14 years, 51 weeks, 6 days, 23 hours, 59"
+    before: |
+      \                 14 years, 51 weeks, 6 days, 23 hours, 59
+    after: "                14 years, 51 weeks, 6 days, 23 hours, 59\n"
     count: 1
   - paths: [
       packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/policy_based_routing.py,

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -53,7 +53,7 @@ replacements:
     before: |
       \ usage computation
       \    https://cloud.google.com/bigquery/docs/querying-wildcard-tables
-    after:  " usage computation\n      https://cloud.google.com/bigquery/docs/querying-wildcard-tables"
+    after:  " usage computation\n      https://cloud.google.com/bigquery/docs/querying-wildcard-tables\n"
     count: 1
   - paths: [
       packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/resources.py,

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -42,6 +42,12 @@ replacements:
     after: "`corpora/*/documents/`"
     count: 1
   - paths: [
+      packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever.py,
+    ]
+    before: \"corpora/\*/documents/\*/chunks/\"
+    after: "corpora/*/documents/*/chunks/"
+    count: 1    
+  - paths: [
       packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/usage.py,
     ]
     before: |

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -77,6 +77,13 @@ replacements:
       \            resource. Format: projects/\*/loggingConfig
     after:  "            resource. Format: `projects/*/loggingConfig`\n"
     count: 1
+  - paths: [
+      packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project.py,
+    ]
+    before: |
+      \            resource. Format: projects/\*/alertConfig
+    after:  "            resource. Format: `projects/*/alertConfig`\n"
+    count: 1
   - paths: [    packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py,
     ]
     before: "2. A failure occurred during creation of the\n                module."

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -48,7 +48,8 @@ replacements:
     after: "corpora/*/documents/*/chunks/"
     count: 1    
   - paths: [
-      packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/async_client.py
+      packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/async_client.py,
+      packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/client.py
       ]
     before: |
       \                role's permitted operations:
@@ -62,12 +63,24 @@ replacements:
     after: "                role's permitted operations:\n\n                - reader can use the resource (e.g.\n                  tuned model) for inference\n                - writer has reader's permissions and\n                  additionally can edit and share\n                - owner has writer's permissions and\n                  additionally can delete\n"
     count: 1
   - paths: [
+    packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/permission.py,
+      ]
+    before: |
+      \    previous role's permitted operations:
+      \
+      \     - reader can use the resource (e.g. tuned model) for inference
+      \     - writer has reader's permissions and additionally can edit and
+      \      share
+      \     - owner has writer's permissions and additionally can delete
+    after: "    previous role's permitted operations:\n\n    - reader can use the resource (e.g. tuned model) for inference\n    - writer has reader's permissions and additionally can edit and\n      share\n    - owner has writer's permissions and additionally can delete\n"
+    count: 1
+  - paths: [
       packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/usage.py,
     ]
     before: |
-      \ usage computation
+      \      references are not yet counted in usage computation
       \    https://cloud.google.com/bigquery/docs/querying-wildcard-tables
-    after:  " usage computation\n      https://cloud.google.com/bigquery/docs/querying-wildcard-tables\n"
+    after:  "      references are not yet counted in usage computation\n      https://cloud.google.com/bigquery/docs/querying-wildcard-tables\n"
     count: 1
   - paths: [
       packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/resources.py,
@@ -111,27 +124,41 @@ replacements:
   - paths: [
       packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py,
     ]
-    before: "2. A failure occurred while trying to delete the\n                module."
-    after:  "2. A failure occurred while trying to delete the\n            module."
+    before: |
+      \            module could still fail because 1. the state
+      \            could have changed \(e.g. IAM permission lost\) or
+      \            2. A failure occurred while trying to update the
+      \                module.
+    after:  "            module could still fail because\n\n            - The state could have changed (e.g. IAM permission lost) or\n            - A failure occurred while trying to update the module.\n"
     count: 2
   - paths: [
       packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py,
     ]
-    before: "2. A failure occurred while trying to update the\n                module."
-    after:  "2. A failure occurred while trying to update the\n            module."
-    count: 2    
-  - paths: [    packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py,
+    before: |
+      \            module could still fail because 1. the state
+      \            could have changed \(e.g. IAM permission lost\) or
+      \            2. A failure occurred while trying to delete the
+      \                module.
+    after:  "            module could still fail because\n\n            - The state could have changed (e.g. IAM permission lost) or\n            - A failure occurred while trying to delete the module.\n"
+    count: 2
+  - paths: [
+      packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py,
     ]
-    before: "2. A failure occurred during creation of the\n                module."
-    after:  "2. A failure occurred during creation of the\n            module."
+    before: |
+      \            module could still fail because 1. the state
+      \            could have changed \(e.g. IAM permission lost\) or
+      \            2. A failure occurred during creation of the
+      \                module.
+    after:  "            module could still fail because\n\n            - The state could have changed (e.g. IAM permission lost) or\n            - A failure occurred during creation of the module.\n"
     count: 1
   - paths: [
       packages/google-cloud-visionai/google/cloud/visionai_v1/types/platform.py,
+      packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/platform.py,
     ]
     before: |
-      \'ingestionTime': DOUBLE; \(UNIX timestamp\)
+      \                  'ingestionTime': DOUBLE; \(UNIX timestamp\)
       \            'application': STRING;
-    after: "'ingestionTime': DOUBLE; (UNIX timestamp)\n                  'application': STRING;\n"
+    after: "                  'ingestionTime': DOUBLE; (UNIX timestamp)\n                  'application': STRING;\n"
     count: 1
   - paths: [
     packages/google-cloud-visionai/google/cloud/visionai_v1/types/platform.py,
@@ -140,4 +167,3 @@ replacements:
     after:  "'processor': STRING;\n\n             }\n\n        dynamic_config_input_topic "
     count: 1
 
-    

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -114,8 +114,10 @@ replacements:
   - paths: [
       packages/google-cloud-visionai/google/cloud/visionai_v1/types/platform.py,
     ]
-    before: "'application': STRING;"
-    after:  "      'application': STRING;"
+    before: |
+      \'ingestionTime': DOUBLE; \(UNIX timestamp\)
+      \            'application': STRING;
+    after: "'ingestionTime': DOUBLE; (UNIX timestamp)\n                  'application': STRING;\n"
     count: 1
   - paths: [
     packages/google-cloud-visionai/google/cloud/visionai_v1/types/platform.py,

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -35,3 +35,57 @@ replacements:
     before: \"NS_\"
     after: "`NS_`"
     count: 2
+  - paths: [
+      packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever.py,
+    ]
+    before: "`corpora/*/documents/`"
+    after: "``corpora/*/documents/``"
+    count: 1
+  - paths: [
+      packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/usage.py,
+    ]
+    # this replacement does not seem to work
+    before: |
+      \ usage computation
+      \    https://cloud.google.com/bigquery/docs/querying-wildcard-tables
+    after:  " usage computation\n      https://cloud.google.com/bigquery/docs/querying-wildcard-tables"
+    count: 1
+  - paths: [
+      packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/resources.py,
+    ]
+    # this replacement does not seem to work
+    before: " 14 years, 51 weeks, 6 days, 23 hours, 59"
+    after:  "14 years, 51 weeks, 6 days, 23 hours, 59"
+    count: 1
+  - paths: [
+      packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/policy_based_routing.py,
+    ]
+    # this replacement does not seem to work
+    before: "    65535, inclusive"
+    after:  "65535, inclusive"
+    count: 1
+  - paths: [
+      packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project.py,
+    ]
+    before: "resource. Format: projects/\*/loggingConfig"
+    after:  "resource. Format: `projects/*/loggingConfig`"
+    count: 1
+  - paths: [    packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py,
+    ]
+    before: "2. A failure occurred during creation of the\n                module."
+    after:  "2. A failure occurred during creation of the\n            module."
+    count: 1
+  - paths: [
+    packages/google-cloud-visionai/google/cloud/visionai_v1/types/platform.py,
+    ]
+    before: "'application': STRING;"
+    after:  "      'application': STRING;"
+    count: 1
+  - paths: [
+    packages/google-cloud-visionai/google/cloud/visionai_v1/types/platform.py,
+    ]
+    before: "'processor': STRING;\n             }\n        dynamic_config_input_topic "
+    after:  "'processor': STRING;\n\n             }\n\n        dynamic_config_input_topic "
+    count: 1
+
+    

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -84,6 +84,28 @@ replacements:
       \            resource. Format: projects/\*/alertConfig
     after:  "            resource. Format: `projects/*/alertConfig`\n"
     count: 1
+  - paths: [
+      packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py,
+    ]
+    before: |
+      \             1. the state could have changed \(e.g. IAM
+      \                permission lost\) or
+      \             2. A failure occurred during creation of the
+      \                module. Defaults to false.
+    after:  "            - The state could have changed (e.g. IAM permission lost) or\n            - A failure occurred during creation of the module. Defaults to false.\n"
+    count: 1
+  - paths: [
+      packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py,
+    ]
+    before: "2. A failure occurred while trying to delete the\n                module."
+    after:  "2. A failure occurred while trying to delete the\n            module."
+    count: 2
+  - paths: [
+      packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py,
+    ]
+    before: "2. A failure occurred while trying to update the\n                module."
+    after:  "2. A failure occurred while trying to update the\n            module."
+    count: 2    
   - paths: [    packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py,
     ]
     before: "2. A failure occurred during creation of the\n                module."

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -112,7 +112,7 @@ replacements:
     after:  "2. A failure occurred during creation of the\n            module."
     count: 1
   - paths: [
-    packages/google-cloud-visionai/google/cloud/visionai_v1/types/platform.py,
+      packages/google-cloud-visionai/google/cloud/visionai_v1/types/platform.py,
     ]
     before: "'application': STRING;"
     after:  "      'application': STRING;"

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -45,7 +45,7 @@ replacements:
       packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever.py,
     ]
     before: \"corpora/\*/documents/\*/chunks/\"
-    after: "corpora/*/documents/*/chunks/"
+    after: "`corpora/*/documents/*/chunks/`"
     count: 1    
   - paths: [
       packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/async_client.py,
@@ -61,14 +61,14 @@ replacements:
       \                 - owner has writer's permissions and
       \                  additionally can delete
     after: "                role's permitted operations:\n\n                - reader can use the resource (e.g.\n                  tuned model) for inference\n                - writer has reader's permissions and\n                  additionally can edit and share\n                - owner has writer's permissions and\n                  additionally can delete\n"
-    count: 1
+    count: 6
   - paths: [
     packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/permission.py,
       ]
     before: |
       \    previous role's permitted operations:
       \
-      \     - reader can use the resource (e.g. tuned model) for inference
+      \     - reader can use the resource \(e.g. tuned model\) for inference
       \     - writer has reader's permissions and additionally can edit and
       \      share
       \     - owner has writer's permissions and additionally can delete

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -44,7 +44,6 @@ replacements:
   - paths: [
       packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/usage.py,
     ]
-    # this replacement does not seem to work
     before: |
       \ usage computation
       \    https://cloud.google.com/bigquery/docs/querying-wildcard-tables
@@ -53,14 +52,12 @@ replacements:
   - paths: [
       packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/resources.py,
     ]
-    # this replacement does not seem to work
     before: " 14 years, 51 weeks, 6 days, 23 hours, 59"
     after:  "14 years, 51 weeks, 6 days, 23 hours, 59"
     count: 1
   - paths: [
       packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/policy_based_routing.py,
     ]
-    # this replacement does not seem to work
     before: "    65535, inclusive"
     after:  "65535, inclusive"
     count: 1

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -65,8 +65,10 @@ replacements:
   - paths: [
       packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/policy_based_routing.py,
     ]
-    before: "    65535, inclusive"
-    after:  "65535, inclusive"
+    before: |
+      \            1000. The priority value must be from 1 to
+      \                65535, inclusive.
+    after: "            1000. The priority value must be from 1 to\n            65535, inclusive.\n"
     count: 1
   - paths: [
       packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project.py,

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -73,8 +73,9 @@ replacements:
   - paths: [
       packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project.py,
     ]
-    before: "resource. Format: projects/\*/loggingConfig"
-    after:  "resource. Format: `projects/*/loggingConfig`"
+    before: |
+      \            resource. Format: projects/\*/loggingConfig
+    after:  "            resource. Format: `projects/*/loggingConfig`\n"
     count: 1
   - paths: [    packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py,
     ]

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -48,6 +48,24 @@ replacements:
     after: "corpora/*/documents/*/chunks/"
     count: 1    
   - paths: [
+      packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/async_client.py
+      ]
+    before: |
+      \                 - reader can use the resource (e.g.
+      \                  tuned model) for inference
+      \                 - writer has reader's permissions and
+      \                  additionally can edit and share
+      \                 - owner has writer's permissions and
+      \                  additionally can delete
+    after: |
+      \                 - reader can use the resource (e.g.
+      \                   tuned model) for inference
+      \                 - writer has reader's permissions and
+      \                   additionally can edit and share
+      \                 - owner has writer's permissions and
+      \                   additionally can delete
+    count: 1    
+  - paths: [
       packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/usage.py,
     ]
     before: |

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -59,16 +59,8 @@ replacements:
       \                  additionally can edit and share
       \                 - owner has writer's permissions and
       \                  additionally can delete
-    after: |
-      \                role's permitted operations:
-      \
-      \                - reader can use the resource (e.g.
-      \                  tuned model) for inference
-      \                - writer has reader's permissions and
-      \                  additionally can edit and share
-      \                - owner has writer's permissions and
-      \                  additionally can delete
-    count: 1    
+    after: "                role's permitted operations:\n\n                - reader can use the resource (e.g.\n                  tuned model) for inference\n                - writer has reader's permissions and\n                  additionally can edit and share\n                - owner has writer's permissions and\n                  additionally can delete\n"
+    count: 1
   - paths: [
       packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/usage.py,
     ]

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -38,8 +38,8 @@ replacements:
   - paths: [
       packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever.py,
     ]
-    before: "`corpora/*/documents/`"
-    after: "``corpora/*/documents/``"
+    before: \"corpora/\*/documents/\"
+    after: "`corpora/*/documents/`"
     count: 1
   - paths: [
       packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/usage.py,

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -51,6 +51,8 @@ replacements:
       packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/async_client.py
       ]
     before: |
+      \                role's permitted operations:
+      \
       \                 - reader can use the resource (e.g.
       \                  tuned model) for inference
       \                 - writer has reader's permissions and
@@ -58,12 +60,14 @@ replacements:
       \                 - owner has writer's permissions and
       \                  additionally can delete
     after: |
-      \                 - reader can use the resource (e.g.
-      \                   tuned model) for inference
-      \                 - writer has reader's permissions and
-      \                   additionally can edit and share
-      \                 - owner has writer's permissions and
-      \                   additionally can delete
+      \                role's permitted operations:
+      \
+      \                - reader can use the resource (e.g.
+      \                  tuned model) for inference
+      \                - writer has reader's permissions and
+      \                  additionally can edit and share
+      \                - owner has writer's permissions and
+      \                  additionally can delete
     count: 1    
   - paths: [
       packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/usage.py,

--- a/scripts/client-post-processing/doc-formatting.yaml
+++ b/scripts/client-post-processing/doc-formatting.yaml
@@ -53,8 +53,8 @@ replacements:
     before: |
       \                role's permitted operations:
       \
-      \                 - reader can use the resource (e.g.
-      \                  tuned model) for inference
+      \                 - reader can use the resource \(e.g.
+      \                  tuned model\) for inference
       \                 - writer has reader's permissions and
       \                  additionally can edit and share
       \                 - owner has writer's permissions and


### PR DESCRIPTION
This attempts to configure post-processing for the repeated docs failures we're seeing. This is a short-term workaround, listing the individual cases with violations.

We envision eventually implementing  a proper fix, probably involving stricter upstream standards, but that will take a while, and these failures are drudge work at the moment.

Note that I was only able to apply the first of these changes in my local client to the cloned PRs that were generating these errors; I'm not sure what's wrong with my incantation. Feedback welcome!

(At the very least, this is a listing of the specific docs fixes we need to implement.)