### PR TITLE
docs: group Security Command Center packages together on cloud.google.com

### DIFF
--- a/packages/google-cloud-modelarmor/.repo-metadata.json
+++ b/packages/google-cloud-modelarmor/.repo-metadata.json
@@ -10,8 +10,8 @@
     "library_type": "GAPIC_AUTO",
     "repo": "googleapis/google-cloud-python",
     "distribution_name": "google-cloud-modelarmor",
-    "api_id": "modelarmor.googleapis.com",
+    "api_id": "securitycenter.googleapis.com",
     "default_version": "v1",
     "codeowner_team": "",
-    "api_shortname": "modelarmor"
+    "api_shortname": "securitycenter"
 }

--- a/packages/google-cloud-securitycentermanagement/.repo-metadata.json
+++ b/packages/google-cloud-securitycentermanagement/.repo-metadata.json
@@ -10,8 +10,8 @@
     "library_type": "GAPIC_AUTO",
     "repo": "googleapis/google-cloud-python",
     "distribution_name": "google-cloud-securitycentermanagement",
-    "api_id": "securitycentermanagement.googleapis.com",
+    "api_id": "securitycenter.googleapis.com",
     "default_version": "v1",
     "codeowner_team": "",
-    "api_shortname": "securitycentermanagement"
+    "api_shortname": "securitycenter"
 }

--- a/packages/google-cloud-websecurityscanner/.repo-metadata.json
+++ b/packages/google-cloud-websecurityscanner/.repo-metadata.json
@@ -10,9 +10,9 @@
     "library_type": "GAPIC_AUTO",
     "repo": "googleapis/google-cloud-python",
     "distribution_name": "google-cloud-websecurityscanner",
-    "api_id": "websecurityscanner.googleapis.com",
+    "api_id": "securitycenter.googleapis.com",
     "requires_billing": true,
     "default_version": "v1",
     "codeowner_team": "",
-    "api_shortname": "websecurityscanner"
+    "api_shortname": "securitycenter"
 }


### PR DESCRIPTION
On https://cloud.google.com/python/docs/reference, the Security Command Center _product_ should be listed with the client libraries for all of the _services_ that it provides, including the following:

* [modelarmor.googleapis.com](https://cloud.google.com/security-command-center/docs/reference/model-armor/rest)
* [securitycenter.googleapis.com](https://cloud.google.com/security-command-center/docs/reference/rest)
* [securitycentermanagement.googleapis.com](https://cloud.google.com/security-command-center/docs/reference/security-center-management/rest)
* [securityposture.googleapis.com](https://cloud.google.com/security-command-center/docs/reference/securityposture/rest) (no client libraries yet)
* [websecurityscanner.googleapis.com](https://cloud.google.com/security-command-center/docs/reference/web-security-scanner/rest)

This PR updates the metadata for these services' client libraries so that they all use the same `api_id` and `api_shortname`. According to @tbph, this is the correct way to group all of these client libraries together on https://cloud.google.com/python/docs/reference.

This is also consistent with what we do for other products that have multiple client libraries, such as BeyondCorp Enterprise. (For example, compare the metadata for [`google-cloud-beyondcorp-appconnections`](https://github.com/googleapis/google-cloud-python/blob/a37aa650281f4621f323b0ac1237ebddef635fbc/packages/google-cloud-beyondcorp-appconnections/.repo-metadata.json) and [`google-cloud-beyondcorp-appgateways`](https://github.com/googleapis/google-cloud-python/blob/a37aa650281f4621f323b0ac1237ebddef635fbc/packages/google-cloud-beyondcorp-appgateways/.repo-metadata.json).)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #13714