### PR TITLE
chore: disable gencode updates for google-cloud-access-context-manager

### DIFF
--- a/packages/google-cloud-access-context-manager/.OwlBot.yaml
+++ b/packages/google-cloud-access-context-manager/.OwlBot.yaml
@@ -16,13 +16,5 @@
 deep-remove-regex:
   - /owl-bot-staging
 
-deep-copy-regex:
-  - source: /google/identity/accesscontextmanager/type/(accesscontextmanager-type-py)/(device_resources.*)
-    dest: /owl-bot-staging/google-cloud-access-context-manager/$1/google/identity/accesscontextmanager/type/$2
-  - source: /google/identity/accesscontextmanager/v1/(identity-accesscontextmanager-v1-py)/(.*access.*)
-    dest: /owl-bot-staging/google-cloud-access-context-manager/$1/google/identity/accesscontextmanager/v1/$2
-  - source: /google/identity/accesscontextmanager/v1/(identity-accesscontextmanager-v1-py)/(service_perimeter.*)
-    dest: /owl-bot-staging/google-cloud-access-context-manager/$1/google/identity/accesscontextmanager/v1/$2
-
 begin-after-commit-hash: d7c95df3ab1ea1b4c22a4542bad4924cc46d1388
 


### PR DESCRIPTION
Similar to these PRs:

https://github.com/googleapis/google-cloud-python/pull/13868
https://github.com/googleapis/google-cloud-python/pull/13867
https://github.com/googleapis/google-cloud-python/pull/13866
https://github.com/googleapis/google-cloud-python/pull/13865

Towards b/413654538