### PR TITLE
build: update post processor image

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:1f0395c6ed234c13632415ed0bf904591c10b876769347b2732a1f043364f311
+  digest: sha256:c566a3be202aa78c35395084556e09501a45bc3581dac5bb97fb93a9b6aa7ecc

--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:9786b1c0a79c49022430a8d1380a514c3cf24ecf0d261dc4ccf15241edb2dbf3
+  digest: sha256:ce884263a90884d55705e8ce796bc612b21a87a7eea15a8051c668c5bc4352e5

--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:c566a3be202aa78c35395084556e09501a45bc3581dac5bb97fb93a9b6aa7ecc
+  digest: sha256:9786b1c0a79c49022430a8d1380a514c3cf24ecf0d261dc4ccf15241edb2dbf3


### PR DESCRIPTION
Update to the newest version of the post processor which includes the changes from the following PRs
https://github.com/googleapis/synthtool/pull/2085
https://github.com/googleapis/synthtool/pull/2083
https://github.com/googleapis/synthtool/pull/2082
https://github.com/googleapis/synthtool/pull/2081
https://github.com/googleapis/synthtool/pull/2080
https://github.com/googleapis/synthtool/pull/2079
https://github.com/googleapis/synthtool/pull/2078
https://github.com/googleapis/synthtool/pull/2077
https://github.com/googleapis/synthtool/pull/2076


Run the following commands to obtain the latest sha256
```
docker pull gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
```

```
docker inspect --format='{{.RepoDigests}}' gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
[gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:ce884263a90884d55705e8ce796bc612b21a87a7eea15a8051c668c5bc4352e5]
```
