### PR TITLE
fix: Set API shortname storagecontrol to storage

### DIFF
--- a/packages/google-cloud-storage-control/.repo-metadata.json
+++ b/packages/google-cloud-storage-control/.repo-metadata.json
@@ -13,5 +13,5 @@
     "api_id": "storage.googleapis.com",
     "default_version": "v2",
     "codeowner_team": "@googleapis/gcs-sdk-team",
-    "api_shortname": "storagecontrol"
+    "api_shortname": "storage"
 }


### PR DESCRIPTION


Fixes #14082 🦕 