### PR TITLE
build: use ubuntu 22.04 for tests

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   unit:
+    # TODO(https://github.com/googleapis/gapic-generator-python/issues/2303): use `ubuntu-latest` once this bug is fixed.
     # Use ubuntu-22.04 until Python 3.7 is removed from the test matrix
     # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
     runs-on: ubuntu-22.04

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -13,7 +13,9 @@ permissions:
 
 jobs:
   unit:
-    runs-on: ubuntu-latest
+    # Use ubuntu-22.04 until Python 3.7 is removed from the test matrix
+    # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python: ['3.7', '3.8', '3.9', '3.10', "3.11", "3.12", "3.13"]

--- a/packages/google-cloud-servicehealth/CHANGELOG.md
+++ b/packages/google-cloud-servicehealth/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
- 
+
 ## [0.1.9](https://github.com/googleapis/google-cloud-python/compare/google-cloud-servicehealth-v0.1.8...google-cloud-servicehealth-v0.1.9) (2024-12-12)
 
 

--- a/packages/google-cloud-servicehealth/CHANGELOG.md
+++ b/packages/google-cloud-servicehealth/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-
+ 
 ## [0.1.9](https://github.com/googleapis/google-cloud-python/compare/google-cloud-servicehealth-v0.1.8...google-cloud-servicehealth-v0.1.9) (2024-12-12)
 
 


### PR DESCRIPTION
This PR resolves the following issue [when running Python 3.7 tests](https://github.com/googleapis/google-cloud-python/actions/runs/12406551833/job/34635201044?pr=13374) :

```
  Version 3.7 was not found in the local cache
  Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
```

