### PR TITLE
chore(revert): revert "chore: remove events subscription v1beta"

### DIFF
--- a/packages/google-apps-events-subscriptions/.OwlBot.yaml
+++ b/packages/google-apps-events-subscriptions/.OwlBot.yaml
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-deep-preserve-regex:
-    - /owl-bot-staging/google-apps-events-subscriptions/v1beta
 deep-copy-regex:
     - source: /google/apps/events/subscriptions/(v.*)/.*-py
       dest: /owl-bot-staging/google-apps-events-subscriptions/$1


### PR DESCRIPTION
Reverts googleapis/google-cloud-python#13949

See https://github.com/googleapis/google-cloud-python/pull/13960

Towards b/421467004