### PR TITLE
chore: restore PY_VERSION

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,7 +63,8 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: docs
-        PY_VERSION: "3.10"
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh
   docs-warnings:    
@@ -91,7 +92,8 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: docs
-        PY_VERSION: "3.10"
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh
   docfx:
@@ -117,7 +119,8 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: docfx
-        PY_VERSION: "3.10"
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh
   docfx-warnings:
@@ -145,6 +148,7 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: docfx
-        PY_VERSION: "3.10"
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,7 +63,7 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: docs
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
         PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh
@@ -92,7 +92,7 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: docs
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
         PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh
@@ -119,7 +119,7 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: docfx
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
         PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh
@@ -148,7 +148,7 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: docfx
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
         PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,7 +64,7 @@ jobs:
         BUILD_TYPE: presubmit
         TEST_TYPE: docs
         # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
-        PY_VERSION: ""
+        PY_VERSION: "unused"
       run: |
         ci/run_conditional_tests.sh
   docs-warnings:    
@@ -93,7 +93,7 @@ jobs:
         BUILD_TYPE: presubmit
         TEST_TYPE: docs
         # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
-        PY_VERSION: ""
+        PY_VERSION: "unused"
       run: |
         ci/run_conditional_tests.sh
   docfx:
@@ -120,7 +120,7 @@ jobs:
         BUILD_TYPE: presubmit
         TEST_TYPE: docfx
         # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
-        PY_VERSION: ""
+        PY_VERSION: "unused"
       run: |
         ci/run_conditional_tests.sh
   docfx-warnings:
@@ -149,6 +149,6 @@ jobs:
         BUILD_TYPE: presubmit
         TEST_TYPE: docfx
         # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
-        PY_VERSION: ""
+        PY_VERSION: "unused"
       run: |
         ci/run_conditional_tests.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
         BUILD_TYPE: presubmit
         TEST_TYPE: lint
         # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
-        PY_VERSION: ""
+        PY_VERSION: "unused"
       run: |
         ci/run_conditional_tests.sh
     - name: Run lint_setup_py
@@ -43,6 +43,6 @@ jobs:
         BUILD_TYPE: presubmit
         TEST_TYPE: lint_setup_py
         # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
-        PY_VERSION: ""
+        PY_VERSION: "unused"
       run: |
         ci/run_conditional_tests.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,11 +34,14 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: lint
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh
     - name: Run lint_setup_py
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: lint_setup_py
+        PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: lint
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
         PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh
@@ -42,7 +42,7 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: lint_setup_py
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
         PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,6 +42,7 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: lint_setup_py
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
         PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -76,7 +76,7 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: ${{ matrix.option }}
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
         PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -77,7 +77,7 @@ jobs:
         BUILD_TYPE: presubmit
         TEST_TYPE: ${{ matrix.option }}
         # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
-        PY_VERSION: ""
+        PY_VERSION: "unused"
       run: |
         ci/run_conditional_tests.sh
 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -76,7 +76,8 @@ jobs:
       env:
         BUILD_TYPE: presubmit
         TEST_TYPE: ${{ matrix.option }}
-        PY_VERSION: ${{ matrix.python }}
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Remove `PY_VERSION` since it's not used
+        PY_VERSION: ""
       run: |
         ci/run_conditional_tests.sh
 


### PR DESCRIPTION
`PY_VERSION` is only used when `TEST_TYPE` environment variable is set to `unit`. We can set `PY_VERSION` to `unused` otherwise to reflect that it is not being. See https://github.com/googleapis/google-cloud-python/issues/13775 to follow up on supporting `PY_VERSION` for all values of `TEST_TYPE`, rather than just `unit`