### PR TITLE
chore: updates to networkmanagement

### DIFF
--- a/packages/google-cloud-network-management/google/cloud/network_management/gapic_version.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "1.26.1"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-cloud-network-management/google/cloud/network_management_v1/gapic_version.py
+++ b/packages/google-cloud-network-management/google/cloud/network_management_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "1.26.1"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-cloud-network-management/samples/generated_samples/snippet_metadata_google.cloud.networkmanagement.v1.json
+++ b/packages/google-cloud-network-management/samples/generated_samples/snippet_metadata_google.cloud.networkmanagement.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-network-management",
-    "version": "1.26.1"
+    "version": "0.1.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
This splits the changes that were joined together in https://github.com/googleapis/google-cloud-python/pull/14063 so that releases can have proper release notes.

BEGIN_COMMIT_OVERRIDE

docs: Various documentation and comment improvements, Enable organization-level support for VPC Flow Logs
feat: Enable organization-level support for VPC Flow Logs
feat: add field service_uri to message Endpoint.CloudRunRevisionEndpoint
feat: add message Endpoint.SingleEdgeResponse
feat: add http additional_bindings
feat: add enum Status to message InstanceInfo
feat: add field running to message InstanceInfo
feat: add field policy_priority to message NetworkInfo
feat: add enum value RouteInfo.NextHopType.SECURE_WEB_PROXY_GATEWAY
feat: add enum DeliverInfo.GoogleServiceType
feat: add field google_service_type to message DeliverInfo
feat: add enum value AbortInfo.Cause.GOOGLE_MANAGED_SERVICE_AMBIGUOUS_ENDPOINT
feat: add enum values NO_ROUTE_FROM_EXTERNAL_IPV6_SOURCE_TO_PRIVATE_IPV6_ADDRESS, TRAFFIC_FROM_HYBRID_ENDPOINT_TO_INTERNET_DISALLOWED, NO_MATCHING_NAT64_GATEWAY, LOAD_BALANCER_BACKEND_IP_VERSION_MISMATCH, and NO_KNOWN_ROUTE_FROM_NCC_NETWORK_TO_DESTINATION to DropInfo.Cause
feat: add rpc VpcFlowLogsService.QueryOrgVpcFlowLogsConfigs
feat: add service OrganizationVpcFlowLogsService
feat: add enum VpcFlowLogsConfig.CrossProjectMetadata
feat: add enum VpcFlowLogsConfig.TargetResourceState
feat: add fields cross_project_metadata, target_resource_state, network, and subnet to message VpcFlowLogsConfig

END_COMMIT_OVERRIDE

PiperOrigin-RevId: 778807926

