### PR TITLE
chore(librarian): allow onboarding new packages

### DIFF
--- a/scripts/configure_state_yaml/configure_state_yaml.py
+++ b/scripts/configure_state_yaml/configure_state_yaml.py
@@ -62,6 +62,8 @@ def configure_state_yaml() -> None:
                     ]
                 )
 
+        # Skip libraries which are not present in the release please manifest as
+        # these are likely libraries that have already onboarded.
         if release_please_manifest.get(f"packages/{package_name}", None):
             state_dict["libraries"].append(
                 {


### PR DESCRIPTION
This PR resolves the following error by ignoring libraries which which do not have entries in `release-please-manifest.json` when onboarding new packages. These are likely libraries that have already onboarded. We will also preserve existing entries in state.yaml for these libraries.

```
(py392) partheniou@partheniou-vm-3:~/git/google-cloud-python/scripts/configure_state_yaml$ python3 configure_state_yaml.py 
Traceback (most recent call last):
  File "/usr/local/google/home/partheniou/git/google-cloud-python/scripts/configure_state_yaml/configure_state_yaml.py", line 94, in <module>
    configure_state_yaml()
  File "/usr/local/google/home/partheniou/git/google-cloud-python/scripts/configure_state_yaml/configure_state_yaml.py", line 67, in configure_state_yaml
    "version": release_please_manifest[f"packages/{package_name}"],
KeyError: 'packages/google-cloud-dlp'
```

Towards https://github.com/googleapis/librarian/issues/761