### PR TITLE
chore: remove symlink to prepare for librarian migration

### DIFF
--- a/packages/google-cloud-language/docs/CHANGELOG.md
+++ b/packages/google-cloud-language/docs/CHANGELOG.md
@@ -1,1 +1,587 @@
-../CHANGELOG.md
+# Changelog
+
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-language/#history
+
+## [2.17.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.17.1...google-cloud-language-v2.17.2) (2025-06-11)
+
+
+### Documentation
+
+* Update import statement example in README ([868b006](https://github.com/googleapis/google-cloud-python/commit/868b0069baf1a4bf6705986e0b6885419b35cdcc))
+
+## [2.17.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.17.0...google-cloud-language-v2.17.1) (2025-03-15)
+
+
+### Bug Fixes
+
+* [Many APIs] Allow Protobuf 6.x ([c8bbf32](https://github.com/googleapis/google-cloud-python/commit/c8bbf32606e790b559b261bf96700c76b6e2bfce))
+* remove setup.cfg configuration for creating universal wheels ([#13659](https://github.com/googleapis/google-cloud-python/issues/13659)) ([59bfd42](https://github.com/googleapis/google-cloud-python/commit/59bfd42cf8a2eaeed696a7504890bce5aae815ce))
+
+## [2.17.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.16.0...google-cloud-language-v2.17.0) (2025-02-12)
+
+
+### Features
+
+* Add REST Interceptors which support reading metadata ([908d742](https://github.com/googleapis/google-cloud-python/commit/908d7421a4adadd7407df7ec2a25e25688ff180f))
+* Add support for reading selective GAPIC generation methods from service YAML ([908d742](https://github.com/googleapis/google-cloud-python/commit/908d7421a4adadd7407df7ec2a25e25688ff180f))
+
+## [2.16.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.15.1...google-cloud-language-v2.16.0) (2024-12-12)
+
+
+### Features
+
+* Add support for opt-in debug logging ([feb5c03](https://github.com/googleapis/google-cloud-python/commit/feb5c0348d0efbe5d3c01d5470f2daaef5302842))
+
+
+### Bug Fixes
+
+* Fix typing issue with gRPC metadata when key ends in -bin ([feb5c03](https://github.com/googleapis/google-cloud-python/commit/feb5c0348d0efbe5d3c01d5470f2daaef5302842))
+
+## [2.15.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.15.0...google-cloud-language-v2.15.1) (2024-11-11)
+
+
+### Bug Fixes
+
+* disable universe-domain validation ([#13243](https://github.com/googleapis/google-cloud-python/issues/13243)) ([d794dec](https://github.com/googleapis/google-cloud-python/commit/d794dec5eff5f23a1ff926012bf9e6cad719e020))
+
+## [2.15.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.14.0...google-cloud-language-v2.15.0) (2024-10-24)
+
+
+### Features
+
+* Add support for Python 3.13 ([#13207](https://github.com/googleapis/google-cloud-python/issues/13207)) ([ceb9be8](https://github.com/googleapis/google-cloud-python/commit/ceb9be8f89ac7355d842bac1d77b2926eb0b649c))
+
+## [2.14.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.13.4...google-cloud-language-v2.14.0) (2024-07-30)
+
+
+### Features
+
+* [google-cloud-language] add model_version in ModerateTextRequest and expose severity score in ClassificationCategory ([#12945](https://github.com/googleapis/google-cloud-python/issues/12945)) ([ff45b04](https://github.com/googleapis/google-cloud-python/commit/ff45b04acb49540bd36bfdf7d58db0e0886013c0))
+
+
+### Bug Fixes
+
+* Retry and timeout values do not propagate in requests during pagination ([189922a](https://github.com/googleapis/google-cloud-python/commit/189922a0fbe969dedc7b0f78a62ccb2e5d3f29a9))
+
+## [2.13.4](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.13.3...google-cloud-language-v2.13.4) (2024-07-08)
+
+
+### Bug Fixes
+
+* Allow Protobuf 5.x ([#12867](https://github.com/googleapis/google-cloud-python/issues/12867)) ([3362176](https://github.com/googleapis/google-cloud-python/commit/33621762b989106ccf85adb538cf531c513a746c))
+
+## [2.13.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.13.2...google-cloud-language-v2.13.3) (2024-03-05)
+
+
+### Bug Fixes
+
+* **deps:** Exclude google-auth 2.24.0 and 2.25.0 ([#12385](https://github.com/googleapis/google-cloud-python/issues/12385)) ([d50f4d0](https://github.com/googleapis/google-cloud-python/commit/d50f4d042774e2f12e9fe03459eae9ce91247df3))
+
+## [2.13.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.13.1...google-cloud-language-v2.13.2) (2024-02-22)
+
+
+### Bug Fixes
+
+* **deps:** [Many APIs] Require `google-api-core&gt;=1.34.1` ([#12307](https://github.com/googleapis/google-cloud-python/issues/12307)) ([be87bc4](https://github.com/googleapis/google-cloud-python/commit/be87bc4a33fe32a512448a42246c9873da88269f))
+* fix ValueError in test__validate_universe_domain ([dd749df](https://github.com/googleapis/google-cloud-python/commit/dd749dfb4caf2e33f1152dfd8c4b0ac5424c381c))
+
+## [2.13.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.13.0...google-cloud-language-v2.13.1) (2024-02-06)
+
+
+### Bug Fixes
+
+* Add google-auth as a direct dependency ([27dceb9](https://github.com/googleapis/google-cloud-python/commit/27dceb901cb9bf28da82925ad382ce7c58e91f38))
+* Add staticmethod decorator to _get_client_cert_source and _get_api_endpoint ([27dceb9](https://github.com/googleapis/google-cloud-python/commit/27dceb901cb9bf28da82925ad382ce7c58e91f38))
+* Resolve AttributeError 'Credentials' object has no attribute 'universe_domain' ([27dceb9](https://github.com/googleapis/google-cloud-python/commit/27dceb901cb9bf28da82925ad382ce7c58e91f38))
+
+## [2.13.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.12.0...google-cloud-language-v2.13.0) (2024-02-01)
+
+
+### Features
+
+* Allow users to explicitly configure universe domain ([#12241](https://github.com/googleapis/google-cloud-python/issues/12241)) ([aae72f5](https://github.com/googleapis/google-cloud-python/commit/aae72f5e6c7d48e777fdf68d1012b2b51b912bad))
+
+## [2.12.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.11.1...google-cloud-language-v2.12.0) (2023-12-07)
+
+
+### Features
+
+* Add support for python 3.12 ([f46b37f](https://github.com/googleapis/google-cloud-python/commit/f46b37f825f96add7b127282414346c1a1a96231))
+* Introduce compatibility with native namespace packages ([f46b37f](https://github.com/googleapis/google-cloud-python/commit/f46b37f825f96add7b127282414346c1a1a96231))
+
+
+### Bug Fixes
+
+* Require proto-plus &gt;= 1.22.3 ([f46b37f](https://github.com/googleapis/google-cloud-python/commit/f46b37f825f96add7b127282414346c1a1a96231))
+* Use `retry_async` instead of `retry` in async client ([f46b37f](https://github.com/googleapis/google-cloud-python/commit/f46b37f825f96add7b127282414346c1a1a96231))
+
+## [2.11.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.11.0...google-cloud-language-v2.11.1) (2023-09-19)
+
+
+### Documentation
+
+* Minor formatting ([1ae610b](https://github.com/googleapis/google-cloud-python/commit/1ae610bb3b321ceac7bd23a455a002e39645d84f))
+
+## [2.11.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v2.10.1...google-cloud-language-v2.11.0) (2023-08-11)
+
+
+### Features
+
+* Add support for the v2 API ([#11566](https://github.com/googleapis/google-cloud-python/issues/11566)) ([e0e5ce2](https://github.com/googleapis/google-cloud-python/commit/e0e5ce2ae0b2b2b5a3023162a06fbf8c87a5a8c7))
+
+## [2.10.1](https://github.com/googleapis/python-language/compare/v2.10.0...v2.10.1) (2023-07-04)
+
+
+### Bug Fixes
+
+* Add async context manager return types ([#440](https://github.com/googleapis/python-language/issues/440)) ([f6322f4](https://github.com/googleapis/python-language/commit/f6322f471be25c7f8f5c1392d78ebfcb4f498785))
+
+## [2.10.0](https://github.com/googleapis/python-language/compare/v2.9.1...v2.10.0) (2023-05-25)
+
+
+### Features
+
+* Add support for ModerateText ([#433](https://github.com/googleapis/python-language/issues/433)) ([033a20b](https://github.com/googleapis/python-language/commit/033a20bf9aee96b2cbadd15a36d520b4ec40c7ab))
+
+## [2.9.1](https://github.com/googleapis/python-language/compare/v2.9.0...v2.9.1) (2023-03-23)
+
+
+### Documentation
+
+* Fix formatting of request arg in docstring ([#429](https://github.com/googleapis/python-language/issues/429)) ([475e787](https://github.com/googleapis/python-language/commit/475e787aa7c2cd6a6268c2656d6d9e3cd3a76735))
+
+## [2.9.0](https://github.com/googleapis/python-language/compare/v2.8.1...v2.9.0) (2023-02-16)
+
+
+### Features
+
+* Enable "rest" transport in Python for services supporting numeric enums ([#423](https://github.com/googleapis/python-language/issues/423)) ([21c09b8](https://github.com/googleapis/python-language/commit/21c09b8e009a560c77d96f8fa92c5e91cfdad29f))
+
+## [2.8.1](https://github.com/googleapis/python-language/compare/v2.8.0...v2.8.1) (2023-01-20)
+
+
+### Bug Fixes
+
+* Add context manager return types ([a26c418](https://github.com/googleapis/python-language/commit/a26c418a54cb26825c9c539282ed37cb9d9eac0c))
+
+
+### Documentation
+
+* Add documentation for enums ([a26c418](https://github.com/googleapis/python-language/commit/a26c418a54cb26825c9c539282ed37cb9d9eac0c))
+
+## [2.8.0](https://github.com/googleapis/python-language/compare/v2.7.0...v2.8.0) (2023-01-10)
+
+
+### Features
+
+* Add support for python 3.11 ([#413](https://github.com/googleapis/python-language/issues/413)) ([c156e1e](https://github.com/googleapis/python-language/commit/c156e1e67a3430d55664e3abad27951d4af07daf))
+
+## [2.7.0](https://github.com/googleapis/python-language/compare/v2.6.1...v2.7.0) (2022-12-14)
+
+
+### Features
+
+* Add support for `google.cloud.language.__version__` ([3ff2900](https://github.com/googleapis/python-language/commit/3ff2900b0d4c00d408dc9743d80bb034677be978))
+* Add typing to proto.Message based class attributes ([3ff2900](https://github.com/googleapis/python-language/commit/3ff2900b0d4c00d408dc9743d80bb034677be978))
+
+
+### Bug Fixes
+
+* Add dict typing for client_options ([3ff2900](https://github.com/googleapis/python-language/commit/3ff2900b0d4c00d408dc9743d80bb034677be978))
+* **deps:** Require google-api-core &gt;=1.34.0, >=2.11.0  ([fa4547f](https://github.com/googleapis/python-language/commit/fa4547f61179b9e8a4065bdd0a2bd7760b033985))
+* Drop usage of pkg_resources ([fa4547f](https://github.com/googleapis/python-language/commit/fa4547f61179b9e8a4065bdd0a2bd7760b033985))
+* Fix timeout default values ([fa4547f](https://github.com/googleapis/python-language/commit/fa4547f61179b9e8a4065bdd0a2bd7760b033985))
+
+
+### Miscellaneous Chores
+
+* Release-please updates snippet metadata ([cb52907](https://github.com/googleapis/python-language/commit/cb5290723a1f13d6ea3929cdf2fce103ee464910))
+
+
+### Documentation
+
+* **samples:** Snippetgen handling of repeated enum field ([3ff2900](https://github.com/googleapis/python-language/commit/3ff2900b0d4c00d408dc9743d80bb034677be978))
+* **samples:** Snippetgen should call await on the operation coroutine before calling result ([fa4547f](https://github.com/googleapis/python-language/commit/fa4547f61179b9e8a4065bdd0a2bd7760b033985))
+* Specify client library version requirement in samples/v1/language_classify_text.py ([#388](https://github.com/googleapis/python-language/issues/388)) ([bff4a65](https://github.com/googleapis/python-language/commit/bff4a65b6a3bb28bf205cdc2fcf5ad914665c453))
+
+## [2.6.1](https://github.com/googleapis/python-language/compare/v2.6.0...v2.6.1) (2022-10-10)
+
+
+### Bug Fixes
+
+* **deps:** Allow protobuf 3.19.5 ([#385](https://github.com/googleapis/python-language/issues/385)) ([99e1907](https://github.com/googleapis/python-language/commit/99e1907440c08894c213e7d7c9a29618a4b3d0d8))
+
+## [2.6.0](https://github.com/googleapis/python-language/compare/v2.5.2...v2.6.0) (2022-09-29)
+
+
+### Features
+
+* Add support for V1 and V2 classification models ([#376](https://github.com/googleapis/python-language/issues/376)) ([3ba5c56](https://github.com/googleapis/python-language/commit/3ba5c568179b04326ef9cc9874f2d18da99e51d6))
+
+
+### Bug Fixes
+
+* **deps:** Require protobuf >= 3.20.2 ([#381](https://github.com/googleapis/python-language/issues/381)) ([06f74b0](https://github.com/googleapis/python-language/commit/06f74b0cba8d3a5191caf5bee814c15bd0371813))
+
+
+### Documentation
+
+* Update classification sample to use v2 model ([#378](https://github.com/googleapis/python-language/issues/378)) ([73670e2](https://github.com/googleapis/python-language/commit/73670e27e2c2056f4a53d1225bb99399e8cbd05e))
+
+## [2.5.2](https://github.com/googleapis/python-language/compare/v2.5.1...v2.5.2) (2022-08-11)
+
+
+### Bug Fixes
+
+* **deps:** allow protobuf < 5.0.0 ([#349](https://github.com/googleapis/python-language/issues/349)) ([a9c90c3](https://github.com/googleapis/python-language/commit/a9c90c3706a0108db1b0f7924d02d54c507efaf4))
+* **deps:** require proto-plus >= 1.22.0 ([a9c90c3](https://github.com/googleapis/python-language/commit/a9c90c3706a0108db1b0f7924d02d54c507efaf4))
+
+## [2.5.1](https://github.com/googleapis/python-language/compare/v2.5.0...v2.5.1) (2022-07-13)
+
+
+### Bug Fixes
+
+* **deps:** require google-api-core>=1.32.0,>=2.8.0 ([#339](https://github.com/googleapis/python-language/issues/339)) ([b971d59](https://github.com/googleapis/python-language/commit/b971d5995aad01f97ddde1caf2039ea64ae45c31))
+
+## [2.5.0](https://github.com/googleapis/python-language/compare/v2.4.3...v2.5.0) (2022-07-07)
+
+
+### Features
+
+* add audience parameter ([592e7f8](https://github.com/googleapis/python-language/commit/592e7f85503f40373263b4d36118d6e4542f48cf))
+
+
+### Bug Fixes
+
+* **deps:** require google-api-core >= 2.8.0 ([#334](https://github.com/googleapis/python-language/issues/334)) ([592e7f8](https://github.com/googleapis/python-language/commit/592e7f85503f40373263b4d36118d6e4542f48cf))
+* require python 3.7+ ([#336](https://github.com/googleapis/python-language/issues/336)) ([b36b40f](https://github.com/googleapis/python-language/commit/b36b40f1ea7a32ccc3b99c7bb815c89cdd75ff53))
+
+## [2.4.3](https://github.com/googleapis/python-language/compare/v2.4.2...v2.4.3) (2022-06-06)
+
+
+### Bug Fixes
+
+* **deps:** require protobuf <4.0.0dev ([#325](https://github.com/googleapis/python-language/issues/325)) ([1048350](https://github.com/googleapis/python-language/commit/1048350a2b4cf175b445c52bd52142166d104fc6))
+
+
+### Documentation
+
+* fix changelog header to consistent size ([#324](https://github.com/googleapis/python-language/issues/324)) ([11aa986](https://github.com/googleapis/python-language/commit/11aa9864db65556a3a27c1a7a99bf96ea60ad434))
+
+## [2.4.2](https://github.com/googleapis/python-language/compare/v2.4.1...v2.4.2) (2022-05-17)
+
+
+### Documentation
+
+* fix type in docstring for map fields ([41c28cd](https://github.com/googleapis/python-language/commit/41c28cd35b91adcbe3221a898419c323875b5cfd))
+
+## [2.4.1](https://github.com/googleapis/python-language/compare/v2.4.0...v2.4.1) (2022-03-05)
+
+
+### Bug Fixes
+
+* **deps:** require google-api-core>=1.31.5, >=2.3.2 ([#273](https://github.com/googleapis/python-language/issues/273)) ([94b2ae4](https://github.com/googleapis/python-language/commit/94b2ae43c46cd6d56e0ee407a44011b42d8e77b1))
+* **deps:** require proto-plus>=1.15.0 ([94b2ae4](https://github.com/googleapis/python-language/commit/94b2ae43c46cd6d56e0ee407a44011b42d8e77b1))
+
+## [2.4.0](https://github.com/googleapis/python-language/compare/v2.3.2...v2.4.0) (2022-02-28)
+
+
+### Features
+
+* add api key support ([#256](https://github.com/googleapis/python-language/issues/256)) ([593ec8a](https://github.com/googleapis/python-language/commit/593ec8a998c612b3a87b4b9a53bd166c0b2c10f6))
+
+
+### Bug Fixes
+
+* resolve DuplicateCredentialArgs error when using credentials_file ([3e7c964](https://github.com/googleapis/python-language/commit/3e7c96410914d9080ecd0325c61bdc624adf08e1))
+
+## [2.3.2](https://github.com/googleapis/python-language/compare/v2.3.1...v2.3.2) (2022-01-20)
+
+
+### Documentation
+
+* **samples:** Document -> types.Document ([#227](https://github.com/googleapis/python-language/issues/227)) ([01367d7](https://github.com/googleapis/python-language/commit/01367d7b1e0ddba6e6b920f125730aa97d51ada0))
+
+## [2.3.1](https://www.github.com/googleapis/python-language/compare/v2.3.0...v2.3.1) (2021-11-01)
+
+
+### Bug Fixes
+
+* **deps:** drop packaging dependency ([6374e7f](https://www.github.com/googleapis/python-language/commit/6374e7fc497897fc44c02cd86f57759874c29e82))
+* **deps:** require google-api-core >= 1.28.0 ([6374e7f](https://www.github.com/googleapis/python-language/commit/6374e7fc497897fc44c02cd86f57759874c29e82))
+
+
+### Documentation
+
+* list oneofs in docstring ([6374e7f](https://www.github.com/googleapis/python-language/commit/6374e7fc497897fc44c02cd86f57759874c29e82))
+
+## [2.3.0](https://www.github.com/googleapis/python-language/compare/v2.2.2...v2.3.0) (2021-10-09)
+
+
+### Features
+
+* add context manager support in client ([#203](https://www.github.com/googleapis/python-language/issues/203)) ([91d48a8](https://www.github.com/googleapis/python-language/commit/91d48a8fee63b8279b235b70921d018206084b50))
+
+## [2.2.2](https://www.github.com/googleapis/python-language/compare/v2.2.1...v2.2.2) (2021-07-28)
+
+
+### Bug Fixes
+
+* enable self signed jwt for grpc ([#168](https://www.github.com/googleapis/python-language/issues/168)) ([4249607](https://www.github.com/googleapis/python-language/commit/4249607b20905b54b14e84d313838e46727bad54))
+
+
+### Documentation
+
+* add Samples section to CONTRIBUTING.rst ([#161](https://www.github.com/googleapis/python-language/issues/161)) ([5c28a16](https://www.github.com/googleapis/python-language/commit/5c28a169c9723fec23fac8bb5e2aa9e0dd420c66))
+
+
+### Miscellaneous Chores
+
+* release as 2.2.2 ([#170](https://www.github.com/googleapis/python-language/issues/170)) ([4d40053](https://www.github.com/googleapis/python-language/commit/4d400539508ec81cbc76e3f6166e3ec86054ed65))
+
+## [2.2.1](https://www.github.com/googleapis/python-language/compare/v2.2.0...v2.2.1) (2021-07-20)
+
+
+### Bug Fixes
+
+* **deps:** pin 'google-{api,cloud}-core', 'google-auth' to allow 2.x versions ([#160](https://www.github.com/googleapis/python-language/issues/160)) ([f8f9092](https://www.github.com/googleapis/python-language/commit/f8f90924ca4332016d5bbd9ed131cc82f07c7f9f))
+
+## [2.2.0](https://www.github.com/googleapis/python-language/compare/v2.1.0...v2.2.0) (2021-07-01)
+
+
+### Features
+
+* add always_use_jwt_access ([#138](https://www.github.com/googleapis/python-language/issues/138)) ([242aa5e](https://www.github.com/googleapis/python-language/commit/242aa5e997161104b760f554f69f2eecd86cd560))
+
+
+### Bug Fixes
+
+* disable always_use_jwt_access ([#143](https://www.github.com/googleapis/python-language/issues/143)) ([21c9d6e](https://www.github.com/googleapis/python-language/commit/21c9d6e1a96707007bdcf23ce667f02b42c8a207))
+
+
+### Documentation
+
+* omit mention of Python 2.7 in 'CONTRIBUTING.rst' ([#1127](https://www.github.com/googleapis/python-language/issues/1127)) ([#132](https://www.github.com/googleapis/python-language/issues/132)) ([bc5f89e](https://www.github.com/googleapis/python-language/commit/bc5f89e3d21bccd2d78ae3f2f4038b19db54871d))
+
+## [2.1.0](https://www.github.com/googleapis/python-language/compare/v1.4.0...v2.1.0) (2021-06-16)
+
+
+### Features
+
+* add 'from_service_account_info' factory to clients ([cc8a180](https://www.github.com/googleapis/python-language/commit/cc8a18032af7c8d8bf45130898eeae7efb17a91e))
+* add common resource helper methods; expose client transport ([#55](https://www.github.com/googleapis/python-language/issues/55)) ([8dde55c](https://www.github.com/googleapis/python-language/commit/8dde55cdd0e956c333039c0b74e49a06dd6ad33b))
+* add from_service_account_info factory and fix sphinx identifiers  ([#66](https://www.github.com/googleapis/python-language/issues/66)) ([cc8a180](https://www.github.com/googleapis/python-language/commit/cc8a18032af7c8d8bf45130898eeae7efb17a91e))
+* support self-signed JWT flow for service accounts ([0dcb15e](https://www.github.com/googleapis/python-language/commit/0dcb15eb46b60bd816a6919464be1331c2c8de41))
+
+
+### Bug Fixes
+
+* add async client to %name_%version/init.py ([0dcb15e](https://www.github.com/googleapis/python-language/commit/0dcb15eb46b60bd816a6919464be1331c2c8de41))
+* adds underscore to "type" to NL API samples ([#49](https://www.github.com/googleapis/python-language/issues/49)) ([36aa320](https://www.github.com/googleapis/python-language/commit/36aa320bf3e0018d66a7d0c91ce4733f20e9acc0))
+* **deps:** add packaging requirement ([#113](https://www.github.com/googleapis/python-language/issues/113)) ([7e711ac](https://www.github.com/googleapis/python-language/commit/7e711ac63c95c1018d24c7c4db3bc02c191efcfc))
+* fix sphinx identifiers ([cc8a180](https://www.github.com/googleapis/python-language/commit/cc8a18032af7c8d8bf45130898eeae7efb17a91e))
+* remove client recv msg limit fix: add enums to `types/__init__.py` ([#62](https://www.github.com/googleapis/python-language/issues/62)) ([3476c0f](https://www.github.com/googleapis/python-language/commit/3476c0f72529cbcbe61ea5c7e6a22291777bed7e))
+* use correct retry deadlines ([#83](https://www.github.com/googleapis/python-language/issues/83)) ([e2be2d8](https://www.github.com/googleapis/python-language/commit/e2be2d8ecf849940f2ea066655fda3bee68d8a74))
+
+
+### Documentation
+
+* fix typos ([#125](https://www.github.com/googleapis/python-language/issues/125)) ([788176f](https://www.github.com/googleapis/python-language/commit/788176feff5fb541e0d16f236b10b765d04ecb98))
+
+
+### Miscellaneous Chores
+
+* release as 2.1.0 ([#126](https://www.github.com/googleapis/python-language/issues/126)) ([92fa7f9](https://www.github.com/googleapis/python-language/commit/92fa7f995013c302f3bd3eb6bec53d92d8d9990c))
+
+## [2.0.0](https://www.github.com/googleapis/python-language/compare/v1.3.0...v2.0.0) (2020-10-16)
+
+
+### Features
+
+* Migrate API to use python micro-generator ([#41](https://www.github.com/googleapis/python-language/issues/41)) ([b408b14](https://www.github.com/googleapis/python-language/commit/b408b1431194d8e1373b5d986d476add639f7e87))
+
+
+### Documentation
+
+* add multiprocessing note ([#26](https://www.github.com/googleapis/python-language/issues/26)) ([a489102](https://www.github.com/googleapis/python-language/commit/a489102ca0f5ab302ec8974728a52065f2ea8857))
+* add spacing for readability ([#22](https://www.github.com/googleapis/python-language/issues/22)) ([7dff809](https://www.github.com/googleapis/python-language/commit/7dff809b94b5a1d001aeb1e7763dbbe624865600))
+* fix small typo ([#5](https://www.github.com/googleapis/python-language/issues/5)) ([7a9d4dd](https://www.github.com/googleapis/python-language/commit/7a9d4ddf676f2a77e1bd83e02b8d7987a72c6525))
+* **language:** change docstring formatting; bump copyright year to 2020 (via synth) ([#10234](https://www.github.com/googleapis/python-language/issues/10234)) ([b68b216](https://www.github.com/googleapis/python-language/commit/b68b2166d8e4d81a7e51e701f8facdfd7fb82a26))
+* **language:** edit hyphenation of "part-of-speech" (via synth) ([#9954](https://www.github.com/googleapis/python-language/issues/9954)) ([6246ef9](https://www.github.com/googleapis/python-language/commit/6246ef904871405334c0b3bd6c2490b79ffe56fa))
+* **language:** fixes typo in Natural Language samples ([#10134](https://www.github.com/googleapis/python-language/issues/10134)) ([223d614](https://www.github.com/googleapis/python-language/commit/223d6140145dcf5c48af206212db58a062a7937b))
+* add python 2 sunset banner to documentation ([#9036](https://www.github.com/googleapis/python-language/issues/9036)) ([1fe4105](https://www.github.com/googleapis/python-language/commit/1fe4105e078f84f1d4ea713550c26bdf91096d4a))
+* fix intersphinx reference to requests ([#9294](https://www.github.com/googleapis/python-language/issues/9294)) ([e97a0ae](https://www.github.com/googleapis/python-language/commit/e97a0ae6c2e3a26afc9b3af7d91118ac3c0aa1f7))
+* Remove CI for gh-pages, use googleapis.dev for api_core refs. ([#9085](https://www.github.com/googleapis/python-language/issues/9085)) ([6b15df6](https://www.github.com/googleapis/python-language/commit/6b15df6091378ed444642fc813d49d8bbbb6365d))
+
+## 1.3.0
+
+07-24-2019 16:44 PDT
+
+
+### Implementation Changes
+- Allow kwargs to be passed to create_channel  ([#8396](https://github.com/googleapis/google-cloud-python/pull/8396))
+
+### New Features
+- Add 'client_options' support (via synth). ([#8515](https://github.com/googleapis/google-cloud-python/pull/8515))
+
+### Dependencies
+- Bump minimum version for google-api-core to 1.14.0. ([#8709](https://github.com/googleapis/google-cloud-python/pull/8709))
+
+### Documentation
+- Link to googleapis.dev documentation in READMEs. ([#8705](https://github.com/googleapis/google-cloud-python/pull/8705))
+- Add compatibility check badges to READMEs. ([#8288](https://github.com/googleapis/google-cloud-python/pull/8288))
+- Add google.api proto annotations, update docstrings (via synth). ([#7659](https://github.com/googleapis/google-cloud-python/pull/7659))
+
+### Internal / Testing Changes
+- Pin black version (via synth). ([#8588](https://github.com/googleapis/google-cloud-python/pull/8588))
+- Add docs job to publish to googleapis.dev. ([#8464](https://github.com/googleapis/google-cloud-python/pull/8464))
+- Declare encoding as utf-8 in pb2 files (via synth). ([#8357](https://github.com/googleapis/google-cloud-python/pull/8357))
+- Add disclaimer to auto-generated template files (via synth).  ([#8319](https://github.com/googleapis/google-cloud-python/pull/8319))
+- Suppress checking 'cov-fail-under' in nox default session (via synth).  ([#8246](https://github.com/googleapis/google-cloud-python/pull/8246))
+- Blacken 'noxfile.py' / 'setup.py' (via synth). ([#8158](https://github.com/googleapis/google-cloud-python/pull/8158))
+- Add empty lines (via synth). ([#8063](https://github.com/googleapis/google-cloud-python/pull/8063))
+- Add nox session `docs` (via synth). ([#7776](https://github.com/googleapis/google-cloud-python/pull/7776))
+
+## 1.2.0
+
+03-29-2019 09:53 PDT
+
+
+### Implementation Changes
+- Remove classifier for Python 3.4 for end-of-life. ([#7535](https://github.com/googleapis/google-cloud-python/pull/7535))
+- Protoc-generated serialization update. ([#7087](https://github.com/googleapis/google-cloud-python/pull/7087))
+
+### New Features
+- Add new entity types (via synth). ([#7510](https://github.com/googleapis/google-cloud-python/pull/7510))
+
+### Documentation
+- Update client library documentation URLs. ([#7307](https://github.com/googleapis/google-cloud-python/pull/7307))
+- Update copyright headers
+- Pick up stub docstring fix in GAPIC generator. ([#6975](https://github.com/googleapis/google-cloud-python/pull/6975))
+
+### Internal / Testing Changes
+- Copy lintified proto files (via synth). ([#7468](https://github.com/googleapis/google-cloud-python/pull/7468))
+- Add clarifying comment to blacken nox target. ([#7397](https://github.com/googleapis/google-cloud-python/pull/7397))
+- Copy in correct proto versions via synth. [#7257](https://github.com/googleapis/google-cloud-python/pull/7257))
+- Add protos as an artifact to library ([#7205](https://github.com/googleapis/google-cloud-python/pull/7205))
+
+## 1.1.1
+
+12-18-2018 09:34 PST
+
+
+### Implementation Changes
+- Import `iam.policy` from `google.api_core`. ([#6741](https://github.com/googleapis/google-cloud-python/pull/6741))
+- Pick up fixes to GAPIC generator. ([#6521](https://github.com/googleapis/google-cloud-python/pull/6521))
+- Fix `client_info` bug, update docstrings. ([#6415](https://github.com/googleapis/google-cloud-python/pull/6415))
+
+### Dependencies
+- Bump minimum `api_core` version for all GAPIC libs to 1.4.1. ([#6391](https://github.com/googleapis/google-cloud-python/pull/6391))
+
+### Documentation
+- Document Python 2 deprecation ([#6910](https://github.com/googleapis/google-cloud-python/pull/6910))
+- Normalize use of support level badges ([#6159](https://github.com/googleapis/google-cloud-python/pull/6159))
+- Fix usage docs example for entity extraction ([#6193](https://github.com/googleapis/google-cloud-python/pull/6193))
+
+### Internal / Testing Changes
+- Update noxfile.
+- Blacken all gen'd libs ([#6792](https://github.com/googleapis/google-cloud-python/pull/6792))
+- Omit local deps ([#6701](https://github.com/googleapis/google-cloud-python/pull/6701))
+- Run black at end of synth.py ([#6698](https://github.com/googleapis/google-cloud-python/pull/6698))
+- Run Black on Generated libraries ([#6666](https://github.com/googleapis/google-cloud-python/pull/6666))
+- Add templates for flake8, coveragerc, noxfile, and black. ([#6642](https://github.com/googleapis/google-cloud-python/pull/6642))
+- Add synth metadata. ([#6570](https://github.com/googleapis/google-cloud-python/pull/6570))
+- Use new Nox ([#6175](https://github.com/googleapis/google-cloud-python/pull/6175))
+
+## 1.1.0
+
+10-05-2018 13:52 PDT
+
+### Implementation Changes
+
+- The library has been regenerated to pick up changes in the underlying API.
+- Add Test runs for Python 3.7 and remove 3.4 ([#5295](https://github.com/googleapis/google-cloud-python/pull/5295))
+
+### Documentation
+
+- Translate / Logging / Language: restore detailed usage docs. ([#5999](https://github.com/googleapis/google-cloud-python/pull/5999))
+- Redirect renamed 'usage.html'/'client.html' -> 'index.html'. ([#5996](https://github.com/googleapis/google-cloud-python/pull/5996))
+- Prep language docs for repo split. ([#5932](https://github.com/googleapis/google-cloud-python/pull/5932))
+
+### Internal / Testing Changes
+
+- Language: add 'synth.py'. ([#6080](https://github.com/googleapis/google-cloud-python/pull/6080))
+- Nox: use inplace installs ([#5865](https://github.com/googleapis/google-cloud-python/pull/5865))
+- Avoid overwriting '__module__' of messages from shared modules. ([#5364](https://github.com/googleapis/google-cloud-python/pull/5364))
+- Modify system tests to use prerelease versions of grpcio ([#5304](https://github.com/googleapis/google-cloud-python/pull/5304))
+
+## 1.0.2
+
+### Packaging
+- Update setuptools before packaging (#5265)
+- Update setup.py to use recommended method for python-verson specific dependencies (#5266)
+- Fix bad trove classifier
+
+## 1.0.1
+
+### Dependencies
+
+- Update dependency range for api-core to include v1.0.0 releases (#4944)
+
+### Testing and internal changes
+
+- Install local dependencies when running lint (#4936)
+- Re-enable lint for tests, remove usage of pylint (#4921)
+- Normalize all setup.py files (#4909)
+- Fix coveragerc to correctly omit generated files (#4843)
+
+## 1.0.0
+
+[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style&#x3D;flat)](https://cloud.google.com/terms/launch-stages)
+
+### Features
+
+##### General Availability
+
+The `google-cloud-language` package is now supported at the **general availability** quality level. This means it is stable; the code and API surface will not change in backwards-incompatible ways unless absolutely necessary (e.g. because of critical security issues) or with an extensive deprecation period.
+
+One exception to this: We will remove beta endpoints (as a semver-minor update) at whatever point the underlying endpoints go away.
+
+## 0.31.0
+
+### Release Candidate
+
+  * This update is considered a final "release candidate", and
+    the `google-cloud-language` package is preparing for a GA release
+    in the near future.
+
+### :warning: Breaking Changes!
+
+  * Some rarely-used arguments to the `LanguageServiceClient` constructor
+    have been removed (in favor of a subclass or a custom gRPC channel).
+    It is unlikely that you used these, but if you did, then this update
+    will represent a breaking change.
+      * The removed arguments are: `client_config`, `lib_name`, `lib_version`
+        `metrics_headers`, `ssl_credentials`, and `scopes`.
+
+### Features
+
+  * Added the `classify_text` method on the primary (`v1`) endpoint. (#4283)
+
+## 0.30.0
+
+### Documentation
+
+- Added link to "Python Development Environment Setup Guide" in
+  project README (#4187, h/t to @michaelawyu)
+
+### Dependencies
+
+- Upgrading to `google-cloud-core >= 0.28.0` and adding dependency
+  on `google-api-core` (#4221, #4280)
+- Deferring to `google-api-core` for `grpcio` and
+  `googleapis-common-protos`dependencies (#4096, #4098)
+
+PyPI: https://pypi.org/project/google-cloud-language/0.30.0/


### PR DESCRIPTION
This is necessary as part of the migration from Owlbot to Librarian as Librarian doesn't support symlinks

Towards https://github.com/googleapis/librarian/issues/1796