### PR TITLE
chore: make librarian team full codeowners so they can approve Librarian generated PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 *                         @googleapis/python-core-client-libraries
-* @googleapis/cloud-sdk-librarian-team
+*                         @googleapis/cloud-sdk-librarian-team


### PR DESCRIPTION
As part of onboarding libraries to Librarian, the cloud sdk platform team will be taking over approving and merging the automatically generated PRs.  