### PR TITLE
build: update post processor image

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
-  digest: sha256:ce884263a90884d55705e8ce796bc612b21a87a7eea15a8051c668c5bc4352e5
+  digest: sha256:7b11b4d4928854121e276fcdf8358ad030ab3166edb338573d11c04a6baf9a74


### PR DESCRIPTION
Update to the newest version of the post processor which includes the changes from the following PRs
https://github.com/googleapis/synthtool/pull/2086


Run the following commands to obtain the latest sha256
```
docker pull gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
```

```
docker inspect --format='{{.RepoDigests}}' gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo:latest
[gcr.io/cloud-devrel-public-resources/owlbot-python-mono-repo@sha256:7b11b4d4928854121e276fcdf8358ad030ab3166edb338573d11c04a6baf9a74]
```
