### PR TITLE
chore: exclude setup.py and pyproject.toml in renovate-bot config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
     "schedule:weekly"
   ],
   "ignorePaths": [
-    ".kokoro/docker/docs/requirements.txt",
-    ".github/workflows/unittest.yml"
+    ".github/workflows/unittest.yml",
+    "**/pyproject.toml",
+    "**/setup.py"
   ]
 }


### PR DESCRIPTION
The files `setup.py` and `pyproject.toml` which exist in subfolders under the `packages` directory are automatically generated and do not require updates from `renovate-bot`. In addition, PR https://github.com/googleapis/google-cloud-python/pull/13623 does not contain the desired change. 

We see `protobuf>=6.30.0,<6.30.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5` instead of `protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5`

`setup.py` is already excluded in the renovate-bot configuration for split repositories via this configuration: https://github.com/googleapis/synthtool/blob/bb0a3506602525f63c7002f8d13345be3678effb/synthtool/gcp/templates/python_library/renovate.json#L8
