### PR TITLE
chore: add .librarian/config.yaml

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -1,0 +1,6 @@
+global_files_allowlist:
+  # Allow the container to read and write the root `CHANGELOG.md`
+  # file during the `release` step to update the latest client library
+  # versions which are hardcoded in the file.
+  - path: "CHANGELOG.md"
+    permissions: "read-write"


### PR DESCRIPTION
Add a [.librarian/config.yaml](https://github.com/googleapis/librarian/blob/main/doc/language-onboarding.md#configyaml) file to allow the [language specific container](https://github.com/googleapis/librarian/blob/main/doc/language-onboarding.md#container-contracts) to access the `CHANGELOG.md` file when the [librarian release init](https://github.com/googleapis/librarian/blob/main/doc/language-onboarding.md#release-init) command is used.

The proposed `config.yaml` is similar to the examples in https://github.com/googleapis/librarian/blob/main/doc/language-onboarding.md#release-init

This is needed to update the root [CHANGELOG.md](https://github.com/googleapis/google-cloud-python/blob/main/CHANGELOG.md) file which is currently updated using the Github action [here](https://github.com/googleapis/google-cloud-python/blob/main/.github/workflows/updatechangelog.yml). We will be able to remove the Github action once all libraries have migrated off of `release-please` to `librarian release init`