### PR TITLE
build: remove dev from post processing scripts

### DIFF
--- a/scripts/client-post-processing/integrate-isolated-handwritten-code.yaml
+++ b/scripts/client-post-processing/integrate-isolated-handwritten-code.yaml
@@ -60,19 +60,19 @@ replacements:
     ]
     before: |
       dependencies = \[
-          "google-api-core\[grpc\] >= 1.34.1, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          "google-api-core\[grpc\] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
           # Exclude incompatible versions of `google-auth`
           # See https://github.com/googleapis/google-cloud-python/issues/12364
-          "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",
-          "proto-plus >= 1.22.3, <2.0.0dev",
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "proto-plus >= 1.22.3, <2.0.0",
     after: |
       dependencies = [
-          "google-api-core[grpc] >= 1.34.1, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
           # Exclude incompatible versions of `google-auth`
           # See https://github.com/googleapis/google-cloud-python/issues/12364
-          "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",
-          "google-cloud-core >= 1.4.4, <3.0.0dev",
-          "proto-plus >= 1.22.3, <2.0.0dev",
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "google-cloud-core >= 1.4.4, <3.0.0",
+          "proto-plus >= 1.22.3, <2.0.0",
     count: 1
   - paths: [
       "packages/google-cloud-translate/testing/constraints-3.7.txt"
@@ -198,7 +198,7 @@ replacements:
       extras = {
           "libcst": "libcst >= 0.2.5",
           "pandas": ["pandas>=1.0.5"],
-          "storage": ["google-cloud-storage >=1.18.0, <3.0.0dev"],
+          "storage": ["google-cloud-storage >=1.18.0, <4.0.0"],
       }
     count: 1
   - paths: [


### PR DESCRIPTION
Towards https://github.com/googleapis/google-cloud-python/issues/13585

Remove `dev` from post processing scripts