### PR TITLE
fix: set `include` in `tool.setuptools.packages.find`

### DIFF
--- a/packages/googleapis-common-protos/pyproject.toml
+++ b/packages/googleapis-common-protos/pyproject.toml
@@ -51,4 +51,4 @@ Repository = "https://github.com/googleapis/google-cloud-python/tree/main/packag
 grpc = ["grpcio >= 1.44.0, < 2.0.0"]
 
 [tool.setuptools.packages.find]
-exclude = ["tests*", "testing*", "docs*"]
+include = ["google*"]


### PR DESCRIPTION
This PR fixes an issue in `googleapis-common-protos` where `excludes` is set in `tool.setuptools.packages.find`, without specifying `include` which may cause strange installation behaviour as seen in this [build log](https://github.com/googleapis/google-cloud-python/actions/runs/13822574147/job/38671145919) from PR https://github.com/googleapis/google-cloud-python/pull/13657.

https://github.com/googleapis/google-cloud-python/blob/a2466af25d832eab04153e8bde446a9e9e523d2b/packages/googleapis-common-protos/pyproject.toml#L53-L54


See the following from the log
```
2025-03-13T02:08:01.5380028Z       copying google/type/timeofday.proto -> build/lib/google/type
2025-03-13T02:08:01.5380508Z       copying google/type/timeofday_pb2.pyi -> build/lib/google/type
2025-03-13T02:08:01.5381044Z       copying google/longrunning/operations_proto.proto -> build/lib/google/longrunning
2025-03-13T02:08:01.5381779Z       copying google/longrunning/operations_proto_pb2.pyi -> build/lib/google/longrunning
2025-03-13T02:08:01.5382515Z       copying google/cloud/extended_operations.proto -> build/lib/google/cloud
2025-03-13T02:08:01.5383066Z       copying google/cloud/extended_operations_pb2.pyi -> build/lib/google/cloud
2025-03-13T02:08:01.5383725Z       copying google/logging/type/http_request.proto -> build/lib/google/logging/type
2025-03-13T02:08:01.5384343Z       copying google/logging/type/http_request_pb2.pyi -> build/lib/google/logging/type
2025-03-13T02:08:01.5384894Z       copying google/logging/type/log_severity.proto -> build/lib/google/logging/type
2025-03-13T02:08:01.5385554Z       copying google/logging/type/log_severity_pb2.pyi -> build/lib/google/logging/type
2025-03-13T02:08:01.5386189Z       copying google/gapic/metadata/gapic_metadata.proto -> build/lib/google/gapic/metadata
2025-03-13T02:08:01.5386932Z       copying google/gapic/metadata/gapic_metadata_pb2.pyi -> build/lib/google/gapic/metadata
2025-03-13T02:08:01.5387616Z       copying google/rpc/context/attribute_context.proto -> build/lib/google/rpc/context
2025-03-13T02:08:01.5388236Z       copying google/rpc/context/attribute_context_pb2.pyi -> build/lib/google/rpc/context
2025-03-13T02:08:01.5388920Z       copying google/rpc/context/audit_context.proto -> build/lib/google/rpc/context
2025-03-13T02:08:01.5389497Z       copying google/rpc/context/audit_context_pb2.pyi -> build/lib/google/rpc/context
2025-03-13T02:08:01.5390104Z       copying google/cloud/location/locations.proto -> build/lib/google/cloud/location
2025-03-13T02:08:01.5390777Z       copying google/cloud/location/locations_pb2.pyi -> build/lib/google/cloud/location
2025-03-13T02:08:01.5413887Z       copying build/lib/build/lib/build/lib/build/lib/build/lib/build/lib/build/lib/build/lib....../lib/google/api
```

I've confirmed that setting `include = ["google*"]` for `tool.setuptools.packages.find` fixes the issue. See build log [here](https://github.com/googleapis/google-cloud-python/actions/runs/13862478909/job/38794042745) from PR https://github.com/googleapis/google-cloud-python/pull/13657.

We also do this in other packages:

https://github.com/googleapis/google-cloud-python/blob/a2466af25d832eab04153e8bde446a9e9e523d2b/packages/grpc-google-iam-v1/pyproject.toml#L52-L53

See https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration for more information on `tool.setuptools.packages.find`