### PR TITLE
chore: set gcs-sdk-team as storage codeowners

### DIFF
--- a/packages/google-cloud-storage-control/.repo-metadata.json
+++ b/packages/google-cloud-storage-control/.repo-metadata.json
@@ -12,6 +12,6 @@
     "distribution_name": "google-cloud-storage-control",
     "api_id": "storage.googleapis.com",
     "default_version": "v2",
-    "codeowner_team": "",
+    "codeowner_team": "@googleapis/gcs-sdk-team",
     "api_shortname": "storagecontrol"
 }

--- a/packages/google-cloud-storage-transfer/.repo-metadata.json
+++ b/packages/google-cloud-storage-transfer/.repo-metadata.json
@@ -11,7 +11,7 @@
     "distribution_name": "google-cloud-storage-transfer",
     "api_id": "storagetransfer.googleapis.com",
     "default_version": "v1",
-    "codeowner_team": "@googleapis/cloud-storage-dpe",
+    "codeowner_team": "@googleapis/gcs-sdk-team",
     "api_shortname": "storagetransfer",
     "api_description": "Secure, low-cost services for transferring data from cloud or on-premises sources."
 }

--- a/packages/google-cloud-storageinsights/.repo-metadata.json
+++ b/packages/google-cloud-storageinsights/.repo-metadata.json
@@ -12,6 +12,6 @@
     "distribution_name": "google-cloud-storageinsights",
     "api_id": "storageinsights.googleapis.com",
     "default_version": "v1",
-    "codeowner_team": "",
+    "codeowner_team": "@googleapis/gcs-sdk-team",
     "api_shortname": "storageinsights"
 }


### PR DESCRIPTION
Clean up outdated cloud-storage-dpe team