### PR TITLE
feat!: update release level to stable

### DIFF
--- a/packages/google-shopping-merchant-notifications/.repo-metadata.json
+++ b/packages/google-shopping-merchant-notifications/.repo-metadata.json
@@ -5,13 +5,13 @@
     "product_documentation": "https://developers.google.com/merchant/api",
     "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-notifications/latest",
     "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
-    "release_level": "preview",
+    "release_level": "stable",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "repo": "googleapis/google-cloud-python",
     "distribution_name": "google-shopping-merchant-notifications",
     "api_id": "merchantapi.googleapis.com",
-    "default_version": "v1beta",
+    "default_version": "v1",
     "codeowner_team": "",
     "api_shortname": "notifications"
 }

--- a/packages/google-shopping-merchant-notifications/README.rst
+++ b/packages/google-shopping-merchant-notifications/README.rst
@@ -1,14 +1,14 @@
 Python Client for Merchant API
 ==============================
 
-|preview| |pypi| |versions|
+|stable| |pypi| |versions|
 
 `Merchant API`_: Programmatically manage your Merchant Center accounts.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |preview| image:: https://img.shields.io/badge/support-preview-orange.svg
+.. |stable| image:: https://img.shields.io/badge/support-stable-gold.svg
    :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#stability-levels
 .. |pypi| image:: https://img.shields.io/pypi/v/google-shopping-merchant-notifications.svg
    :target: https://pypi.org/project/google-shopping-merchant-notifications/

--- a/packages/google-shopping-merchant-notifications/docs/index.rst
+++ b/packages/google-shopping-merchant-notifications/docs/index.rst
@@ -3,16 +3,8 @@
 .. include:: multiprocessing.rst
 
 This package includes clients for multiple versions of Merchant API.
-By default, you will get version ``merchant_notifications_v1beta``.
+By default, you will get version ``merchant_notifications_v1``.
 
-
-API Reference
--------------
-.. toctree::
-    :maxdepth: 2
-
-    merchant_notifications_v1beta/services_
-    merchant_notifications_v1beta/types_
 
 API Reference
 -------------
@@ -21,6 +13,14 @@ API Reference
 
     merchant_notifications_v1/services_
     merchant_notifications_v1/types_
+
+API Reference
+-------------
+.. toctree::
+    :maxdepth: 2
+
+    merchant_notifications_v1beta/services_
+    merchant_notifications_v1beta/types_
 
 
 Changelog

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications/__init__.py
@@ -18,23 +18,21 @@ from google.shopping.merchant_notifications import gapic_version as package_vers
 __version__ = package_version.__version__
 
 
-from google.shopping.merchant_notifications_v1beta.services.notifications_api_service.async_client import (
+from google.shopping.merchant_notifications_v1.services.notifications_api_service.async_client import (
     NotificationsApiServiceAsyncClient,
 )
-from google.shopping.merchant_notifications_v1beta.services.notifications_api_service.client import (
+from google.shopping.merchant_notifications_v1.services.notifications_api_service.client import (
     NotificationsApiServiceClient,
 )
-from google.shopping.merchant_notifications_v1beta.types.notificationsapi import (
-    Attribute,
+from google.shopping.merchant_notifications_v1.types.notificationsapi import (
     CreateNotificationSubscriptionRequest,
     DeleteNotificationSubscriptionRequest,
+    GetNotificationSubscriptionHealthMetricsRequest,
     GetNotificationSubscriptionRequest,
     ListNotificationSubscriptionsRequest,
     ListNotificationSubscriptionsResponse,
     NotificationSubscription,
-    ProductChange,
-    ProductStatusChangeMessage,
-    Resource,
+    NotificationSubscriptionHealthMetrics,
     UpdateNotificationSubscriptionRequest,
 )
 
@@ -43,13 +41,11 @@ __all__ = (
     "NotificationsApiServiceAsyncClient",
     "CreateNotificationSubscriptionRequest",
     "DeleteNotificationSubscriptionRequest",
+    "GetNotificationSubscriptionHealthMetricsRequest",
     "GetNotificationSubscriptionRequest",
     "ListNotificationSubscriptionsRequest",
     "ListNotificationSubscriptionsResponse",
     "NotificationSubscription",
-    "ProductChange",
-    "ProductStatusChangeMessage",
+    "NotificationSubscriptionHealthMetrics",
     "UpdateNotificationSubscriptionRequest",
-    "Attribute",
-    "Resource",
 )

--- a/packages/google-shopping-merchant-notifications/scripts/client-post-processing/add-missing-dependencies-to-setup-py-constraints.yaml
+++ b/packages/google-shopping-merchant-notifications/scripts/client-post-processing/add-missing-dependencies-to-setup-py-constraints.yaml
@@ -1,0 +1,1 @@
+../../../../scripts/client-post-processing/add-missing-dependencies-to-setup-py-constraints.yaml

--- a/packages/google-shopping-merchant-notifications/testing/constraints-3.7.txt
+++ b/packages/google-shopping-merchant-notifications/testing/constraints-3.7.txt
@@ -7,5 +7,5 @@
 google-api-core==1.34.1
 google-auth==2.14.1
 proto-plus==1.22.3
-protobuf==3.20.2
 google-shopping-type==0.1.6
+protobuf==3.20.2

--- a/scripts/client-post-processing/add-missing-dependencies-to-setup-py-constraints.yaml
+++ b/scripts/client-post-processing/add-missing-dependencies-to-setup-py-constraints.yaml
@@ -183,7 +183,7 @@ replacements:
           "proto-plus >= 1.22.3, <2.0.0",
           "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
           "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
-          "google-shopping-type >= 0.1.6, <1.0.0",
+          "google-shopping-type >= 1.0.0, <2.0.0",
       ]
     count: 1
   - paths: [
@@ -198,6 +198,6 @@ replacements:
       google-api-core==1.34.1
       google-auth==2.14.1
       proto-plus==1.22.3
-      google-shopping-type==0.1.6
+      google-shopping-type==1.0.0
       protobuf==3.20.2
     count: 1

--- a/scripts/client-post-processing/add-missing-dependencies-to-setup-py-constraints.yaml
+++ b/scripts/client-post-processing/add-missing-dependencies-to-setup-py-constraints.yaml
@@ -161,3 +161,43 @@ replacements:
           "google-cloud-org-policy >= 1.0.0, <2.0.0",
           "proto-plus >= 1.22.3, <2.0.0",
     count: 1
+  - paths: [
+      packages/google-shopping-merchant-notifications/setup.py
+    ]
+    before: |
+      dependencies = \[
+          "google-api-core\[grpc\] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+          "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
+          "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
+      \]
+    after:  |
+      dependencies = [
+          "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+          # Exclude incompatible versions of `google-auth`
+          # See https://github.com/googleapis/google-cloud-python/issues/12364
+          "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+          "proto-plus >= 1.22.3, <2.0.0",
+          "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
+          "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
+          "google-shopping-type >= 0.1.6, <1.0.0",
+      ]
+    count: 1
+  - paths: [
+      packages/google-shopping-merchant-notifications/testing/constraints-3.7.txt
+    ]
+    before: |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      proto-plus==1.22.3
+      protobuf==3.20.2
+    after:  |
+      google-api-core==1.34.1
+      google-auth==2.14.1
+      proto-plus==1.22.3
+      google-shopping-type==0.1.6
+      protobuf==3.20.2
+    count: 1


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: update release level to stable
feat!: set `google.shopping.merchant_notifications_v1` as the default import for `google.shopping.merchant_notifications`

Release-As: 1.0.0
END_COMMIT_OVERRIDE