### PR TITLE
chore: updates to networkservices

### DIFF
--- a/packages/google-cloud-network-services/google/cloud/network_services/gapic_version.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.5.23"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/gapic_version.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.5.23"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/service_lb_policy.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/service_lb_policy.py
@@ -67,6 +67,9 @@ class ServiceLbPolicy(proto.Message):
         failover_config (google.cloud.network_services_v1.types.ServiceLbPolicy.FailoverConfig):
             Optional. Configuration related to health
             based failover.
+        isolation_config (google.cloud.network_services_v1.types.ServiceLbPolicy.IsolationConfig):
+            Optional. Configuration to provide isolation
+            support for the associated Backend Service.
     """
 
     class LoadBalancingAlgorithm(proto.Enum):
@@ -100,6 +103,41 @@ class ServiceLbPolicy(proto.Message):
         SPRAY_TO_REGION = 4
         WATERFALL_BY_REGION = 5
         WATERFALL_BY_ZONE = 6
+
+    class IsolationGranularity(proto.Enum):
+        r"""The granularity of this isolation restriction.
+
+        Values:
+            ISOLATION_GRANULARITY_UNSPECIFIED (0):
+                No isolation is configured for the backend
+                service. Traffic can overflow based on the load
+                balancing algorithm.
+            REGION (1):
+                Traffic for this service will be isolated at
+                the cloud region level.
+        """
+        ISOLATION_GRANULARITY_UNSPECIFIED = 0
+        REGION = 1
+
+    class IsolationMode(proto.Enum):
+        r"""The mode of this isolation restriction, defining whether
+        clients in a given region are allowed to reach out to another
+        region.
+
+        Values:
+            ISOLATION_MODE_UNSPECIFIED (0):
+                No isolation mode is configured for the
+                backend service.
+            NEAREST (1):
+                Traffic will be sent to the nearest region.
+            STRICT (2):
+                Traffic will fail if no serving backends are
+                available in the same region as the load
+                balancer.
+        """
+        ISOLATION_MODE_UNSPECIFIED = 0
+        NEAREST = 1
+        STRICT = 2
 
     class AutoCapacityDrain(proto.Message):
         r"""Option to specify if an unhealthy IG/NEG should be considered
@@ -146,6 +184,30 @@ class ServiceLbPolicy(proto.Message):
             number=1,
         )
 
+    class IsolationConfig(proto.Message):
+        r"""Configuration to provide isolation support for the associated
+        Backend Service.
+
+        Attributes:
+            isolation_granularity (google.cloud.network_services_v1.types.ServiceLbPolicy.IsolationGranularity):
+                Optional. The isolation granularity of the
+                load balancer.
+            isolation_mode (google.cloud.network_services_v1.types.ServiceLbPolicy.IsolationMode):
+                Optional. The isolation mode of the load
+                balancer.
+        """
+
+        isolation_granularity: "ServiceLbPolicy.IsolationGranularity" = proto.Field(
+            proto.ENUM,
+            number=1,
+            enum="ServiceLbPolicy.IsolationGranularity",
+        )
+        isolation_mode: "ServiceLbPolicy.IsolationMode" = proto.Field(
+            proto.ENUM,
+            number=2,
+            enum="ServiceLbPolicy.IsolationMode",
+        )
+
     name: str = proto.Field(
         proto.STRING,
         number=1,
@@ -183,6 +245,11 @@ class ServiceLbPolicy(proto.Message):
         proto.MESSAGE,
         number=10,
         message=FailoverConfig,
+    )
+    isolation_config: IsolationConfig = proto.Field(
+        proto.MESSAGE,
+        number=11,
+        message=IsolationConfig,
     )
 
 

--- a/packages/google-cloud-network-services/samples/generated_samples/snippet_metadata_google.cloud.networkservices.v1.json
+++ b/packages/google-cloud-network-services/samples/generated_samples/snippet_metadata_google.cloud.networkservices.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-network-services",
-    "version": "0.5.23"
+    "version": "0.1.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-network-services/tests/unit/gapic/network_services_v1/test_network_services.py
+++ b/packages/google-cloud-network-services/tests/unit/gapic/network_services_v1/test_network_services.py
@@ -47285,6 +47285,7 @@ def test_create_service_lb_policy_rest_call_success(request_type):
         "load_balancing_algorithm": 3,
         "auto_capacity_drain": {"enable": True},
         "failover_config": {"failover_health_threshold": 2649},
+        "isolation_config": {"isolation_granularity": 1, "isolation_mode": 1},
     }
     # The version of a generated dependency at test runtime may differ from the version used during generation.
     # Delete any fields which are not present in the current runtime dependency
@@ -47496,6 +47497,7 @@ def test_update_service_lb_policy_rest_call_success(request_type):
         "load_balancing_algorithm": 3,
         "auto_capacity_drain": {"enable": True},
         "failover_config": {"failover_health_threshold": 2649},
+        "isolation_config": {"isolation_granularity": 1, "isolation_mode": 1},
     }
     # The version of a generated dependency at test runtime may differ from the version used during generation.
     # Delete any fields which are not present in the current runtime dependency


### PR DESCRIPTION
This splits the changes that were joined together in https://github.com/googleapis/google-cloud-python/pull/14063 so that releases can have proper release notes.

BEGIN_COMMIT_OVERRIDE

feat: Add isolation support to prevent cross-region overflow by adding a new field "isolation_config" to message "ServiceLbPolicy"

END_COMMIT_OVERRIDE

