### PR TITLE
build: use python 3.13 for lint session

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.13"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel
@@ -34,13 +34,11 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: lint
-        PY_VERSION: "3.10"
       run: |
         ci/run_conditional_tests.sh
     - name: Run lint_setup_py
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: lint_setup_py
-        PY_VERSION: "3.10"
       run: |
         ci/run_conditional_tests.sh


### PR DESCRIPTION
This fixes an issue seen in https://github.com/googleapis/google-cloud-python/pull/13772 where the `lint` presubmit fails with `nox > Session lint failed: Python interpreter 3.13 not found.`
