### PR TITLE
chore(librarian): update exception and valid namespaces

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -508,14 +508,32 @@ def _verify_library_namespace(library_id: str, repo: str):
         repo (str): The path to the root of the repository.
     """
     # TODO(https://github.com/googleapis/google-cloud-python/issues/14376): Update the list of namespaces which are exceptions.
-    exception_namespaces = ["google.cloud.billing"]
+    exception_namespaces = [
+        "google.area120",
+        "google.apps.script",
+        "google.apps.script.type",
+        "google.cloud.alloydb",
+        "google.cloud.billing",
+        "google.cloud.devtools",
+        "google.cloud.gkeconnect",
+        "google.cloud.gkehub_v1",
+        "google.cloud.orchestration.airflow",
+        "google.cloud.security",
+        "google.cloud.video",
+        "google.cloud.workflows",
+        "google.monitoring",
+    ]
     valid_namespaces = [
         "google",
+        "google.analytics",
         "google.apps",
         "google.ads",
+        "google.ai",
         "google.cloud",
+        "google.geo",
         "google.maps",
         "google.shopping",
+        "grafeas",
         *exception_namespaces,
     ]
     gapic_version_file = "gapic_version.py"


### PR DESCRIPTION
This fixes the following issue which caused https://github.com/googleapis/google-cloud-python/pull/14457 to fail with `Generation failed for google-cloud-video-live-stream`

```
ValueError: Build failed.
    raise ValueError("Build failed.") from e
  File "/app/./cli.py", line 601, in handle_build
    args.func(librarian=args.librarian, repo=args.repo)
  File "/app/./cli.py", line 1014, in <module>
Traceback (most recent call last):
The above exception was the direct cause of the following exception:
ValueError: The namespace `google.cloud.video` for `google-cloud-video-live-stream` must be one of ['google', 'google.apps', 'google.ads', 'google.cloud', 'google.maps', 'google.shopping', 'google.cloud.billing'].
    raise ValueError(
  File "/app/./cli.py", line 546, in _verify_library_namespace
    _verify_library_namespace(library_id, repo)
  File "/app/./cli.py", line 597, in handle_build
Traceback (most recent call last):
```