### PR TITLE
chore: release google-shopping-type

### DIFF
--- a/packages/google-shopping-type/CHANGELOG.md
+++ b/packages/google-shopping-type/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-type-v0.1.12...google-shopping-type-v1.0.0) (2025-08-13)
+
+
+### Features
+
+* update release level to stable ([36b954f](https://github.com/googleapis/google-cloud-python/commit/36b954fa18367a079311efcad7b18444c5c00c03))
+
 ## [0.1.12](https://github.com/googleapis/google-cloud-python/compare/google-shopping-type-v0.1.11...google-shopping-type-v0.1.12) (2025-06-11)
 
 

--- a/packages/google-shopping-type/google/shopping/type/gapic_version.py
+++ b/packages/google-shopping-type/google/shopping/type/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.1.12"  # {x-release-please-version}
+__version__ = "1.0.0"  # {x-release-please-version}


### PR DESCRIPTION
Towards #14230 (see [comment](https://github.com/googleapis/google-cloud-python/pull/14230#issuecomment-3185953202)).