### PR TITLE
chore(librarian): add google-ads-marketingplatform-admin, google-ai-generativelanguage, google-analytics-admin, google-analytics-data

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -132,3 +132,25 @@ libraries:
     remove_regex:
       - packages/google-analytics-admin
     tag_format: '{id}-v{version}'
+  - id: google-analytics-data
+    version: 0.18.19
+    last_generated_commit: d300b151a973ce0425ae4ad07b3de957ca31bec6
+    apis:
+      - path: google/analytics/data/v1alpha
+      - path: google/analytics/data/v1beta
+    source_roots:
+      - packages/google-analytics-data
+    preserve_regex:
+      - packages/google-analytics-data/CHANGELOG.md
+      - docs/CHANGELOG.md
+      - docs/README.rst
+      - samples/README.txt
+      - tar.gz
+      - gapic_version.py
+      - samples/generated_samples/snippet_metadata_
+      - scripts/client-post-processing
+      - samples/snippets/README.rst
+      - tests/system
+    remove_regex:
+      - packages/google-analytics-data
+    tag_format: '{id}-v{version}'

--- a/scripts/configure_state_yaml/packages_to_onboard.yaml
+++ b/scripts/configure_state_yaml/packages_to_onboard.yaml
@@ -17,6 +17,7 @@ packages_to_onboard: [
   "google-ads-marketingplatform-admin",
   "google-ai-generativelanguage",
   "google-analytics-admin",
+  "google-analytics-data",
   "google-cloud-dlp",
   "google-cloud-eventarc",
   "google-cloud-video-live-stream",


### PR DESCRIPTION
Onboard `google-ads-marketingplatform-admin`, `google-ai-generativelanguage`, `google-analytics-admin`, `google-analytics-data` to librarian

Towards https://github.com/googleapis/librarian/issues/761