### PR TITLE
feat: update release level to stable

### DIFF
--- a/packages/google-shopping-merchant-ordertracking/.repo-metadata.json
+++ b/packages/google-shopping-merchant-ordertracking/.repo-metadata.json
@@ -5,13 +5,13 @@
   "product_documentation": "https://developers.google.com/merchant/api",
   "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-ordertracking/latest",
   "issue_tracker": "https://issuetracker.google.com/issues/new?component=171084&template=555201",
-  "release_level": "preview",
+  "release_level": "stable",
   "language": "python",
   "library_type": "GAPIC_AUTO",
   "repo": "googleapis/google-cloud-python",
   "distribution_name": "google-shopping-merchant-ordertracking",
   "api_id": "ordertracking.googleapis.com",
-  "default_version": "v1beta",
+  "default_version": "v1",
   "codeowner_team": "",
   "api_shortname": "ordertracking"
 }

--- a/packages/google-shopping-merchant-ordertracking/README.rst
+++ b/packages/google-shopping-merchant-ordertracking/README.rst
@@ -1,14 +1,14 @@
 Python Client for Merchant API
 ==============================
 
-|preview| |pypi| |versions|
+|stable| |pypi| |versions|
 
 `Merchant API`_: Programmatically manage your Merchant Center Accounts. 
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |preview| image:: https://img.shields.io/badge/support-preview-orange.svg
+.. |stable| image:: https://img.shields.io/badge/support-stable-gold.svg
    :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#stability-levels
 .. |pypi| image:: https://img.shields.io/pypi/v/google-shopping-merchant-ordertracking.svg
    :target: https://pypi.org/project/google-shopping-merchant-ordertracking/

--- a/packages/google-shopping-merchant-ordertracking/docs/index.rst
+++ b/packages/google-shopping-merchant-ordertracking/docs/index.rst
@@ -3,16 +3,8 @@
 .. include:: multiprocessing.rst
 
 This package includes clients for multiple versions of Merchant API.
-By default, you will get version ``merchant_ordertracking_v1beta``.
+By default, you will get version ``merchant_ordertracking_v1``.
 
-
-API Reference
--------------
-.. toctree::
-    :maxdepth: 2
-
-    merchant_ordertracking_v1beta/services_
-    merchant_ordertracking_v1beta/types_
 
 API Reference
 -------------
@@ -21,6 +13,14 @@ API Reference
 
     merchant_ordertracking_v1/services_
     merchant_ordertracking_v1/types_
+
+API Reference
+-------------
+.. toctree::
+    :maxdepth: 2
+
+    merchant_ordertracking_v1beta/services_
+    merchant_ordertracking_v1beta/types_
 
 
 Changelog

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking/__init__.py
@@ -18,13 +18,13 @@ from google.shopping.merchant_ordertracking import gapic_version as package_vers
 __version__ = package_version.__version__
 
 
-from google.shopping.merchant_ordertracking_v1beta.services.order_tracking_signals_service.async_client import (
+from google.shopping.merchant_ordertracking_v1.services.order_tracking_signals_service.async_client import (
     OrderTrackingSignalsServiceAsyncClient,
 )
-from google.shopping.merchant_ordertracking_v1beta.services.order_tracking_signals_service.client import (
+from google.shopping.merchant_ordertracking_v1.services.order_tracking_signals_service.client import (
     OrderTrackingSignalsServiceClient,
 )
-from google.shopping.merchant_ordertracking_v1beta.types.order_tracking_signals import (
+from google.shopping.merchant_ordertracking_v1.types.order_tracking_signals import (
     CreateOrderTrackingSignalRequest,
     OrderTrackingSignal,
 )


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: update release level to stable
feat: set `google.shopping.merchant_ordertracking_v1` as the default import for `google.shopping.merchant_ordertracking`

Release-As: 1.0.0
END_COMMIT_OVERRIDE