### PR TITLE
ci: release-please to tag pull request number

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,3 @@
 handleGHRelease: true
 manifest: true
+tagPullRequestNumber: true


### PR DESCRIPTION
This repository creates multiple Git tags upon one release pull request. Example: https://github.com/googleapis/google-cloud-python/commit/f49ee521c42726fb97fd68621ecc57d0e64f5ece.

To adopt the new release pipeline based on Git tags, this `tagPullRequestNumber` creates an additional `release-please-<pr number>` tag to a release. We'll monitor that tag to trigger one release job for one release. This option has been working good for google-cloud-go ([example](https://github.com/googleapis/google-cloud-go/commit/8332a9bdf43cd7bbf0256057e48ee49b2a7f1144)).

b/415834227

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