### PR TITLE
chore: remove unused .txt files

### DIFF
--- a/packages/google-cloud-bigquery-connection/.eggs/README.txt
+++ b/packages/google-cloud-bigquery-connection/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/packages/google-cloud-bigquery-reservation/.eggs/README.txt
+++ b/packages/google-cloud-bigquery-reservation/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/packages/google-cloud-billing/.eggs/README.txt
+++ b/packages/google-cloud-billing/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/packages/google-cloud-documentai/.eggs/README.txt
+++ b/packages/google-cloud-documentai/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/packages/google-cloud-media-translation/.eggs/README.txt
+++ b/packages/google-cloud-media-translation/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/packages/google-cloud-memcache/.eggs/README.txt
+++ b/packages/google-cloud-memcache/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/packages/google-cloud-os-config/.eggs/README.txt
+++ b/packages/google-cloud-os-config/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/packages/google-cloud-recaptcha-enterprise/.eggs/README.txt
+++ b/packages/google-cloud-recaptcha-enterprise/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/packages/google-cloud-recommendations-ai/.eggs/README.txt
+++ b/packages/google-cloud-recommendations-ai/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/packages/google-cloud-service-directory/.eggs/README.txt
+++ b/packages/google-cloud-service-directory/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-


### PR DESCRIPTION
Some packages have an `.eggs` directory with a README.txt. This file doesn't add value and is unused.

https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-bigquery-connection/.eggs

The `.eggs` directory is ignored however these files may have been added prior to this `.gitignore` change.
https://github.com/googleapis/google-cloud-python/blob/3c829a0e14848fd084ceb1fcdaf5c5336e261df8/.gitignore#L13

I also removed `packages/google-cloud-common/google-cloud-common/google-cloud-common.txt` which is not used.