### PR TITLE
chore: preserve .repo-metadata.json

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -302,6 +302,10 @@ def _clean_up_files_after_post_processing(output: str, library_id: str):
     Path(f"{output}/{path_to_library}/docs/CHANGELOG.md").unlink(missing_ok=True)
     Path(f"{output}/{path_to_library}/docs/README.rst").unlink(missing_ok=True)
 
+    # Remove  `.repo-metadata.json` file to avoid ownership issues between
+    # the container and librarian. Instead, preserve this file in the destination.
+    Path(f"{output}/{path_to_library}/.repo-metadata.json").unlink(missing_ok=True)
+
     # The glob loops are already safe, as they do nothing if no files match.
     for post_processing_file in glob.glob(
         f"{output}/{path_to_library}/scripts/client-post-processing/*.yaml"

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -11,6 +11,7 @@ libraries:
   - packages/google-cloud-language
   preserve_regex:
   - .OwlBot.yaml
+  - .repo-metadata.json
   - packages/google-cloud-language/CHANGELOG.md
   - docs/CHANGELOG.md
   - docs/README.rst


### PR DESCRIPTION
This PR fixes the following error when running librarian locally

```
2025/08/29 23:26:15 ERROR failed to generate library id=google-cloud-language err="failed to copy google-cloud-language to /usr/local/google/home/partheniou/git/google-cloud-python/packages/google-cloud-language: open .repo-metadata.json: permission denied"
2025/08/29 23:26:15 all 1 libraries failed to generate
```