### PR TITLE
build: fix system test

### DIFF
--- a/packages/google-cloud-compute/tests/system/base.py
+++ b/packages/google-cloud-compute/tests/system/base.py
@@ -41,7 +41,8 @@ class TestBase(unittest.TestCase):
                 self.DEFAULT_PROJECT
             )
         )
-        self.DISK_IMAGE = "projects/debian-cloud/global/images/family/debian-10"
+        # Choose a debian family from https://cloud.google.com/compute/docs/images/os-details#debian
+        self.DISK_IMAGE = "projects/debian-cloud/global/images/family/debian-12"
 
     @staticmethod
     def get_unique_name(placeholder=""):


### PR DESCRIPTION
`debian-10` no longer exists in https://cloud.google.com/compute/docs/images/os-details#debian

https://github.com/googleapis/google-cloud-python/blob/3609c907cf4c03bf08418de150c84c32da9dae1e/packages/google-cloud-compute/tests/system/base.py#L44

This will fix an issue in the system tests for `google-cloud-compute` which is failing because `projects/debian-cloud/global/images/family/debian-10` doesn't exist. We should use `projects/debian-cloud/global/images/family/debian-12` instead.

```
E           google.api_core.exceptions.NotFound: 404 POST https://compute.googleapis.com/compute/v1/projects/<REDACTED>/zones/us-central1-a/instances: The resource 'projects/debian-cloud/global/images/family/debian-10' was not found
```

See the build log [here](https://btx.cloud.google.com/invocations/f8ae2e10-a8a6-4719-ba02-52b19db56991/log). 
