### PR TITLE
build: add a new presubmit core_deps_from_source

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -49,11 +49,13 @@ jobs:
       with:
         name: coverage-artifact-${{ '{{' }} matrix.python {{ '}}' }}
         path: .coverage-${{ matrix.python }}
-  prerelease:
+  unit-extended:
+    name: ${{ matrix.option }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.13']
+        python: ["3.13"]
+        option: ["prerelease", "core_deps_from_source"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -70,10 +72,10 @@ jobs:
       run: |
         python -m pip install --upgrade setuptools pip wheel
         python -m pip install nox
-    - name: Run prerelease tests
+    - name: Run ${{ matrix.option }} tests
       env:
         BUILD_TYPE: presubmit
-        TEST_TYPE: prerelease
+        TEST_TYPE: ${{ matrix.option }}
         PY_VERSION: ${{ matrix.python }}
       run: |
         ci/run_conditional_tests.sh

--- a/ci/run_conditional_tests.sh
+++ b/ci/run_conditional_tests.sh
@@ -15,7 +15,8 @@
 
 # This script requires the following environment variables to be set:
 # `BUILD_TYPE` should be one of ["presubmit", "continuous"]
-# `TEST_TYPE` should be one of ["lint", "lint_setup_py", "docs", "docfx", "prerelease", "unit"]
+# `TEST_TYPE` should be one of ["docs", "docfx", "prerelease", "unit"]
+# or match the name of the nox session that you want to run.
 # `PY_VERSION` should be one of ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
 # `TEST_TYPE` and `PY_VERSION` are required by the script `ci/run_single_test.sh`

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -40,14 +40,6 @@ fi
 set +e
 
 case ${TEST_TYPE} in
-    lint)
-        nox -s lint
-        retval=$?
-        ;;
-    lint_setup_py)
-        nox -s lint_setup_py
-        retval=$?
-        ;;
     docs)
         nox -s docs
         # This line needs to be directly after `nox -s docs` in order
@@ -103,9 +95,16 @@ case ${TEST_TYPE} in
             retval=$?
             ;;
         *)
+            echo "unsupported PY_VERSION"
+            exit 1
             ;;
         esac
-esac
+        ;;
+    *)
+        nox -s ${TEST_TYPE}
+        retval=$?
+        ;;
+    esac
 
 # Clean up `__pycache__` and `.nox` directories to avoid error
 # `No space left on device` seen when running tests in Github Actions


### PR DESCRIPTION
This PR adds a new presubmit `core_deps_from_source` which depends on https://github.com/googleapis/synthtool/pull/2061

The presubmit will install core dependencies from source in order to get early feedback on changes made at HEAD of dependencies.