### PR TITLE
chore: add client post-processing to .librarian/generator-input

### DIFF
--- a/.librarian/generator-input/client-post-processing/add-dependency-google-cloud-common.yaml
+++ b/.librarian/generator-input/client-post-processing/add-dependency-google-cloud-common.yaml
@@ -1,0 +1,48 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: Add missing dependency for google-cloud-common
+url: https://github.com/googleapis/gapic-generator-python/issues/1836
+replacements:
+  - paths: [
+      packages/google-cloud-filestore/setup.py,
+    ]
+    before: |
+      dependencies = \[
+          "google-api-core\[grpc\] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    after: |
+      dependencies = [
+          "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "google-cloud-common >= 1.0.0, <2.0.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    count: 1
+  - paths: [
+      packages/google-cloud-filestore/testing/constraints-3.7.txt
+    ]
+    before: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      proto-plus==1.22.3
+    after: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      google-cloud-common==1.0.0
+      proto-plus==1.22.3
+    count: 1

--- a/.librarian/generator-input/client-post-processing/add-missing-dependencies-to-setup-py-constraints.yaml
+++ b/.librarian/generator-input/client-post-processing/add-missing-dependencies-to-setup-py-constraints.yaml
@@ -1,0 +1,163 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: setup.py and testing/constraints-3.7.txt are missing necessary dependencies
+url: https://github.com/googleapis/gapic-generator-python/issues/1831
+replacements:
+  - paths: [
+      packages/google-cloud-gke-hub/setup.py
+    ]
+    before: |
+      dependencies = \[
+          "google-api-core\[grpc\] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    after:  |
+      dependencies = [
+          "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "grpc-google-iam-v1 >=0.12.4, <1.0.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    count: 1
+  - paths: [
+      packages/google-cloud-gke-hub/testing/constraints-3.7.txt
+    ]
+    before: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      proto-plus==1.22.3
+    after: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      grpc-google-iam-v1==0.12.4
+      proto-plus==1.22.3
+    count: 1
+  - paths: [
+      packages/google-cloud-build/setup.py
+    ]
+    before: |
+      dependencies = \[
+          "google-api-core\[grpc\] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    after:  |
+      dependencies = [
+          "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "grpc-google-iam-v1 >=0.12.4, <1.0.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    count: 1
+  - paths: [
+      packages/google-cloud-build/testing/constraints-3.7.txt
+    ]
+    before: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      proto-plus==1.22.3
+    after: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      grpc-google-iam-v1==0.12.4
+      proto-plus==1.22.3
+    count: 1
+  - paths: [
+      packages/google-cloud-binary-authorization/setup.py
+    ]
+    before: |
+      dependencies = \[
+          "google-api-core\[grpc\] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    after:  |
+      dependencies = [
+          "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "grafeas >= 1.1.2, <2.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    count: 1
+  - paths: [
+      packages/google-cloud-binary-authorization/testing/constraints-3.7.txt
+    ]
+    before: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      proto-plus==1.22.3
+    after: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      grafeas==1.1.2
+      proto-plus==1.22.3
+    count: 1
+  - paths: [
+      packages/google-cloud-iam/testing/constraints-3.7.txt
+    ]
+    before: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      proto-plus==1.22.3
+    after: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      grpc-google-iam-v1==0.12.4
+      proto-plus==1.22.3
+    count: 1
+  - paths: [
+      packages/google-cloud-iam/setup.py
+    ]
+    before: |
+      dependencies = \[
+          "google-api-core\[grpc\] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    after:  |
+      dependencies = [
+          "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "grpc-google-iam-v1 >=0.12.4, <1.0.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    count: 1
+  - paths: [
+      packages/google-cloud-policysimulator/setup.py
+    ]
+    before: |
+      dependencies = \[
+          "google-api-core\[grpc\] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    after:  |
+      dependencies = [
+          "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "google-cloud-org-policy >= 1.0.0, <2.0.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    count: 1

--- a/.librarian/generator-input/client-post-processing/containeranalysis-grafeas-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/containeranalysis-grafeas-integration.yaml
@@ -1,0 +1,168 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: Customizations related to the integration with grafeas
+url: https://github.com/googleapis/gapic-generator-python/issues/1830
+replacements:
+  - paths: [
+      packages/google-cloud-containeranalysis/setup.py
+    ]
+    before: |
+      dependencies = \[
+          "google-api-core\[grpc\] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    after: |
+      dependencies = [
+          "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "grafeas >=1.4.1, <2.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    count: 1
+  - paths: [
+      packages/google-cloud-containeranalysis/testing/constraints-3.7.txt
+    ]
+    before: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      proto-plus==1.22.3
+    after: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      grafeas==1.4.1
+      proto-plus==1.22.3
+    count: 1
+  - paths: [
+      packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/client.py,
+      packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/async_client.py,
+    ]
+    before: |
+      from google.iam.v1 import policy_pb2  # type: ignore\n
+    after: |
+      from google.iam.v1 import policy_pb2  # type: ignore
+      from grafeas import grafeas_v1
+      from grafeas.grafeas_v1.services.grafeas import transports\n
+    count: 2
+  - paths: [
+      packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/client.py,
+    ]
+    before: |
+      \,\n                        "credentialsType": None,
+      \                    \},
+      \                \)
+      \
+      \    def set_iam_policy\(
+    after: |
+      ,\n                        "credentialsType": None,
+                          },
+                      )\n
+          def get_grafeas_client(self) -> grafeas_v1.GrafeasClient:
+              grafeas_transport = grafeas_v1.services.grafeas.transports.GrafeasGrpcTransport(
+                  credentials=self.transport._credentials,
+                  # Set ``credentials_file`` to ``None`` here as
+                  # transport._credentials contains the credentials
+                  # which are saved
+                  credentials_file=None,
+                  host=self.transport._host,
+                  scopes=self.transport.AUTH_SCOPES,
+              )
+              return grafeas_v1.GrafeasClient(transport=grafeas_transport)\n
+          def set_iam_policy(
+    count: 1
+  - paths: [
+      packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/services/container_analysis/async_client.py,
+    ]
+    before: |
+      \,\n                    "credentialsType": None,
+      \                \},
+      \            \)
+      \
+      \    async def set_iam_policy\(
+    after: |
+      ,\n                    "credentialsType": None,
+                      },
+                  )\n
+          def get_grafeas_client(self) -> grafeas_v1.GrafeasClient:
+              grafeas_transport = grafeas_v1.services.grafeas.transports.GrafeasGrpcTransport(
+                  credentials=self.transport._credentials,
+                  # Set ``credentials_file`` to ``None`` here as
+                  # transport._credentials contains the credentials
+                  # which are saved
+                  credentials_file=None,
+                  host=self.transport._host,
+                  scopes=self.transport.AUTH_SCOPES,
+              )
+              return grafeas_v1.GrafeasClient(transport=grafeas_transport)\n
+          async def set_iam_policy(
+    count: 1
+  - paths: [
+    packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/types/containeranalysis.py
+    ]
+    before: from grafeas.v1 import severity_pb2  # type: ignore
+    after: import grafeas.grafeas_v1  # type: ignore
+    count: 1
+  - paths: [
+      packages/google-cloud-containeranalysis/tests/unit/gapic/containeranalysis_v1/test_container_analysis.py
+    ]
+    before: |
+      \)
+      \        create_channel.assert_called_with\(
+      \            "containeranalysis.googleapis.com:443",
+      \            credentials=file_creds,
+      \            credentials_file=None,
+      \            quota_project_id=None,
+      \            default_scopes=\("https://www.googleapis.com/auth/cloud-platform",\),
+      \            scopes=None,
+      \            default_host="containeranalysis.googleapis.com",
+      \            ssl_credentials=None,
+      \            options=\[
+      \                \("grpc.max_send_message_length", -1\),
+      \                \("grpc.max_receive_message_length", -1\),
+      \            \],
+      \        \)\n\n
+    after: |
+      )
+              create_channel.assert_called_with(
+                  "containeranalysis.googleapis.com:443",
+                  credentials=file_creds,
+                  credentials_file=None,
+                  quota_project_id=None,
+                  default_scopes=("https://www.googleapis.com/auth/cloud-platform",),
+                  scopes=None,
+                  default_host="containeranalysis.googleapis.com",
+                  ssl_credentials=None,
+                  options=[
+                      ("grpc.max_send_message_length", -1),
+                      ("grpc.max_receive_message_length", -1),
+                  ],
+              )
+
+              # Also check client.get_grafeas_client() to make sure that the file credentials are used
+              assert file_creds == client.get_grafeas_client().transport._credentials\n\n
+    count: 1
+  - paths: [
+      packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/types/containeranalysis.py
+    ]
+    before: grafeas.v1.severity_pb2.Severity
+    after: grafeas.v1.grafeas.grafeas_v1.Severity
+    count: 1
+  - paths: [
+      packages/google-cloud-containeranalysis/google/cloud/devtools/containeranalysis_v1/types/containeranalysis.py
+    ]
+    before: severity_pb2
+    after: grafeas.grafeas_v1
+    count: 2

--- a/.librarian/generator-input/client-post-processing/doc-formatting.yaml
+++ b/.librarian/generator-input/client-post-processing/doc-formatting.yaml
@@ -1,0 +1,658 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: Fix formatting issues in docs
+url: https://github.com/googleapis/gapic-generator-python/issues/1829
+replacements:
+  - paths: [
+      packages/google-cloud-compute/google/cloud/compute_v1/types/compute.py,
+    ]
+    before: \"IT_\"
+    after: "`IT_`"
+    count: 2
+  - paths: [
+      packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/types/compute.py,
+    ]
+    before: \"IT_\"
+    after: "`IT_`"
+    count: 2
+  - paths: [
+      packages/google-cloud-compute/google/cloud/compute_v1/types/compute.py,
+    ]
+    before: \"NS_\"
+    after: "`NS_`"
+    count: 2
+  - paths: [
+      packages/google-cloud-compute-v1beta/google/cloud/compute_v1beta/types/compute.py,
+    ]
+    before: \"NS_\"
+    after: "`NS_`"
+    count: 2
+  - paths: [
+      packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/retriever.py,
+      packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever.py,
+    ]
+    before: \"corpora/\*/documents/\"
+    after: "`corpora/*/documents/`"
+    count: 2
+  - paths: [
+      packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever.py,
+    ]
+    before: \"corpora/\*/documents/\*/chunks/\"
+    after: "`corpora/*/documents/*/chunks/`"
+    count: 1    
+  - paths: [
+      packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/async_client.py,
+      packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/client.py
+      ]
+    before: |
+      \                role's permitted operations:
+      \
+      \                 - reader can use the resource \(e.g.
+      \                  tuned model\) for inference
+      \                 - writer has reader's permissions and
+      \                  additionally can edit and share
+      \                 - owner has writer's permissions and
+      \                  additionally can delete
+    after: "                role's permitted operations:\n\n                - reader can use the resource (e.g.\n                  tuned model) for inference\n                - writer has reader's permissions and\n                  additionally can edit and share\n                - owner has writer's permissions and\n                  additionally can delete\n"
+    count: 6
+  - paths: [
+    packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/permission.py,
+      ]
+    before: |
+      \    previous role's permitted operations:
+      \
+      \     - reader can use the resource \(e.g. tuned model\) for inference
+      \     - writer has reader's permissions and additionally can edit and
+      \      share
+      \     - owner has writer's permissions and additionally can delete
+    after: "    previous role's permitted operations:\n\n    - reader can use the resource (e.g. tuned model) for inference\n    - writer has reader's permissions and additionally can edit and\n      share\n    - owner has writer's permissions and additionally can delete\n"
+    count: 1
+  - paths: [
+      packages/google-cloud-datacatalog/google/cloud/datacatalog_v1beta1/types/usage.py,
+    ]
+    before: |
+      \      references are not yet counted in usage computation
+      \    https://cloud.google.com/bigquery/docs/querying-wildcard-tables
+    after:  "      references are not yet counted in usage computation\n      https://cloud.google.com/bigquery/docs/querying-wildcard-tables\n"
+    count: 1
+  - paths: [
+      packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/resources.py,
+    ]
+    before: |
+      \                 14 years, 51 weeks, 6 days, 23 hours, 59
+    after: "                14 years, 51 weeks, 6 days, 23 hours, 59\n"
+    count: 1
+  - paths: [
+      packages/google-cloud-network-connectivity/google/cloud/networkconnectivity_v1/types/policy_based_routing.py,
+    ]
+    before: |
+      \            1000. The priority value must be from 1 to
+      \                65535, inclusive.
+    after: "            1000. The priority value must be from 1 to\n            65535, inclusive.\n"
+    count: 1
+  - paths: [
+      packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project.py,
+    ]
+    before: |
+      \            resource. Format: projects/\*/loggingConfig
+    after:  "            resource. Format: `projects/*/loggingConfig`\n"
+    count: 1
+  - paths: [
+      packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project.py,
+      packages/google-cloud-retail/google/cloud/retail_v2beta/types/project.py,
+    ]
+    before: |
+      \            resource. Format: projects/\*/alertConfig
+    after:  "            resource. Format: `projects/*/alertConfig`\n"
+    count: 2
+  - paths: [
+      packages/google-cloud-visionai/google/cloud/visionai_v1/types/platform.py,
+      packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/platform.py,
+    ]
+    before: |
+      \                  'ingestionTime': DOUBLE; \(UNIX timestamp\)
+      \            'application': STRING;
+    after: "                  'ingestionTime': DOUBLE; (UNIX timestamp)\n                  'application': STRING;\n"
+    count: 2
+  - paths: [
+      packages/google-cloud-visionai/google/cloud/visionai_v1/types/platform.py,
+      packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/platform.py,
+    ]
+    before: "'processor': STRING;\n             }\n"
+    after:  "'processor': STRING;\n\n             }\n\n"
+    count: 2
+  - paths: [
+      packages/google-cloud-documentai/google/cloud/documentai_v1beta3/types/document_service.py,
+    ]
+    before: |
+      \n            Currently support query strings are:
+      \            ------------------------------------
+      \
+      \            ``SplitType=DATASET_SPLIT_TEST\|DATASET_SPLIT_TRAIN\|DATASET_SPLIT_UNASSIGNED``
+      \
+      \            -  ``LabelingState=DOCUMENT_LABELED\|DOCUMENT_UNLABELED\|DOCUMENT_AUTO_LABELED``
+    after:  "\n            Currently support query strings are:\n\n            - ``SplitType=DATASET_SPLIT_TEST|DATASET_SPLIT_TRAIN|DATASET_SPLIT_UNASSIGNED``\n            -  ``LabelingState=DOCUMENT_LABELED|DOCUMENT_UNLABELED|DOCUMENT_AUTO_LABELED``\n"
+    count: 1
+  - paths: [
+      packages/google-ads-admanager/google/ads/admanager_v1/types/report_messages.py,
+    ]
+    before: CUSTOM_DIMENSION_\\\*
+    after: "`CUSTOM_DIMENSION_*`"
+    count: 1
+  - paths: [
+      packages/google-ads-admanager/google/ads/admanager_v1/types/report_messages.py,
+    ]
+    before: ORDER_CUSTOM_FIELD_\\\*
+    after: "`ORDER_CUSTOM_FIELD_*`"
+    count: 1
+  - paths: [
+      packages/google-ads-admanager/google/ads/admanager_v1/types/report_messages.py,
+    ]
+    before: LINE_ITEM_CUSTOM_FIELD_\\\*
+    after: "`LINE_ITEM_CUSTOM_FIELD_*`"
+    count: 1
+  - paths: [
+      packages/google-ads-admanager/google/ads/admanager_v1/types/report_messages.py,
+    ]
+    before: CREATIVE_CUSTOM_FIELD_\\\*
+    after: "`CREATIVE_CUSTOM_FIELD_*`"
+    count: 1
+  - paths: [
+      packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/async_client.py,
+      packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/client.py,
+      packages/google-analytics-admin/google/analytics/admin_v1alpha/types/analytics_admin.py,
+    ]
+    before: \/\[a-zA-Z0-9_\]\/
+    after: "`[a-zA-Z0-9_]`"
+    count: 3
+  - paths: [
+      packages/google-apps-chat/google/apps/chat_v1/services/chat_service/async_client.py,
+    ]
+    before: \|Message sent with app authentication\|
+    after: "|Message sent with app authentication async|"
+    count: 2
+  - paths: [
+      packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/grpc_asyncio.py,
+    ]
+    before: \|Message sent with app authentication\|
+    after: "|Message sent with app authentication async gRPC|"
+    count: 2
+  - paths: [
+      packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/grpc.py,
+    ]
+    before: \|Message sent with app authentication\|
+    after: "|Message sent with app authentication gRPC|"
+    count: 2
+  - paths: [
+      packages/google-apps-chat/google/apps/chat_v1/services/chat_service/async_client.py,
+    ]
+    before: \|Message sent with user authentication\|
+    after: "|Message sent with user authentication async|"
+    count: 2
+  - paths: [
+      packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/grpc_asyncio.py,
+    ]
+    before: \|Message sent with user authentication\|
+    after: "|Message sent with user authentication async gRPC|"
+    count: 2
+  - paths: [
+      packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/grpc.py,
+    ]
+    before: \|Message sent with user authentication\|
+    after: "|Message sent with user authentication gRPC|"
+    count: 2
+  - paths: [
+      packages/google-cloud-alloydb/google/cloud/alloydb_v1/types/resources.py,
+      packages/google-cloud-alloydb/google/cloud/alloydb_v1alpha/types/resources.py,
+      packages/google-cloud-alloydb/google/cloud/alloydb_v1beta/types/resources.py,
+    ]
+    before: |
+      \                1024. Any integer between 256 and 4500 is
+      \                    considered valid.
+    after: "                1024. Any integer between 256 and 4500 is\n                considered valid.\n"
+    count: 3
+  - paths: [
+      packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/catalog.py,
+    ]
+    before: entry_type=projects\/another-project\/locations\/\*
+    after: "entry_type=projects/another-project/locations/\\*"
+    count: 1
+  - paths: [
+      packages/google-cloud-deploy/google/cloud/deploy_v1/types/cloud_deploy.py,
+    ]
+    before: \"gs:\/\/my-bucket\/dir\/configs\/\*\"
+    after: "`gs://my-bucket/dir/configs/*`"
+    count: 1
+  - paths: [
+      packages/google-cloud-dms/google/cloud/clouddms_v1/types/conversionworkspace_resources.py,
+    ]
+    before: |
+      Optional. Column fractional seconds precision
+      \            - used only for timestamp based datatypes - if
+      \              not specified and relevant uses the source
+    after: |
+      Optional. Column fractional seconds precision:
+
+                  - used only for timestamp based datatypes
+                  - if not specified and relevant uses the source
+    count: 1
+  - paths: [
+      packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/types/resources.py,
+    ]
+    before: projects\/\\ \*\/locations\/\*\/operations\/\*.
+    after: "`projects/*/locations/*/operations/*.`"
+    count: 1
+  - paths: [
+      packages/google-cloud-enterpriseknowledgegraph/google/cloud/enterpriseknowledgegraph_v1/types/service.py,
+    ]
+    before: |
+      If true, separate clusters by their
+      \                geographic region \(from geocoding\). Uses the
+      \                following entity features:\n
+      \                - schema.org/addressLocality
+      \                - schema.org/addressRegion
+      \                - schema.org/addressCountry
+      \                Warning: processing will no longer be
+      \                regionalized!
+    after: |
+      If true, separate clusters by their
+                      geographic region (from geocoding). Uses the
+                      following entity features:\n
+                      - schema.org/addressLocality
+                      - schema.org/addressRegion
+                      - schema.org/addressCountry\n
+                      Warning: processing will no longer be
+                      regionalized!
+    count: 1
+  - paths: [
+      packages/google-cloud-gdchardwaremanagement/google/cloud/gdchardwaremanagement_v1alpha/types/resources.py,
+    ]
+    before: |
+      Optional. Any additional notes for this Site.
+      \            Please include information about:\n
+      \             - security or access restrictions
+      \             - any regulations affecting the technicians
+      \              visiting the site
+      \             - any special process or approval required to
+      \              move the equipment
+      \             - whether a representative will be available
+      \              during site visits
+    after: |
+      Optional. Any additional notes for this Site.
+                  Please include information about:\n
+                  - security or access restrictions
+                  - any regulations affecting the technicians
+                    visiting the site
+                  - any special process or approval required to
+                    move the equipment
+                  - whether a representative will be available
+                    during site visits\n
+    count: 1
+  - paths: [
+      packages/google-cloud-network-management/google/cloud/network_management_v1/types/connectivity_test.py,
+    ]
+    before: |
+      \             projects\/\{project\}\/global\/forwardingRules\/\{id\}
+    after: "            projects/{project}/global/forwardingRules/{id}\n"
+    count: 1
+  - paths: [
+      packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/exadata_infra.py,
+    ]
+    before: |
+      Optional. The window of hours during the day
+      \            when maintenance should be performed. The window
+      \            is a 4 hour slot. Valid values are:\n
+      \              0 - represents time slot 0:00 - 3:59 UTC
+      \              4 - represents time slot 4:00 - 7:59 UTC
+      \              8 - represents time slot 8:00 - 11:59 UTC
+      \              12 - represents time slot 12:00 - 15:59 UTC
+      \            16 - represents time slot 16:00 - 19:59 UTC   20
+      \            - represents time slot 20:00 - 23:59 UTC
+    after: |
+      Optional. The window of hours during the day
+                  when maintenance should be performed. The window
+                  is a 4 hour slot. Valid values are:\n
+                  0 - represents time slot 0:00 - 3:59 UTC
+                  4 - represents time slot 4:00 - 7:59 UTC
+                  8 - represents time slot 8:00 - 11:59 UTC
+                  12 - represents time slot 12:00 - 15:59 UTC
+                  16 - represents time slot 16:00 - 19:59 UTC
+                  20 - represents time slot 20:00 - 23:59 UTC
+    count: 1
+  - paths: [
+      packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/service_controller.py,
+    ]
+    before: |
+      The Google cloud project number, e.g.
+      \                1234567890. A value of 0 indicates no project
+      \                    number is found.
+    after: |
+      The Google cloud project number, e.g.
+                      1234567890. A value of 0 indicates no project
+                      number is found.
+    count: 1
+  - paths: [
+      packages/google-maps-routing/google/maps/routing_v2/types/toll_passes.py,
+    ]
+    before: |
+      E-card provided by multiple banks used to pay
+      \            for tolls. All e-cards via banks are charged the
+      \            same so only one enum value is needed. E.g.
+      \            - Bank Mandiri
+    after: |
+      E-card provided by multiple banks used to pay
+                  for tolls. All e-cards via banks are charged the
+                  same so only one enum value is needed. E.g.\n
+                  - Bank Mandiri
+    count: 1
+  - paths: [
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/async_client.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/client.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/grpc.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/grpc_asyncio.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/async_client.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/client.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/grpc.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/grpc_asyncio.py,
+    ]
+    before: name=accounts\/\*\/users\/me\/emailPreferences alias
+    after: "`name=accounts/*/users/me/emailPreferences` alias"
+    count: 16
+  - paths: [
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/async_client.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/client.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/grpc.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/grpc_asyncio.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/async_client.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/client.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/grpc.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/grpc_asyncio.py,
+    ]
+    before: "This API defines the following resource model:\n    --------------------------------------------------------\n\n    `OnlineReturnPolicy"
+    after: "This API defines the following resource model:\n\n    - `OnlineReturnPolicy"
+    count: 8
+  - paths: [
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/async_client.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/client.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/grpc.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/grpc_asyncio.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/async_client.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/client.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/grpc.py,
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/grpc_asyncio.py,
+    ]
+    before: |
+        This API defines the following resource model:
+        \    ----------------------------------------------\n
+        \    \[OmnichannelSetting\]\[google.shopping.merchant.accounts.v1.OmnichannelSetting\]
+    after: |
+        This API defines the following resource model:
+            - [OmnichannelSetting][google.shopping.merchant.accounts.v1.OmnichannelSetting]
+    count: 8
+  - paths: [
+      packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/shippingsettings.py
+    ]
+    before: |
+      Required. This field is used for avoid async
+      \            issue. Make sure shipping setting data
+      \             didn't change between get call and insert call.
+    after: |
+      Required. This field is used for avoid async
+                  issue. Make sure shipping setting data
+                  didn't change between get call and insert call.
+    count: 1
+  - paths: [
+      packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/types/reports.py,
+      packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/types/reports.py,
+      packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/types/reports.py,
+    ]
+    before: |
+      Here's an example of how the aggregated status is computed:\n
+      \        Free listings \\\| Shopping ads \\\| Status
+      \        --------------\|--------------\|------------------------------
+      \        Approved \\\| Approved \\\| ELIGIBLE Approved \\\| Pending \\\| ELIGIBLE
+      \        Approved \\\| Disapproved \\\| ELIGIBLE_LIMITED Pending \\\| Pending \\\|
+      \        PENDING Disapproved \\\| Disapproved \\\| NOT_ELIGIBLE_OR_DISAPPROVED\n
+      \        Values:
+    after: |
+      Here's an example of how the aggregated status is computed:\n
+              ```
+              Free listings \| Shopping ads \| Status
+              --------------|--------------|------------------------------
+              Approved \| Approved \| ELIGIBLE Approved \| Pending \| ELIGIBLE
+              Approved \| Disapproved \| ELIGIBLE_LIMITED Pending \| Pending \|
+              PENDING Disapproved \| Disapproved \| NOT_ELIGIBLE_OR_DISAPPROVED
+              ```\n
+              Values:
+    count: 3
+  - paths: [
+      packages/google-cloud-monitoring/google/cloud/monitoring_v3/types/metric_service.py
+    ]
+    before: |
+      Optional. If true, only metrics and monitored
+      \            resource types that have recent data \(within
+      \            roughly 25 hours\) will be included in the
+      \            response.
+      \             - If a metric descriptor enumerates monitored
+      \              resource types, only the    monitored resource
+      \              types for which the metric type has recent
+      \              data will    be included in the returned
+      \              metric descriptor, and if none of them have
+      \              recent data, the metric descriptor will not be
+      \              returned.
+      \             - If a metric descriptor does not enumerate the
+      \              compatible monitored    resource types, it
+      \              will be returned only if the metric type has
+      \              recent    data for some monitored resource
+      \              type. The returned descriptor will not
+      \              enumerate any monitored resource types.
+    after: |
+      Optional. If true, only metrics and monitored
+                  resource types that have recent data (within
+                  roughly 25 hours) will be included in the
+                  response.\n
+                  - If a metric descriptor enumerates monitored
+                    resource types, only the monitored resource
+                    types for which the metric type has recent
+                    data will be included in the returned
+                    metric descriptor, and if none of them have
+                    recent data, the metric descriptor will not be
+                    returned.
+                  - If a metric descriptor does not enumerate the
+                    compatible monitored resource types, it
+                    will be returned only if the metric type has
+                    recent data for some monitored resource
+                    type. The returned descriptor will not
+                    enumerate any monitored resource types.
+    count: 1
+  - paths: [
+      packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/environments.py,
+      packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/environments.py,
+    ]
+    before: |
+      \{
+                    "example": "ZXhhbXBsZV92YWx1ZQ==",
+                    "another-example":
+                  "YW5vdGhlcl9leGFtcGxlX3ZhbHVl" \}
+    after: |
+        .. code-block:: json\n
+                      {
+                        "example": "ZXhhbXBsZV92YWx1ZQ==",
+                        "another-example": "YW5vdGhlcl9leGFtcGxlX3ZhbHVl"
+                      }\n
+    count: 2
+  - paths: [
+      packages/google-cloud-financialservices/google/cloud/financialservices_v1/types/engine_version.py,
+    ]
+    before: \"state:\*\"
+    after: "`state:*`"
+    count: 1
+  - paths: [
+      packages/google-cloud-automl/google/cloud/automl_v1/types/io.py,
+    ]
+    before: "Classification\n    ''''''''''''''"
+    after: "Classification:"
+    count: 6
+  - paths: [
+      packages/google-cloud-automl/google/cloud/automl_v1/types/io.py,
+    ]
+    before: |
+      AutoML Vision
+      \    \^\^\^\^\^\^\^\^\^\^\^\^\^
+    after: |
+      AutoML Vision:
+    count: 2
+  - paths: [
+      packages/google-cloud-automl/google/cloud/automl_v1/types/io.py,
+    ]
+    before: |
+      AutoML Tables
+      \    \^\^\^\^\^\^\^\^\^\^\^\^\^
+    after: |
+      AutoML Tables:
+    count: 2
+  - paths: [
+      packages/google-cloud-automl/google/cloud/automl_v1/types/io.py,
+    ]
+    before: |
+      AutoML Tables
+      \            \^\^\^\^\^\^\^\^\^\^\^\^\^
+    after: |
+      AutoML Tables:
+    count: 1
+  - paths: [
+      packages/google-cloud-automl/google/cloud/automl_v1/types/io.py,
+    ]
+    before: "Entity Extraction\n    '''''''''''''''''"
+    after: "Entity Extraction:"
+    count: 2
+  - paths: [
+      packages/google-cloud-automl/google/cloud/automl_v1/types/io.py,
+    ]
+    before: "Sentiment Analysis\n    ''''''''''''''''''"
+    after: "Sentiment Analysis:"
+    count: 2
+  - paths: [
+      packages/google-cloud-automl/google/cloud/automl_v1/types/io.py,
+    ]
+    before: "Object Tracking\n    '''''''''''''''"
+    after: "Object Tracking:"
+    count: 2
+  - paths: [
+      packages/google-cloud-automl/google/cloud/automl_v1/types/io.py,
+    ]
+    before: |
+      AutoML Video Intelligence
+      \    \^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^
+    after: |
+      AutoML Video Intelligence:
+    count: 2
+  - paths: [
+      packages/google-cloud-automl/google/cloud/automl_v1/types/io.py,
+    ]
+    before: "Object Detection\n    ''''''''''''''''"
+    after: "Object Detection:"
+    count: 2
+  - paths: [
+      packages/google-cloud-automl/google/cloud/automl_v1/types/io.py,
+    ]
+    before: |
+      AutoML Natural Language
+      \    \^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^
+    after: |
+      AutoML Natural Language:
+    count: 2
+  - paths: [
+      packages/google-cloud-workflows/google/cloud/workflows_v1/types/workflows.py,
+    ]
+    before: |
+      The maximum number of revisions to return per
+      \            page. If a value is not specified, a default
+      \            value of 20 is used. The maximum permitted value
+      \            is
+      \            100. Values greater than 100 are coerced down to
+      \                100.
+    after: |
+      The maximum number of revisions to return per
+                  page. If a value is not specified, a default
+                  value of 20 is used. The maximum permitted value
+                  is 100. Values greater than 100 are coerced down
+                  to 100.
+    count: 1
+  - paths: [
+      packages/google-cloud-managedkafka/google/cloud/managedkafka_v1/types/resources.py,
+    ]
+    before: \"User:\*\"
+    after: "`User:*`"
+    count: 1
+  - paths: [
+      packages/google-cloud-network-services/google/cloud/network_services_v1/types/service_lb_policy.py,
+    ]
+    before: |
+      Optional. If set to 'True', an unhealthy
+      \                IG/NEG will be set as drained.
+      \                - An IG/NEG is considered unhealthy if less than
+    after: |
+      Optional. If set to 'True', an unhealthy
+                      IG/NEG will be set as drained.\n
+                      - An IG/NEG is considered unhealthy if less than
+    count: 1
+  - paths: [
+      packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/types/schema_registry.py,
+      packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/client.py,
+      packages/google-cloud-managedkafka-schemaregistry/google/cloud/managedkafka_schemaregistry_v1/services/managed_schema_registry/async_client.py,
+    ]
+    before: |
+      -  projects/\{project\}/locations/\{location\}/schemaRegistries/\{schema_registry\}/compatibility/subjects/\*/versions:
+    after: "-  `projects/{project}/locations/{location}/schemaRegistries/{schema_registry}/compatibility/subjects/*/versions`:\n"
+    count: 3
+  - paths: [
+      packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1/types/search_service.py,
+      packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1alpha/types/search_service.py,
+      packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/search_service.py,
+    ]
+    before: |
+      Example #1 \(multi-turn /search API calls\):
+      \
+      \              Call /search API with the session ID generated
+      \            in the first call.   Here, the previous search
+      \            query gets considered in query   standing. I.e.,
+      \            if the first query is "How did Alphabet do in
+      \            2022\?"   and the current query is "How about
+      \            2023\?", the current query will   be interpreted
+      \            as "How did Alphabet do in 2023\?".
+      \
+      \            Example #2 \(coordination between /search API
+      \            calls and /answer API calls\):
+      \
+      \              Call /answer API with the session ID generated
+      \            in the first call.   Here, the answer generation
+      \            happens in the context of the search   results
+      \            from the first search call.
+    after: |
+      Example #1 (multi-turn /search API calls):\n
+                  - Call /search API with the session ID generated
+                    in the first call.   Here, the previous search
+                    query gets considered in query   standing. I.e.,
+                    if the first query is "How did Alphabet do in
+                    2022?"   and the current query is "How about
+                    2023?", the current query will   be interpreted
+                    as "How did Alphabet do in 2023?".\n
+                  Example #2 (coordination between /search API
+                  calls and /answer API calls):\n
+                  - Call /answer API with the session ID generated
+                    in the first call.   Here, the answer generation
+                    happens in the context of the search   results
+                    from the first search call.
+    count: 3

--- a/.librarian/generator-input/client-post-processing/docs-index-rst-for-unversioned-apis.yaml
+++ b/.librarian/generator-input/client-post-processing/docs-index-rst-for-unversioned-apis.yaml
@@ -1,0 +1,174 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: docs/index.rst is handwritten for unversioned APIs
+url: https://github.com/googleapis/gapic-generator-python/issues/1837
+replacements:
+  - paths: [
+      packages/google-cloud-common/docs/index.rst
+    ]
+    before: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          common/services_
+          common/types_
+    after: |
+      .. include:: README.rst
+
+      .. include:: multiprocessing.rst
+
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+
+          common/services_
+          common/types_
+
+      Changelog
+      ---------
+
+      For a list of all ``google-cloud-common`` releases:
+
+      .. toctree::
+        :maxdepth: 2
+
+        CHANGELOG
+
+      .. toctree::
+        :hidden:
+
+        summary_overview.md
+    count: 1
+  - paths: [
+      packages/google-shopping-type/docs/index.rst
+    ]
+    before: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          type/services_
+          type/types_
+    after: |
+      .. include:: README.rst
+
+      .. include:: multiprocessing.rst
+
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+
+          type/services_
+          type/types_
+
+      Changelog
+      ---------
+
+      For a list of all ``google-shopping-type`` releases:
+
+      .. toctree::
+        :maxdepth: 2
+
+        CHANGELOG
+    count: 1
+  - paths: [
+      packages/google-apps-script-type/docs/index.rst
+    ]
+    before: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          type/services_
+          type/types_
+    after: |
+      .. include:: README.rst
+
+      .. include:: multiprocessing.rst
+
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+
+          calendar/services_
+          calendar/types_
+          docs/services_
+          docs/types_
+          drive/services_
+          drive/types_
+          gmail/services_
+          gmail/types_
+          sheets/services_
+          sheets/types_
+          slides/services_
+          slides/types_
+          type/services_
+          type/types_
+
+
+      Changelog
+      ---------
+
+      For a list of all ``google-apps-script-type`` releases:
+
+      .. toctree::
+          :maxdepth: 2
+
+          CHANGELOG
+    count: 1
+  - paths: [
+      packages/google-geo-type/docs/index.rst
+    ]
+    before: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          type/services_
+          type/types_
+    after: |
+      .. include:: README.rst
+
+      .. include:: multiprocessing.rst
+
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+
+          type/services_
+          type/types_
+
+      Changelog
+      ---------
+
+      For a list of all ``google-geo-type`` releases:
+
+      .. toctree::
+          :maxdepth: 2
+
+          CHANGELOG
+    count: 1

--- a/.librarian/generator-input/client-post-processing/integrate-isolated-handwritten-code.yaml
+++ b/.librarian/generator-input/client-post-processing/integrate-isolated-handwritten-code.yaml
@@ -1,0 +1,271 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: Integrate isolated handwritten helpers/mixin code
+url: https://github.com/googleapis/gapic-generator-python/issues/1642
+replacements:
+  - paths: [
+      packages/google-cloud-vision/google/cloud/vision/__init__.py
+    ]
+    before: |
+      from google.cloud.vision_v1.services.image_annotator.client import ImageAnnotatorClient
+    after:  |
+      from google.cloud.vision_v1 import ImageAnnotatorClient
+    count: 1
+  - paths: [
+      packages/google-cloud-vision/google/cloud/vision_v1/__init__.py,
+      packages/google-cloud-vision/google/cloud/vision_v1p1beta1/__init__.py,
+      packages/google-cloud-vision/google/cloud/vision_v1p2beta1/__init__.py,
+      packages/google-cloud-vision/google/cloud/vision_v1p3beta1/__init__.py,
+      packages/google-cloud-vision/google/cloud/vision_v1p4beta1/__init__.py,
+    ]
+    before: |
+      from .services.image_annotator import ImageAnnotatorAsyncClient, ImageAnnotatorClient
+    after: |
+      from google.cloud.vision_helpers import VisionHelpers
+      from google.cloud.vision_helpers.decorators import add_single_feature_methods\n
+      from .services.image_annotator import ImageAnnotatorAsyncClient
+      from .services.image_annotator import ImageAnnotatorClient as IacImageAnnotatorClient
+    count: 5
+  - paths: [
+      packages/google-cloud-vision/google/cloud/vision_v1/__init__.py,
+      packages/google-cloud-vision/google/cloud/vision_v1p1beta1/__init__.py,
+      packages/google-cloud-vision/google/cloud/vision_v1p2beta1/__init__.py,
+      packages/google-cloud-vision/google/cloud/vision_v1p3beta1/__init__.py,
+      packages/google-cloud-vision/google/cloud/vision_v1p4beta1/__init__.py,
+    ]    
+    before: |
+      from .types.web_detection import WebDetection\n
+      __all__ = \(
+    after: |
+      from .types.web_detection import WebDetection\n\n
+      @add_single_feature_methods
+      class ImageAnnotatorClient(VisionHelpers, IacImageAnnotatorClient):
+          __doc__ = IacImageAnnotatorClient.__doc__
+          Feature = Feature\n\n
+      __all__ = (
+    count: 5
+  - paths: [
+      "packages/google-cloud-translate/setup.py"
+    ]
+    before: |
+      dependencies = \[
+          "google-api-core\[grpc\] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    after: |
+      dependencies = [
+          "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "google-cloud-core >= 1.4.4, <3.0.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    count: 1
+  - paths: [
+      "packages/google-cloud-translate/testing/constraints-3.7.txt"
+    ]
+    before: |
+      proto-plus==1.22.3
+      protobuf==3.20.2
+    after: |
+      proto-plus==1.22.3
+      google-cloud-core==1.4.4
+      protobuf==3.20.2
+    count: 1
+  - paths: [
+      "packages/google-cloud-translate/docs/index.rst",
+    ]
+    before: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          translate_v2/services_
+          translate_v2/types_
+    after: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          v2
+    count: 1
+  - paths: [
+      packages/google-cloud-speech/google/cloud/speech_v1/__init__.py,
+    ]    
+    before: |
+      \)
+
+      __all__ = \(
+    after: |
+      )
+
+      from google.cloud.speech_v1.helpers import SpeechHelpers\n\n
+      class SpeechClient(SpeechHelpers, SpeechClient):
+          __doc__ = SpeechClient.__doc__\n\n
+      __all__ = (
+    count: 1
+  - paths: [
+      packages/google-cloud-speech/google/cloud/speech_v1p1beta1/__init__.py,
+    ]    
+    before: |
+      \)\n
+      __all__ = \(
+    after: |
+      )\n
+      from google.cloud.speech_v1.helpers import SpeechHelpers
+      \n
+      class SpeechClient(SpeechHelpers, SpeechClient):
+          __doc__ = SpeechClient.__doc__\n\n
+      __all__ = (
+    count: 1
+  - paths: [
+      packages/google-cloud-speech/google/cloud/speech/__init__.py,
+    ]    
+    before: |
+      from google.cloud.speech_v1.services.speech.client import SpeechClient
+    after: |
+      from google.cloud.speech_v1 import SpeechClient
+    count: 1
+  - paths: [
+      packages/google-cloud-monitoring/setup.py,
+    ]
+    before: extras = \{\}
+    after: |
+      extras = {"pandas": "pandas >= 0.23.2"}
+    count: 1
+  - paths: [
+      packages/google-cloud-monitoring/testing/constraints-3.7.txt,
+    ]
+    before: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      proto-plus==1.22.3
+    after: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      pandas==0.23.2
+      proto-plus==1.22.3
+    count: 1
+  - paths: [
+      packages/google-cloud-monitoring/noxfile.py,
+    ]
+    before: |
+      UNIT_TEST_EXTRAS: List\[str\] = \[\]
+    after: |
+      UNIT_TEST_EXTRAS: List[str] = ["pandas"]
+    count: 1
+  - paths: [
+      packages/google-cloud-monitoring/docs/index.rst,
+    ]
+    before: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          monitoring_v3/services_
+          monitoring_v3/types_
+    after: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          query.rst
+          monitoring_v3/services_
+          monitoring_v3/types_
+    count: 1
+  - paths: [
+      packages/google-cloud-automl/setup.py,
+    ]
+    before: extras = \{\}
+    after: |
+      extras = {
+          "libcst": "libcst >= 0.2.5",
+          "pandas": ["pandas>=1.0.5"],
+          "storage": ["google-cloud-storage >=1.18.0, <4.0.0"],
+      }
+    count: 1
+  - paths: [
+      packages/google-cloud-automl/testing/constraints-3.7.txt,
+    ]
+    before: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      proto-plus==1.22.3
+    after: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      google-cloud-storage==1.18.0
+      libcst==0.2.5
+      pandas==1.0.5
+      proto-plus==1.22.3
+    count: 1
+  - paths: [
+      packages/google-cloud-automl/docs/automl_v1beta1/services_.rst,
+    ]
+    before: |
+      Services for Google Cloud Automl v1beta1 API
+      ============================================
+      .. toctree::
+          :maxdepth: 2
+
+          auto_ml
+          prediction_service
+    after: |
+      Services for Google Cloud Automl v1beta1 API
+      ============================================
+      .. toctree::
+          :maxdepth: 2
+
+          tables
+          auto_ml
+          prediction_service
+    count: 1
+  - paths: [
+      packages/google-cloud-automl/google/cloud/automl_v1beta1/__init__.py,
+    ]
+    before: |
+      \)
+      from .types.annotation_payload import AnnotationPayload
+    after: |
+      )
+      from .services.tables.gcs_client import GcsClient
+      from .services.tables.tables_client import TablesClient
+      from .types.annotation_payload import AnnotationPayload
+    count: 1
+  - paths: [
+      packages/google-cloud-automl/google/cloud/automl_v1beta1/__init__.py,
+    ]
+    before: |
+      __all__ = \(
+          "AutoMlAsyncClient",
+    after: |
+      __all__ = (
+          "GcsClient",
+          "TablesClient",
+          "AutoMlAsyncClient",
+    count: 1
+  - paths: [
+      packages/google-cloud-automl/noxfile.py,
+    ]
+    before: |
+      UNIT_TEST_EXTRAS: List\[str\] = \[\]
+    after: |
+      UNIT_TEST_EXTRAS: List[str] = ["pandas", "storage"]
+    count: 1

--- a/.librarian/generator-input/client-post-processing/mypy-error-with-org-policy-as-dependency.yaml
+++ b/.librarian/generator-input/client-post-processing/mypy-error-with-org-policy-as-dependency.yaml
@@ -1,0 +1,48 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: Mypy error in asset golden files when adding dependency for google-cloud-org-policy
+url: https://github.com/googleapis/gapic-generator-python/issues/1806
+replacements:
+  - paths: [
+      packages/google-cloud-asset/setup.py
+    ]
+    before: |
+      dependencies = \[
+          "google-api-core\[grpc\] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    after:  |
+      dependencies = [
+          "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "google-cloud-org-policy >= 0.1.2, <2.0.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+    count: 1
+  - paths: [
+      packages/google-cloud-asset/testing/constraints-3.7.txt
+    ]
+    before: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      proto-plus==1.22.3
+    after: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      google-cloud-org-policy==0.1.2
+      proto-plus==1.22.3
+    count: 1

--- a/.librarian/generator-input/client-post-processing/proto-plus-dependency-with-modified-namespace.yaml
+++ b/.librarian/generator-input/client-post-processing/proto-plus-dependency-with-modified-namespace.yaml
@@ -1,0 +1,74 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: Unable to generate client if it has a proto-plus dependency with a modified namespace
+url: https://github.com/googleapis/gapic-generator-python/issues/1796
+replacements:
+  - paths: [
+      packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/service.py,
+    ]
+    before: |
+      from grafeas.v1 import attestation_pb2  # type: ignore
+    after: |
+      import grafeas.grafeas_v1.types  # type: ignore
+    count: 1
+  - paths: [
+      packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/service.py,
+    ]
+    before: attestation_pb2
+    after: grafeas.grafeas_v1.types
+    count: 3
+  - paths: [
+      packages/google-cloud-binary-authorization/google/cloud/binaryauthorization_v1/types/service.py,
+    ]
+    before: grafeas.v1.grafeas.grafeas_v1.types.AttestationOccurrence
+    after: grafeas.grafeas_v1.types.AttestationOccurrence
+    count: 1
+  - paths: [
+      packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/types/troubleshooter.py,
+    ]
+    before: from google.iam.v2 import policy_pb2  # type: ignore
+    after: from google.cloud.iam_v2 import Policy  # type: ignore
+    count: 1
+  - paths: [
+      packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/types/troubleshooter.py,
+    ]
+    before: |
+      deny_access_state: "DenyAccessState" = proto.Field\(
+              proto.ENUM,
+              number=1,
+              enum="DenyAccessState",
+          \)
+          policy: policy_pb2.Policy = proto.Field\(
+              proto.MESSAGE,
+              number=2,
+              message=policy_pb2.Policy,
+          \)
+    after: |
+      deny_access_state: "DenyAccessState" = proto.Field(
+              proto.ENUM,
+              number=1,
+              enum="DenyAccessState",
+          )
+          policy: Policy = proto.Field(
+              proto.MESSAGE,
+              number=2,
+              message=Policy,
+          )
+    count: 1
+  - paths: [
+      packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/types/troubleshooter.py,
+    ]
+    before: google.iam.v2.policy_pb2.Policy
+    after: google.cloud.iam_v2.Policy
+    count: 1

--- a/.librarian/generator-input/client-post-processing/remove-erroneous-client.yaml
+++ b/.librarian/generator-input/client-post-processing/remove-erroneous-client.yaml
@@ -1,0 +1,36 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: google-cloud-monitoring-dashboards has an erroneous client google/monitoring/dashboard
+url: https://github.com/googleapis/google-cloud-python/issues/11858
+replacements:
+  - paths: [
+      packages/google-cloud-monitoring-dashboards/docs/index.rst
+    ]
+    before: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          dashboard_v1/services_
+          dashboard_v1/types_
+    after:  |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          monitoring_dashboard_v1/services_
+          monitoring_dashboard_v1/types_
+    count: 1

--- a/.librarian/generator-input/client-post-processing/remove-unused-imports.yaml
+++ b/.librarian/generator-input/client-post-processing/remove-unused-imports.yaml
@@ -1,0 +1,34 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: Remove unused imports
+url: https://github.com/googleapis/gapic-generator-python/issues/1833
+replacements:
+  - paths: [
+      packages/google-cloud-gke-hub/tests/unit/gapic/gkehub_v1/test_gke_hub.py
+    ]
+    before: |
+      from google.cloud.gkehub.configmanagement.v1 import configmanagement_pb2  # type: ignore
+      from google.cloud.gkehub.multiclusteringress.v1 import \(
+          multiclusteringress_pb2,
+      \)  # type: ignore
+    after:  ""
+    count: 1
+  - paths: [
+      packages/google-cloud-binary-authorization/tests/unit/gapic/binaryauthorization_v1/test_validation_helper_v1.py
+    ]
+    before: |
+      from grafeas.v1 import attestation_pb2  # type: ignore
+      from grafeas.v1 import common_pb2  # type: ignore
+    after:  ""
+    count: 1

--- a/.librarian/generator-input/client-post-processing/revert-reserved-words.yaml
+++ b/.librarian/generator-input/client-post-processing/revert-reserved-words.yaml
@@ -1,0 +1,41 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: Contradicts reserved words defined in gapic-generator-python
+url: https://github.com/googleapis/google-cloud-python/issues/11924
+replacements:
+  - paths: [
+      packages/google-cloud-trace/google/cloud/trace_v2/types/trace.py,
+    ]
+    before: "type_"
+    after: "type"
+    count: 4
+  - paths: [
+      packages/google-cloud-kms/google/cloud/kms_v1/types/resources.py,
+      packages/google-cloud-kms/tests/unit/gapic/kms_v1/test_key_management_service.py,
+    ]
+    before: "format_"
+    after: "format"
+    count: 7
+  - paths: [
+      packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/metrics.py
+    ]
+    before: set \(google.protobuf.struct_pb2.Value\)
+    after: set_ (google.protobuf.struct_pb2.Value)
+    count: 1
+  - paths: [
+      packages/google-cloud-dataflow-client/google/cloud/dataflow_v1beta3/types/metrics.py
+    ]
+    before: "set: struct_pb2.Value = proto.Field"
+    after: "set_: struct_pb2.Value = proto.Field"
+    count: 1

--- a/.librarian/generator-input/client-post-processing/sub-api-versioned-namespace.yaml
+++ b/.librarian/generator-input/client-post-processing/sub-api-versioned-namespace.yaml
@@ -1,0 +1,189 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: Update sub-API namespace to reflect parent API
+url: https://github.com/googleapis/gapic-generator-python/issues/1832
+replacements:
+  - paths: [
+      packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/feature.py
+    ]
+    before: |
+      from google.cloud.gkehub.configmanagement.v1 import configmanagement_pb2  # type: ignore
+      from google.cloud.gkehub.multiclusteringress.v1 import \(
+          multiclusteringress_pb2,
+      \)  # type: ignore
+    after: |
+      from google.cloud.gkehub_v1 import configmanagement_v1  # type: ignore
+      from google.cloud.gkehub_v1 import multiclusteringress_v1  # type: ignore
+    count: 1
+  - paths: [
+      packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/feature.py
+    ]
+    before: google.cloud.gkehub.configmanagement.v1.configmanagement_pb2
+    after: google.cloud.gkehub_v1.configmanagement_v1
+    count: 2
+  - paths: [
+      packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/feature.py
+    ]
+    before: google.cloud.gkehub.multiclusteringress.v1.multiclusteringress_pb2
+    after: google.cloud.gkehub_v1.multiclusteringress_v1
+    count: 1
+  - paths: [
+      packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/feature.py
+    ]
+    before: multiclusteringress_pb2
+    after: multiclusteringress_v1
+    count: 2
+  - paths: [
+      packages/google-cloud-gke-hub/google/cloud/gkehub_v1/types/feature.py
+    ]
+    before: configmanagement_pb2
+    after: configmanagement_v1
+    count: 4
+  - paths: [
+      packages/google-cloud-gke-hub/google/cloud/gkehub_v1/configmanagement_v1/__init__.py
+    ]
+    before: |
+      from google.cloud.gkehub.configmanagement_v1 import gapic_version as package_version
+    after: |
+      from google.cloud.gkehub_v1 import gapic_version as package_version
+    count: 1
+  - paths: [
+      packages/google-cloud-gke-hub/google/cloud/gkehub_v1/multiclusteringress_v1/__init__.py
+    ]
+    before: |
+      from google.cloud.gkehub.multiclusteringress_v1 import gapic_version as package_version
+    after: |
+      from google.cloud.gkehub_v1 import gapic_version as package_version
+    count: 1
+  - paths: [
+      packages/google-cloud-gke-hub/docs/index.rst
+    ]
+    before: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          gkehub_v1/services_
+          gkehub_v1/types_\n
+    after: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          gkehub_v1/services_
+          gkehub_v1/types_
+          gkehub_v1/configmanagement_v1/services_
+          gkehub_v1/configmanagement_v1/types_
+          gkehub_v1/multiclusteringress_v1/services_
+          gkehub_v1/multiclusteringress_v1/types_\n
+    count: 1
+  - paths: [
+      packages/google-cloud-workflows/docs/index.rst
+    ]
+    before: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          workflows_v1/services_
+          workflows_v1/types_
+
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          workflows_v1beta/services_
+          workflows_v1beta/types_\n\n
+    after: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          workflows_v1/services_
+          workflows_v1/types_
+
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          workflows_v1beta/services_
+          workflows_v1beta/types_
+
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          executions_v1/services_
+          executions_v1/types_
+
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          executions_v1beta/services_
+          executions_v1beta/types_\n
+    count: 1
+  - paths: [
+      packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/async_client.py,
+      packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/client.py,
+      packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/base.py,
+      packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/grpc_asyncio.py,
+      packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/grpc.py,
+      packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/rest_base.py,
+      packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/rest.py,
+      packages/google-cloud-os-login/google/cloud/oslogin_v1/types/oslogin.py,
+      packages/google-cloud-os-login/tests/unit/gapic/oslogin_v1/test_os_login_service.py,
+    ]
+    before: |
+      from google.cloud.oslogin.common.types import common
+    after: |
+      from google.cloud.oslogin_v1.common.types import common
+    count: 9
+  - paths: [
+      packages/google-cloud-os-login/docs/index.rst,
+    ]
+    before: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          oslogin_v1/services_
+          oslogin_v1/types_\n
+    after: |
+      API Reference
+      -------------
+      .. toctree::
+          :maxdepth: 2
+
+          oslogin_v1/services_
+          oslogin_v1/types_
+          oslogin_v1/common/types\n
+    count: 1
+  - paths: [
+      packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/async_client.py,
+      packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/client.py,
+      packages/google-cloud-os-login/google/cloud/oslogin_v1/types/oslogin.py,
+    ]
+    before: google.cloud.oslogin.common
+    after: google.cloud.oslogin_v1.common
+    count: 17

--- a/.librarian/generator-input/client-post-processing/unique-grafeas-client.yaml
+++ b/.librarian/generator-input/client-post-processing/unique-grafeas-client.yaml
@@ -1,0 +1,1940 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: Grafeas client is unique and requires customizations as described in PR 8186 below
+url: https://github.com/googleapis/gapic-generator-python/issues/1830
+replacements:
+  - paths: [
+      packages/grafeas/grafeas/grafeas_v1/services/grafeas/async_client.py
+    ]
+    # Use backslashes to preserve leading spaces
+    before: |
+      \    # Copy defaults from the synchronous client for use here.
+      \    # Note: DEFAULT_ENDPOINT is deprecated. Use _DEFAULT_ENDPOINT_TEMPLATE instead.
+      \    DEFAULT_ENDPOINT = GrafeasClient.DEFAULT_ENDPOINT
+      \    DEFAULT_MTLS_ENDPOINT = GrafeasClient.DEFAULT_MTLS_ENDPOINT
+      \    _DEFAULT_ENDPOINT_TEMPLATE = GrafeasClient._DEFAULT_ENDPOINT_TEMPLATE
+      \    _DEFAULT_UNIVERSE = GrafeasClient._DEFAULT_UNIVERSE\n
+    after: ""
+    count: 1
+  - paths: [
+      packages/grafeas/grafeas/grafeas_v1/services/grafeas/client.py
+    ]
+    # Use backslashes to preserve leading spaces
+    before: |
+      \    # Note: DEFAULT_ENDPOINT is deprecated. Use _DEFAULT_ENDPOINT_TEMPLATE instead.
+      \    DEFAULT_ENDPOINT = "containeranalysis.googleapis.com"
+      \    DEFAULT_MTLS_ENDPOINT = _get_default_mtls_endpoint.__func__\(  # type: ignore
+      \        DEFAULT_ENDPOINT
+      \    \)
+      \
+      \    _DEFAULT_ENDPOINT_TEMPLATE = "containeranalysis.{UNIVERSE_DOMAIN}"
+      \    _DEFAULT_UNIVERSE = "googleapis.com"\n
+    after: ""
+    count: 1
+  - paths: [
+      packages/grafeas/grafeas/grafeas_v1/services/grafeas/async_client.py
+    ]
+    # Use backslashes to preserve leading spaces
+    before: |
+      \    @classmethod
+      \    def from_service_account_file\(cls, filename: str, \*args, \*\*kwargs\):
+      \        """Creates an instance of this client using the provided credentials
+      \            file.
+      \
+      \        Args:
+      \            filename \(str\): The path to the service account private key json
+      \                file.
+      \            args: Additional arguments to pass to the constructor.
+      \            kwargs: Additional arguments to pass to the constructor.
+      \
+      \        Returns:
+      \            GrafeasAsyncClient: The constructed client.
+      \        """
+      \        return GrafeasClient.from_service_account_file.__func__\(GrafeasAsyncClient, filename, \*args, \*\*kwargs\)  # type: ignore
+      \
+      \    from_service_account_json = from_service_account_file
+      \
+      \    @classmethod
+      \    def get_mtls_endpoint_and_cert_source\(
+      \        cls, client_options: Optional\[ClientOptions\] = None
+      \    \):
+      \        """Return the API endpoint and client cert source for mutual TLS.
+      \
+      \        The client cert source is determined in the following order:
+      \        \(1\) if `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is not "true", the
+      \        client cert source is None.
+      \        \(2\) if `client_options.client_cert_source` is provided, use the provided one; if the
+      \        default client cert source exists, use the default one; otherwise the client cert
+      \        source is None.
+      \
+      \        The API endpoint is determined in the following order:
+      \        \(1\) if `client_options.api_endpoint` if provided, use the provided one.
+      \        \(2\) if `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is "always", use the
+      \        default mTLS endpoint; if the environment variable is "never", use the default API
+      \        endpoint; otherwise if client cert source exists, use the default mTLS endpoint, otherwise
+      \        use the default API endpoint.
+      \
+      \        More details can be found at https://google.aip.dev/auth/4114.
+      \
+      \        Args:
+      \            client_options \(google.api_core.client_options.ClientOptions\): Custom options for the
+      \                client. Only the `api_endpoint` and `client_cert_source` properties may be used
+      \                in this method.
+      \
+      \        Returns:
+      \            Tuple\[str, Callable\[\[\], Tuple\[bytes, bytes\]\]\]: returns the API endpoint and the
+      \                client cert source to use.
+      \
+      \        Raises:
+      \            google.auth.exceptions.MutualTLSChannelError: If any errors happen.
+      \        """
+      \        return GrafeasClient.get_mtls_endpoint_and_cert_source\(client_options\)  # type: ignore\n
+    after: ""
+    count: 1
+  - paths: [
+      packages/grafeas/grafeas/grafeas_v1/services/grafeas/client.py,
+    ]
+    # Use backslashes to preserve leading spaces
+    before: |
+      \    @classmethod
+      \    def from_service_account_file\(cls, filename: str, \*args, \*\*kwargs\):
+      \        """Creates an instance of this client using the provided credentials
+      \            file.
+      \
+      \        Args:
+      \            filename \(str\): The path to the service account private key json
+      \                file.
+      \            args: Additional arguments to pass to the constructor.
+      \            kwargs: Additional arguments to pass to the constructor.
+      \
+      \        Returns:
+      \            GrafeasClient: The constructed client.
+      \        """
+      \        credentials = service_account.Credentials.from_service_account_file\(filename\)
+      \        kwargs\["credentials"\] = credentials
+      \        return cls\(\*args, \*\*kwargs\)
+      \
+      \    from_service_account_json = from_service_account_file\n
+    after: ""
+    count: 1
+  - paths: [
+      packages/grafeas/tests/unit/gapic/grafeas_v1/test_grafeas.py,
+    ]
+    before: |
+      \)\n\n\n@pytest.mark.parametrize\(
+          "client_class,transport_class",
+          \[
+              \(GrafeasClient, transports.GrafeasGrpcTransport\),
+              \(GrafeasAsyncClient, transports.GrafeasGrpcAsyncIOTransport\),
+          \],
+      \)
+      def test_api_key_credentials\(client_class, transport_class\):
+          with mock.patch.object\(
+              google.auth._default, "get_api_key_credentials", create=True
+          \) as get_api_key_credentials:
+              mock_cred = mock.Mock\(\)
+              get_api_key_credentials.return_value = mock_cred
+              options = client_options.ClientOptions\(\)
+              options.api_key = "api_key"
+              with mock.patch.object\(transport_class, "__init__"\) as patched:
+                  patched.return_value = None
+                  client = client_class\(client_options=options\)
+                  patched.assert_called_once_with\(
+                      credentials=mock_cred,
+                      credentials_file=None,
+                      host=client._DEFAULT_ENDPOINT_TEMPLATE.format\(
+                          UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                      \),
+                      scopes=None,
+                      client_cert_source_for_mtls=None,
+                      quota_project_id=None,
+                      client_info=transports.base.DEFAULT_CLIENT_INFO,
+                      always_use_jwt_access=True,
+                      api_audience=None,
+                  \)
+    after: ")\n"
+    count: 1
+  - paths: [
+      packages/grafeas/tests/unit/gapic/grafeas_v1/test_grafeas.py,
+    ]
+    # Use backslashes to preserve leading spaces
+    before: |
+      def test_client_with_default_client_info\(\):
+          client_info = gapic_v1.client_info.ClientInfo\(\)
+
+          with mock.patch.object\(
+              transports.GrafeasTransport, "_prep_wrapped_messages"
+          \) as prep:
+              client = GrafeasClient\(
+                  credentials=ga_credentials.AnonymousCredentials\(\),
+                  client_info=client_info,
+              \)
+              prep.assert_called_once_with\(client_info\)
+
+          with mock.patch.object\(
+              transports.GrafeasTransport, "_prep_wrapped_messages"
+          \) as prep:
+              transport_class = GrafeasClient.get_transport_class\(\)
+              transport = transport_class\(
+                  credentials=ga_credentials.AnonymousCredentials\(\),
+                  client_info=client_info,
+              \)
+              prep.assert_called_once_with\(client_info\)\n\n
+    after: ""
+    count: 1
+  - paths: [
+      packages/grafeas/tests/unit/gapic/grafeas_v1/test_grafeas.py,
+    ]
+    before: |
+      @pytest.mark.parametrize\(
+          "transport_name",
+          \[
+              "grpc",
+              "grpc_asyncio",
+              "rest",
+          \],
+      \)
+      def test_grafeas_host_no_port\(transport_name\):
+          client = GrafeasClient\(
+              credentials=ga_credentials.AnonymousCredentials\(\),
+              client_options=client_options.ClientOptions\(
+                  api_endpoint="containeranalysis.googleapis.com"
+              \),
+              transport=transport_name,
+          \)
+          assert client.transport._host == \(
+              "containeranalysis.googleapis.com:443"
+              if transport_name in \["grpc", "grpc_asyncio"\]
+              else "https://containeranalysis.googleapis.com"
+          \)
+
+
+      @pytest.mark.parametrize\(
+          "transport_name",
+          \[
+              "grpc",
+              "grpc_asyncio",
+              "rest",
+          \],
+      \)
+      def test_grafeas_host_with_port\(transport_name\):
+          client = GrafeasClient\(
+              credentials=ga_credentials.AnonymousCredentials\(\),
+              client_options=client_options.ClientOptions\(
+                  api_endpoint="containeranalysis.googleapis.com:8000"
+              \),
+              transport=transport_name,
+          \)
+          assert client.transport._host == \(
+              "containeranalysis.googleapis.com:8000"
+              if transport_name in \["grpc", "grpc_asyncio"\]
+              else "https://containeranalysis.googleapis.com:8000"
+          \)
+
+
+      @pytest.mark.parametrize\(
+          "transport_name",
+          \[
+              "rest",
+          \],
+      \)
+      def test_grafeas_client_transport_session_collision\(transport_name\):
+          creds1 = ga_credentials.AnonymousCredentials\(\)
+          creds2 = ga_credentials.AnonymousCredentials\(\)
+          client1 = GrafeasClient\(
+              credentials=creds1,
+              transport=transport_name,
+          \)
+          client2 = GrafeasClient\(
+              credentials=creds2,
+              transport=transport_name,
+          \)
+          session1 = client1.transport.get_occurrence._session
+          session2 = client2.transport.get_occurrence._session
+          assert session1 != session2
+          session1 = client1.transport.list_occurrences._session
+          session2 = client2.transport.list_occurrences._session
+          assert session1 != session2
+          session1 = client1.transport.delete_occurrence._session
+          session2 = client2.transport.delete_occurrence._session
+          assert session1 != session2
+          session1 = client1.transport.create_occurrence._session
+          session2 = client2.transport.create_occurrence._session
+          assert session1 != session2
+          session1 = client1.transport.batch_create_occurrences._session
+          session2 = client2.transport.batch_create_occurrences._session
+          assert session1 != session2
+          session1 = client1.transport.update_occurrence._session
+          session2 = client2.transport.update_occurrence._session
+          assert session1 != session2
+          session1 = client1.transport.get_occurrence_note._session
+          session2 = client2.transport.get_occurrence_note._session
+          assert session1 != session2
+          session1 = client1.transport.get_note._session
+          session2 = client2.transport.get_note._session
+          assert session1 != session2
+          session1 = client1.transport.list_notes._session
+          session2 = client2.transport.list_notes._session
+          assert session1 != session2
+          session1 = client1.transport.delete_note._session
+          session2 = client2.transport.delete_note._session
+          assert session1 != session2
+          session1 = client1.transport.create_note._session
+          session2 = client2.transport.create_note._session
+          assert session1 != session2
+          session1 = client1.transport.batch_create_notes._session
+          session2 = client2.transport.batch_create_notes._session
+          assert session1 != session2
+          session1 = client1.transport.update_note._session
+          session2 = client2.transport.update_note._session
+          assert session1 != session2
+          session1 = client1.transport.list_note_occurrences._session
+          session2 = client2.transport.list_note_occurrences._session
+          assert session1 != session2\n\n
+    after: ""
+    count: 1
+  - paths: [
+      packages/grafeas/tests/unit/gapic/grafeas_v1/test_grafeas.py,
+    ]    
+    before: |
+      def test_grafeas_base_transport_error\(\):
+          # Passing both a credentials object and credentials_file should raise an error
+          with pytest.raises\(core_exceptions.DuplicateCredentialArgs\):
+              transport = transports.GrafeasTransport\(
+                  credentials=ga_credentials.AnonymousCredentials\(\),
+                  credentials_file="credentials.json",
+              \)\n\n
+    after: ""
+    count: 1
+  - paths: [
+      packages/grafeas/tests/unit/gapic/grafeas_v1/test_grafeas.py,
+    ]    
+    before: |
+      def test_credentials_transport_error\(\):
+          # It is an error to provide credentials and a transport instance.
+          transport = transports.GrafeasGrpcTransport\(
+              credentials=ga_credentials.AnonymousCredentials\(\),
+          \)
+          with pytest.raises\(ValueError\):
+              client = GrafeasClient\(
+                  credentials=ga_credentials.AnonymousCredentials\(\),
+                  transport=transport,
+              \)
+
+          # It is an error to provide a credentials file and a transport instance.
+          transport = transports.GrafeasGrpcTransport\(
+              credentials=ga_credentials.AnonymousCredentials\(\),
+          \)
+          with pytest.raises\(ValueError\):
+              client = GrafeasClient\(
+                  client_options={"credentials_file": "credentials.json"},
+                  transport=transport,
+              \)
+
+          # It is an error to provide an api_key and a transport instance.
+          transport = transports.GrafeasGrpcTransport\(
+              credentials=ga_credentials.AnonymousCredentials\(\),
+          \)
+          options = client_options.ClientOptions\(\)
+          options.api_key = "api_key"
+          with pytest.raises\(ValueError\):
+              client = GrafeasClient\(
+                  client_options=options,
+                  transport=transport,
+              \)
+
+          # It is an error to provide an api_key and a credential.
+          options = client_options.ClientOptions\(\)
+          options.api_key = "api_key"
+          with pytest.raises\(ValueError\):
+              client = GrafeasClient\(
+                  client_options=options, credentials=ga_credentials.AnonymousCredentials\(\)
+              \)
+
+          # It is an error to provide scopes and a transport instance.
+          transport = transports.GrafeasGrpcTransport\(
+              credentials=ga_credentials.AnonymousCredentials\(\),
+          \)
+          with pytest.raises\(ValueError\):
+              client = GrafeasClient\(
+                  client_options={"scopes": \["1", "2"\]},
+                  transport=transport,
+              \)\n\n
+    after: ""
+    count: 1
+  - paths: [
+        packages/grafeas/tests/unit/gapic/grafeas_v1/test_grafeas.py,
+      ]
+    before: |
+      # If default endpoint is localhost, then default mtls endpoint will be the same.
+      # This method modifies the default endpoint so the client can produce a different
+      # mtls endpoint for endpoint testing purposes.
+      def modify_default_endpoint\(client\):
+          return \(
+              "foo.googleapis.com"
+              if \("localhost" in client.DEFAULT_ENDPOINT\)
+              else client.DEFAULT_ENDPOINT
+          \)
+
+
+      # If default endpoint template is localhost, then default mtls endpoint will be the same.
+      # This method modifies the default endpoint template so the client can produce a different
+      # mtls endpoint for endpoint testing purposes.
+      def modify_default_endpoint_template\(client\):
+          return \(
+              "test.{UNIVERSE_DOMAIN}"
+              if \("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE\)
+              else client._DEFAULT_ENDPOINT_TEMPLATE
+          \)
+
+
+      def test__get_default_mtls_endpoint\(\):
+          api_endpoint = "example.googleapis.com"
+          api_mtls_endpoint = "example.mtls.googleapis.com"
+          sandbox_endpoint = "example.sandbox.googleapis.com"
+          sandbox_mtls_endpoint = "example.mtls.sandbox.googleapis.com"
+          non_googleapi = "api.example.com"
+
+          assert GrafeasClient._get_default_mtls_endpoint\(None\) is None
+          assert GrafeasClient._get_default_mtls_endpoint\(api_endpoint\) == api_mtls_endpoint
+          assert \(
+              GrafeasClient._get_default_mtls_endpoint\(api_mtls_endpoint\) == api_mtls_endpoint
+          \)
+          assert \(
+              GrafeasClient._get_default_mtls_endpoint\(sandbox_endpoint\)
+              == sandbox_mtls_endpoint
+          \)
+          assert \(
+              GrafeasClient._get_default_mtls_endpoint\(sandbox_mtls_endpoint\)
+              == sandbox_mtls_endpoint
+          \)
+          assert GrafeasClient._get_default_mtls_endpoint\(non_googleapi\) == non_googleapi
+
+
+      def test__read_environment_variables\(\):
+          assert GrafeasClient._read_environment_variables\(\) == \(False, "auto", None\)
+
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}\):
+              assert GrafeasClient._read_environment_variables\(\) == \(True, "auto", None\)
+
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "false"}\):
+              assert GrafeasClient._read_environment_variables\(\) == \(False, "auto", None\)
+
+          with mock.patch.dict\(
+              os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "Unsupported"}
+          \):
+              with pytest.raises\(ValueError\) as excinfo:
+                  GrafeasClient._read_environment_variables\(\)
+          assert \(
+              str\(excinfo.value\)
+              == "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`"
+          \)
+
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "never"}\):
+              assert GrafeasClient._read_environment_variables\(\) == \(False, "never", None\)
+
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "always"}\):
+              assert GrafeasClient._read_environment_variables\(\) == \(False, "always", None\)
+
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "auto"}\):
+              assert GrafeasClient._read_environment_variables\(\) == \(False, "auto", None\)
+
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "Unsupported"}\):
+              with pytest.raises\(MutualTLSChannelError\) as excinfo:
+                  GrafeasClient._read_environment_variables\(\)
+          assert \(
+              str\(excinfo.value\)
+              == "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
+          \)
+
+          with mock.patch.dict\(os.environ, {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"}\):
+              assert GrafeasClient._read_environment_variables\(\) == \(False, "auto", "foo.com"\)
+
+
+      def test__get_client_cert_source\(\):
+          mock_provided_cert_source = mock.Mock\(\)
+          mock_default_cert_source = mock.Mock\(\)
+
+          assert GrafeasClient._get_client_cert_source\(None, False\) is None
+          assert \(
+              GrafeasClient._get_client_cert_source\(mock_provided_cert_source, False\) is None
+          \)
+          assert \(
+              GrafeasClient._get_client_cert_source\(mock_provided_cert_source, True\)
+              == mock_provided_cert_source
+          \)
+
+          with mock.patch\(
+              "google.auth.transport.mtls.has_default_client_cert_source", return_value=True
+          \):
+              with mock.patch\(
+                  "google.auth.transport.mtls.default_client_cert_source",
+                  return_value=mock_default_cert_source,
+              \):
+                  assert \(
+                      GrafeasClient._get_client_cert_source\(None, True\)
+                      is mock_default_cert_source
+                  \)
+                  assert \(
+                      GrafeasClient._get_client_cert_source\(mock_provided_cert_source, "true"\)
+                      is mock_provided_cert_source
+                  \)
+
+
+      @mock.patch.object\(
+          GrafeasClient,
+          "_DEFAULT_ENDPOINT_TEMPLATE",
+          modify_default_endpoint_template\(GrafeasClient\),
+      \)
+      @mock.patch.object\(
+          GrafeasAsyncClient,
+          "_DEFAULT_ENDPOINT_TEMPLATE",
+          modify_default_endpoint_template\(GrafeasAsyncClient\),
+      \)
+      def test__get_api_endpoint\(\):
+          api_override = "foo.com"
+          mock_client_cert_source = mock.Mock\(\)
+          default_universe = GrafeasClient._DEFAULT_UNIVERSE
+          default_endpoint = GrafeasClient._DEFAULT_ENDPOINT_TEMPLATE.format\(
+              UNIVERSE_DOMAIN=default_universe
+          \)
+          mock_universe = "bar.com"
+          mock_endpoint = GrafeasClient._DEFAULT_ENDPOINT_TEMPLATE.format\(
+              UNIVERSE_DOMAIN=mock_universe
+          \)
+
+          assert \(
+              GrafeasClient._get_api_endpoint\(
+                  api_override, mock_client_cert_source, default_universe, "always"
+              \)
+              == api_override
+          \)
+          assert \(
+              GrafeasClient._get_api_endpoint\(
+                  None, mock_client_cert_source, default_universe, "auto"
+              \)
+              == GrafeasClient.DEFAULT_MTLS_ENDPOINT
+          \)
+          assert \(
+              GrafeasClient._get_api_endpoint\(None, None, default_universe, "auto"\)
+              == default_endpoint
+          \)
+          assert \(
+              GrafeasClient._get_api_endpoint\(None, None, default_universe, "always"\)
+              == GrafeasClient.DEFAULT_MTLS_ENDPOINT
+          \)
+          assert \(
+              GrafeasClient._get_api_endpoint\(
+                  None, mock_client_cert_source, default_universe, "always"
+              \)
+              == GrafeasClient.DEFAULT_MTLS_ENDPOINT
+          \)
+          assert \(
+              GrafeasClient._get_api_endpoint\(None, None, mock_universe, "never"\)
+              == mock_endpoint
+          \)
+          assert \(
+              GrafeasClient._get_api_endpoint\(None, None, default_universe, "never"\)
+              == default_endpoint
+          \)
+
+          with pytest.raises\(MutualTLSChannelError\) as excinfo:
+              GrafeasClient._get_api_endpoint\(
+                  None, mock_client_cert_source, mock_universe, "auto"
+              \)
+          assert \(
+              str\(excinfo.value\)
+              == "mTLS is not supported in any universe other than googleapis.com."
+          \)
+
+
+      def test__get_universe_domain\(\):
+          client_universe_domain = "foo.com"
+          universe_domain_env = "bar.com"
+
+          assert \(
+              GrafeasClient._get_universe_domain\(client_universe_domain, universe_domain_env\)
+              == client_universe_domain
+          \)
+          assert \(
+              GrafeasClient._get_universe_domain\(None, universe_domain_env\)
+              == universe_domain_env
+          \)
+          assert \(
+              GrafeasClient._get_universe_domain\(None, None\)
+              == GrafeasClient._DEFAULT_UNIVERSE
+          \)
+
+          with pytest.raises\(ValueError\) as excinfo:
+              GrafeasClient._get_universe_domain\("", None\)
+          assert str\(excinfo.value\) == "Universe Domain cannot be an empty string."
+
+
+      @pytest.mark.parametrize\(
+          "error_code,cred_info_json,show_cred_info",
+          \[
+              \(401, CRED_INFO_JSON, True\),
+              \(403, CRED_INFO_JSON, True\),
+              \(404, CRED_INFO_JSON, True\),
+              \(500, CRED_INFO_JSON, False\),
+              \(401, None, False\),
+              \(403, None, False\),
+              \(404, None, False\),
+              \(500, None, False\),
+          \],
+      \)
+      def test__add_cred_info_for_auth_errors\(error_code, cred_info_json, show_cred_info\):
+          cred = mock.Mock\(\["get_cred_info"\]\)
+          cred.get_cred_info = mock.Mock\(return_value=cred_info_json\)
+          client = GrafeasClient\(credentials=cred\)
+          client._transport._credentials = cred
+
+          error = core_exceptions.GoogleAPICallError\("message", details=\["foo"\]\)
+          error.code = error_code
+
+          client._add_cred_info_for_auth_errors\(error\)
+          if show_cred_info:
+              assert error.details == \["foo", CRED_INFO_STRING\]
+          else:
+              assert error.details == \["foo"\]
+
+
+      @pytest.mark.parametrize\("error_code", \[401, 403, 404, 500\]\)
+      def test__add_cred_info_for_auth_errors_no_get_cred_info\(error_code\):
+          cred = mock.Mock\(\[\]\)
+          assert not hasattr\(cred, "get_cred_info"\)
+          client = GrafeasClient\(credentials=cred\)
+          client._transport._credentials = cred
+
+          error = core_exceptions.GoogleAPICallError\("message", details=\[\]\)
+          error.code = error_code
+
+          client._add_cred_info_for_auth_errors\(error\)
+          assert error.details == \[\]
+
+
+      @pytest.mark.parametrize\(
+          "client_class,transport_name",
+          \[
+              \(GrafeasClient, "grpc"\),
+              \(GrafeasAsyncClient, "grpc_asyncio"\),
+              \(GrafeasClient, "rest"\),
+          \],
+      \)
+      def test_grafeas_client_from_service_account_info\(client_class, transport_name\):
+          creds = ga_credentials.AnonymousCredentials\(\)
+          with mock.patch.object\(
+              service_account.Credentials, "from_service_account_info"
+          \) as factory:
+              factory.return_value = creds
+              info = {"valid": True}
+              client = client_class.from_service_account_info\(info, transport=transport_name\)
+              assert client.transport._credentials == creds
+              assert isinstance\(client, client_class\)
+
+              assert client.transport._host == \(
+                  "containeranalysis.googleapis.com:443"
+                  if transport_name in \["grpc", "grpc_asyncio"\]
+                  else "https://containeranalysis.googleapis.com"
+              \)
+
+
+      @pytest.mark.parametrize\(
+          "transport_class,transport_name",
+          \[
+              \(transports.GrafeasGrpcTransport, "grpc"\),
+              \(transports.GrafeasGrpcAsyncIOTransport, "grpc_asyncio"\),
+              \(transports.GrafeasRestTransport, "rest"\),
+          \],
+      \)
+      def test_grafeas_client_service_account_always_use_jwt\(transport_class, transport_name\):
+          with mock.patch.object\(
+              service_account.Credentials, "with_always_use_jwt_access", create=True
+          \) as use_jwt:
+              creds = service_account.Credentials\(None, None, None\)
+              transport = transport_class\(credentials=creds, always_use_jwt_access=True\)
+              use_jwt.assert_called_once_with\(True\)
+
+          with mock.patch.object\(
+              service_account.Credentials, "with_always_use_jwt_access", create=True
+          \) as use_jwt:
+              creds = service_account.Credentials\(None, None, None\)
+              transport = transport_class\(credentials=creds, always_use_jwt_access=False\)
+              use_jwt.assert_not_called\(\)
+
+
+      @pytest.mark.parametrize\(
+          "client_class,transport_name",
+          \[
+              \(GrafeasClient, "grpc"\),
+              \(GrafeasAsyncClient, "grpc_asyncio"\),
+              \(GrafeasClient, "rest"\),
+          \],
+      \)
+      def test_grafeas_client_from_service_account_file\(client_class, transport_name\):
+          creds = ga_credentials.AnonymousCredentials\(\)
+          with mock.patch.object\(
+              service_account.Credentials, "from_service_account_file"
+          \) as factory:
+              factory.return_value = creds
+              client = client_class.from_service_account_file\(
+                  "dummy/file/path.json", transport=transport_name
+              \)
+              assert client.transport._credentials == creds
+              assert isinstance\(client, client_class\)
+
+              client = client_class.from_service_account_json\(
+                  "dummy/file/path.json", transport=transport_name
+              \)
+              assert client.transport._credentials == creds
+              assert isinstance\(client, client_class\)
+
+              assert client.transport._host == \(
+                  "containeranalysis.googleapis.com:443"
+                  if transport_name in \["grpc", "grpc_asyncio"\]
+                  else "https://containeranalysis.googleapis.com"
+              \)
+
+
+      def test_grafeas_client_get_transport_class\(\):
+          transport = GrafeasClient.get_transport_class\(\)
+          available_transports = \[
+              transports.GrafeasGrpcTransport,
+              transports.GrafeasRestTransport,
+          \]
+          assert transport in available_transports
+
+          transport = GrafeasClient.get_transport_class\("grpc"\)
+          assert transport == transports.GrafeasGrpcTransport
+
+
+      @pytest.mark.parametrize\(
+          "client_class,transport_class,transport_name",
+          \[
+              \(GrafeasClient, transports.GrafeasGrpcTransport, "grpc"\),
+              \(GrafeasAsyncClient, transports.GrafeasGrpcAsyncIOTransport, "grpc_asyncio"\),
+              \(GrafeasClient, transports.GrafeasRestTransport, "rest"\),
+          \],
+      \)
+      @mock.patch.object\(
+          GrafeasClient,
+          "_DEFAULT_ENDPOINT_TEMPLATE",
+          modify_default_endpoint_template\(GrafeasClient\),
+      \)
+      @mock.patch.object\(
+          GrafeasAsyncClient,
+          "_DEFAULT_ENDPOINT_TEMPLATE",
+          modify_default_endpoint_template\(GrafeasAsyncClient\),
+      \)
+      def test_grafeas_client_client_options\(client_class, transport_class, transport_name\):
+          # Check that if channel is provided we won't create a new one.
+          with mock.patch.object\(GrafeasClient, "get_transport_class"\) as gtc:
+              transport = transport_class\(credentials=ga_credentials.AnonymousCredentials\(\)\)
+              client = client_class\(transport=transport\)
+              gtc.assert_not_called\(\)
+
+          # Check that if channel is provided via str we will create a new one.
+          with mock.patch.object\(GrafeasClient, "get_transport_class"\) as gtc:
+              client = client_class\(transport=transport_name\)
+              gtc.assert_called\(\)
+
+          # Check the case api_endpoint is provided.
+          options = client_options.ClientOptions\(api_endpoint="squid.clam.whelk"\)
+          with mock.patch.object\(transport_class, "__init__"\) as patched:
+              patched.return_value = None
+              client = client_class\(transport=transport_name, client_options=options\)
+              patched.assert_called_once_with\(
+                  credentials=None,
+                  credentials_file=None,
+                  host="squid.clam.whelk",
+                  scopes=None,
+                  client_cert_source_for_mtls=None,
+                  quota_project_id=None,
+                  client_info=transports.base.DEFAULT_CLIENT_INFO,
+                  always_use_jwt_access=True,
+                  api_audience=None,
+              \)
+
+          # Check the case api_endpoint is not provided and GOOGLE_API_USE_MTLS_ENDPOINT is
+          # "never".
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "never"}\):
+              with mock.patch.object\(transport_class, "__init__"\) as patched:
+                  patched.return_value = None
+                  client = client_class\(transport=transport_name\)
+                  patched.assert_called_once_with\(
+                      credentials=None,
+                      credentials_file=None,
+                      host=client._DEFAULT_ENDPOINT_TEMPLATE.format\(
+                          UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                      \),
+                      scopes=None,
+                      client_cert_source_for_mtls=None,
+                      quota_project_id=None,
+                      client_info=transports.base.DEFAULT_CLIENT_INFO,
+                      always_use_jwt_access=True,
+                      api_audience=None,
+                  \)
+
+          # Check the case api_endpoint is not provided and GOOGLE_API_USE_MTLS_ENDPOINT is
+          # "always".
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "always"}\):
+              with mock.patch.object\(transport_class, "__init__"\) as patched:
+                  patched.return_value = None
+                  client = client_class\(transport=transport_name\)
+                  patched.assert_called_once_with\(
+                      credentials=None,
+                      credentials_file=None,
+                      host=client.DEFAULT_MTLS_ENDPOINT,
+                      scopes=None,
+                      client_cert_source_for_mtls=None,
+                      quota_project_id=None,
+                      client_info=transports.base.DEFAULT_CLIENT_INFO,
+                      always_use_jwt_access=True,
+                      api_audience=None,
+                  \)
+
+          # Check the case api_endpoint is not provided and GOOGLE_API_USE_MTLS_ENDPOINT has
+          # unsupported value.
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "Unsupported"}\):
+              with pytest.raises\(MutualTLSChannelError\) as excinfo:
+                  client = client_class\(transport=transport_name\)
+          assert \(
+              str\(excinfo.value\)
+              == "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
+          \)
+
+          # Check the case GOOGLE_API_USE_CLIENT_CERTIFICATE has unsupported value.
+          with mock.patch.dict\(
+              os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "Unsupported"}
+          \):
+              with pytest.raises\(ValueError\) as excinfo:
+                  client = client_class\(transport=transport_name\)
+          assert \(
+              str\(excinfo.value\)
+              == "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`"
+          \)
+
+          # Check the case quota_project_id is provided
+          options = client_options.ClientOptions\(quota_project_id="octopus"\)
+          with mock.patch.object\(transport_class, "__init__"\) as patched:
+              patched.return_value = None
+              client = client_class\(client_options=options, transport=transport_name\)
+              patched.assert_called_once_with\(
+                  credentials=None,
+                  credentials_file=None,
+                  host=client._DEFAULT_ENDPOINT_TEMPLATE.format\(
+                      UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                  \),
+                  scopes=None,
+                  client_cert_source_for_mtls=None,
+                  quota_project_id="octopus",
+                  client_info=transports.base.DEFAULT_CLIENT_INFO,
+                  always_use_jwt_access=True,
+                  api_audience=None,
+              \)
+          # Check the case api_endpoint is provided
+          options = client_options.ClientOptions\(
+              api_audience="https://language.googleapis.com"
+          \)
+          with mock.patch.object\(transport_class, "__init__"\) as patched:
+              patched.return_value = None
+              client = client_class\(client_options=options, transport=transport_name\)
+              patched.assert_called_once_with\(
+                  credentials=None,
+                  credentials_file=None,
+                  host=client._DEFAULT_ENDPOINT_TEMPLATE.format\(
+                      UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                  \),
+                  scopes=None,
+                  client_cert_source_for_mtls=None,
+                  quota_project_id=None,
+                  client_info=transports.base.DEFAULT_CLIENT_INFO,
+                  always_use_jwt_access=True,
+                  api_audience="https://language.googleapis.com",
+              \)
+
+
+      @pytest.mark.parametrize\(
+          "client_class,transport_class,transport_name,use_client_cert_env",
+          \[
+              \(GrafeasClient, transports.GrafeasGrpcTransport, "grpc", "true"\),
+              \(
+                  GrafeasAsyncClient,
+                  transports.GrafeasGrpcAsyncIOTransport,
+                  "grpc_asyncio",
+                  "true",
+              \),
+              \(GrafeasClient, transports.GrafeasGrpcTransport, "grpc", "false"\),
+              \(
+                  GrafeasAsyncClient,
+                  transports.GrafeasGrpcAsyncIOTransport,
+                  "grpc_asyncio",
+                  "false",
+              \),
+              \(GrafeasClient, transports.GrafeasRestTransport, "rest", "true"\),
+              \(GrafeasClient, transports.GrafeasRestTransport, "rest", "false"\),
+          \],
+      \)
+      @mock.patch.object\(
+          GrafeasClient,
+          "_DEFAULT_ENDPOINT_TEMPLATE",
+          modify_default_endpoint_template\(GrafeasClient\),
+      \)
+      @mock.patch.object\(
+          GrafeasAsyncClient,
+          "_DEFAULT_ENDPOINT_TEMPLATE",
+          modify_default_endpoint_template\(GrafeasAsyncClient\),
+      \)
+      @mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "auto"}\)
+      def test_grafeas_client_mtls_env_auto\(
+          client_class, transport_class, transport_name, use_client_cert_env
+      \):
+          # This tests the endpoint autoswitch behavior. Endpoint is autoswitched to the default
+          # mtls endpoint, if GOOGLE_API_USE_CLIENT_CERTIFICATE is "true" and client cert exists.
+
+          # Check the case client_cert_source is provided. Whether client cert is used depends on
+          # GOOGLE_API_USE_CLIENT_CERTIFICATE value.
+          with mock.patch.dict\(
+              os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert_env}
+          \):
+              options = client_options.ClientOptions\(
+                  client_cert_source=client_cert_source_callback
+              \)
+              with mock.patch.object\(transport_class, "__init__"\) as patched:
+                  patched.return_value = None
+                  client = client_class\(client_options=options, transport=transport_name\)
+
+                  if use_client_cert_env == "false":
+                      expected_client_cert_source = None
+                      expected_host = client._DEFAULT_ENDPOINT_TEMPLATE.format\(
+                          UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                      \)
+                  else:
+                      expected_client_cert_source = client_cert_source_callback
+                      expected_host = client.DEFAULT_MTLS_ENDPOINT
+
+                  patched.assert_called_once_with\(
+                      credentials=None,
+                      credentials_file=None,
+                      host=expected_host,
+                      scopes=None,
+                      client_cert_source_for_mtls=expected_client_cert_source,
+                      quota_project_id=None,
+                      client_info=transports.base.DEFAULT_CLIENT_INFO,
+                      always_use_jwt_access=True,
+                      api_audience=None,
+                  \)
+
+          # Check the case ADC client cert is provided. Whether client cert is used depends on
+          # GOOGLE_API_USE_CLIENT_CERTIFICATE value.
+          with mock.patch.dict\(
+              os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert_env}
+          \):
+              with mock.patch.object\(transport_class, "__init__"\) as patched:
+                  with mock.patch\(
+                      "google.auth.transport.mtls.has_default_client_cert_source",
+                      return_value=True,
+                  \):
+                      with mock.patch\(
+                          "google.auth.transport.mtls.default_client_cert_source",
+                          return_value=client_cert_source_callback,
+                      \):
+                          if use_client_cert_env == "false":
+                              expected_host = client._DEFAULT_ENDPOINT_TEMPLATE.format\(
+                                  UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                              \)
+                              expected_client_cert_source = None
+                          else:
+                              expected_host = client.DEFAULT_MTLS_ENDPOINT
+                              expected_client_cert_source = client_cert_source_callback
+
+                          patched.return_value = None
+                          client = client_class\(transport=transport_name\)
+                          patched.assert_called_once_with\(
+                              credentials=None,
+                              credentials_file=None,
+                              host=expected_host,
+                              scopes=None,
+                              client_cert_source_for_mtls=expected_client_cert_source,
+                              quota_project_id=None,
+                              client_info=transports.base.DEFAULT_CLIENT_INFO,
+                              always_use_jwt_access=True,
+                              api_audience=None,
+                          \)
+
+          # Check the case client_cert_source and ADC client cert are not provided.
+          with mock.patch.dict\(
+              os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert_env}
+          \):
+              with mock.patch.object\(transport_class, "__init__"\) as patched:
+                  with mock.patch\(
+                      "google.auth.transport.mtls.has_default_client_cert_source",
+                      return_value=False,
+                  \):
+                      patched.return_value = None
+                      client = client_class\(transport=transport_name\)
+                      patched.assert_called_once_with\(
+                          credentials=None,
+                          credentials_file=None,
+                          host=client._DEFAULT_ENDPOINT_TEMPLATE.format\(
+                              UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                          \),
+                          scopes=None,
+                          client_cert_source_for_mtls=None,
+                          quota_project_id=None,
+                          client_info=transports.base.DEFAULT_CLIENT_INFO,
+                          always_use_jwt_access=True,
+                          api_audience=None,
+                      \)
+
+
+      @pytest.mark.parametrize\("client_class", \[GrafeasClient, GrafeasAsyncClient\]\)
+      @mock.patch.object\(
+          GrafeasClient, "DEFAULT_ENDPOINT", modify_default_endpoint\(GrafeasClient\)
+      \)
+      @mock.patch.object\(
+          GrafeasAsyncClient, "DEFAULT_ENDPOINT", modify_default_endpoint\(GrafeasAsyncClient\)
+      \)
+      def test_grafeas_client_get_mtls_endpoint_and_cert_source\(client_class\):
+          mock_client_cert_source = mock.Mock\(\)
+
+          # Test the case GOOGLE_API_USE_CLIENT_CERTIFICATE is "true".
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}\):
+              mock_api_endpoint = "foo"
+              options = client_options.ClientOptions\(
+                  client_cert_source=mock_client_cert_source, api_endpoint=mock_api_endpoint
+              \)
+              api_endpoint, cert_source = client_class.get_mtls_endpoint_and_cert_source\(
+                  options
+              \)
+              assert api_endpoint == mock_api_endpoint
+              assert cert_source == mock_client_cert_source
+
+          # Test the case GOOGLE_API_USE_CLIENT_CERTIFICATE is "false".
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "false"}\):
+              mock_client_cert_source = mock.Mock\(\)
+              mock_api_endpoint = "foo"
+              options = client_options.ClientOptions\(
+                  client_cert_source=mock_client_cert_source, api_endpoint=mock_api_endpoint
+              \)
+              api_endpoint, cert_source = client_class.get_mtls_endpoint_and_cert_source\(
+                  options
+              \)
+              assert api_endpoint == mock_api_endpoint
+              assert cert_source is None
+
+          # Test the case GOOGLE_API_USE_MTLS_ENDPOINT is "never".
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "never"}\):
+              api_endpoint, cert_source = client_class.get_mtls_endpoint_and_cert_source\(\)
+              assert api_endpoint == client_class.DEFAULT_ENDPOINT
+              assert cert_source is None
+
+          # Test the case GOOGLE_API_USE_MTLS_ENDPOINT is "always".
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "always"}\):
+              api_endpoint, cert_source = client_class.get_mtls_endpoint_and_cert_source\(\)
+              assert api_endpoint == client_class.DEFAULT_MTLS_ENDPOINT
+              assert cert_source is None
+
+          # Test the case GOOGLE_API_USE_MTLS_ENDPOINT is "auto" and default cert doesn't exist.
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}\):
+              with mock.patch\(
+                  "google.auth.transport.mtls.has_default_client_cert_source",
+                  return_value=False,
+              \):
+                  api_endpoint, cert_source = client_class.get_mtls_endpoint_and_cert_source\(\)
+                  assert api_endpoint == client_class.DEFAULT_ENDPOINT
+                  assert cert_source is None
+
+          # Test the case GOOGLE_API_USE_MTLS_ENDPOINT is "auto" and default cert exists.
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}\):
+              with mock.patch\(
+                  "google.auth.transport.mtls.has_default_client_cert_source",
+                  return_value=True,
+              \):
+                  with mock.patch\(
+                      "google.auth.transport.mtls.default_client_cert_source",
+                      return_value=mock_client_cert_source,
+                  \):
+                      \(
+                          api_endpoint,
+                          cert_source,
+                      \) = client_class.get_mtls_endpoint_and_cert_source\(\)
+                      assert api_endpoint == client_class.DEFAULT_MTLS_ENDPOINT
+                      assert cert_source == mock_client_cert_source
+
+          # Check the case api_endpoint is not provided and GOOGLE_API_USE_MTLS_ENDPOINT has
+          # unsupported value.
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "Unsupported"}\):
+              with pytest.raises\(MutualTLSChannelError\) as excinfo:
+                  client_class.get_mtls_endpoint_and_cert_source\(\)
+
+              assert \(
+                  str\(excinfo.value\)
+                  == "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
+              \)
+
+          # Check the case GOOGLE_API_USE_CLIENT_CERTIFICATE has unsupported value.
+          with mock.patch.dict\(
+              os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "Unsupported"}
+          \):
+              with pytest.raises\(ValueError\) as excinfo:
+                  client_class.get_mtls_endpoint_and_cert_source\(\)
+      
+              assert \(
+                  str\(excinfo.value\)
+                  == "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`"
+              \)
+
+
+      @pytest.mark.parametrize\("client_class", \[GrafeasClient, GrafeasAsyncClient\]\)
+      @mock.patch.object\(
+          GrafeasClient,
+          "_DEFAULT_ENDPOINT_TEMPLATE",
+          modify_default_endpoint_template\(GrafeasClient\),
+      \)
+      @mock.patch.object\(
+          GrafeasAsyncClient,
+          "_DEFAULT_ENDPOINT_TEMPLATE",
+          modify_default_endpoint_template\(GrafeasAsyncClient\),
+      \)
+      def test_grafeas_client_client_api_endpoint\(client_class\):
+          mock_client_cert_source = client_cert_source_callback
+          api_override = "foo.com"
+          default_universe = GrafeasClient._DEFAULT_UNIVERSE
+          default_endpoint = GrafeasClient._DEFAULT_ENDPOINT_TEMPLATE.format\(
+              UNIVERSE_DOMAIN=default_universe
+          \)
+          mock_universe = "bar.com"
+          mock_endpoint = GrafeasClient._DEFAULT_ENDPOINT_TEMPLATE.format\(
+              UNIVERSE_DOMAIN=mock_universe
+          \)
+
+          # If ClientOptions.api_endpoint is set and GOOGLE_API_USE_CLIENT_CERTIFICATE="true",
+          # use ClientOptions.api_endpoint as the api endpoint regardless.
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}\):
+              with mock.patch\(
+                  "google.auth.transport.requests.AuthorizedSession.configure_mtls_channel"
+              \):
+                  options = client_options.ClientOptions\(
+                      client_cert_source=mock_client_cert_source, api_endpoint=api_override
+                  \)
+                  client = client_class\(
+                      client_options=options,
+                      credentials=ga_credentials.AnonymousCredentials\(\),
+                  \)
+                  assert client.api_endpoint == api_override
+
+          # If ClientOptions.api_endpoint is not set and GOOGLE_API_USE_MTLS_ENDPOINT="never",
+          # use the _DEFAULT_ENDPOINT_TEMPLATE populated with GDU as the api endpoint.
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "never"}\):
+              client = client_class\(credentials=ga_credentials.AnonymousCredentials\(\)\)
+              assert client.api_endpoint == default_endpoint
+
+          # If ClientOptions.api_endpoint is not set and GOOGLE_API_USE_MTLS_ENDPOINT="always",
+          # use the DEFAULT_MTLS_ENDPOINT as the api endpoint.
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "always"}\):
+              client = client_class\(credentials=ga_credentials.AnonymousCredentials\(\)\)
+              assert client.api_endpoint == client_class.DEFAULT_MTLS_ENDPOINT
+
+          # If ClientOptions.api_endpoint is not set, GOOGLE_API_USE_MTLS_ENDPOINT="auto" \(default\),
+          # GOOGLE_API_USE_CLIENT_CERTIFICATE="false" \(default\), default cert source doesn't exist,
+          # and ClientOptions.universe_domain="bar.com",
+          # use the _DEFAULT_ENDPOINT_TEMPLATE populated with universe domain as the api endpoint.
+          options = client_options.ClientOptions\(\)
+          universe_exists = hasattr\(options, "universe_domain"\)
+          if universe_exists:
+              options = client_options.ClientOptions\(universe_domain=mock_universe\)
+              client = client_class\(
+                  client_options=options, credentials=ga_credentials.AnonymousCredentials\(\)
+              \)
+          else:
+              client = client_class\(
+                  client_options=options, credentials=ga_credentials.AnonymousCredentials\(\)
+              \)
+          assert client.api_endpoint == \(
+              mock_endpoint if universe_exists else default_endpoint
+          \)
+          assert client.universe_domain == \(
+              mock_universe if universe_exists else default_universe
+          \)
+
+          # If ClientOptions does not have a universe domain attribute and GOOGLE_API_USE_MTLS_ENDPOINT="never",
+          # use the _DEFAULT_ENDPOINT_TEMPLATE populated with GDU as the api endpoint.
+          options = client_options.ClientOptions\(\)
+          if hasattr\(options, "universe_domain"\):
+              delattr\(options, "universe_domain"\)
+          with mock.patch.dict\(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "never"}\):
+              client = client_class\(
+                  client_options=options, credentials=ga_credentials.AnonymousCredentials\(\)
+              \)
+              assert client.api_endpoint == default_endpoint
+
+
+      @pytest.mark.parametrize\(
+          "client_class,transport_class,transport_name",
+          \[
+              \(GrafeasClient, transports.GrafeasGrpcTransport, "grpc"\),
+              \(GrafeasAsyncClient, transports.GrafeasGrpcAsyncIOTransport, "grpc_asyncio"\),
+              \(GrafeasClient, transports.GrafeasRestTransport, "rest"\),
+          \],
+      \)
+      def test_grafeas_client_client_options_scopes\(
+          client_class, transport_class, transport_name
+      \):
+          # Check the case scopes are provided.
+          options = client_options.ClientOptions\(
+              scopes=\["1", "2"\],
+          \)
+          with mock.patch.object\(transport_class, "__init__"\) as patched:
+              patched.return_value = None
+              client = client_class\(client_options=options, transport=transport_name\)
+              patched.assert_called_once_with\(
+                  credentials=None,
+                  credentials_file=None,
+                  host=client._DEFAULT_ENDPOINT_TEMPLATE.format\(
+                      UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                  \),
+                  scopes=\["1", "2"\],
+                  client_cert_source_for_mtls=None,
+                  quota_project_id=None,
+                  client_info=transports.base.DEFAULT_CLIENT_INFO,
+                  always_use_jwt_access=True,
+                  api_audience=None,
+              \)
+
+
+      @pytest.mark.parametrize\(
+          "client_class,transport_class,transport_name,grpc_helpers",
+          \[
+              \(GrafeasClient, transports.GrafeasGrpcTransport, "grpc", grpc_helpers\),
+              \(
+                  GrafeasAsyncClient,
+                  transports.GrafeasGrpcAsyncIOTransport,
+                  "grpc_asyncio",
+                  grpc_helpers_async,
+              \),
+              \(GrafeasClient, transports.GrafeasRestTransport, "rest", None\),
+          \],
+      \)
+      def test_grafeas_client_client_options_credentials_file\(
+          client_class, transport_class, transport_name, grpc_helpers
+      \):
+          # Check the case credentials file is provided.
+          options = client_options.ClientOptions\(credentials_file="credentials.json"\)
+
+          with mock.patch.object\(transport_class, "__init__"\) as patched:
+              patched.return_value = None
+              client = client_class\(client_options=options, transport=transport_name\)
+              patched.assert_called_once_with\(
+                  credentials=None,
+                  credentials_file="credentials.json",
+                  host=client._DEFAULT_ENDPOINT_TEMPLATE.format\(
+                      UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                  \),
+                  scopes=None,
+                  client_cert_source_for_mtls=None,
+                  quota_project_id=None,
+                  client_info=transports.base.DEFAULT_CLIENT_INFO,
+                  always_use_jwt_access=True,
+                  api_audience=None,
+              \)
+
+
+      def test_grafeas_client_client_options_from_dict\(\):
+          with mock.patch\(
+              "grafeas.grafeas_v1.services.grafeas.transports.GrafeasGrpcTransport.__init__"
+          \) as grpc_transport:
+              grpc_transport.return_value = None
+              client = GrafeasClient\(client_options={"api_endpoint": "squid.clam.whelk"}\)
+              grpc_transport.assert_called_once_with\(
+                  credentials=None,
+                  credentials_file=None,
+                  host="squid.clam.whelk",
+                  scopes=None,
+                  client_cert_source_for_mtls=None,
+                  quota_project_id=None,
+                  client_info=transports.base.DEFAULT_CLIENT_INFO,
+                  always_use_jwt_access=True,
+                  api_audience=None,
+              \)
+
+
+      @pytest.mark.parametrize\(
+          "client_class,transport_class,transport_name,grpc_helpers",
+          \[
+              \(GrafeasClient, transports.GrafeasGrpcTransport, "grpc", grpc_helpers\),
+              \(
+                  GrafeasAsyncClient,
+                  transports.GrafeasGrpcAsyncIOTransport,
+                  "grpc_asyncio",
+                  grpc_helpers_async,
+              \),
+          \],
+      \)
+      def test_grafeas_client_create_channel_credentials_file\(
+          client_class, transport_class, transport_name, grpc_helpers
+      \):
+          # Check the case credentials file is provided.
+          options = client_options.ClientOptions\(credentials_file="credentials.json"\)
+
+          with mock.patch.object\(transport_class, "__init__"\) as patched:
+              patched.return_value = None
+              client = client_class\(client_options=options, transport=transport_name\)
+              patched.assert_called_once_with\(
+                  credentials=None,
+                  credentials_file="credentials.json",
+                  host=client._DEFAULT_ENDPOINT_TEMPLATE.format\(
+                      UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                  \),
+                  scopes=None,
+                  client_cert_source_for_mtls=None,
+                  quota_project_id=None,
+                  client_info=transports.base.DEFAULT_CLIENT_INFO,
+                  always_use_jwt_access=True,
+                  api_audience=None,
+              \)
+
+          # test that the credentials from file are saved and used as the credentials.
+          with mock.patch.object\(
+              google.auth, "load_credentials_from_file", autospec=True
+          \) as load_creds, mock.patch.object\(
+              google.auth, "default", autospec=True
+          \) as adc, mock.patch.object\(
+              grpc_helpers, "create_channel"
+          \) as create_channel:
+              creds = ga_credentials.AnonymousCredentials\(\)
+              file_creds = ga_credentials.AnonymousCredentials\(\)
+              load_creds.return_value = \(file_creds, None\)
+              adc.return_value = \(creds, None\)
+              client = client_class\(client_options=options, transport=transport_name\)
+              create_channel.assert_called_with\(
+                  "containeranalysis.googleapis.com:443",
+                  credentials=file_creds,
+                  credentials_file=None,
+                  quota_project_id=None,
+                  default_scopes=\(\),
+                  scopes=None,
+                  default_host="containeranalysis.googleapis.com",
+                  ssl_credentials=None,
+                  options=\[
+                      \("grpc.max_send_message_length", -1\),
+                      \("grpc.max_receive_message_length", -1\),
+                  \],
+              \)\n\n
+    after: ""
+    count: 1      
+  - paths: [
+      packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/base.py,
+      packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/grpc_asyncio.py,
+      packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/grpc.py,
+      packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/rest.py,
+      packages/grafeas/tests/unit/gapic/grafeas_v1/test_grafeas.py,
+    ]
+    before: "containeranalysis.googleapis.com"
+    after: ""
+    count: 12
+  - paths: [
+      packages/grafeas/grafeas/grafeas_v1/services/grafeas/client.py,
+    ]
+    before: |
+      \}\n
+      \    @classmethod
+      \    def get_mtls_endpoint_and_cert_source\(
+      \        cls, client_options: Optional\[client_options_lib.ClientOptions\] = None
+      \    \):
+      \        """Deprecated. Return the API endpoint and client cert source for mutual TLS.
+      \
+      \        The client cert source is determined in the following order:
+      \        \(1\) if `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is not "true", the
+      \        client cert source is None.
+      \        \(2\) if `client_options.client_cert_source` is provided, use the provided one; if the
+      \        default client cert source exists, use the default one; otherwise the client cert
+      \        source is None.
+      \
+      \        The API endpoint is determined in the following order:
+      \        \(1\) if `client_options.api_endpoint` if provided, use the provided one.
+      \        \(2\) if `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is "always", use the
+      \        default mTLS endpoint; if the environment variable is "never", use the default API
+      \        endpoint; otherwise if client cert source exists, use the default mTLS endpoint, otherwise
+      \        use the default API endpoint.
+      \
+      \        More details can be found at https://google.aip.dev/auth/4114.
+      \
+      \        Args:
+      \            client_options \(google.api_core.client_options.ClientOptions\): Custom options for the
+      \                client. Only the `api_endpoint` and `client_cert_source` properties may be used
+      \                in this method.
+      \
+      \        Returns:
+      \            Tuple\[str, Callable\[\[\], Tuple\[bytes, bytes\]\]\]: returns the API endpoint and the
+      \                client cert source to use.
+      \
+      \        Raises:
+      \            google.auth.exceptions.MutualTLSChannelError: If any errors happen.
+      \        """
+      \
+      \        warnings.warn\(
+      \            "get_mtls_endpoint_and_cert_source is deprecated. Use the api_endpoint property instead.",
+      \            DeprecationWarning,
+      \        \)
+      \        if client_options is None:
+      \            client_options = client_options_lib.ClientOptions\(\)
+      \        use_client_cert = os.getenv\("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false"\)
+      \        use_mtls_endpoint = os.getenv\("GOOGLE_API_USE_MTLS_ENDPOINT", "auto"\)
+      \        if use_client_cert not in \("true", "false"\):
+      \            raise ValueError\(
+      \                "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`"
+      \            \)
+      \        if use_mtls_endpoint not in \("auto", "never", "always"\):
+      \            raise MutualTLSChannelError\(
+      \                "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
+      \            \)
+      \
+      \        # Figure out the client cert source to use.
+      \        client_cert_source = None
+      \        if use_client_cert == "true":
+      \            if client_options.client_cert_source:
+      \                client_cert_source = client_options.client_cert_source
+      \            elif mtls.has_default_client_cert_source\(\):
+      \                client_cert_source = mtls.default_client_cert_source\(\)
+      \
+      \        # Figure out which api endpoint to use.
+      \        if client_options.api_endpoint is not None:
+      \            api_endpoint = client_options.api_endpoint
+      \        elif use_mtls_endpoint == "always" or \(
+      \            use_mtls_endpoint == "auto" and client_cert_source
+      \        \):
+      \            api_endpoint = cls.DEFAULT_MTLS_ENDPOINT
+      \        else:
+      \            api_endpoint = cls.DEFAULT_ENDPOINT
+      \
+      \        return api_endpoint, client_cert_source
+      \
+      \    @staticmethod
+      \    def _read_environment_variables\(\):
+      \        """Returns the environment variables used by the client.
+      \
+      \        Returns:
+      \            Tuple\[bool, str, str\]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+      \            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
+      \
+      \        Raises:
+      \            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
+      \                any of \["true", "false"\].
+      \            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
+      \                is not any of \["auto", "never", "always"\].
+      \        """
+      \        use_client_cert = os.getenv\(
+      \            "GOOGLE_API_USE_CLIENT_CERTIFICATE", "false"
+      \        \).lower\(\)
+      \        use_mtls_endpoint = os.getenv\("GOOGLE_API_USE_MTLS_ENDPOINT", "auto"\).lower\(\)
+      \        universe_domain_env = os.getenv\("GOOGLE_CLOUD_UNIVERSE_DOMAIN"\)
+      \        if use_client_cert not in \("true", "false"\):
+      \            raise ValueError\(
+      \                "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`"
+      \            \)
+      \        if use_mtls_endpoint not in \("auto", "never", "always"\):
+      \            raise MutualTLSChannelError\(
+      \                "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
+      \            \)
+      \        return use_client_cert == "true", use_mtls_endpoint, universe_domain_env
+      \
+      \    @staticmethod
+      \    def _get_client_cert_source\(provided_cert_source, use_cert_flag\):
+      \        """Return the client cert source to be used by the client.
+      \
+      \        Args:
+      \            provided_cert_source \(bytes\): The client certificate source provided.
+      \            use_cert_flag \(bool\): A flag indicating whether to use the client certificate.
+      \
+      \        Returns:
+      \            bytes or None: The client cert source to be used by the client.
+      \        """
+      \        client_cert_source = None
+      \        if use_cert_flag:
+      \            if provided_cert_source:
+      \                client_cert_source = provided_cert_source
+      \            elif mtls.has_default_client_cert_source\(\):
+      \                client_cert_source = mtls.default_client_cert_source\(\)
+      \        return client_cert_source
+      \
+      \    @staticmethod
+      \    def _get_api_endpoint\(
+      \        api_override, client_cert_source, universe_domain, use_mtls_endpoint
+      \    \):
+      \        """Return the API endpoint used by the client.
+      \
+      \        Args:
+      \            api_override \(str\): The API endpoint override. If specified, this is always
+      \                the return value of this function and the other arguments are not used.
+      \            client_cert_source \(bytes\): The client certificate source used by the client.
+      \            universe_domain \(str\): The universe domain used by the client.
+      \            use_mtls_endpoint \(str\): How to use the mTLS endpoint, which depends also on the other parameters.
+      \                Possible values are "always", "auto", or "never".
+      \
+      \        Returns:
+      \            str: The API endpoint to be used by the client.
+      \        """
+      \        if api_override is not None:
+      \            api_endpoint = api_override
+      \        elif use_mtls_endpoint == "always" or \(
+      \            use_mtls_endpoint == "auto" and client_cert_source
+      \        \):
+      \            _default_universe = GrafeasClient._DEFAULT_UNIVERSE
+      \            if universe_domain != _default_universe:
+      \                raise MutualTLSChannelError\(
+      \                    f"mTLS is not supported in any universe other than {_default_universe}."
+      \                \)
+      \            api_endpoint = GrafeasClient.DEFAULT_MTLS_ENDPOINT
+      \        else:
+      \            api_endpoint = GrafeasClient._DEFAULT_ENDPOINT_TEMPLATE.format\(
+      \                UNIVERSE_DOMAIN=universe_domain
+      \            \)
+      \        return api_endpoint
+      \
+      \    @staticmethod
+      \    def _get_universe_domain\(
+      \        client_universe_domain: Optional\[str\], universe_domain_env: Optional\[str\]
+      \    \) -> str:
+      \        """Return the universe domain used by the client.
+      \
+      \        Args:
+      \            client_universe_domain \(Optional\[str\]\): The universe domain configured via the client options.
+      \            universe_domain_env \(Optional\[str\]\): The universe domain configured via the "GOOGLE_CLOUD_UNIVERSE_DOMAIN" environment variable.
+      \
+      \        Returns:
+      \            str: The universe domain to be used by the client.
+      \
+      \        Raises:
+      \            ValueError: If the universe domain is an empty string.
+      \        """
+      \        universe_domain = GrafeasClient._DEFAULT_UNIVERSE
+      \        if client_universe_domain is not None:
+      \            universe_domain = client_universe_domain
+      \        elif universe_domain_env is not None:
+      \            universe_domain = universe_domain_env
+      \        if len\(universe_domain.strip\(\)\) == 0:
+      \            raise ValueError\("Universe Domain cannot be an empty string."\)
+      \        return universe_domain
+      \
+      \    def _validate_universe_domain\(self\):
+      \        """Validates client's and credentials' universe domains are consistent.
+      \
+      \        Returns:
+      \            bool: True iff the configured universe domain is valid.
+      \
+      \        Raises:
+      \            ValueError: If the configured universe domain is not valid.
+      \        """
+      \
+      \        # NOTE \(b\/349488459\): universe validation is disabled until further notice.
+      \        return True
+      \
+      \    def _add_cred_info_for_auth_errors\(
+      \        self, error: core_exceptions.GoogleAPICallError
+      \    \) -> None:
+      \        """Adds credential info string to error details for 401/403/404 errors.
+      \
+      \        Args:
+      \            error \(google.api_core.exceptions.GoogleAPICallError\): The error to add the cred info.
+      \        """
+      \        if error.code not in \[
+      \            HTTPStatus.UNAUTHORIZED,
+      \            HTTPStatus.FORBIDDEN,
+      \            HTTPStatus.NOT_FOUND,
+      \        \]:
+      \            return
+      \
+      \        cred = self._transport._credentials
+      \
+      \        # get_cred_info is only available in google-auth>=2.35.0
+      \        if not hasattr\(cred, "get_cred_info"\):
+      \            return
+      \
+      \        # ignore the type check since pypy test fails when get_cred_info
+      \        # is not available
+      \        cred_info = cred.get_cred_info\(\)  # type: ignore
+      \        if cred_info and hasattr\(error._details, "append"\):
+      \            error._details.append\(json.dumps\(cred_info\)\)
+      \
+      \    @property
+      \    def api_endpoint\(self\):
+      \        """Return the API endpoint used by the client instance.
+      \
+      \        Returns:
+      \            str: The API endpoint used by the client instance.
+      \        """
+      \        return self._api_endpoint
+      \
+      \    @property
+      \    def universe_domain\(self\) -> str:
+      \        """Return the universe domain used by the client instance.
+      \
+      \        Returns:
+      \            str: The universe domain used by the client instance.
+      \        """
+      \        return self._universe_domain\n
+    after: "}"
+    count: 1
+  - paths: [
+      packages/grafeas/grafeas/grafeas_v1/services/grafeas/client.py
+    ]
+    # Use backslashes to preserve leading spaces
+    before: |
+      \    def __init__\(
+      \        self,
+      \        \*,
+      \        credentials: Optional\[ga_credentials.Credentials\] = None,
+      \        transport: Optional\[
+      \            Union\[str, GrafeasTransport, Callable\[..., GrafeasTransport\]\]
+      \        \] = None,
+      \        client_options: Optional\[Union\[client_options_lib.ClientOptions, dict\]\] = None,
+      \        client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
+      \    \) -> None:
+      \        """Instantiates the grafeas client.
+      \
+      \        Args:
+      \            credentials \(Optional\[google.auth.credentials.Credentials\]\): The
+      \                authorization credentials to attach to requests. These
+      \                credentials identify the application to the service; if none
+      \                are specified, the client will attempt to ascertain the
+      \                credentials from the environment.
+      \            transport \(Optional\[Union\[str,GrafeasTransport,Callable\[..., GrafeasTransport\]\]\]\):
+      \                The transport to use, or a Callable that constructs and returns a new transport.
+      \                If a Callable is given, it will be called with the same set of initialization
+      \                arguments as used in the GrafeasTransport constructor.
+      \                If set to None, a transport is chosen automatically.
+      \            client_options \(Optional\[Union\[google.api_core.client_options.ClientOptions, dict\]\]\):
+      \                Custom options for the client.
+      \
+      \                1. The ``api_endpoint`` property can be used to override the
+      \                default endpoint provided by the client when ``transport`` is
+      \                not explicitly provided. Only if this property is not set and
+      \                ``transport`` was not explicitly provided, the endpoint is
+      \                determined by the GOOGLE_API_USE_MTLS_ENDPOINT environment
+      \                variable, which have one of the following values:
+      \                "always" \(always use the default mTLS endpoint\), "never" \(always
+      \                use the default regular endpoint\) and "auto" \(auto-switch to the
+      \                default mTLS endpoint if client certificate is present; this is
+      \                the default value\).
+      \
+      \                2. If the GOOGLE_API_USE_CLIENT_CERTIFICATE environment variable
+      \                is "true", then the ``client_cert_source`` property can be used
+      \                to provide a client certificate for mTLS transport. If
+      \                not provided, the default SSL client certificate will be used if
+      \                present. If GOOGLE_API_USE_CLIENT_CERTIFICATE is "false" or not
+      \                set, no client certificate will be used.
+      \
+      \                3. The ``universe_domain`` property can be used to override the
+      \                default "googleapis.com" universe. Note that the ``api_endpoint``
+      \                property still takes precedence; and ``universe_domain`` is
+      \                currently not supported for mTLS.
+      \
+      \            client_info \(google.api_core.gapic_v1.client_info.ClientInfo\):
+      \                The client info used to send a user-agent string along with
+      \                API requests. If ``None``, then default info will be used.
+      \                Generally, you only need to set this if you're developing
+      \                your own client library.
+      \
+      \        Raises:
+      \            google.auth.exceptions.MutualTLSChannelError: If mutual TLS transport
+      \                creation failed for any reason.
+      \        """
+      \        self._client_options = client_options
+      \        if isinstance\(self._client_options, dict\):
+      \            self._client_options = client_options_lib.from_dict\(self._client_options\)
+      \        if self._client_options is None:
+      \            self._client_options = client_options_lib.ClientOptions\(\)
+      \        self._client_options = cast\(
+      \            client_options_lib.ClientOptions, self._client_options
+      \        \)
+      \
+      \        universe_domain_opt = getattr\(self._client_options, "universe_domain", None\)
+      \
+      \        \(
+      \            self._use_client_cert,
+      \            self._use_mtls_endpoint,
+      \            self._universe_domain_env,
+      \        \) = GrafeasClient._read_environment_variables\(\)
+      \        self._client_cert_source = GrafeasClient._get_client_cert_source\(
+      \            self._client_options.client_cert_source, self._use_client_cert
+      \        \)
+      \        self._universe_domain = GrafeasClient._get_universe_domain\(
+      \            universe_domain_opt, self._universe_domain_env
+      \        \)
+      \        self._api_endpoint = None  # updated below, depending on `transport`
+      \
+      \        # Initialize the universe domain validation.
+      \        self._is_universe_domain_valid = False
+      \
+      \        if CLIENT_LOGGING_SUPPORTED:  # pragma: NO COVER
+      \            # Setup logging.
+      \            client_logging.initialize_logging\(\)
+      \
+      \        api_key_value = getattr\(self._client_options, "api_key", None\)
+      \        if api_key_value and credentials:
+      \            raise ValueError\(
+      \                "client_options.api_key and credentials are mutually exclusive"
+      \            \)
+      \
+      \        # Save or instantiate the transport.
+      \        # Ordinarily, we provide the transport, but allowing a custom transport
+      \        # instance provides an extensibility point for unusual situations.
+      \        transport_provided = isinstance\(transport, GrafeasTransport\)
+      \        if transport_provided:
+      \            # transport is a GrafeasTransport instance.
+      \            if credentials or self._client_options.credentials_file or api_key_value:
+      \                raise ValueError\(
+      \                    "When providing a transport instance, "
+      \                    "provide its credentials directly."
+      \                \)
+      \            if self._client_options.scopes:
+      \                raise ValueError\(
+      \                    "When providing a transport instance, provide its scopes "
+      \                    "directly."
+      \                \)
+      \            self._transport = cast\(GrafeasTransport, transport\)
+      \            self._api_endpoint = self._transport.host
+      \
+      \        self._api_endpoint = self._api_endpoint or GrafeasClient._get_api_endpoint\(
+      \            self._client_options.api_endpoint,
+      \            self._client_cert_source,
+      \            self._universe_domain,
+      \            self._use_mtls_endpoint,
+      \        \)
+      \
+      \        if not transport_provided:
+      \            import google.auth._default  # type: ignore
+      \
+      \            if api_key_value and hasattr\(
+      \                google.auth._default, "get_api_key_credentials"
+      \            \):
+      \                credentials = google.auth._default.get_api_key_credentials\(
+      \                    api_key_value
+      \                \)
+      \
+      \            transport_init: Union\[
+      \                Type\[GrafeasTransport\], Callable\[..., GrafeasTransport\]
+      \            \] = \(
+      \                GrafeasClient.get_transport_class\(transport\)
+      \                if isinstance\(transport, str\) or transport is None
+      \                else cast\(Callable\[..., GrafeasTransport\], transport\)
+      \            \)
+      \            # initialize with the provided callable or the passed in class
+      \            self._transport = transport_init\(
+      \                credentials=credentials,
+      \                credentials_file=self._client_options.credentials_file,
+      \                host=self._api_endpoint,
+      \                scopes=self._client_options.scopes,
+      \                client_cert_source_for_mtls=self._client_cert_source,
+      \                quota_project_id=self._client_options.quota_project_id,
+      \                client_info=client_info,
+      \                always_use_jwt_access=True,
+      \                api_audience=self._client_options.api_audience,
+      \            \)
+      \
+      \        if "async" not in str\(self._transport\):
+      \            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor\(
+      \                std_logging.DEBUG
+      \            \):  # pragma: NO COVER
+      \                _LOGGER.debug\(
+      \                    "Created client `grafeas_v1.GrafeasClient`.",
+      \                    extra=\{
+      \                        "serviceName": "grafeas.v1.Grafeas",
+      \                        "universeDomain": getattr\(
+      \                            self._transport._credentials, "universe_domain", ""
+      \                        \),
+      \                        "credentialsType": f"\{type\(self._transport._credentials\).__module__\}.\{type\(self._transport._credentials\).__qualname__\}",
+      \                        "credentialsInfo": getattr\(
+      \                            self.transport._credentials, "get_cred_info", lambda: None
+      \                        \)\(\),
+      \                    \}
+      \                    if hasattr\(self._transport, "_credentials"\)
+      \                    else \{
+      \                        "serviceName": "grafeas.v1.Grafeas",
+      \                        "credentialsType": None,
+      \                    \},
+      \                \)
+    after: |
+      \n
+          def __init__(
+              self,
+              *,
+              transport: Union[str, GrafeasTransport] = None,
+              credentials: Optional[ga_credentials.Credentials] = None,
+          ) -> None:
+              """Instantiate the grafeas client.
+
+              Args:
+                  transport (Union[str, ~.GrafeasTransport]): The
+                      transport to use.
+                  credentials (Optional[google.auth.credentials.Credentials]): The
+                      authorization credentials to attach to requests. These
+                      credentials identify the application to the service; if none
+                      are specified, the client will attempt to ascertain the
+                      credentials from the environment.
+
+              Raises:
+                  google.auth.exceptions.MutualTLSChannelError: If mutual TLS transport
+                      creation failed for any reason.
+              """
+
+              if isinstance(transport, GrafeasTransport):
+                  self._transport = transport
+              else:
+                  Transport = GrafeasClient.get_transport_class(transport)
+                  self._transport = Transport(credentials=credentials)
+    count: 1
+  - paths: [
+      packages/grafeas/grafeas/grafeas_v1/services/grafeas/async_client.py
+    ]
+    before: |
+      GrafeasClient.get_transport_class\n
+      \    def __init__\(
+      \        self,
+      \        \*,
+      \        credentials: Optional\[ga_credentials.Credentials\] = None,
+      \        transport: Optional\[
+      \            Union\[str, GrafeasTransport, Callable\[..., GrafeasTransport\]\]
+      \        \] = "grpc_asyncio",
+      \        client_options: Optional\[ClientOptions\] = None,
+      \        client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
+      \    \) -> None:
+      \        """Instantiates the grafeas async client.
+      \
+      \        Args:
+      \            credentials \(Optional\[google.auth.credentials.Credentials\]\): The
+      \                authorization credentials to attach to requests. These
+      \                credentials identify the application to the service; if none
+      \                are specified, the client will attempt to ascertain the
+      \                credentials from the environment.
+      \            transport \(Optional\[Union\[str,GrafeasTransport,Callable\[..., GrafeasTransport\]\]\]\):
+      \                The transport to use, or a Callable that constructs and returns a new transport to use.
+      \                If a Callable is given, it will be called with the same set of initialization
+      \                arguments as used in the GrafeasTransport constructor.
+      \                If set to None, a transport is chosen automatically.
+      \            client_options \(Optional\[Union\[google.api_core.client_options.ClientOptions, dict\]\]\):
+      \                Custom options for the client.
+      \
+      \                1. The ``api_endpoint`` property can be used to override the
+      \                default endpoint provided by the client when ``transport`` is
+      \                not explicitly provided. Only if this property is not set and
+      \                ``transport`` was not explicitly provided, the endpoint is
+      \                determined by the GOOGLE_API_USE_MTLS_ENDPOINT environment
+      \                variable, which have one of the following values:
+      \                "always" \(always use the default mTLS endpoint\), "never" \(always
+      \                use the default regular endpoint\) and "auto" \(auto-switch to the
+      \                default mTLS endpoint if client certificate is present; this is
+      \                the default value\).
+      \
+      \                2. If the GOOGLE_API_USE_CLIENT_CERTIFICATE environment variable
+      \                is "true", then the ``client_cert_source`` property can be used
+      \                to provide a client certificate for mTLS transport. If
+      \                not provided, the default SSL client certificate will be used if
+      \                present. If GOOGLE_API_USE_CLIENT_CERTIFICATE is "false" or not
+      \                set, no client certificate will be used.
+      \
+      \                3. The ``universe_domain`` property can be used to override the
+      \                default "googleapis.com" universe. Note that ``api_endpoint``
+      \                property still takes precedence; and ``universe_domain`` is
+      \                currently not supported for mTLS.
+      \
+      \            client_info \(google.api_core.gapic_v1.client_info.ClientInfo\):
+      \                The client info used to send a user-agent string along with
+      \                API requests. If ``None``, then default info will be used.
+      \                Generally, you only need to set this if you're developing
+      \                your own client library.
+      \
+      \        Raises:
+      \            google.auth.exceptions.MutualTlsChannelError: If mutual TLS transport
+      \                creation failed for any reason.
+      \        """
+      \        self._client = GrafeasClient\(
+      \            credentials=credentials,
+      \            transport=transport,
+      \            client_options=client_options,
+      \            client_info=client_info,
+      \        \)
+    after: |
+      GrafeasClient.get_transport_class\n
+          def __init__(
+              self,
+              *,
+              transport: Union[str, GrafeasTransport] = "grpc_asyncio",
+              credentials: Optional[ga_credentials.Credentials] = None,
+          ) -> None:
+              """Instantiate the grafeas client.
+      
+              Args:
+                  transport (Union[str, ~.GrafeasTransport]): The
+                      transport to use.
+                  credentials (Optional[google.auth.credentials.Credentials]): The
+                      authorization credentials to attach to requests. These
+                      credentials identify the application to the service; if none
+                      are specified, the client will attempt to ascertain the
+                      credentials from the environment.
+      
+              Raises:
+                  google.auth.exceptions.MutualTlsChannelError: If mutual TLS transport
+                      creation failed for any reason.
+              """
+      
+              self._client = GrafeasClient(
+                  transport=transport,
+                  credentials=credentials,
+              )
+    count: 1
+  - paths: [
+        packages/grafeas/grafeas/grafeas_v1/services/grafeas/client.py
+    ]
+    # Use backslashes to preserve leading spaces
+    before: |
+      \        # Validate the universe domain.
+      \        self._validate_universe_domain\(\)\n
+    after: ""
+    count: 14
+  - paths: [
+        packages/grafeas/grafeas/grafeas_v1/services/grafeas/async_client.py
+    ]
+    # Use backslashes to preserve leading spaces
+    before: |
+      \        # Validate the universe domain.
+      \        self._client._validate_universe_domain\(\)\n
+    after: ""
+    count: 14
+  - paths: [
+        packages/grafeas/grafeas/grafeas_v1/services/grafeas/async_client.py
+    ]
+    # Use backslashes to preserve leading spaces
+    before: |
+      \    @property
+      \    def api_endpoint\(self\):
+      \        """Return the API endpoint used by the client instance.
+      \
+      \        Returns:
+      \            str: The API endpoint used by the client instance.
+      \        """
+      \        return self._client._api_endpoint
+      \
+      \    @property
+      \    def universe_domain\(self\) -> str:
+      \        """Return the universe domain used by the client instance.
+      \
+      \        Returns:
+      \            str: The universe domain used
+      \                by the client instance.
+      \        """
+      \        return self._client._universe_domain\n
+    after: ""
+    count: 1

