### PR TITLE
chore(librarian): require reviews from core and librarian teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,10 @@
 # This file controls who is tagged for review for any given pull request.
 
 # Default owner for all directories not owned by others
-*                         @googleapis/python-core-client-libraries
-*                         @googleapis/cloud-sdk-librarian-team
+*                                             @googleapis/python-core-client-libraries @googleapis/cloud-sdk-librarian-team
 
-/packages/google-cloud-bigquery-storage/        @googleapis/api-bigquery
+# Packages onboarded to librarian require review from both groups
+/packages/google-cloud-dlp/                   @googleapis/python-core-client-libraries
+/packages/google-cloud-dlp/                   @googleapis/cloud-sdk-librarian-team
+
+/packages/google-cloud-bigquery-storage/      @googleapis/api-bigquery


### PR DESCRIPTION
This will ensure that packages onboarded to librarian  (currently only `google-cloud-dlp`) require reviews from both `googleapis/python-core-client-libraries` and `googleapis/cloud-sdk-librarian-team`