### PR TITLE
chore: librarian release pull request: 20250915T153347Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator:latest
 libraries:
     - id: google-cloud-dlp
-      version: 3.31.0
+      version: 3.32.0
       last_generated_commit: f8776fec04e336527ba7279d960105533a1c4e21
       apis:
         - path: google/privacy/dlp/v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ Changelogs
 - [google-cloud-dialogflow-cx==1.42.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-dialogflow-cx/CHANGELOG.md)
 - [google-cloud-dialogflow==2.41.2](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-dialogflow/CHANGELOG.md)
 - [google-cloud-discoveryengine==0.13.11](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-discoveryengine/CHANGELOG.md)
-- [google-cloud-dlp==3.31.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-dlp/CHANGELOG.md)
+- [google-cloud-dlp==3.32.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-dlp/CHANGELOG.md)
 - [google-cloud-dms==1.12.4](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-dms/CHANGELOG.md)
 - [google-cloud-documentai==3.5.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-documentai/CHANGELOG.md)
 - [google-cloud-domains==1.10.2](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-domains/CHANGELOG.md)

--- a/packages/google-cloud-dlp/CHANGELOG.md
+++ b/packages/google-cloud-dlp/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-cloud-dlp/#history
 
+## [3.32.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-dlp-v3.31.0...google-cloud-dlp-v3.32.0) (2025-09-15)
+
+
+### Features
+
+* [google-cloud-dlp] add ([09f78e3ca85671594e20c3182038238e58d3d8cb](https://github.com/googleapis/google-cloud-python/commit/09f78e3ca85671594e20c3182038238e58d3d8cb))
+
 ## [3.31.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-dlp-v3.30.0...google-cloud-dlp-v3.31.0) (2025-06-19)
 
 

--- a/packages/google-cloud-dlp/google/cloud/dlp/gapic_version.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "3.32.0"  # {x-release-please-version}

--- a/packages/google-cloud-dlp/google/cloud/dlp_v2/gapic_version.py
+++ b/packages/google-cloud-dlp/google/cloud/dlp_v2/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "3.32.0"  # {x-release-please-version}

--- a/packages/google-cloud-dlp/samples/generated_samples/snippet_metadata_google.privacy.dlp.v2.json
+++ b/packages/google-cloud-dlp/samples/generated_samples/snippet_metadata_google.privacy.dlp.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-dlp",
-    "version": "0.1.0"
+    "version": "3.32.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
Librarian Version: not available
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator:latest
<details><summary>google-cloud-dlp: 3.32.0</summary>

## [3.32.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-dlp-v3.31.0...google-cloud-dlp-v3.32.0) (2025-09-15)

### Features

* [google-cloud-dlp] add ([09f78e3](https://github.com/googleapis/google-cloud-python/commit/09f78e3ca85671594e20c3182038238e58d3d8cb))

</details>