### PR TITLE
chore: updates to dataplex

### DIFF
--- a/packages/google-cloud-dataplex/google/cloud/dataplex/gapic_version.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.10.2"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/gapic_version.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.10.2"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/catalog.py
+++ b/packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/catalog.py
@@ -1886,6 +1886,10 @@ class SearchEntriesRequest(proto.Message):
             ``projects/<project_ref>``. If it is unspecified, it
             defaults to the organization where the project provided in
             ``name`` is located.
+        semantic_search (bool):
+            Optional. Specifies whether the search should
+            understand the meaning and intent behind the
+            query, rather than just matching keywords.
     """
 
     name: str = proto.Field(
@@ -1911,6 +1915,10 @@ class SearchEntriesRequest(proto.Message):
     scope: str = proto.Field(
         proto.STRING,
         number=7,
+    )
+    semantic_search: bool = proto.Field(
+        proto.BOOL,
+        number=11,
     )
 
 

--- a/packages/google-cloud-dataplex/samples/generated_samples/snippet_metadata_google.cloud.dataplex.v1.json
+++ b/packages/google-cloud-dataplex/samples/generated_samples/snippet_metadata_google.cloud.dataplex.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-dataplex",
-    "version": "2.10.2"
+    "version": "0.1.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-dataplex/scripts/fixup_dataplex_v1_keywords.py
+++ b/packages/google-cloud-dataplex/scripts/fixup_dataplex_v1_keywords.py
@@ -125,7 +125,7 @@ class dataplexCallTransformer(cst.CSTTransformer):
         'lookup_entry': ('name', 'entry', 'view', 'aspect_types', 'paths', ),
         'run_data_scan': ('name', ),
         'run_task': ('name', 'labels', 'args', ),
-        'search_entries': ('name', 'query', 'page_size', 'page_token', 'order_by', 'scope', ),
+        'search_entries': ('name', 'query', 'page_size', 'page_token', 'order_by', 'scope', 'semantic_search', ),
         'set_iam_policy': ('resource', 'policy', 'update_mask', ),
         'test_iam_permissions': ('resource', 'permissions', ),
         'update_aspect_type': ('aspect_type', 'update_mask', 'validate_only', ),

--- a/packages/google-cloud-dataplex/tests/unit/gapic/dataplex_v1/test_catalog_service.py
+++ b/packages/google-cloud-dataplex/tests/unit/gapic/dataplex_v1/test_catalog_service.py
@@ -15614,6 +15614,7 @@ def test_search_entries_rest_required_fields(request_type=catalog.SearchEntriesR
             "page_token",
             "query",
             "scope",
+            "semantic_search",
         )
     )
     jsonified_request.update(unset_fields)
@@ -15686,6 +15687,7 @@ def test_search_entries_rest_unset_required_fields():
                 "pageToken",
                 "query",
                 "scope",
+                "semanticSearch",
             )
         )
         & set(


### PR DESCRIPTION
This splits the changes that were joined together in https://github.com/googleapis/google-cloud-python/pull/14063 so that releases can have proper release notes.

BEGIN_COMMIT_OVERRIDE

feat: A new field semantic_search is added to message.google.cloud.dataplex.v1.SearchEntriesRequest

END_COMMIT_OVERRIDE

PiperOrigin-RevId: 778817135

