### PR TITLE
chore: updates to managedkafka

### DIFF
--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka/__init__.py
@@ -100,7 +100,9 @@ from google.cloud.managedkafka_v1.types.resources import (
     OperationMetadata,
     RebalanceConfig,
     TaskRetryPolicy,
+    TlsConfig,
     Topic,
+    TrustConfig,
 )
 
 __all__ = (
@@ -173,5 +175,7 @@ __all__ = (
     "OperationMetadata",
     "RebalanceConfig",
     "TaskRetryPolicy",
+    "TlsConfig",
     "Topic",
+    "TrustConfig",
 )

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka/gapic_version.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.1.11"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/__init__.py
@@ -93,7 +93,9 @@ from .types.resources import (
     OperationMetadata,
     RebalanceConfig,
     TaskRetryPolicy,
+    TlsConfig,
     Topic,
+    TrustConfig,
 )
 
 __all__ = (
@@ -160,7 +162,9 @@ __all__ = (
     "StopConnectorRequest",
     "StopConnectorResponse",
     "TaskRetryPolicy",
+    "TlsConfig",
     "Topic",
+    "TrustConfig",
     "UpdateAclRequest",
     "UpdateClusterRequest",
     "UpdateConnectClusterRequest",

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/gapic_version.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.1.11"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/async_client.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/async_client.py
@@ -85,6 +85,8 @@ class ManagedKafkaAsyncClient:
 
     acl_path = staticmethod(ManagedKafkaClient.acl_path)
     parse_acl_path = staticmethod(ManagedKafkaClient.parse_acl_path)
+    ca_pool_path = staticmethod(ManagedKafkaClient.ca_pool_path)
+    parse_ca_pool_path = staticmethod(ManagedKafkaClient.parse_ca_pool_path)
     cluster_path = staticmethod(ManagedKafkaClient.cluster_path)
     parse_cluster_path = staticmethod(ManagedKafkaClient.parse_cluster_path)
     consumer_group_path = staticmethod(ManagedKafkaClient.consumer_group_path)

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/client.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/services/managed_kafka/client.py
@@ -229,6 +229,28 @@ class ManagedKafkaClient(metaclass=ManagedKafkaClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
+    def ca_pool_path(
+        project: str,
+        location: str,
+        ca_pool: str,
+    ) -> str:
+        """Returns a fully-qualified ca_pool string."""
+        return "projects/{project}/locations/{location}/caPools/{ca_pool}".format(
+            project=project,
+            location=location,
+            ca_pool=ca_pool,
+        )
+
+    @staticmethod
+    def parse_ca_pool_path(path: str) -> Dict[str, str]:
+        """Parses a ca_pool path into its component segments."""
+        m = re.match(
+            r"^projects/(?P<project>.+?)/locations/(?P<location>.+?)/caPools/(?P<ca_pool>.+?)$",
+            path,
+        )
+        return m.groupdict() if m else {}
+
+    @staticmethod
     def cluster_path(
         project: str,
         location: str,

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/__init__.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/__init__.py
@@ -83,7 +83,9 @@ from .resources import (
     OperationMetadata,
     RebalanceConfig,
     TaskRetryPolicy,
+    TlsConfig,
     Topic,
+    TrustConfig,
 )
 
 __all__ = (
@@ -152,5 +154,7 @@ __all__ = (
     "OperationMetadata",
     "RebalanceConfig",
     "TaskRetryPolicy",
+    "TlsConfig",
     "Topic",
+    "TrustConfig",
 )

--- a/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/resources.py
+++ b/packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/resources.py
@@ -30,6 +30,8 @@ __protobuf__ = proto.module(
         "NetworkConfig",
         "AccessConfig",
         "GcpConfig",
+        "TlsConfig",
+        "TrustConfig",
         "Topic",
         "ConsumerTopicMetadata",
         "ConsumerPartitionMetadata",
@@ -86,6 +88,9 @@ class Cluster(proto.Message):
             Output only. Reserved for future use.
 
             This field is a member of `oneof`_ ``_satisfies_pzs``.
+        tls_config (google.cloud.managedkafka_v1.types.TlsConfig):
+            Optional. TLS configuration for the Kafka
+            cluster.
     """
 
     class State(proto.Enum):
@@ -155,6 +160,11 @@ class Cluster(proto.Message):
         proto.BOOL,
         number=12,
         optional=True,
+    )
+    tls_config: "TlsConfig" = proto.Field(
+        proto.MESSAGE,
+        number=13,
+        message="TlsConfig",
     )
 
 
@@ -277,6 +287,75 @@ class GcpConfig(proto.Message):
     kms_key: str = proto.Field(
         proto.STRING,
         number=2,
+    )
+
+
+class TlsConfig(proto.Message):
+    r"""The TLS configuration for the Kafka cluster.
+
+    Attributes:
+        trust_config (google.cloud.managedkafka_v1.types.TrustConfig):
+            Optional. The configuration of the broker
+            truststore. If specified, clients can use mTLS
+            for authentication.
+        ssl_principal_mapping_rules (str):
+            Optional. A list of rules for mapping from SSL principal
+            names to short names. These are applied in order by Kafka.
+            Refer to the Apache Kafka documentation for
+            ``ssl.principal.mapping.rules`` for the precise formatting
+            details and syntax. Example:
+            "RULE:^CN=(.*?),OU=ServiceUsers.*\ $/$1@example.com/,DEFAULT"
+
+            This is a static Kafka broker configuration. Setting or
+            modifying this field will trigger a rolling restart of the
+            Kafka brokers to apply the change. An empty string means no
+            rules are applied (Kafka default).
+    """
+
+    trust_config: "TrustConfig" = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        message="TrustConfig",
+    )
+    ssl_principal_mapping_rules: str = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+
+
+class TrustConfig(proto.Message):
+    r"""Sources of CA certificates to install in the broker's
+    truststore.
+
+    Attributes:
+        cas_configs (MutableSequence[google.cloud.managedkafka_v1.types.TrustConfig.CertificateAuthorityServiceConfig]):
+            Optional. Configuration for the Google
+            Certificate Authority Service. Maximum 10.
+    """
+
+    class CertificateAuthorityServiceConfig(proto.Message):
+        r"""A configuration for the Google Certificate Authority Service.
+
+        Attributes:
+            ca_pool (str):
+                Required. The name of the CA pool to pull CA certificates
+                from. Structured like:
+                projects/{project}/locations/{location}/caPools/{ca_pool}.
+                The CA pool does not need to be in the same project or
+                location as the Kafka cluster.
+        """
+
+        ca_pool: str = proto.Field(
+            proto.STRING,
+            number=1,
+        )
+
+    cas_configs: MutableSequence[
+        CertificateAuthorityServiceConfig
+    ] = proto.RepeatedField(
+        proto.MESSAGE,
+        number=1,
+        message=CertificateAuthorityServiceConfig,
     )
 
 

--- a/packages/google-cloud-managedkafka/samples/generated_samples/snippet_metadata_google.cloud.managedkafka.v1.json
+++ b/packages/google-cloud-managedkafka/samples/generated_samples/snippet_metadata_google.cloud.managedkafka.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-managedkafka",
-    "version": "0.1.11"
+    "version": "0.1.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-managedkafka/tests/unit/gapic/managedkafka_v1/test_managed_kafka.py
+++ b/packages/google-cloud-managedkafka/tests/unit/gapic/managedkafka_v1/test_managed_kafka.py
@@ -14684,6 +14684,10 @@ def test_create_cluster_rest_call_success(request_type):
         "state": 1,
         "satisfies_pzi": True,
         "satisfies_pzs": True,
+        "tls_config": {
+            "trust_config": {"cas_configs": [{"ca_pool": "ca_pool_value"}]},
+            "ssl_principal_mapping_rules": "ssl_principal_mapping_rules_value",
+        },
     }
     # The version of a generated dependency at test runtime may differ from the version used during generation.
     # Delete any fields which are not present in the current runtime dependency
@@ -14893,6 +14897,10 @@ def test_update_cluster_rest_call_success(request_type):
         "state": 1,
         "satisfies_pzi": True,
         "satisfies_pzs": True,
+        "tls_config": {
+            "trust_config": {"cas_configs": [{"ca_pool": "ca_pool_value"}]},
+            "ssl_principal_mapping_rules": "ssl_principal_mapping_rules_value",
+        },
     }
     # The version of a generated dependency at test runtime may differ from the version used during generation.
     # Delete any fields which are not present in the current runtime dependency
@@ -19136,10 +19144,36 @@ def test_parse_acl_path():
     assert expected == actual
 
 
-def test_cluster_path():
+def test_ca_pool_path():
     project = "winkle"
     location = "nautilus"
-    cluster = "scallop"
+    ca_pool = "scallop"
+    expected = "projects/{project}/locations/{location}/caPools/{ca_pool}".format(
+        project=project,
+        location=location,
+        ca_pool=ca_pool,
+    )
+    actual = ManagedKafkaClient.ca_pool_path(project, location, ca_pool)
+    assert expected == actual
+
+
+def test_parse_ca_pool_path():
+    expected = {
+        "project": "abalone",
+        "location": "squid",
+        "ca_pool": "clam",
+    }
+    path = ManagedKafkaClient.ca_pool_path(**expected)
+
+    # Check that the path construction is reversible.
+    actual = ManagedKafkaClient.parse_ca_pool_path(path)
+    assert expected == actual
+
+
+def test_cluster_path():
+    project = "whelk"
+    location = "octopus"
+    cluster = "oyster"
     expected = "projects/{project}/locations/{location}/clusters/{cluster}".format(
         project=project,
         location=location,
@@ -19151,9 +19185,9 @@ def test_cluster_path():
 
 def test_parse_cluster_path():
     expected = {
-        "project": "abalone",
-        "location": "squid",
-        "cluster": "clam",
+        "project": "nudibranch",
+        "location": "cuttlefish",
+        "cluster": "mussel",
     }
     path = ManagedKafkaClient.cluster_path(**expected)
 
@@ -19163,10 +19197,10 @@ def test_parse_cluster_path():
 
 
 def test_consumer_group_path():
-    project = "whelk"
-    location = "octopus"
-    cluster = "oyster"
-    consumer_group = "nudibranch"
+    project = "winkle"
+    location = "nautilus"
+    cluster = "scallop"
+    consumer_group = "abalone"
     expected = "projects/{project}/locations/{location}/clusters/{cluster}/consumerGroups/{consumer_group}".format(
         project=project,
         location=location,
@@ -19181,10 +19215,10 @@ def test_consumer_group_path():
 
 def test_parse_consumer_group_path():
     expected = {
-        "project": "cuttlefish",
-        "location": "mussel",
-        "cluster": "winkle",
-        "consumer_group": "nautilus",
+        "project": "squid",
+        "location": "clam",
+        "cluster": "whelk",
+        "consumer_group": "octopus",
     }
     path = ManagedKafkaClient.consumer_group_path(**expected)
 
@@ -19194,10 +19228,10 @@ def test_parse_consumer_group_path():
 
 
 def test_crypto_key_path():
-    project = "scallop"
-    location = "abalone"
-    key_ring = "squid"
-    crypto_key = "clam"
+    project = "oyster"
+    location = "nudibranch"
+    key_ring = "cuttlefish"
+    crypto_key = "mussel"
     expected = "projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}".format(
         project=project,
         location=location,
@@ -19210,10 +19244,10 @@ def test_crypto_key_path():
 
 def test_parse_crypto_key_path():
     expected = {
-        "project": "whelk",
-        "location": "octopus",
-        "key_ring": "oyster",
-        "crypto_key": "nudibranch",
+        "project": "winkle",
+        "location": "nautilus",
+        "key_ring": "scallop",
+        "crypto_key": "abalone",
     }
     path = ManagedKafkaClient.crypto_key_path(**expected)
 
@@ -19223,10 +19257,10 @@ def test_parse_crypto_key_path():
 
 
 def test_topic_path():
-    project = "cuttlefish"
-    location = "mussel"
-    cluster = "winkle"
-    topic = "nautilus"
+    project = "squid"
+    location = "clam"
+    cluster = "whelk"
+    topic = "octopus"
     expected = "projects/{project}/locations/{location}/clusters/{cluster}/topics/{topic}".format(
         project=project,
         location=location,
@@ -19239,10 +19273,10 @@ def test_topic_path():
 
 def test_parse_topic_path():
     expected = {
-        "project": "scallop",
-        "location": "abalone",
-        "cluster": "squid",
-        "topic": "clam",
+        "project": "oyster",
+        "location": "nudibranch",
+        "cluster": "cuttlefish",
+        "topic": "mussel",
     }
     path = ManagedKafkaClient.topic_path(**expected)
 
@@ -19252,7 +19286,7 @@ def test_parse_topic_path():
 
 
 def test_common_billing_account_path():
-    billing_account = "whelk"
+    billing_account = "winkle"
     expected = "billingAccounts/{billing_account}".format(
         billing_account=billing_account,
     )
@@ -19262,7 +19296,7 @@ def test_common_billing_account_path():
 
 def test_parse_common_billing_account_path():
     expected = {
-        "billing_account": "octopus",
+        "billing_account": "nautilus",
     }
     path = ManagedKafkaClient.common_billing_account_path(**expected)
 
@@ -19272,7 +19306,7 @@ def test_parse_common_billing_account_path():
 
 
 def test_common_folder_path():
-    folder = "oyster"
+    folder = "scallop"
     expected = "folders/{folder}".format(
         folder=folder,
     )
@@ -19282,7 +19316,7 @@ def test_common_folder_path():
 
 def test_parse_common_folder_path():
     expected = {
-        "folder": "nudibranch",
+        "folder": "abalone",
     }
     path = ManagedKafkaClient.common_folder_path(**expected)
 
@@ -19292,7 +19326,7 @@ def test_parse_common_folder_path():
 
 
 def test_common_organization_path():
-    organization = "cuttlefish"
+    organization = "squid"
     expected = "organizations/{organization}".format(
         organization=organization,
     )
@@ -19302,7 +19336,7 @@ def test_common_organization_path():
 
 def test_parse_common_organization_path():
     expected = {
-        "organization": "mussel",
+        "organization": "clam",
     }
     path = ManagedKafkaClient.common_organization_path(**expected)
 
@@ -19312,7 +19346,7 @@ def test_parse_common_organization_path():
 
 
 def test_common_project_path():
-    project = "winkle"
+    project = "whelk"
     expected = "projects/{project}".format(
         project=project,
     )
@@ -19322,7 +19356,7 @@ def test_common_project_path():
 
 def test_parse_common_project_path():
     expected = {
-        "project": "nautilus",
+        "project": "octopus",
     }
     path = ManagedKafkaClient.common_project_path(**expected)
 
@@ -19332,8 +19366,8 @@ def test_parse_common_project_path():
 
 
 def test_common_location_path():
-    project = "scallop"
-    location = "abalone"
+    project = "oyster"
+    location = "nudibranch"
     expected = "projects/{project}/locations/{location}".format(
         project=project,
         location=location,
@@ -19344,8 +19378,8 @@ def test_common_location_path():
 
 def test_parse_common_location_path():
     expected = {
-        "project": "squid",
-        "location": "clam",
+        "project": "cuttlefish",
+        "location": "mussel",
     }
     path = ManagedKafkaClient.common_location_path(**expected)
 


### PR DESCRIPTION
This splits the changes that were joined together in https://github.com/googleapis/google-cloud-python/pull/14063 so that releases can have proper release notes.

BEGIN_COMMIT_OVERRIDE

feat: update libraries and clients for Managed Kafka

END_COMMIT_OVERRIDE

PiperOrigin-RevId: 780098649

