### PR TITLE
chore(librarian): update last_generated_commit for dlp

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2,7 +2,7 @@ image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-li
 libraries:
 - id: google-cloud-dlp
   version: 3.31.0
-  last_generated_commit: 97a83d76a09a7f6dcab43675c87bdfeb5bcf1cb5
+  last_generated_commit: d300b151a973ce0425ae4ad07b3de957ca31bec6
   apis:
   - path: google/privacy/dlp/v2
   source_roots:


### PR DESCRIPTION
See https://github.com/googleapis/google-cloud-python/pull/14338 which references https://github.com/googleapis/googleapis/commit/d300b151a973ce0425ae4ad07b3de957ca31bec6 in the PR description