### PR TITLE
chore: preserve files for librarian generation

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -16,5 +16,8 @@ libraries:
   - docs/README.rst
   - samples/README.txt
   - tar.gz
+  - gapic_version.py
+  - samples/generated_samples/snippet_metadata_
+  - scripts/client-post-processing
   remove_regex:
   - ^packages/google-cloud-language

--- a/scripts/configure_state_yaml/configure_state_yaml.py
+++ b/scripts/configure_state_yaml/configure_state_yaml.py
@@ -73,6 +73,9 @@ def configure_state_yaml() -> None:
                     "docs/README.rst",
                     "samples/README.txt",
                     "tar.gz",
+                    "gapic_version.py",
+                    "samples/generated_samples/snippet_metadata_",
+                    "scripts/client-post-processing",
                 ],
                 "remove_regex": [f"^packages/{package_path.name}"],
             }


### PR DESCRIPTION
This PR adds the following patterns to `preserve_regex` to reduce the diff during client library generation using [librarian
](https://github.com/googleapis/librarian).

  - gapic_version.py
  - samples/generated_samples/snippet_metadata_
  - scripts/client-post-processing

If we don't do this, we will have ~500 changed files when we migrate the client library generation from [owlbot](https://github.com/googleapis/repo-automation-bots/tree/main/packages/owl-bot) to [librarian
](https://github.com/googleapis/librarian), which would be too noisy.