### PR TITLE
build: allow *.proto files to be copied for google/longrunning

### DIFF
--- a/packages/googleapis-common-protos/.OwlBot.yaml
+++ b/packages/googleapis-common-protos/.OwlBot.yaml
@@ -28,7 +28,7 @@ deep-copy-regex:
     dest: /owl-bot-staging/googleapis-common-protos/$1/google/logging/type/$2
   - source: /google/logging/type/(logging-type-py)/(log_severity.*)
     dest: /owl-bot-staging/googleapis-common-protos/$1/google/logging/type/$2
-  - source: /google/longrunning/(operations-py)/(operations)(.*pb2.*)
+  - source: /google/longrunning/(operations-py)/(operations)(.*pb2.*|.*.proto)
     dest: /owl-bot-staging/googleapis-common-protos/$1/google/longrunning/$2_proto$3
   - source: /google/rpc/(rpc-py)/(.*)
     dest: /owl-bot-staging/googleapis-common-protos/$1/google/rpc/$2


### PR DESCRIPTION
Towards https://github.com/googleapis/google-cloud-python/issues/13545

This PR depends on https://github.com/googleapis/gapic-generator-python/pull/2349 