### PR TITLE
Add Documentation link in README of google-ai-generativelanguage

### DIFF
--- a/packages/google-ai-generativelanguage/README.rst
+++ b/packages/google-ai-generativelanguage/README.rst
@@ -18,6 +18,11 @@ Python Client for Generative Language API
 .. _Client Library Documentation: https://googleapis.dev/python/generativelanguage/latest
 .. _Product Documentation:  https://ai.google.dev/docs
 
+Documentation
+-------------
+
+See the `docs folder <https://github.com/googleapis/google-cloud-python/tree/main/packages/google-ai-generativelanguage/docs>`_ for additional documentation.
+
 Quick Start
 -----------
 


### PR DESCRIPTION
Add Documentation link in README of google-ai-generativelanguage

When I try to package google-ai-generativelanguage, one reviewer told me that your pypi release lacks docs.
And its GitHub release lacks setup.py or pyproject.toml.
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1085071

I suggest you to add docs for its pypi release and add a link in README, thanks.
