### PR TITLE
feat: update release level to stable

### DIFF
--- a/packages/google-shopping-merchant-promotions/.repo-metadata.json
+++ b/packages/google-shopping-merchant-promotions/.repo-metadata.json
@@ -5,13 +5,13 @@
     "product_documentation": "https://developers.google.com/merchant/api",
     "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-promotions/latest",
     "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
-    "release_level": "preview",
+    "release_level": "stable",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "repo": "googleapis/google-cloud-python",
     "distribution_name": "google-shopping-merchant-promotions",
     "api_id": "promotions.googleapis.com",
-    "default_version": "v1beta",
+    "default_version": "v1",
     "codeowner_team": "",
     "api_shortname": "promotions"
 }

--- a/packages/google-shopping-merchant-promotions/README.rst
+++ b/packages/google-shopping-merchant-promotions/README.rst
@@ -1,14 +1,14 @@
 Python Client for Merchant API
 ==============================
 
-|preview| |pypi| |versions|
+|stable| |pypi| |versions|
 
 `Merchant API`_: Programmatically manage your Merchant Center accounts.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |preview| image:: https://img.shields.io/badge/support-preview-orange.svg
+.. |stable| image:: https://img.shields.io/badge/support-stable-gold.svg
    :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#stability-levels
 .. |pypi| image:: https://img.shields.io/pypi/v/google-shopping-merchant-promotions.svg
    :target: https://pypi.org/project/google-shopping-merchant-promotions/

--- a/packages/google-shopping-merchant-promotions/docs/index.rst
+++ b/packages/google-shopping-merchant-promotions/docs/index.rst
@@ -3,16 +3,8 @@
 .. include:: multiprocessing.rst
 
 This package includes clients for multiple versions of Merchant API.
-By default, you will get version ``merchant_promotions_v1beta``.
+By default, you will get version ``merchant_promotions_v1``.
 
-
-API Reference
--------------
-.. toctree::
-    :maxdepth: 2
-
-    merchant_promotions_v1beta/services_
-    merchant_promotions_v1beta/types_
 
 API Reference
 -------------
@@ -21,6 +13,14 @@ API Reference
 
     merchant_promotions_v1/services_
     merchant_promotions_v1/types_
+
+API Reference
+-------------
+.. toctree::
+    :maxdepth: 2
+
+    merchant_promotions_v1beta/services_
+    merchant_promotions_v1beta/types_
 
 
 Changelog

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions/__init__.py
@@ -18,20 +18,20 @@ from google.shopping.merchant_promotions import gapic_version as package_version
 __version__ = package_version.__version__
 
 
-from google.shopping.merchant_promotions_v1beta.services.promotions_service.async_client import (
+from google.shopping.merchant_promotions_v1.services.promotions_service.async_client import (
     PromotionsServiceAsyncClient,
 )
-from google.shopping.merchant_promotions_v1beta.services.promotions_service.client import (
+from google.shopping.merchant_promotions_v1.services.promotions_service.client import (
     PromotionsServiceClient,
 )
-from google.shopping.merchant_promotions_v1beta.types.promotions import (
+from google.shopping.merchant_promotions_v1.types.promotions import (
     GetPromotionRequest,
     InsertPromotionRequest,
     ListPromotionsRequest,
     ListPromotionsResponse,
     Promotion,
 )
-from google.shopping.merchant_promotions_v1beta.types.promotions_common import (
+from google.shopping.merchant_promotions_v1.types.promotions_common import (
     Attributes,
     CouponValueType,
     OfferType,


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: update release level to stable
feat: set `google.shopping.merchant_promotions_v1` as the default import for `google.shopping.merchant_promotions`

Release-As: 1.0.0
END_COMMIT_OVERRIDE