### PR TITLE
build: update post processor image

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:0f8cdd9fcf12ba04082b6d1801edc5bd6d8a8f79a7447c071565c55717fdf15d
+  digest: sha256:1f0395c6ed234c13632415ed0bf904591c10b876769347b2732a1f043364f311


### PR DESCRIPTION
Update to the newest version of the post processor which includes the changes from https://github.com/googleapis/synthtool/pull/2071


Run the following commands to obtain the latest sha256
```
docker pull gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
```

```
docker inspect --format='{{.RepoDigests}}' gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
[gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:1f0395c6ed234c13632415ed0bf904591c10b876769347b2732a1f043364f311]
```
