### PR TITLE
fix! [google-ai-generativelanguage] prevent 0xa api_key suffix

### DIFF
--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/client.py
@@ -646,6 +646,10 @@ class GenerativeServiceClient(metaclass=GenerativeServiceClientMeta):
             raise ValueError(
                 "client_options.api_key and credentials are mutually exclusive"
             )
+        if api_key_value and api_key_value[-1] == '\x0a':
+            raise ValueError(
+                "client_options.api_key cannot end in a new_line (x0a) character"
+            )
 
         # Save or instantiate the transport.
         # Ordinarily, we provide the transport, but allowing a custom transport

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta/test_generative_service.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta/test_generative_service.py
@@ -7038,3 +7038,13 @@ def test_api_key_credentials(client_class, transport_class):
                 always_use_jwt_access=True,
                 api_audience=None,
             )
+
+def test_api_key_with_invalid_characters():
+    # It is an error to provide a key with a new line (x0a) suffix
+    # this is because the underlying grpc will fail with an Illegal header value error
+    options = client_options.ClientOptions()
+    options.api_key = "api_key\x0a"
+    with pytest.raises(ValueError):
+        client = GenerativeServiceClient(
+            client_options=options,
+        )


### PR DESCRIPTION
if a 0xa character appears at the end of
the api_key, the underlying grpc implementation
will fail with an invalid value header error.

see: https://gitlab.uni-hannover.de/tci-gateway-module/grpc/-/blob/v1.9.x/src/core/lib/surface/validate_metadata.cc#L84

to reproduce this, simply add a 0xa character to an api_key and try to perform any generative action via grpc transport.


