### PR TITLE
chore: update librarian to use prod python generator image

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,4 +1,4 @@
-image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-dev/python-librarian-generator:latest
+image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator:latest
 libraries:
 - id: google-cloud-language
   version: 2.17.2


### PR DESCRIPTION
AR exit gates is setup correctly, so we should migrate to use the prod image