### PR TITLE
chore(librarian): update configure_state_yaml.py to avoid duplicate entries

### DIFF
--- a/scripts/configure_state_yaml/configure_state_yaml.py
+++ b/scripts/configure_state_yaml/configure_state_yaml.py
@@ -48,7 +48,14 @@ def configure_state_yaml() -> None:
     with open(LIBRARIAN_YAML, "r") as state_yaml_file:
         state_dict = yaml.safe_load(state_yaml_file)
 
+    existing_library_ids = {library["id"] for library in state_dict.get("libraries", [])}
+
     for package_name in packages_to_onboard["packages_to_onboard"]:
+        # Check for duplication
+        if package_name in existing_library_ids:
+            print(f"Skipping package '{package_name}' as it already exists in state.yaml.")
+            continue
+
         package_path = Path(PACKAGES_DIR / package_name).resolve()
         api_paths = []
         for individual_metadata_file in package_path.rglob(f"**/{GAPIC_METADATA_JSON}"):


### PR DESCRIPTION
See output below for `google-cloud-dlp` and `google-cloud-eventarc` which already exist in `.librarian/state.yaml`

```
partheniou@partheniou-vm-3:~/git/google-cloud-python/scripts/configure_state_yaml$ python3 configure_state_yaml.py 
Skipping package 'google-cloud-dlp' as it already exists in state.yaml.
Skipping package 'google-cloud-eventarc' as it already exists in state.yaml.
```