--- a/.librarian/generator-input/client-post-processing/update-readme-with-pycharm-workaround.yaml
+++ b/.librarian/generator-input/client-post-processing/update-readme-with-pycharm-workaround.yaml
@@ -1,0 +1,41 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: Update README to provide a workaround for PyCharm users
+url: https://github.com/googleapis/gapic-generator-python/issues/1252
+replacements:
+  - paths: [
+      packages/google-cloud-compute/README.rst
+    ]
+    before: |
+      .. _`venv`: https://docs.python.org/3/library/venv.html
+
+
+      Code samples and snippets
+      ~~~~~~~~~~~~~~~~~~~~~~~~~
+    after: |
+      .. _`venv`: https://docs.python.org/3/library/venv.html
+
+      PyCharm/JetBrains IDEs
+      ~~~~~~~~~~~~~~~~~~~~~~
+      This library has now grown in size past the `JetBrains default size limit of ~2.5Mb`_.
+      As a result, code completion in JetBrains products can fail to work with the classes from our library. To
+      fix this, you need to update the ``idea.max.intellisense.filesize`` setting in custom properties
+      (Help -> Edit custom properties...). Just add the line ``idea.max.intellisense.filesize = 10000`` to change this
+      limit to ~10Mb.
+
+      .. _JetBrains default size limit of ~2.5Mb: https://www.jetbrains.com/help/pycharm/file-idea-properties.html
+
+      Code samples and snippets
+      ~~~~~~~~~~~~~~~~~~~~~~~~~
+    count: 1


### PR DESCRIPTION
This PR adds a `client-post-processing` directory and corresponding post-processing files to `.librarian/generator-input` as these files are needed for client library generation.

This PR was created using the following commands

```
mkdir .librarian/generator-input/client-post-processing
cp -r scripts/client-post-processing/* .librarian/generator-input/client-post-processing
```

The directory `scripts/client-post-processing` can be removed once all of the `.OwlBot.yaml` files have been removed and [owlbot automation](https://github.com/googleapis/repo-automation-bots/tree/main/packages/owl-bot) is no longer used.