### PR TITLE
chore(librarian): resolve issue where gapic_version.py cannot be written

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -73,6 +73,7 @@ def _write_text_file(path: str, updated_content: str):
         updated_content(str): The contents to write to the file.
     """
 
+    os.makedirs(Path(path).parent, exist_ok=True)
     with open(path, "w") as f:
         f.write(updated_content)
 


### PR DESCRIPTION
Fixes the following error when running `librarian release init`

```
Release init failed: [Errno 2] No such file or directory: '/output/packages/google-cloud-language/google/cloud/language/gapic_version.py'
```