### PR TITLE
chore: run yamlfmt on `.librarian/state.yaml`

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,23 +1,23 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator:latest
 libraries:
-- id: google-cloud-dlp
-  version: 3.31.0
-  last_generated_commit: d300b151a973ce0425ae4ad07b3de957ca31bec6
-  apis:
-  - path: google/privacy/dlp/v2
-  source_roots:
-  - packages/google-cloud-dlp
-  preserve_regex:
-  - packages/google-cloud-dlp/CHANGELOG.md
-  - docs/CHANGELOG.md
-  - docs/README.rst
-  - samples/README.txt
-  - tar.gz
-  - gapic_version.py
-  - samples/generated_samples/snippet_metadata_
-  - scripts/client-post-processing
-  - samples/snippets/README.rst
-  - tests/system
-  remove_regex:
-  - packages/google-cloud-dlp
-  tag_format: '{id}-v{version}'
+  - id: google-cloud-dlp
+    version: 3.31.0
+    last_generated_commit: d300b151a973ce0425ae4ad07b3de957ca31bec6
+    apis:
+      - path: google/privacy/dlp/v2
+    source_roots:
+      - packages/google-cloud-dlp
+    preserve_regex:
+      - packages/google-cloud-dlp/CHANGELOG.md
+      - docs/CHANGELOG.md
+      - docs/README.rst
+      - samples/README.txt
+      - tar.gz
+      - gapic_version.py
+      - samples/generated_samples/snippet_metadata_
+      - scripts/client-post-processing
+      - samples/snippets/README.rst
+      - tests/system
+    remove_regex:
+      - packages/google-cloud-dlp
+    tag_format: '{id}-v{version}'


### PR DESCRIPTION
Ran the following to fix the formatting in `.librarian/state.yaml`

```
go install github.com/google/yamlfmt/cmd/yamlfmt@latest
export PATH="/usr/local/google/home/partheniou/go/bin:$PATH"
yamlfmt .librarian/state.yaml
```

We can run `yamlfmt` anytime we make changes to `.librarian/state.yaml` to reduce the diff due to formatting differences as librarian uses `yamlfmt`