### PR TITLE
chore: run system tests only for modified packages

### DIFF
--- a/.kokoro/system.sh
+++ b/.kokoro/system.sh
@@ -45,7 +45,6 @@ git config --global --add safe.directory $(realpath .)
 for dir in `find 'packages' -type d -wholename 'packages/*/tests/system'`; do
   # Get the path to the package by removing the suffix /tests/system
   package=$(echo $dir | cut -f -2 -d '/')
-  should_test=false
 
   files_to_check=${package}/CHANGELOG.md
 
@@ -57,11 +56,7 @@ for dir in `find 'packages' -type d -wholename 'packages/*/tests/system'`; do
       echo "no change detected in ${files_to_check}, skipping"
   else
       echo "change detected in ${files_to_check}"
-      should_test=true
-  fi
-  if [ "${should_test}" = true ]; then
       echo "Running system tests for ${package}"
-
       pushd ${package}
       # Temporarily allow failure.
       set +e

--- a/packages/google-cloud-dlp/CHANGELOG.md
+++ b/packages/google-cloud-dlp/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [PyPI History][1]
 
+
 [1]: https://pypi.org/project/google-cloud-dlp/#history
 
 ## [3.32.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-dlp-v3.31.0...google-cloud-dlp-v3.32.0) (2025-09-15)

--- a/packages/google-cloud-dlp/CHANGELOG.md
+++ b/packages/google-cloud-dlp/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 [PyPI History][1]
 
-
 [1]: https://pypi.org/project/google-cloud-dlp/#history
 
 ## [3.32.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-dlp-v3.31.0...google-cloud-dlp-v3.32.0) (2025-09-15)


### PR DESCRIPTION
Currently the system test runs for all packages. This PR adds logic to check if there is a change to the package level `CHANGELOG.md` so that we only runs system tests for packages that have changed. We are only interested in `packages/<package>/CHANGELOG.md` changing as we only want to run system tests on release PRs.

Fixes https://github.com/googleapis/librarian/issues/2067