### PR TITLE
chore: update .OwlBot.yaml in google-cloud-compute

### DIFF
--- a/packages/google-cloud-compute/.OwlBot.yaml
+++ b/packages/google-cloud-compute/.OwlBot.yaml
@@ -17,7 +17,7 @@ deep-remove-regex:
   - /owl-bot-staging
 
 deep-copy-regex:
-- source: /google/cloud/compute/(v1)/compute-v.*-py
+  - source: /google/cloud/compute/(v1)/compute-v.*-py
     dest: /owl-bot-staging/google-cloud-compute/$1
 
 begin-after-commit-hash: 70f7f0525414fe4dfeb2fc2e81546b073f83a621

--- a/packages/google-cloud-compute/.OwlBot.yaml
+++ b/packages/google-cloud-compute/.OwlBot.yaml
@@ -17,7 +17,7 @@ deep-remove-regex:
   - /owl-bot-staging
 
 deep-copy-regex:
-  - source: /google/cloud/compute/(v.*)/compute-v.*-py
+- source: /google/cloud/compute/(v1)/compute-v.*-py
     dest: /owl-bot-staging/google-cloud-compute/$1
 
 begin-after-commit-hash: 70f7f0525414fe4dfeb2fc2e81546b073f83a621


### PR DESCRIPTION
Ensure that only `google/cloud/compute/v1` is copied from `googleapis-gen`. `google/cloud/compute/v1beta` will be a separate package `google-cloud-compute-beta`

Towards https://github.com/googleapis/google-cloud-python/issues/12471