### PR TITLE
chore: updates to privateca

### DIFF
--- a/packages/google-cloud-private-ca/google/cloud/security/privateca/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca/__init__.py
@@ -25,6 +25,8 @@ from google.cloud.security.privateca_v1.services.certificate_authority_service.c
     CertificateAuthorityServiceClient,
 )
 from google.cloud.security.privateca_v1.types.resources import (
+    AttributeType,
+    AttributeTypeAndValue,
     CaPool,
     Certificate,
     CertificateAuthority,
@@ -37,6 +39,7 @@ from google.cloud.security.privateca_v1.types.resources import (
     KeyUsage,
     ObjectId,
     PublicKey,
+    RelativeDistinguishedName,
     RevocationReason,
     Subject,
     SubjectAltNames,
@@ -88,6 +91,7 @@ from google.cloud.security.privateca_v1.types.service import (
 __all__ = (
     "CertificateAuthorityServiceClient",
     "CertificateAuthorityServiceAsyncClient",
+    "AttributeTypeAndValue",
     "CaPool",
     "Certificate",
     "CertificateAuthority",
@@ -100,11 +104,13 @@ __all__ = (
     "KeyUsage",
     "ObjectId",
     "PublicKey",
+    "RelativeDistinguishedName",
     "Subject",
     "SubjectAltNames",
     "SubordinateConfig",
     "X509Extension",
     "X509Parameters",
+    "AttributeType",
     "RevocationReason",
     "SubjectRequestMode",
     "ActivateCertificateAuthorityRequest",

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca/gapic_version.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "1.14.3"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/__init__.py
@@ -23,6 +23,8 @@ from .services.certificate_authority_service import (
     CertificateAuthorityServiceClient,
 )
 from .types.resources import (
+    AttributeType,
+    AttributeTypeAndValue,
     CaPool,
     Certificate,
     CertificateAuthority,
@@ -35,6 +37,7 @@ from .types.resources import (
     KeyUsage,
     ObjectId,
     PublicKey,
+    RelativeDistinguishedName,
     RevocationReason,
     Subject,
     SubjectAltNames,
@@ -86,6 +89,8 @@ from .types.service import (
 __all__ = (
     "CertificateAuthorityServiceAsyncClient",
     "ActivateCertificateAuthorityRequest",
+    "AttributeType",
+    "AttributeTypeAndValue",
     "CaPool",
     "Certificate",
     "CertificateAuthority",
@@ -128,6 +133,7 @@ __all__ = (
     "ObjectId",
     "OperationMetadata",
     "PublicKey",
+    "RelativeDistinguishedName",
     "RevocationReason",
     "RevokeCertificateRequest",
     "Subject",

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/gapic_version.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "1.14.3"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/async_client.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/async_client.py
@@ -412,8 +412,9 @@ class CertificateAuthorityServiceAsyncClient:
                 the regular expression ``[a-zA-Z0-9_-]{1,63}``. This
                 field is required when using a
                 [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
-                in the Enterprise [CertificateAuthority.Tier][], but is
-                optional and its value is ignored otherwise.
+                in the Enterprise
+                [CertificateAuthority.tier][google.cloud.security.privateca.v1.CertificateAuthority.tier],
+                but is optional and its value is ignored otherwise.
 
                 This corresponds to the ``certificate_id`` field
                 on the ``request`` instance; if ``request`` is provided, this

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/client.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/client.py
@@ -910,8 +910,9 @@ class CertificateAuthorityServiceClient(
                 the regular expression ``[a-zA-Z0-9_-]{1,63}``. This
                 field is required when using a
                 [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
-                in the Enterprise [CertificateAuthority.Tier][], but is
-                optional and its value is ignored otherwise.
+                in the Enterprise
+                [CertificateAuthority.tier][google.cloud.security.privateca.v1.CertificateAuthority.tier],
+                but is optional and its value is ignored otherwise.
 
                 This corresponds to the ``certificate_id`` field
                 on the ``request`` instance; if ``request`` is provided, this

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/__init__.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 from .resources import (
+    AttributeType,
+    AttributeTypeAndValue,
     CaPool,
     Certificate,
     CertificateAuthority,
@@ -26,6 +28,7 @@ from .resources import (
     KeyUsage,
     ObjectId,
     PublicKey,
+    RelativeDistinguishedName,
     RevocationReason,
     Subject,
     SubjectAltNames,
@@ -75,6 +78,7 @@ from .service import (
 )
 
 __all__ = (
+    "AttributeTypeAndValue",
     "CaPool",
     "Certificate",
     "CertificateAuthority",
@@ -87,11 +91,13 @@ __all__ = (
     "KeyUsage",
     "ObjectId",
     "PublicKey",
+    "RelativeDistinguishedName",
     "Subject",
     "SubjectAltNames",
     "SubordinateConfig",
     "X509Extension",
     "X509Parameters",
+    "AttributeType",
     "RevocationReason",
     "SubjectRequestMode",
     "ActivateCertificateAuthorityRequest",

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/resources.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/resources.py
@@ -25,6 +25,7 @@ import proto  # type: ignore
 __protobuf__ = proto.module(
     package="google.cloud.security.privateca.v1",
     manifest={
+        "AttributeType",
         "RevocationReason",
         "SubjectRequestMode",
         "CertificateAuthority",
@@ -40,12 +41,50 @@ __protobuf__ = proto.module(
         "ObjectId",
         "X509Extension",
         "KeyUsage",
+        "AttributeTypeAndValue",
+        "RelativeDistinguishedName",
         "Subject",
         "SubjectAltNames",
         "CertificateIdentityConstraints",
         "CertificateExtensionConstraints",
     },
 )
+
+
+class AttributeType(proto.Enum):
+    r"""[AttributeType][google.cloud.security.privateca.v1.AttributeType]
+    specifies the type of Attribute in a relative distinguished name.
+
+    Values:
+        ATTRIBUTE_TYPE_UNSPECIFIED (0):
+            Attribute type is unspecified.
+        COMMON_NAME (1):
+            The "common name" of the subject.
+        COUNTRY_CODE (2):
+            The country code of the subject.
+        ORGANIZATION (3):
+            The organization of the subject.
+        ORGANIZATIONAL_UNIT (4):
+            The organizational unit of the subject.
+        LOCALITY (5):
+            The locality or city of the subject.
+        PROVINCE (6):
+            The province, territory, or regional state of
+            the subject.
+        STREET_ADDRESS (7):
+            The street address of the subject.
+        POSTAL_CODE (8):
+            The postal code of the subject.
+    """
+    ATTRIBUTE_TYPE_UNSPECIFIED = 0
+    COMMON_NAME = 1
+    COUNTRY_CODE = 2
+    ORGANIZATION = 3
+    ORGANIZATIONAL_UNIT = 4
+    LOCALITY = 5
+    PROVINCE = 6
+    STREET_ADDRESS = 7
+    POSTAL_CODE = 8
 
 
 class RevocationReason(proto.Enum):
@@ -126,6 +165,17 @@ class SubjectRequestMode(proto.Enum):
             are specified in the certificate request. This mode requires
             the caller to have the ``privateca.certificates.create``
             permission.
+        RDN_SEQUENCE (3):
+            A mode used to get an accurate representation of the Subject
+            field's distinguished name. Indicates that the certificate's
+            [Subject][google.cloud.security.privateca.v1.Subject] and/or
+            [SubjectAltNames][google.cloud.security.privateca.v1.SubjectAltNames]
+            are specified in the certificate request. When parsing a PEM
+            CSR this mode will maintain the sequence of RDNs found in
+            the CSR's subject field in the issued
+            [Certificate][google.cloud.security.privateca.v1.Certificate].
+            This mode requires the caller to have the
+            ``privateca.certificates.create`` permission.
         REFLECTED_SPIFFE (2):
             A mode reserved for special cases. Indicates that the
             certificate should have one SPIFFE
@@ -140,6 +190,7 @@ class SubjectRequestMode(proto.Enum):
     """
     SUBJECT_REQUEST_MODE_UNSPECIFIED = 0
     DEFAULT = 1
+    RDN_SEQUENCE = 3
     REFLECTED_SPIFFE = 2
 
 
@@ -153,7 +204,7 @@ class CertificateAuthority(proto.Message):
 
     Attributes:
         name (str):
-            Output only. The resource name for this
+            Identifier. The resource name for this
             [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
             in the format
             ``projects/*/locations/*/caPools/*/certificateAuthorities/*``.
@@ -244,6 +295,15 @@ class CertificateAuthority(proto.Message):
             state.
         labels (MutableMapping[str, str]):
             Optional. Labels with user-defined metadata.
+        user_defined_access_urls (google.cloud.security.privateca_v1.types.CertificateAuthority.UserDefinedAccessUrls):
+            Optional. User-defined URLs for CA
+            certificate and CRLs. The service does not
+            publish content to these URLs. It is up to the
+            user to mirror content to these URLs.
+        satisfies_pzs (bool):
+            Output only. Reserved for future use.
+        satisfies_pzi (bool):
+            Output only. Reserved for future use.
     """
 
     class Type(proto.Enum):
@@ -426,6 +486,36 @@ class CertificateAuthority(proto.Message):
             enum="CertificateAuthority.SignHashAlgorithm",
         )
 
+    class UserDefinedAccessUrls(proto.Message):
+        r"""User-defined URLs for accessing content published by this
+        [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority].
+
+        Attributes:
+            aia_issuing_certificate_urls (MutableSequence[str]):
+                Optional. A list of URLs where the issuer CA certificate may
+                be downloaded, which appears in the "Authority Information
+                Access" extension in the certificate. If specified, the
+                default [Cloud Storage
+                URLs][google.cloud.security.privateca.v1.CertificateAuthority.AccessUrls.ca_certificate_access_url]
+                will be omitted.
+            crl_access_urls (MutableSequence[str]):
+                Optional. A list of URLs where to obtain CRL information,
+                i.e. the DistributionPoint.fullName described by
+                https://tools.ietf.org/html/rfc5280#section-4.2.1.13. If
+                specified, the default [Cloud Storage
+                URLs][google.cloud.security.privateca.v1.CertificateAuthority.AccessUrls.crl_access_urls]
+                will be omitted.
+        """
+
+        aia_issuing_certificate_urls: MutableSequence[str] = proto.RepeatedField(
+            proto.STRING,
+            number=1,
+        )
+        crl_access_urls: MutableSequence[str] = proto.RepeatedField(
+            proto.STRING,
+            number=2,
+        )
+
     name: str = proto.Field(
         proto.STRING,
         number=1,
@@ -510,6 +600,19 @@ class CertificateAuthority(proto.Message):
         proto.STRING,
         number=17,
     )
+    user_defined_access_urls: UserDefinedAccessUrls = proto.Field(
+        proto.MESSAGE,
+        number=18,
+        message=UserDefinedAccessUrls,
+    )
+    satisfies_pzs: bool = proto.Field(
+        proto.BOOL,
+        number=19,
+    )
+    satisfies_pzi: bool = proto.Field(
+        proto.BOOL,
+        number=20,
+    )
 
 
 class CaPool(proto.Message):
@@ -525,7 +628,7 @@ class CaPool(proto.Message):
 
     Attributes:
         name (str):
-            Output only. The resource name for this
+            Identifier. The resource name for this
             [CaPool][google.cloud.security.privateca.v1.CaPool] in the
             format ``projects/*/locations/*/caPools/*``.
         tier (google.cloud.security.privateca_v1.types.CaPool.Tier):
@@ -649,6 +752,17 @@ class CaPool(proto.Message):
                 is specified, then the certificate request's public key must
                 match one of the key types listed here. Otherwise, any key
                 may be used.
+            backdate_duration (google.protobuf.duration_pb2.Duration):
+                Optional. The duration to backdate all certificates issued
+                from this
+                [CaPool][google.cloud.security.privateca.v1.CaPool]. If not
+                set, the certificates will be issued with a not_before_time
+                of the issuance time (i.e. the current time). If set, the
+                certificates will be issued with a not_before_time of the
+                issuance time minus the backdate_duration. The
+                not_after_time will be adjusted to preserve the requested
+                lifetime. The backdate_duration must be less than or equal
+                to 48 hours.
             maximum_lifetime (google.protobuf.duration_pb2.Duration):
                 Optional. The maximum lifetime allowed for issued
                 [Certificates][google.cloud.security.privateca.v1.Certificate].
@@ -855,6 +969,11 @@ class CaPool(proto.Message):
             number=1,
             message="CaPool.IssuancePolicy.AllowedKeyType",
         )
+        backdate_duration: duration_pb2.Duration = proto.Field(
+            proto.MESSAGE,
+            number=7,
+            message=duration_pb2.Duration,
+        )
         maximum_lifetime: duration_pb2.Duration = proto.Field(
             proto.MESSAGE,
             number=2,
@@ -916,7 +1035,7 @@ class CertificateRevocationList(proto.Message):
 
     Attributes:
         name (str):
-            Output only. The resource name for this
+            Identifier. The resource name for this
             [CertificateRevocationList][google.cloud.security.privateca.v1.CertificateRevocationList]
             in the format
             ``projects/*/locations/*/caPools/*certificateAuthorities/*/ certificateRevocationLists/*``.
@@ -1067,7 +1186,7 @@ class Certificate(proto.Message):
 
     Attributes:
         name (str):
-            Output only. The resource name for this
+            Identifier. The resource name for this
             [Certificate][google.cloud.security.privateca.v1.Certificate]
             in the format
             ``projects/*/locations/*/caPools/*/certificates/*``.
@@ -1235,7 +1354,7 @@ class CertificateTemplate(proto.Message):
 
     Attributes:
         name (str):
-            Output only. The resource name for this
+            Identifier. The resource name for this
             [CertificateTemplate][google.cloud.security.privateca.v1.CertificateTemplate]
             in the format
             ``projects/*/locations/*/certificateTemplates/*``.
@@ -1370,7 +1489,9 @@ class X509Parameters(proto.Message):
         ca_options (google.cloud.security.privateca_v1.types.X509Parameters.CaOptions):
             Optional. Describes options in this
             [X509Parameters][google.cloud.security.privateca.v1.X509Parameters]
-            that are relevant in a CA certificate.
+            that are relevant in a CA certificate. If not specified, a
+            default basic constraints extension with ``is_ca=false``
+            will be added for leaf certificates.
         policy_ids (MutableSequence[google.cloud.security.privateca_v1.types.ObjectId]):
             Optional. Describes the X.509 certificate
             policy object identifiers, per
@@ -1388,26 +1509,29 @@ class X509Parameters(proto.Message):
     """
 
     class CaOptions(proto.Message):
-        r"""Describes values that are relevant in a CA certificate.
+        r"""Describes the X.509 basic constraints extension, per `RFC 5280
+        section
+        4.2.1.9 <https://tools.ietf.org/html/rfc5280#section-4.2.1.9>`__
+
 
         .. _oneof: https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields
 
         Attributes:
             is_ca (bool):
-                Optional. Refers to the "CA" X.509 extension,
-                which is a boolean value. When this value is
-                missing, the extension will be omitted from the
-                CA certificate.
+                Optional. Refers to the "CA" boolean field in
+                the X.509 extension. When this value is missing,
+                the basic constraints extension will be omitted
+                from the certificate.
 
                 This field is a member of `oneof`_ ``_is_ca``.
             max_issuer_path_length (int):
                 Optional. Refers to the path length
-                restriction X.509 extension. For a CA
-                certificate, this value describes the depth of
-                subordinate CA certificates that are allowed.
+                constraint field in the X.509 extension. For a
+                CA certificate, this value describes the depth
+                of subordinate CA certificates that are allowed.
                 If this value is less than 0, the request will
                 fail. If this value is missing, the max path
-                length will be omitted from the CA certificate.
+                length will be omitted from the certificate.
 
                 This field is a member of `oneof`_ ``_max_issuer_path_length``.
         """
@@ -1788,6 +1912,12 @@ class CertificateDescription(proto.Message):
             Access" extension in the certificate.
         cert_fingerprint (google.cloud.security.privateca_v1.types.CertificateDescription.CertificateFingerprint):
             The hash of the x.509 certificate.
+        tbs_certificate_digest (str):
+            The hash of the pre-signed certificate, which
+            will be signed by the CA. Corresponds to the TBS
+            Certificate in
+            https://tools.ietf.org/html/rfc5280#section-4.1.2.
+            The field will always be populated.
     """
 
     class SubjectDescription(proto.Message):
@@ -1914,6 +2044,10 @@ class CertificateDescription(proto.Message):
         proto.MESSAGE,
         number=8,
         message=CertificateFingerprint,
+    )
+    tbs_certificate_digest: str = proto.Field(
+        proto.STRING,
+        number=9,
     )
 
 
@@ -2126,6 +2260,69 @@ class KeyUsage(proto.Message):
     )
 
 
+class AttributeTypeAndValue(proto.Message):
+    r"""[AttributeTypeAndValue][google.cloud.security.privateca.v1.AttributeTypeAndValue]
+    specifies an attribute type and value. It can use either a OID or
+    enum value to specify the attribute type.
+
+    This message has `oneof`_ fields (mutually exclusive fields).
+    For each oneof, at most one member field can be set at the same time.
+    Setting any member of the oneof automatically clears all other
+    members.
+
+    .. _oneof: https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields
+
+    Attributes:
+        type_ (google.cloud.security.privateca_v1.types.AttributeType):
+            The attribute type of the attribute and value
+            pair.
+
+            This field is a member of `oneof`_ ``attribute_type``.
+        object_id (google.cloud.security.privateca_v1.types.ObjectId):
+            Object ID for an attribute type of an
+            attribute and value pair.
+
+            This field is a member of `oneof`_ ``attribute_type``.
+        value (str):
+            The value for the attribute type.
+    """
+
+    type_: "AttributeType" = proto.Field(
+        proto.ENUM,
+        number=1,
+        oneof="attribute_type",
+        enum="AttributeType",
+    )
+    object_id: "ObjectId" = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        oneof="attribute_type",
+        message="ObjectId",
+    )
+    value: str = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+
+
+class RelativeDistinguishedName(proto.Message):
+    r"""[RelativeDistinguishedName][google.cloud.security.privateca.v1.RelativeDistinguishedName]
+    specifies a relative distinguished name which will be used to build
+    a distinguished name.
+
+    Attributes:
+        attributes (MutableSequence[google.cloud.security.privateca_v1.types.AttributeTypeAndValue]):
+            Attributes describes the attribute value
+            assertions in the RDN.
+    """
+
+    attributes: MutableSequence["AttributeTypeAndValue"] = proto.RepeatedField(
+        proto.MESSAGE,
+        number=1,
+        message="AttributeTypeAndValue",
+    )
+
+
 class Subject(proto.Message):
     r"""[Subject][google.cloud.security.privateca.v1.Subject] describes
     parts of a distinguished name that, in turn, describes the subject
@@ -2149,6 +2346,9 @@ class Subject(proto.Message):
             The street address of the subject.
         postal_code (str):
             The postal code of the subject.
+        rdn_sequence (MutableSequence[google.cloud.security.privateca_v1.types.RelativeDistinguishedName]):
+            This field can be used in place of the named
+            subject fields.
     """
 
     common_name: str = proto.Field(
@@ -2182,6 +2382,11 @@ class Subject(proto.Message):
     postal_code: str = proto.Field(
         proto.STRING,
         number=8,
+    )
+    rdn_sequence: MutableSequence["RelativeDistinguishedName"] = proto.RepeatedField(
+        proto.MESSAGE,
+        number=9,
+        message="RelativeDistinguishedName",
     )
 
 

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/service.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/service.py
@@ -83,8 +83,9 @@ class CreateCertificateRequest(proto.Message):
             regular expression ``[a-zA-Z0-9_-]{1,63}``. This field is
             required when using a
             [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
-            in the Enterprise [CertificateAuthority.Tier][], but is
-            optional and its value is ignored otherwise.
+            in the Enterprise
+            [CertificateAuthority.tier][google.cloud.security.privateca.v1.CertificateAuthority.tier],
+            but is optional and its value is ignored otherwise.
         certificate (google.cloud.security.privateca_v1.types.Certificate):
             Required. A
             [Certificate][google.cloud.security.privateca.v1.Certificate]
@@ -258,8 +259,8 @@ class ListCertificatesResponse(proto.Message):
             [Certificates][google.cloud.security.privateca.v1.Certificate].
         next_page_token (str):
             A token to retrieve next page of results. Pass this value in
-            [ListCertificatesRequest.next_page_token][] to retrieve the
-            next page of results.
+            [ListCertificatesRequest.page_token][google.cloud.security.privateca.v1.ListCertificatesRequest.page_token]
+            to retrieve the next page of results.
         unreachable (MutableSequence[str]):
             A list of locations (e.g. "us-west1") that
             could not be reached.
@@ -713,8 +714,8 @@ class ListCertificateAuthoritiesResponse(proto.Message):
             [CertificateAuthorities][google.cloud.security.privateca.v1.CertificateAuthority].
         next_page_token (str):
             A token to retrieve next page of results. Pass this value in
-            [ListCertificateAuthoritiesRequest.next_page_token][] to
-            retrieve the next page of results.
+            [ListCertificateAuthoritiesRequest.page_token][google.cloud.security.privateca.v1.ListCertificateAuthoritiesRequest.page_token]
+            to retrieve the next page of results.
         unreachable (MutableSequence[str]):
             A list of locations (e.g. "us-west1") that
             could not be reached.
@@ -1218,8 +1219,8 @@ class ListCaPoolsResponse(proto.Message):
             [CaPools][google.cloud.security.privateca.v1.CaPool].
         next_page_token (str):
             A token to retrieve next page of results. Pass this value in
-            [ListCertificateAuthoritiesRequest.next_page_token][] to
-            retrieve the next page of results.
+            [ListCertificateAuthoritiesRequest.page_token][google.cloud.security.privateca.v1.ListCertificateAuthoritiesRequest.page_token]
+            to retrieve the next page of results.
         unreachable (MutableSequence[str]):
             A list of locations (e.g. "us-west1") that
             could not be reached.
@@ -1326,8 +1327,8 @@ class ListCertificateRevocationListsResponse(proto.Message):
             [CertificateRevocationLists][google.cloud.security.privateca.v1.CertificateRevocationList].
         next_page_token (str):
             A token to retrieve next page of results. Pass this value in
-            [ListCertificateRevocationListsRequest.next_page_token][] to
-            retrieve the next page of results.
+            [ListCertificateRevocationListsRequest.page_token][google.cloud.security.privateca.v1.ListCertificateRevocationListsRequest.page_token]
+            to retrieve the next page of results.
         unreachable (MutableSequence[str]):
             A list of locations (e.g. "us-west1") that
             could not be reached.
@@ -1585,8 +1586,8 @@ class ListCertificateTemplatesResponse(proto.Message):
             [CertificateTemplates][google.cloud.security.privateca.v1.CertificateTemplate].
         next_page_token (str):
             A token to retrieve next page of results. Pass this value in
-            [ListCertificateTemplatesRequest.next_page_token][] to
-            retrieve the next page of results.
+            [ListCertificateTemplatesRequest.page_token][google.cloud.security.privateca.v1.ListCertificateTemplatesRequest.page_token]
+            to retrieve the next page of results.
         unreachable (MutableSequence[str]):
             A list of locations (e.g. "us-west1") that
             could not be reached.
@@ -1685,9 +1686,11 @@ class OperationMetadata(proto.Message):
         requested_cancellation (bool):
             Output only. Identifies whether the user has requested
             cancellation of the operation. Operations that have
-            successfully been cancelled have [Operation.error][] value
-            with a [google.rpc.Status.code][google.rpc.Status.code] of
-            1, corresponding to ``Code.CANCELLED``.
+            successfully been cancelled have
+            [google.longrunning.Operation.error][google.longrunning.Operation.error]
+            value with a
+            [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            corresponding to ``Code.CANCELLED``.
         api_version (str):
             Output only. API version used to start the
             operation.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/gapic_version.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "1.14.3"  # {x-release-please-version}
+__version__ = "0.0.0"  # {x-release-please-version}

--- a/packages/google-cloud-private-ca/samples/generated_samples/snippet_metadata_google.cloud.security.privateca.v1.json
+++ b/packages/google-cloud-private-ca/samples/generated_samples/snippet_metadata_google.cloud.security.privateca.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-private-ca",
-    "version": "1.14.3"
+    "version": "0.1.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-private-ca/samples/generated_samples/snippet_metadata_google.cloud.security.privateca.v1beta1.json
+++ b/packages/google-cloud-private-ca/samples/generated_samples/snippet_metadata_google.cloud.security.privateca.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-private-ca",
-    "version": "1.14.3"
+    "version": "0.1.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-private-ca/tests/unit/gapic/privateca_v1/test_certificate_authority_service.py
+++ b/packages/google-cloud-private-ca/tests/unit/gapic/privateca_v1/test_certificate_authority_service.py
@@ -3277,7 +3277,6 @@ def test_activate_certificate_authority_non_empty_request_with_auto_populated_fi
     request = service.ActivateCertificateAuthorityRequest(
         name="name_value",
         pem_ca_certificate="pem_ca_certificate_value",
-        request_id="request_id_value",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3293,7 +3292,6 @@ def test_activate_certificate_authority_non_empty_request_with_auto_populated_fi
         assert args[0] == service.ActivateCertificateAuthorityRequest(
             name="name_value",
             pem_ca_certificate="pem_ca_certificate_value",
-            request_id="request_id_value",
         )
 
 
@@ -3998,7 +3996,6 @@ def test_disable_certificate_authority_non_empty_request_with_auto_populated_fie
     # if they meet the requirements of AIP 4235.
     request = service.DisableCertificateAuthorityRequest(
         name="name_value",
-        request_id="request_id_value",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4013,7 +4010,6 @@ def test_disable_certificate_authority_non_empty_request_with_auto_populated_fie
         _, args, _ = call.mock_calls[0]
         assert args[0] == service.DisableCertificateAuthorityRequest(
             name="name_value",
-            request_id="request_id_value",
         )
 
 
@@ -4347,7 +4343,6 @@ def test_enable_certificate_authority_non_empty_request_with_auto_populated_fiel
     # if they meet the requirements of AIP 4235.
     request = service.EnableCertificateAuthorityRequest(
         name="name_value",
-        request_id="request_id_value",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4362,7 +4357,6 @@ def test_enable_certificate_authority_non_empty_request_with_auto_populated_fiel
         _, args, _ = call.mock_calls[0]
         assert args[0] == service.EnableCertificateAuthorityRequest(
             name="name_value",
-            request_id="request_id_value",
         )
 
 
@@ -5020,6 +5014,8 @@ def test_get_certificate_authority(request_type, transport: str = "grpc"):
             state=resources.CertificateAuthority.State.ENABLED,
             pem_ca_certificates=["pem_ca_certificates_value"],
             gcs_bucket="gcs_bucket_value",
+            satisfies_pzs=True,
+            satisfies_pzi=True,
         )
         response = client.get_certificate_authority(request)
 
@@ -5037,6 +5033,8 @@ def test_get_certificate_authority(request_type, transport: str = "grpc"):
     assert response.state == resources.CertificateAuthority.State.ENABLED
     assert response.pem_ca_certificates == ["pem_ca_certificates_value"]
     assert response.gcs_bucket == "gcs_bucket_value"
+    assert response.satisfies_pzs is True
+    assert response.satisfies_pzi is True
 
 
 def test_get_certificate_authority_non_empty_request_with_auto_populated_field():
@@ -5177,6 +5175,8 @@ async def test_get_certificate_authority_async(
                 state=resources.CertificateAuthority.State.ENABLED,
                 pem_ca_certificates=["pem_ca_certificates_value"],
                 gcs_bucket="gcs_bucket_value",
+                satisfies_pzs=True,
+                satisfies_pzi=True,
             )
         )
         response = await client.get_certificate_authority(request)
@@ -5195,6 +5195,8 @@ async def test_get_certificate_authority_async(
     assert response.state == resources.CertificateAuthority.State.ENABLED
     assert response.pem_ca_certificates == ["pem_ca_certificates_value"]
     assert response.gcs_bucket == "gcs_bucket_value"
+    assert response.satisfies_pzs is True
+    assert response.satisfies_pzi is True
 
 
 @pytest.mark.asyncio
@@ -5958,7 +5960,6 @@ def test_undelete_certificate_authority_non_empty_request_with_auto_populated_fi
     # if they meet the requirements of AIP 4235.
     request = service.UndeleteCertificateAuthorityRequest(
         name="name_value",
-        request_id="request_id_value",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -5973,7 +5974,6 @@ def test_undelete_certificate_authority_non_empty_request_with_auto_populated_fi
         _, args, _ = call.mock_calls[0]
         assert args[0] == service.UndeleteCertificateAuthorityRequest(
             name="name_value",
-            request_id="request_id_value",
         )
 
 
@@ -6307,7 +6307,6 @@ def test_delete_certificate_authority_non_empty_request_with_auto_populated_fiel
     # if they meet the requirements of AIP 4235.
     request = service.DeleteCertificateAuthorityRequest(
         name="name_value",
-        request_id="request_id_value",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -6322,7 +6321,6 @@ def test_delete_certificate_authority_non_empty_request_with_auto_populated_fiel
         _, args, _ = call.mock_calls[0]
         assert args[0] == service.DeleteCertificateAuthorityRequest(
             name="name_value",
-            request_id="request_id_value",
         )
 
 
@@ -6654,9 +6652,7 @@ def test_update_certificate_authority_non_empty_request_with_auto_populated_fiel
     # Populate all string fields in the request which are not UUID4
     # since we want to check that UUID4 are populated automatically
     # if they meet the requirements of AIP 4235.
-    request = service.UpdateCertificateAuthorityRequest(
-        request_id="request_id_value",
-    )
+    request = service.UpdateCertificateAuthorityRequest()
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -6668,9 +6664,7 @@ def test_update_certificate_authority_non_empty_request_with_auto_populated_fiel
         client.update_certificate_authority(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == service.UpdateCertificateAuthorityRequest(
-            request_id="request_id_value",
-        )
+        assert args[0] == service.UpdateCertificateAuthorityRequest()
 
 
 def test_update_certificate_authority_use_cached_wrapped_rpc():
@@ -7012,7 +7006,6 @@ def test_create_ca_pool_non_empty_request_with_auto_populated_field():
     request = service.CreateCaPoolRequest(
         parent="parent_value",
         ca_pool_id="ca_pool_id_value",
-        request_id="request_id_value",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -7026,7 +7019,6 @@ def test_create_ca_pool_non_empty_request_with_auto_populated_field():
         assert args[0] == service.CreateCaPoolRequest(
             parent="parent_value",
             ca_pool_id="ca_pool_id_value",
-            request_id="request_id_value",
         )
 
 
@@ -7360,9 +7352,7 @@ def test_update_ca_pool_non_empty_request_with_auto_populated_field():
     # Populate all string fields in the request which are not UUID4
     # since we want to check that UUID4 are populated automatically
     # if they meet the requirements of AIP 4235.
-    request = service.UpdateCaPoolRequest(
-        request_id="request_id_value",
-    )
+    request = service.UpdateCaPoolRequest()
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_ca_pool), "__call__") as call:
@@ -7372,9 +7362,7 @@ def test_update_ca_pool_non_empty_request_with_auto_populated_field():
         client.update_ca_pool(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == service.UpdateCaPoolRequest(
-            request_id="request_id_value",
-        )
+        assert args[0] == service.UpdateCaPoolRequest()
 
 
 def test_update_ca_pool_use_cached_wrapped_rpc():
@@ -8549,7 +8537,6 @@ def test_delete_ca_pool_non_empty_request_with_auto_populated_field():
     # if they meet the requirements of AIP 4235.
     request = service.DeleteCaPoolRequest(
         name="name_value",
-        request_id="request_id_value",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -8562,7 +8549,6 @@ def test_delete_ca_pool_non_empty_request_with_auto_populated_field():
         _, args, _ = call.mock_calls[0]
         assert args[0] == service.DeleteCaPoolRequest(
             name="name_value",
-            request_id="request_id_value",
         )
 
 
@@ -10487,7 +10473,6 @@ def test_create_certificate_template_non_empty_request_with_auto_populated_field
     request = service.CreateCertificateTemplateRequest(
         parent="parent_value",
         certificate_template_id="certificate_template_id_value",
-        request_id="request_id_value",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -10503,7 +10488,6 @@ def test_create_certificate_template_non_empty_request_with_auto_populated_field
         assert args[0] == service.CreateCertificateTemplateRequest(
             parent="parent_value",
             certificate_template_id="certificate_template_id_value",
-            request_id="request_id_value",
         )
 
 
@@ -10857,7 +10841,6 @@ def test_delete_certificate_template_non_empty_request_with_auto_populated_field
     # if they meet the requirements of AIP 4235.
     request = service.DeleteCertificateTemplateRequest(
         name="name_value",
-        request_id="request_id_value",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -10872,7 +10855,6 @@ def test_delete_certificate_template_non_empty_request_with_auto_populated_field
         _, args, _ = call.mock_calls[0]
         assert args[0] == service.DeleteCertificateTemplateRequest(
             name="name_value",
-            request_id="request_id_value",
         )
 
 
@@ -12107,9 +12089,7 @@ def test_update_certificate_template_non_empty_request_with_auto_populated_field
     # Populate all string fields in the request which are not UUID4
     # since we want to check that UUID4 are populated automatically
     # if they meet the requirements of AIP 4235.
-    request = service.UpdateCertificateTemplateRequest(
-        request_id="request_id_value",
-    )
+    request = service.UpdateCertificateTemplateRequest()
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -12121,9 +12101,7 @@ def test_update_certificate_template_non_empty_request_with_auto_populated_field
         client.update_certificate_template(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == service.UpdateCertificateTemplateRequest(
-            request_id="request_id_value",
-        )
+        assert args[0] == service.UpdateCertificateTemplateRequest()
 
 
 def test_update_certificate_template_use_cached_wrapped_rpc():
@@ -19549,6 +19527,8 @@ async def test_get_certificate_authority_empty_call_grpc_asyncio():
                 state=resources.CertificateAuthority.State.ENABLED,
                 pem_ca_certificates=["pem_ca_certificates_value"],
                 gcs_bucket="gcs_bucket_value",
+                satisfies_pzs=True,
+                satisfies_pzi=True,
             )
         )
         await client.get_certificate_authority(request=None)
@@ -20120,6 +20100,17 @@ def test_create_certificate_rest_call_success(request_type):
                     "province": "province_value",
                     "street_address": "street_address_value",
                     "postal_code": "postal_code_value",
+                    "rdn_sequence": [
+                        {
+                            "attributes": [
+                                {
+                                    "type_": 1,
+                                    "object_id": {"object_id_path": [1456, 1457]},
+                                    "value": "value_value",
+                                }
+                            ]
+                        }
+                    ],
                 },
                 "subject_alt_name": {
                     "dns_names": ["dns_names_value1", "dns_names_value2"],
@@ -20130,11 +20121,7 @@ def test_create_certificate_rest_call_success(request_type):
                     ],
                     "ip_addresses": ["ip_addresses_value1", "ip_addresses_value2"],
                     "custom_sans": [
-                        {
-                            "object_id": {"object_id_path": [1456, 1457]},
-                            "critical": True,
-                            "value": b"value_blob",
-                        }
+                        {"object_id": {}, "critical": True, "value": b"value_blob"}
                     ],
                 },
             },
@@ -20235,6 +20222,7 @@ def test_create_certificate_rest_call_success(request_type):
                 "aia_issuing_certificate_urls_value2",
             ],
             "cert_fingerprint": {"sha256_hash": "sha256_hash_value"},
+            "tbs_certificate_digest": "tbs_certificate_digest_value",
         },
         "pem_certificate_chain": [
             "pem_certificate_chain_value1",
@@ -20886,6 +20874,17 @@ def test_update_certificate_rest_call_success(request_type):
                     "province": "province_value",
                     "street_address": "street_address_value",
                     "postal_code": "postal_code_value",
+                    "rdn_sequence": [
+                        {
+                            "attributes": [
+                                {
+                                    "type_": 1,
+                                    "object_id": {"object_id_path": [1456, 1457]},
+                                    "value": "value_value",
+                                }
+                            ]
+                        }
+                    ],
                 },
                 "subject_alt_name": {
                     "dns_names": ["dns_names_value1", "dns_names_value2"],
@@ -20896,11 +20895,7 @@ def test_update_certificate_rest_call_success(request_type):
                     ],
                     "ip_addresses": ["ip_addresses_value1", "ip_addresses_value2"],
                     "custom_sans": [
-                        {
-                            "object_id": {"object_id_path": [1456, 1457]},
-                            "critical": True,
-                            "value": b"value_blob",
-                        }
+                        {"object_id": {}, "critical": True, "value": b"value_blob"}
                     ],
                 },
             },
@@ -21001,6 +20996,7 @@ def test_update_certificate_rest_call_success(request_type):
                 "aia_issuing_certificate_urls_value2",
             ],
             "cert_fingerprint": {"sha256_hash": "sha256_hash_value"},
+            "tbs_certificate_digest": "tbs_certificate_digest_value",
         },
         "pem_certificate_chain": [
             "pem_certificate_chain_value1",
@@ -21360,6 +21356,17 @@ def test_create_certificate_authority_rest_call_success(request_type):
                     "province": "province_value",
                     "street_address": "street_address_value",
                     "postal_code": "postal_code_value",
+                    "rdn_sequence": [
+                        {
+                            "attributes": [
+                                {
+                                    "type_": 1,
+                                    "object_id": {"object_id_path": [1456, 1457]},
+                                    "value": "value_value",
+                                }
+                            ]
+                        }
+                    ],
                 },
                 "subject_alt_name": {
                     "dns_names": ["dns_names_value1", "dns_names_value2"],
@@ -21370,11 +21377,7 @@ def test_create_certificate_authority_rest_call_success(request_type):
                     ],
                     "ip_addresses": ["ip_addresses_value1", "ip_addresses_value2"],
                     "custom_sans": [
-                        {
-                            "object_id": {"object_id_path": [1456, 1457]},
-                            "critical": True,
-                            "value": b"value_blob",
-                        }
+                        {"object_id": {}, "critical": True, "value": b"value_blob"}
                     ],
                 },
             },
@@ -21487,6 +21490,7 @@ def test_create_certificate_authority_rest_call_success(request_type):
                     "aia_issuing_certificate_urls_value2",
                 ],
                 "cert_fingerprint": {"sha256_hash": "sha256_hash_value"},
+                "tbs_certificate_digest": "tbs_certificate_digest_value",
             }
         ],
         "gcs_bucket": "gcs_bucket_value",
@@ -21499,6 +21503,15 @@ def test_create_certificate_authority_rest_call_success(request_type):
         "delete_time": {},
         "expire_time": {},
         "labels": {},
+        "user_defined_access_urls": {
+            "aia_issuing_certificate_urls": [
+                "aia_issuing_certificate_urls_value1",
+                "aia_issuing_certificate_urls_value2",
+            ],
+            "crl_access_urls": ["crl_access_urls_value1", "crl_access_urls_value2"],
+        },
+        "satisfies_pzs": True,
+        "satisfies_pzi": True,
     }
     # The version of a generated dependency at test runtime may differ from the version used during generation.
     # Delete any fields which are not present in the current runtime dependency
@@ -22112,6 +22125,8 @@ def test_get_certificate_authority_rest_call_success(request_type):
             state=resources.CertificateAuthority.State.ENABLED,
             pem_ca_certificates=["pem_ca_certificates_value"],
             gcs_bucket="gcs_bucket_value",
+            satisfies_pzs=True,
+            satisfies_pzi=True,
         )
 
         # Wrap the value into a proper Response obj
@@ -22134,6 +22149,8 @@ def test_get_certificate_authority_rest_call_success(request_type):
     assert response.state == resources.CertificateAuthority.State.ENABLED
     assert response.pem_ca_certificates == ["pem_ca_certificates_value"]
     assert response.gcs_bucket == "gcs_bucket_value"
+    assert response.satisfies_pzs is True
+    assert response.satisfies_pzi is True
 
 
 @pytest.mark.parametrize("null_interceptor", [True, False])
@@ -22661,6 +22678,17 @@ def test_update_certificate_authority_rest_call_success(request_type):
                     "province": "province_value",
                     "street_address": "street_address_value",
                     "postal_code": "postal_code_value",
+                    "rdn_sequence": [
+                        {
+                            "attributes": [
+                                {
+                                    "type_": 1,
+                                    "object_id": {"object_id_path": [1456, 1457]},
+                                    "value": "value_value",
+                                }
+                            ]
+                        }
+                    ],
                 },
                 "subject_alt_name": {
                     "dns_names": ["dns_names_value1", "dns_names_value2"],
@@ -22671,11 +22699,7 @@ def test_update_certificate_authority_rest_call_success(request_type):
                     ],
                     "ip_addresses": ["ip_addresses_value1", "ip_addresses_value2"],
                     "custom_sans": [
-                        {
-                            "object_id": {"object_id_path": [1456, 1457]},
-                            "critical": True,
-                            "value": b"value_blob",
-                        }
+                        {"object_id": {}, "critical": True, "value": b"value_blob"}
                     ],
                 },
             },
@@ -22788,6 +22812,7 @@ def test_update_certificate_authority_rest_call_success(request_type):
                     "aia_issuing_certificate_urls_value2",
                 ],
                 "cert_fingerprint": {"sha256_hash": "sha256_hash_value"},
+                "tbs_certificate_digest": "tbs_certificate_digest_value",
             }
         ],
         "gcs_bucket": "gcs_bucket_value",
@@ -22800,6 +22825,15 @@ def test_update_certificate_authority_rest_call_success(request_type):
         "delete_time": {},
         "expire_time": {},
         "labels": {},
+        "user_defined_access_urls": {
+            "aia_issuing_certificate_urls": [
+                "aia_issuing_certificate_urls_value1",
+                "aia_issuing_certificate_urls_value2",
+            ],
+            "crl_access_urls": ["crl_access_urls_value1", "crl_access_urls_value2"],
+        },
+        "satisfies_pzs": True,
+        "satisfies_pzi": True,
     }
     # The version of a generated dependency at test runtime may differ from the version used during generation.
     # Delete any fields which are not present in the current runtime dependency
@@ -23006,7 +23040,8 @@ def test_create_ca_pool_rest_call_success(request_type):
                     "elliptic_curve": {"signature_algorithm": 1},
                 }
             ],
-            "maximum_lifetime": {"seconds": 751, "nanos": 543},
+            "backdate_duration": {"seconds": 751, "nanos": 543},
+            "maximum_lifetime": {},
             "allowed_issuance_modes": {
                 "allow_csr_based_issuance": True,
                 "allow_config_based_issuance": True,
@@ -23299,7 +23334,8 @@ def test_update_ca_pool_rest_call_success(request_type):
                     "elliptic_curve": {"signature_algorithm": 1},
                 }
             ],
-            "maximum_lifetime": {"seconds": 751, "nanos": 543},
+            "backdate_duration": {"seconds": 751, "nanos": 543},
+            "maximum_lifetime": {},
             "allowed_issuance_modes": {
                 "allow_csr_based_issuance": True,
                 "allow_config_based_issuance": True,


### PR DESCRIPTION
This splits the changes that were joined together in https://github.com/googleapis/google-cloud-python/pull/14063 so that releases can have proper release notes.

BEGIN_COMMIT_OVERRIDE

feat: add RDN sequence
feat: add User Defined Access URLs
feat: add backdate duration
feat: adds tbs_certificate_digest to CertificateDescription

END_COMMIT_OVERRIDE

