### PR TITLE
build: update post processor image

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:db9568404b062e3bcf060fb7db09ca9aa51275d187b0f4ccd5f0071e82e4521a
+  digest: sha256:4ba56619e605bcaa75a87f8122f285bc437ec8e23576e12a3acac3f96f1634fa


### PR DESCRIPTION
Update to the newest version of the post processor which includes the changes from https://github.com/googleapis/synthtool/pull/2058


Run the following commands to obtain the latest sha256
```
docker pull gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
```

```
docker inspect --format='{{.RepoDigests}}' gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
[gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:4ba56619e605bcaa75a87f8122f285bc437ec8e23576e12a3acac3f96f1634fa]
```