### PR TITLE
build: update .OwlBot.yaml for google-cloud-org-policy

### DIFF
--- a/packages/google-cloud-org-policy/.OwlBot.yaml
+++ b/packages/google-cloud-org-policy/.OwlBot.yaml
@@ -17,7 +17,7 @@ deep-remove-regex:
   - /owl-bot-staging
 
 deep-copy-regex:
-  - source: /google/cloud/orgpolicy/(v1)/.*-py
+  - source: /google/cloud/orgpolicy/(v1)/.*-py/(orgpolicy.*)
     dest: /owl-bot-staging/google-cloud-org-policy/$1/google/cloud/orgpolicy/v1/$2
   - source: /google/cloud/orgpolicy/(v2)/.*-py
     dest: /owl-bot-staging/google-cloud-org-policy/$1


### PR DESCRIPTION
This PR fixes an issue in the `.OwlBot.yaml` for `google-cloud-org-policy` where there is an erroneous folder `$2` in `/owl-bot-staging/google-cloud-org-policy/google/cloud/orgpolicy/v1`

To reproduce the issue run the following commands in a clone of https://github.com/googleapis/googleapis
```
bazelisk build //google/cloud/orgpolicy/v1:orgpolicy-v1-py
bazelisk build //google/cloud/orgpolicy/v2:orgpolicy-v2-py
```
Then in this repository run the following command to copy code from `bazel-bin`

```
docker run --rm --user $(id -u):$(id -g)   -v $(pwd):/repo   -v <path to your bazel-bin>:/bazel-bin   gcr.io/cloud-devrel-public-resources/owlbot-cli:latest copy-bazel-bin   --source-dir /bazel-bin --dest /repo   --config-file=/packages/google-cloud-org-policy/.OwlBot.yaml 
```

and then run the post processor with
```
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
```

Repeat the steps again with the updated `.OwlBot.yaml`  file and see that the erroneous folder `$2` is no longer present