### PR TITLE
chore: update GH action to remove stale entries from .release-please-manifest.json

### DIFF
--- a/.github/workflows/configure_release_please.yml
+++ b/.github/workflows/configure_release_please.yml
@@ -20,6 +20,7 @@ on:
   push:
     paths:
       - '**/gapic_version.py'
+      - '**/.OwlBot.yaml'
     branches:
       - main
 


### PR DESCRIPTION
This PR updates the python script used in [configure_release_please.yml](https://github.com/googleapis/google-cloud-python/blob/main/.github/workflows/configure_release_please.yml) to remove stale entries from [.release-please-manifest.json](https://github.com/googleapis/google-cloud-python/blob/main/.release-please-manifest.json). This will fix the issue seen in https://github.com/googleapis/google-cloud-python/pull/14503 where stale entries are deleted from `release-please-config.json` but not `.release-please-manifest.json`