### PR TITLE
chore: preserve_regex and remove_regex are arrays

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -9,8 +9,8 @@ libraries:
     service_config: ''
   id: google-cloud-language
   last_generated_commit: 97a83d76a09a7f6dcab43675c87bdfeb5bcf1cb5
-  preserve_regex: ''
-  remove_regex: ''
+  preserve_regex: []
+  remove_regex: []
   sourcePaths:
   - packages/google-cloud-language
   version: 2.17.2


### PR DESCRIPTION
This seems to be breaking library builds against HEAD.

LibraryState struct: https://github.com/googleapis/librarian/blob/51e1e24b7b38b97d9f038d52080e0ddb0ec1d3a4/internal/config/state.go#L84-L102