### PR TITLE
chore(librarian): onboard google-ads-admanager

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -154,3 +154,24 @@ libraries:
     remove_regex:
       - packages/google-analytics-data
     tag_format: '{id}-v{version}'
+  - id: google-ads-admanager
+    version: 0.3.0
+    last_generated_commit: d300b151a973ce0425ae4ad07b3de957ca31bec6
+    apis:
+      - path: google/ads/admanager/v1
+    source_roots:
+      - packages/google-ads-admanager
+    preserve_regex:
+      - packages/google-ads-admanager/CHANGELOG.md
+      - docs/CHANGELOG.md
+      - docs/README.rst
+      - samples/README.txt
+      - tar.gz
+      - gapic_version.py
+      - samples/generated_samples/snippet_metadata_
+      - scripts/client-post-processing
+      - samples/snippets/README.rst
+      - tests/system
+    remove_regex:
+      - packages/google-ads-admanager
+    tag_format: '{id}-v{version}'

--- a/scripts/configure_state_yaml/packages_to_onboard.yaml
+++ b/scripts/configure_state_yaml/packages_to_onboard.yaml
@@ -14,6 +14,7 @@
 #
 
 packages_to_onboard: [
+  "google-ads-admanager",
   "google-ads-marketingplatform-admin",
   "google-ai-generativelanguage",
   "google-analytics-admin",


### PR DESCRIPTION
Onboard `google-ads-admanager` to librarian

Towards https://github.com/googleapis/librarian/issues/761