### PR TITLE
build: update post processor image

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:16341f2811634da310cbb106ce4af18ed6394c964f4f2f1bae4dd321566ddaf5
+  digest: sha256:0f8cdd9fcf12ba04082b6d1801edc5bd6d8a8f79a7447c071565c55717fdf15d


### PR DESCRIPTION
Update to the newest version of the post processor which includes the changes from https://github.com/googleapis/synthtool/pull/2062


Run the following commands to obtain the latest sha256
```
docker pull gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
```

```
docker inspect --format='{{.RepoDigests}}' gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
[gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:0f8cdd9fcf12ba04082b6d1801edc5bd6d8a8f79a7447c071565c55717fdf15d]
```