### PR TITLE
feat: update release level to stable

### DIFF
--- a/packages/google-shopping-merchant-reports/.repo-metadata.json
+++ b/packages/google-shopping-merchant-reports/.repo-metadata.json
@@ -5,13 +5,13 @@
     "product_documentation": "https://developers.google.com/merchant/api",
     "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-reports/latest",
     "issue_tracker": "https://issuetracker.google.com/issues/new?component=171084&template=555201",
-    "release_level": "preview",
+    "release_level": "stable",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "repo": "googleapis/google-cloud-python",
     "distribution_name": "google-shopping-merchant-reports",
     "api_id": "reports.googleapis.com",
-    "default_version": "v1beta",
+    "default_version": "v1",
     "codeowner_team": "",
     "api_shortname": "reports"
 }

--- a/packages/google-shopping-merchant-reports/README.rst
+++ b/packages/google-shopping-merchant-reports/README.rst
@@ -1,14 +1,14 @@
 Python Client for Merchant Reports API
 ======================================
 
-|preview| |pypi| |versions|
+|stable| |pypi| |versions|
 
 `Merchant Reports API`_: Programmatically manage your Merchant Center accounts
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |preview| image:: https://img.shields.io/badge/support-preview-orange.svg
+.. |stable| image:: https://img.shields.io/badge/support-stable-gold.svg
    :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#stability-levels
 .. |pypi| image:: https://img.shields.io/pypi/v/google-shopping-merchant-reports.svg
    :target: https://pypi.org/project/google-shopping-merchant-reports/

--- a/packages/google-shopping-merchant-reports/docs/index.rst
+++ b/packages/google-shopping-merchant-reports/docs/index.rst
@@ -3,16 +3,8 @@
 .. include:: multiprocessing.rst
 
 This package includes clients for multiple versions of Merchant Reports API.
-By default, you will get version ``merchant_reports_v1beta``.
+By default, you will get version ``merchant_reports_v1``.
 
-
-API Reference
--------------
-.. toctree::
-    :maxdepth: 2
-
-    merchant_reports_v1beta/services_
-    merchant_reports_v1beta/types_
 
 API Reference
 -------------
@@ -29,6 +21,14 @@ API Reference
 
     merchant_reports_v1alpha/services_
     merchant_reports_v1alpha/types_
+
+API Reference
+-------------
+.. toctree::
+    :maxdepth: 2
+
+    merchant_reports_v1beta/services_
+    merchant_reports_v1beta/types_
 
 
 Changelog

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports/__init__.py
@@ -18,13 +18,13 @@ from google.shopping.merchant_reports import gapic_version as package_version
 __version__ = package_version.__version__
 
 
-from google.shopping.merchant_reports_v1beta.services.report_service.async_client import (
+from google.shopping.merchant_reports_v1.services.report_service.async_client import (
     ReportServiceAsyncClient,
 )
-from google.shopping.merchant_reports_v1beta.services.report_service.client import (
+from google.shopping.merchant_reports_v1.services.report_service.client import (
     ReportServiceClient,
 )
-from google.shopping.merchant_reports_v1beta.types.reports import (
+from google.shopping.merchant_reports_v1.types.reports import (
     BestSellersBrandView,
     BestSellersProductClusterView,
     CompetitiveVisibilityBenchmarkView,


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: update release level to stable
feat: set `google.shopping.merchant_reports_v1` as the default import for `google.shopping.merchant_reports`

Release-As: 1.0.0
END_COMMIT_OVERRIDE