### PR TITLE
chore(librarian): remove samples/generated_samples/snippet_metadata_from preserve_regex

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -224,11 +224,6 @@ def _clean_up_files_after_post_processing(output: str, library_id: str):
     ):  # pragma: NO COVER
         os.remove(gapic_version_file)
 
-    for snippet_metadata_file in glob.glob(
-        f"{output}/{path_to_library}/samples/generated_samples/snippet_metadata*.json"
-    ):  # pragma: NO COVER
-        os.remove(snippet_metadata_file)
-
 
 def handle_generate(
     librarian: str = LIBRARIAN_DIR,

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -15,7 +15,6 @@ libraries:
       - samples/README.txt
       - tar.gz
       - gapic_version.py
-      - samples/generated_samples/snippet_metadata_
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -36,7 +35,6 @@ libraries:
       - samples/README.txt
       - tar.gz
       - gapic_version.py
-      - samples/generated_samples/snippet_metadata_
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -57,7 +55,6 @@ libraries:
       - samples/README.txt
       - tar.gz
       - gapic_version.py
-      - samples/generated_samples/snippet_metadata_
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -78,7 +75,6 @@ libraries:
       - samples/README.txt
       - tar.gz
       - gapic_version.py
-      - samples/generated_samples/snippet_metadata_
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -103,7 +99,6 @@ libraries:
       - samples/README.txt
       - tar.gz
       - gapic_version.py
-      - samples/generated_samples/snippet_metadata_
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -125,7 +120,6 @@ libraries:
       - samples/README.txt
       - tar.gz
       - gapic_version.py
-      - samples/generated_samples/snippet_metadata_
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -147,7 +141,6 @@ libraries:
       - samples/README.txt
       - tar.gz
       - gapic_version.py
-      - samples/generated_samples/snippet_metadata_
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -168,7 +161,6 @@ libraries:
       - samples/README.txt
       - tar.gz
       - gapic_version.py
-      - samples/generated_samples/snippet_metadata_
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system

--- a/scripts/configure_state_yaml/configure_state_yaml.py
+++ b/scripts/configure_state_yaml/configure_state_yaml.py
@@ -87,7 +87,6 @@ def configure_state_yaml() -> None:
                         "samples/README.txt",
                         "tar.gz",
                         "gapic_version.py",
-                        "samples/generated_samples/snippet_metadata_",
                         "scripts/client-post-processing",
                         "samples/snippets/README.rst",
                         "tests/system",


### PR DESCRIPTION
This commit fixes a regression where snippet_metadata files, such as `packages/google-cloud-video-live-stream/samples/generated_samples/snippet_metadata_google.cloud.video.livestream.v1.json`, were not being updated during generation (e.g., in PR #14465).

The root cause was the inclusion of `samples/generated_samples/snippet_metadata_` in the preserve_regex list. While this regex was initially used to reduce diffs during the transition from OwlBot to Librarian, it inadvertently prevented necessary updates to the generated snippet metadata. 