### PR TITLE
fix: update cloud build for exitgates to not use Kaniko as the build image

### DIFF
--- a/cloudbuild-exitgate.yaml
+++ b/cloudbuild-exitgate.yaml
@@ -16,25 +16,10 @@
 # Reduce this timeout by moving the installation of Python runtimes to a separate base image
 timeout: 7200s  # 2 hours for the first uncached run, can be lowered later.
 steps:
-  # A single step using the Kaniko executor to build and cache
-  - name: 'gcr.io/kaniko-project/executor:latest'
-    args:
-      # Specifies the Dockerfile path
-      - '--dockerfile=.generator/Dockerfile'
-      # Specifies the build context directory
-      - '--context=.'
-      # The final destination for the image
-      - '--destination=us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/python-librarian-generator:latest'
-      # Enables Kaniko's remote registry caching
-      - '--cache=true'
-      # (Optional but recommended) Sets a time-to-live for cache layers
-      - '--cache-ttl=24h'
-      # Use a consistent, non-root UID/GID for automated builds.
-      - '--build-arg=UID=1000'
-      - '--build-arg=GID=1000'
-
-# The 'images' section is no longer needed because Kaniko pushes the image itself.
-
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build','-f', '.generator/Dockerfile', '-t', 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/python-librarian-generator', '.']
+images:
+  - 'us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/python-librarian-generator'
 options:
   logging: CLOUD_LOGGING_ONLY
   machineType: E2_HIGHCPU_32


### PR DESCRIPTION
This is required as Kaniko doesn't support exposing the build artifact image to GCB, which is necessary in AR exit gates to chain the deployment process to stage/prod.

Note Kaniko was used for caching purposes which is not necessary for the automated deployment pipeline.