### PR TITLE
docs: Update suggested source of IAM samples

### DIFF
--- a/packages/google-cloud-iam/samples/snippets/README.md
+++ b/packages/google-cloud-iam/samples/snippets/README.md
@@ -1,1 +1,1 @@
-The snippets have been migrated to GoogleCloudPlatform/python-docs-samples in PR: https://github.com/GoogleCloudPlatform/python-docs-samples/pull/8497
+The snippets have been migrated to [GoogleCloudPlatform/python-docs-samples](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/iam/cloud-client/snippets).


### PR DESCRIPTION
The README originally pointed to a PR that only adds deny-based samples, and not actually linking the base folder. I experienced friction when discovering this link (originally from the docs link in https://cloud.google.com/python/docs/reference/iam/latest#code-samples-and-snippets), thinking that there were no Python IAM role/service related snippets (only Deny), but then finding the folder the PR added to full of samples. 