### PR TITLE
chore: add PyPI history to CHANGELOG.md

### DIFF
--- a/packages/google-ads-admanager/CHANGELOG.md
+++ b/packages/google-ads-admanager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-ads-admanager/#history
+
 ## [0.3.0](https://github.com/googleapis/google-cloud-python/compare/google-ads-admanager-v0.2.6...google-ads-admanager-v0.3.0) (2025-07-02)
 
 

--- a/packages/google-ads-marketingplatform-admin/CHANGELOG.md
+++ b/packages/google-ads-marketingplatform-admin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-ads-marketingplatform-admin/#history
+
 ## [0.1.6](https://github.com/googleapis/google-cloud-python/compare/google-ads-marketingplatform-admin-v0.1.5...google-ads-marketingplatform-admin-v0.1.6) (2025-06-11)
 
 

--- a/packages/google-ai-generativelanguage/CHANGELOG.md
+++ b/packages/google-ai-generativelanguage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-ai-generativelanguage/#history
+
 ## [0.7.0](https://github.com/googleapis/google-cloud-python/compare/google-ai-generativelanguage-v0.6.18...google-ai-generativelanguage-v0.7.0) (2025-08-29)
 
 

--- a/packages/google-analytics-admin/CHANGELOG.md
+++ b/packages/google-analytics-admin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-analytics-admin/#history
+
 ## [0.25.0](https://github.com/googleapis/google-cloud-python/compare/google-analytics-admin-v0.24.1...google-analytics-admin-v0.25.0) (2025-08-29)
 
 

--- a/packages/google-analytics-data/CHANGELOG.md
+++ b/packages/google-analytics-data/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-analytics-data/#history
+
 ## [0.18.19](https://github.com/googleapis/google-cloud-python/compare/google-analytics-data-v0.18.18...google-analytics-data-v0.18.19) (2025-06-11)
 
 

--- a/packages/google-apps-card/CHANGELOG.md
+++ b/packages/google-apps-card/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-apps-card/#history
+
 ## [0.1.8](https://github.com/googleapis/google-cloud-python/compare/google-apps-card-v0.1.7...google-apps-card-v0.1.8) (2025-06-11)
 
 

--- a/packages/google-apps-chat/CHANGELOG.md
+++ b/packages/google-apps-chat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-apps-chat/#history
+
 ## [0.2.9](https://github.com/googleapis/google-cloud-python/compare/google-apps-chat-v0.2.8...google-apps-chat-v0.2.9) (2025-08-29)
 
 

--- a/packages/google-apps-events-subscriptions/CHANGELOG.md
+++ b/packages/google-apps-events-subscriptions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-apps-events-subscriptions/#history
+
 ## [0.2.2](https://github.com/googleapis/google-cloud-python/compare/google-apps-events-subscriptions-v0.2.1...google-apps-events-subscriptions-v0.2.2) (2025-06-12)
 
 

--- a/packages/google-apps-meet/CHANGELOG.md
+++ b/packages/google-apps-meet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-apps-meet/#history
+
 ## [0.1.16](https://github.com/googleapis/google-cloud-python/compare/google-apps-meet-v0.1.15...google-apps-meet-v0.1.16) (2025-06-11)
 
 

--- a/packages/google-apps-script-type/CHANGELOG.md
+++ b/packages/google-apps-script-type/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-apps-script-type/#history
+
 ## [0.3.15](https://github.com/googleapis/google-cloud-python/compare/google-apps-script-type-v0.3.14...google-apps-script-type-v0.3.15) (2025-06-11)
 
 

--- a/packages/google-area120-tables/CHANGELOG.md
+++ b/packages/google-area120-tables/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-area120-tables/#history
+
 ## [0.11.17](https://github.com/googleapis/google-cloud-python/compare/google-area120-tables-v0.11.16...google-area120-tables-v0.11.17) (2025-06-11)
 
 

--- a/packages/google-cloud-access-approval/CHANGELOG.md
+++ b/packages/google-cloud-access-approval/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-access-approval/#history
+
 ## [1.16.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-access-approval-v1.16.1...google-cloud-access-approval-v1.16.2) (2025-06-11)
 
 

--- a/packages/google-cloud-access-context-manager/CHANGELOG.md
+++ b/packages/google-cloud-access-context-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-access-context-manager/#history
+
 ## [0.2.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-access-context-manager-v0.2.1...google-cloud-access-context-manager-v0.2.2) (2025-03-15)
 
 

--- a/packages/google-cloud-advisorynotifications/CHANGELOG.md
+++ b/packages/google-cloud-advisorynotifications/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-advisorynotifications/#history
+
 ## [0.3.16](https://github.com/googleapis/google-cloud-python/compare/google-cloud-advisorynotifications-v0.3.15...google-cloud-advisorynotifications-v0.3.16) (2025-06-11)
 
 

--- a/packages/google-cloud-alloydb-connectors/CHANGELOG.md
+++ b/packages/google-cloud-alloydb-connectors/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-alloydb-connectors/#history
+
 ## [0.1.11](https://github.com/googleapis/google-cloud-python/compare/google-cloud-alloydb-connectors-v0.1.10...google-cloud-alloydb-connectors-v0.1.11) (2025-08-29)
 
 

--- a/packages/google-cloud-alloydb/CHANGELOG.md
+++ b/packages/google-cloud-alloydb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-alloydb/#history
+
 ## [0.4.9](https://github.com/googleapis/google-cloud-python/compare/google-cloud-alloydb-v0.4.8...google-cloud-alloydb-v0.4.9) (2025-08-29)
 
 

--- a/packages/google-cloud-api-gateway/CHANGELOG.md
+++ b/packages/google-cloud-api-gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-api-gateway/#history
+
 ## [1.12.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-api-gateway-v1.12.1...google-cloud-api-gateway-v1.12.2) (2025-06-11)
 
 

--- a/packages/google-cloud-api-keys/CHANGELOG.md
+++ b/packages/google-cloud-api-keys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-api-keys/#history
+
 ## [0.5.17](https://github.com/googleapis/google-cloud-python/compare/google-cloud-api-keys-v0.5.16...google-cloud-api-keys-v0.5.17) (2025-06-11)
 
 

--- a/packages/google-cloud-apigee-connect/CHANGELOG.md
+++ b/packages/google-cloud-apigee-connect/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-apigee-connect/#history
+
 ## [1.12.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-apigee-connect-v1.12.1...google-cloud-apigee-connect-v1.12.2) (2025-06-11)
 
 

--- a/packages/google-cloud-apigee-registry/CHANGELOG.md
+++ b/packages/google-cloud-apigee-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-apigee-registry/#history
+
 ## [0.6.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-apigee-registry-v0.6.17...google-cloud-apigee-registry-v0.6.18) (2025-06-11)
 
 

--- a/packages/google-cloud-apihub/CHANGELOG.md
+++ b/packages/google-cloud-apihub/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-apihub/#history
+
 ## [0.2.6](https://github.com/googleapis/google-cloud-python/compare/google-cloud-apihub-v0.2.5...google-cloud-apihub-v0.2.6) (2025-06-11)
 
 

--- a/packages/google-cloud-appengine-admin/CHANGELOG.md
+++ b/packages/google-cloud-appengine-admin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-appengine-admin/#history
+
 ## [1.14.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-appengine-admin-v1.14.1...google-cloud-appengine-admin-v1.14.2) (2025-06-11)
 
 

--- a/packages/google-cloud-appengine-logging/CHANGELOG.md
+++ b/packages/google-cloud-appengine-logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-appengine-logging/#history
+
 ## [1.6.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-appengine-logging-v1.6.1...google-cloud-appengine-logging-v1.6.2) (2025-06-11)
 
 

--- a/packages/google-cloud-apphub/CHANGELOG.md
+++ b/packages/google-cloud-apphub/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-apphub/#history
+
 ## [0.1.10](https://github.com/googleapis/google-cloud-python/compare/google-cloud-apphub-v0.1.9...google-cloud-apphub-v0.1.10) (2025-06-11)
 
 

--- a/packages/google-cloud-artifact-registry/CHANGELOG.md
+++ b/packages/google-cloud-artifact-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-artifact-registry/#history
+
 ## [1.16.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-artifact-registry-v1.16.0...google-cloud-artifact-registry-v1.16.1) (2025-06-11)
 
 

--- a/packages/google-cloud-assured-workloads/CHANGELOG.md
+++ b/packages/google-cloud-assured-workloads/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-assured-workloads/#history
+
 ## [1.15.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-assured-workloads-v1.15.1...google-cloud-assured-workloads-v1.15.2) (2025-06-11)
 
 

--- a/packages/google-cloud-audit-log/CHANGELOG.md
+++ b/packages/google-cloud-audit-log/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-audit-log/#history
+
 ## [0.3.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-audit-log-v0.3.1...google-cloud-audit-log-v0.3.2) (2025-03-15)
 
 

--- a/packages/google-cloud-backupdr/CHANGELOG.md
+++ b/packages/google-cloud-backupdr/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-backupdr/#history
+
 ## [0.2.5](https://github.com/googleapis/google-cloud-python/compare/google-cloud-backupdr-v0.2.4...google-cloud-backupdr-v0.2.5) (2025-07-23)
 
 

--- a/packages/google-cloud-bare-metal-solution/CHANGELOG.md
+++ b/packages/google-cloud-bare-metal-solution/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-bare-metal-solution/#history
+
 ## [1.10.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bare-metal-solution-v1.10.2...google-cloud-bare-metal-solution-v1.10.3) (2025-06-11)
 
 

--- a/packages/google-cloud-batch/CHANGELOG.md
+++ b/packages/google-cloud-batch/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-batch/#history
+
 ## [0.17.36](https://github.com/googleapis/google-cloud-python/compare/google-cloud-batch-v0.17.35...google-cloud-batch-v0.17.36) (2025-06-11)
 
 

--- a/packages/google-cloud-beyondcorp-appconnections/CHANGELOG.md
+++ b/packages/google-cloud-beyondcorp-appconnections/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-beyondcorp-appconnections/#history
+
 ## [0.4.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-beyondcorp-appconnections-v0.4.17...google-cloud-beyondcorp-appconnections-v0.4.18) (2025-06-11)
 
 

--- a/packages/google-cloud-beyondcorp-appconnectors/CHANGELOG.md
+++ b/packages/google-cloud-beyondcorp-appconnectors/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-beyondcorp-appconnectors/#history
+
 ## [0.4.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-beyondcorp-appconnectors-v0.4.17...google-cloud-beyondcorp-appconnectors-v0.4.18) (2025-06-11)
 
 

--- a/packages/google-cloud-beyondcorp-appgateways/CHANGELOG.md
+++ b/packages/google-cloud-beyondcorp-appgateways/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-beyondcorp-appgateways/#history
+
 ## [0.4.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-beyondcorp-appgateways-v0.4.17...google-cloud-beyondcorp-appgateways-v0.4.18) (2025-06-11)
 
 

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/CHANGELOG.md
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-beyondcorp-clientconnectorservices/#history
+
 ## [0.4.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-beyondcorp-clientconnectorservices-v0.4.17...google-cloud-beyondcorp-clientconnectorservices-v0.4.18) (2025-06-11)
 
 

--- a/packages/google-cloud-beyondcorp-clientgateways/CHANGELOG.md
+++ b/packages/google-cloud-beyondcorp-clientgateways/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-beyondcorp-clientgateways/#history
+
 ## [0.4.17](https://github.com/googleapis/google-cloud-python/compare/google-cloud-beyondcorp-clientgateways-v0.4.16...google-cloud-beyondcorp-clientgateways-v0.4.17) (2025-06-11)
 
 

--- a/packages/google-cloud-biglake/CHANGELOG.md
+++ b/packages/google-cloud-biglake/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-biglake/#history
+
 ## 0.1.0 (2025-09-08)
 
 

--- a/packages/google-cloud-bigquery-analyticshub/CHANGELOG.md
+++ b/packages/google-cloud-bigquery-analyticshub/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-bigquery-analyticshub/#history
+
 ## [0.4.20](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigquery-analyticshub-v0.4.19...google-cloud-bigquery-analyticshub-v0.4.20) (2025-09-04)
 
 

--- a/packages/google-cloud-bigquery-biglake/CHANGELOG.md
+++ b/packages/google-cloud-bigquery-biglake/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-bigquery-biglake/#history
+
 ## [0.4.15](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigquery-biglake-v0.4.14...google-cloud-bigquery-biglake-v0.4.15) (2025-06-11)
 
 

--- a/packages/google-cloud-bigquery-connection/CHANGELOG.md
+++ b/packages/google-cloud-bigquery-connection/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-bigquery-connection/#history
+
 ## [1.18.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigquery-connection-v1.18.2...google-cloud-bigquery-connection-v1.18.3) (2025-06-11)
 
 

--- a/packages/google-cloud-bigquery-data-exchange/CHANGELOG.md
+++ b/packages/google-cloud-bigquery-data-exchange/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-bigquery-data-exchange/#history
+
 ## [0.5.20](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigquery-data-exchange-v0.5.19...google-cloud-bigquery-data-exchange-v0.5.20) (2025-06-11)
 
 

--- a/packages/google-cloud-bigquery-datapolicies/CHANGELOG.md
+++ b/packages/google-cloud-bigquery-datapolicies/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-bigquery-datapolicies/#history
+
 ## [0.6.16](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigquery-datapolicies-v0.6.15...google-cloud-bigquery-datapolicies-v0.6.16) (2025-07-23)
 
 

--- a/packages/google-cloud-bigquery-logging/CHANGELOG.md
+++ b/packages/google-cloud-bigquery-logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-bigquery-logging/#history
+
 ## [1.6.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigquery-logging-v1.6.2...google-cloud-bigquery-logging-v1.6.3) (2025-06-11)
 
 

--- a/packages/google-cloud-bigquery-migration/CHANGELOG.md
+++ b/packages/google-cloud-bigquery-migration/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-bigquery-migration/#history
+
 ## [0.11.15](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigquery-migration-v0.11.14...google-cloud-bigquery-migration-v0.11.15) (2025-06-11)
 
 

--- a/packages/google-cloud-bigquery-reservation/CHANGELOG.md
+++ b/packages/google-cloud-bigquery-reservation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-bigquery-reservation/#history
+
 ## [1.19.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigquery-reservation-v1.18.0...google-cloud-bigquery-reservation-v1.19.0) (2025-09-04)
 
 

--- a/packages/google-cloud-billing-budgets/CHANGELOG.md
+++ b/packages/google-cloud-billing-budgets/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-billing-budgets/#history
+
 ## [1.17.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-billing-budgets-v1.17.1...google-cloud-billing-budgets-v1.17.2) (2025-06-11)
 
 

--- a/packages/google-cloud-billing/CHANGELOG.md
+++ b/packages/google-cloud-billing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-billing/#history
+
 ## [1.16.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-billing-v1.16.2...google-cloud-billing-v1.16.3) (2025-06-11)
 
 

--- a/packages/google-cloud-binary-authorization/CHANGELOG.md
+++ b/packages/google-cloud-binary-authorization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-binary-authorization/#history
+
 ## [1.13.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-binary-authorization-v1.13.1...google-cloud-binary-authorization-v1.13.2) (2025-06-11)
 
 

--- a/packages/google-cloud-certificate-manager/CHANGELOG.md
+++ b/packages/google-cloud-certificate-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-certificate-manager/#history
+
 ## [1.10.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-certificate-manager-v1.10.1...google-cloud-certificate-manager-v1.10.2) (2025-06-11)
 
 

--- a/packages/google-cloud-channel/CHANGELOG.md
+++ b/packages/google-cloud-channel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-channel/#history
+
 ## [1.23.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-channel-v1.22.2...google-cloud-channel-v1.23.0) (2025-06-19)
 
 

--- a/packages/google-cloud-chronicle/CHANGELOG.md
+++ b/packages/google-cloud-chronicle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-chronicle/#history
+
 ## 0.1.0 (2025-04-24)
 
 

--- a/packages/google-cloud-cloudcontrolspartner/CHANGELOG.md
+++ b/packages/google-cloud-cloudcontrolspartner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-cloudcontrolspartner/#history
+
 ## [0.2.7](https://github.com/googleapis/google-cloud-python/compare/google-cloud-cloudcontrolspartner-v0.2.6...google-cloud-cloudcontrolspartner-v0.2.7) (2025-05-08)
 
 

--- a/packages/google-cloud-cloudsecuritycompliance/CHANGELOG.md
+++ b/packages/google-cloud-cloudsecuritycompliance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-cloudsecuritycompliance/#history
+
 ## 0.1.0 (2025-09-04)
 
 

--- a/packages/google-cloud-commerce-consumer-procurement/CHANGELOG.md
+++ b/packages/google-cloud-commerce-consumer-procurement/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-commerce-consumer-procurement/#history
+
 ## [0.2.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-commerce-consumer-procurement-v0.1.13...google-cloud-commerce-consumer-procurement-v0.2.0) (2025-05-26)
 
 

--- a/packages/google-cloud-common/CHANGELOG.md
+++ b/packages/google-cloud-common/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-common/#history
+
 ## [1.5.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-common-v1.5.1...google-cloud-common-v1.5.2) (2025-06-11)
 
 

--- a/packages/google-cloud-compute-v1beta/CHANGELOG.md
+++ b/packages/google-cloud-compute-v1beta/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-compute-v1beta/#history
+
 ## [0.1.7](https://github.com/googleapis/google-cloud-python/compare/google-cloud-compute-v1beta-v0.1.6...google-cloud-compute-v1beta-v0.1.7) (2025-09-04)
 
 

--- a/packages/google-cloud-compute/CHANGELOG.md
+++ b/packages/google-cloud-compute/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-compute/#history
+
 ## [1.37.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-compute-v1.36.0...google-cloud-compute-v1.37.0) (2025-09-04)
 
 

--- a/packages/google-cloud-confidentialcomputing/CHANGELOG.md
+++ b/packages/google-cloud-confidentialcomputing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-confidentialcomputing/#history
+
 ## [0.5.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-confidentialcomputing-v0.4.18...google-cloud-confidentialcomputing-v0.5.0) (2025-09-08)
 
 

--- a/packages/google-cloud-config/CHANGELOG.md
+++ b/packages/google-cloud-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-config/#history
+
 ## [0.1.21](https://github.com/googleapis/google-cloud-python/compare/google-cloud-config-v0.1.20...google-cloud-config-v0.1.21) (2025-09-04)
 
 

--- a/packages/google-cloud-configdelivery/CHANGELOG.md
+++ b/packages/google-cloud-configdelivery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-configdelivery/#history
+
 ## [0.1.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-configdelivery-v0.1.2...google-cloud-configdelivery-v0.1.3) (2025-08-06)
 
 

--- a/packages/google-cloud-contact-center-insights/CHANGELOG.md
+++ b/packages/google-cloud-contact-center-insights/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-contact-center-insights/#history
+
 ## [1.23.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-contact-center-insights-v1.23.2...google-cloud-contact-center-insights-v1.23.3) (2025-06-11)
 
 

--- a/packages/google-cloud-containeranalysis/CHANGELOG.md
+++ b/packages/google-cloud-containeranalysis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-containeranalysis/#history
+
 ## [2.18.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-containeranalysis-v2.18.0...google-cloud-containeranalysis-v2.18.1) (2025-06-11)
 
 

--- a/packages/google-cloud-contentwarehouse/CHANGELOG.md
+++ b/packages/google-cloud-contentwarehouse/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-contentwarehouse/#history
+
 ## [0.7.16](https://github.com/googleapis/google-cloud-python/compare/google-cloud-contentwarehouse-v0.7.15...google-cloud-contentwarehouse-v0.7.16) (2025-06-11)
 
 

--- a/packages/google-cloud-data-fusion/CHANGELOG.md
+++ b/packages/google-cloud-data-fusion/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-data-fusion/#history
+
 ## [1.13.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-data-fusion-v1.13.2...google-cloud-data-fusion-v1.13.3) (2025-06-11)
 
 

--- a/packages/google-cloud-data-qna/CHANGELOG.md
+++ b/packages/google-cloud-data-qna/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-data-qna/#history
+
 ## [0.10.17](https://github.com/googleapis/google-cloud-python/compare/google-cloud-data-qna-v0.10.16...google-cloud-data-qna-v0.10.17) (2025-06-11)
 
 

--- a/packages/google-cloud-datacatalog-lineage/CHANGELOG.md
+++ b/packages/google-cloud-datacatalog-lineage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-datacatalog-lineage/#history
+
 ## [0.3.14](https://github.com/googleapis/google-cloud-python/compare/google-cloud-datacatalog-lineage-v0.3.13...google-cloud-datacatalog-lineage-v0.3.14) (2025-06-11)
 
 

--- a/packages/google-cloud-dataflow-client/CHANGELOG.md
+++ b/packages/google-cloud-dataflow-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-dataflow-client/#history
+
 ## [0.9.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-dataflow-client-v0.8.17...google-cloud-dataflow-client-v0.9.0) (2025-05-08)
 
 

--- a/packages/google-cloud-dataform/CHANGELOG.md
+++ b/packages/google-cloud-dataform/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-dataform/#history
+
 ## [0.6.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-dataform-v0.6.1...google-cloud-dataform-v0.6.2) (2025-05-20)
 
 

--- a/packages/google-cloud-dataplex/CHANGELOG.md
+++ b/packages/google-cloud-dataplex/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-dataplex/#history
+
 ## [2.11.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-dataplex-v2.10.2...google-cloud-dataplex-v2.11.0) (2025-07-10)
 
 

--- a/packages/google-cloud-dataproc-metastore/CHANGELOG.md
+++ b/packages/google-cloud-dataproc-metastore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-dataproc-metastore/#history
+
 ## [1.19.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-dataproc-metastore-v1.18.3...google-cloud-dataproc-metastore-v1.19.0) (2025-08-06)
 
 

--- a/packages/google-cloud-datastream/CHANGELOG.md
+++ b/packages/google-cloud-datastream/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-datastream/#history
+
 ## [1.15.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-datastream-v1.14.1...google-cloud-datastream-v1.15.0) (2025-08-10)
 
 

--- a/packages/google-cloud-deploy/CHANGELOG.md
+++ b/packages/google-cloud-deploy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-deploy/#history
+
 ## [2.7.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-deploy-v2.7.0...google-cloud-deploy-v2.7.1) (2025-05-08)
 
 

--- a/packages/google-cloud-developerconnect/CHANGELOG.md
+++ b/packages/google-cloud-developerconnect/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-developerconnect/#history
+
 ## [0.1.10](https://github.com/googleapis/google-cloud-python/compare/google-cloud-developerconnect-v0.1.9...google-cloud-developerconnect-v0.1.10) (2025-07-02)
 
 

--- a/packages/google-cloud-devicestreaming/CHANGELOG.md
+++ b/packages/google-cloud-devicestreaming/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-devicestreaming/#history
+
 ## 0.1.0 (2025-04-15)
 
 

--- a/packages/google-cloud-dialogflow-cx/CHANGELOG.md
+++ b/packages/google-cloud-dialogflow-cx/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-dialogflow-cx/#history
 
 ## [1.42.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-dialogflow-cx-v1.41.1...google-cloud-dialogflow-cx-v1.42.0) (2025-07-04)
 

--- a/packages/google-cloud-discoveryengine/CHANGELOG.md
+++ b/packages/google-cloud-discoveryengine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-discoveryengine/#history
+
 ## [0.13.11](https://github.com/googleapis/google-cloud-python/compare/google-cloud-discoveryengine-v0.13.10...google-cloud-discoveryengine-v0.13.11) (2025-07-26)
 
 

--- a/packages/google-cloud-dms/CHANGELOG.md
+++ b/packages/google-cloud-dms/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-dms/#history
+
 ## [1.12.4](https://github.com/googleapis/google-cloud-python/compare/google-cloud-dms-v1.12.3...google-cloud-dms-v1.12.4) (2025-06-11)
 
 

--- a/packages/google-cloud-documentai/CHANGELOG.md
+++ b/packages/google-cloud-documentai/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-documentai/#history
+
 ## [3.6.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-documentai-v3.5.0...google-cloud-documentai-v3.6.0) (2025-08-29)
 
 

--- a/packages/google-cloud-domains/CHANGELOG.md
+++ b/packages/google-cloud-domains/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-domains/#history
+
 ## [1.10.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-domains-v1.10.1...google-cloud-domains-v1.10.2) (2025-06-11)
 
 

--- a/packages/google-cloud-edgecontainer/CHANGELOG.md
+++ b/packages/google-cloud-edgecontainer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-edgecontainer/#history
+
 ## [0.5.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-edgecontainer-v0.5.17...google-cloud-edgecontainer-v0.5.18) (2025-06-11)
 
 

--- a/packages/google-cloud-edgenetwork/CHANGELOG.md
+++ b/packages/google-cloud-edgenetwork/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-edgenetwork/#history
+
 ## [0.1.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-edgenetwork-v0.1.17...google-cloud-edgenetwork-v0.1.18) (2025-06-11)
 
 

--- a/packages/google-cloud-enterpriseknowledgegraph/CHANGELOG.md
+++ b/packages/google-cloud-enterpriseknowledgegraph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-enterpriseknowledgegraph/#history
+
 ## [0.3.17](https://github.com/googleapis/google-cloud-python/compare/google-cloud-enterpriseknowledgegraph-v0.3.16...google-cloud-enterpriseknowledgegraph-v0.3.17) (2025-06-11)
 
 

--- a/packages/google-cloud-essential-contacts/CHANGELOG.md
+++ b/packages/google-cloud-essential-contacts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-essential-contacts/#history
+
 ## [1.10.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-essential-contacts-v1.10.1...google-cloud-essential-contacts-v1.10.2) (2025-06-11)
 
 

--- a/packages/google-cloud-eventarc-publishing/CHANGELOG.md
+++ b/packages/google-cloud-eventarc-publishing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-eventarc-publishing/#history
+
 ## [0.6.19](https://github.com/googleapis/google-cloud-python/compare/google-cloud-eventarc-publishing-v0.6.18...google-cloud-eventarc-publishing-v0.6.19) (2025-06-11)
 
 

--- a/packages/google-cloud-eventarc/CHANGELOG.md
+++ b/packages/google-cloud-eventarc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-eventarc/#history
+
 ## [1.15.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-eventarc-v1.15.2...google-cloud-eventarc-v1.15.3) (2025-06-11)
 
 

--- a/packages/google-cloud-filestore/CHANGELOG.md
+++ b/packages/google-cloud-filestore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-filestore/#history
+
 ## [1.13.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-filestore-v1.13.1...google-cloud-filestore-v1.13.2) (2025-06-11)
 
 

--- a/packages/google-cloud-financialservices/CHANGELOG.md
+++ b/packages/google-cloud-financialservices/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-financialservices/#history
+
 ## [0.1.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-financialservices-v0.1.2...google-cloud-financialservices-v0.1.3) (2025-08-29)
 
 

--- a/packages/google-cloud-functions/CHANGELOG.md
+++ b/packages/google-cloud-functions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-functions/#history
+
 ## [1.20.4](https://github.com/googleapis/google-cloud-python/compare/google-cloud-functions-v1.20.3...google-cloud-functions-v1.20.4) (2025-06-11)
 
 

--- a/packages/google-cloud-gdchardwaremanagement/CHANGELOG.md
+++ b/packages/google-cloud-gdchardwaremanagement/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-gdchardwaremanagement/#history
+
 ## [0.1.13](https://github.com/googleapis/google-cloud-python/compare/google-cloud-gdchardwaremanagement-v0.1.12...google-cloud-gdchardwaremanagement-v0.1.13) (2025-08-29)
 
 

--- a/packages/google-cloud-geminidataanalytics/CHANGELOG.md
+++ b/packages/google-cloud-geminidataanalytics/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-geminidataanalytics/#history
+
 ## [0.3.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-geminidataanalytics-v0.2.0...google-cloud-geminidataanalytics-v0.3.0) (2025-08-29)
 
 

--- a/packages/google-cloud-gke-backup/CHANGELOG.md
+++ b/packages/google-cloud-gke-backup/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-gke-backup/#history
+
 ## [0.5.19](https://github.com/googleapis/google-cloud-python/compare/google-cloud-gke-backup-v0.5.18...google-cloud-gke-backup-v0.5.19) (2025-05-15)
 
 

--- a/packages/google-cloud-gke-connect-gateway/CHANGELOG.md
+++ b/packages/google-cloud-gke-connect-gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-gke-connect-gateway/#history
+
 ## [0.10.4](https://github.com/googleapis/google-cloud-python/compare/google-cloud-gke-connect-gateway-v0.10.3...google-cloud-gke-connect-gateway-v0.10.4) (2025-06-11)
 
 

--- a/packages/google-cloud-gke-hub/CHANGELOG.md
+++ b/packages/google-cloud-gke-hub/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-gke-hub/#history
+
 ## [1.17.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-gke-hub-v1.17.2...google-cloud-gke-hub-v1.17.3) (2025-06-11)
 
 

--- a/packages/google-cloud-gke-multicloud/CHANGELOG.md
+++ b/packages/google-cloud-gke-multicloud/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-gke-multicloud/#history
+
 ## [0.6.21](https://github.com/googleapis/google-cloud-python/compare/google-cloud-gke-multicloud-v0.6.20...google-cloud-gke-multicloud-v0.6.21) (2025-06-11)
 
 

--- a/packages/google-cloud-gsuiteaddons/CHANGELOG.md
+++ b/packages/google-cloud-gsuiteaddons/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-gsuiteaddons/#history
+
 ## [0.3.17](https://github.com/googleapis/google-cloud-python/compare/google-cloud-gsuiteaddons-v0.3.16...google-cloud-gsuiteaddons-v0.3.17) (2025-06-11)
 
 

--- a/packages/google-cloud-iam-logging/CHANGELOG.md
+++ b/packages/google-cloud-iam-logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-iam-logging/#history
+
 ## [1.4.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-iam-logging-v1.4.2...google-cloud-iam-logging-v1.4.3) (2025-06-11)
 
 

--- a/packages/google-cloud-iap/CHANGELOG.md
+++ b/packages/google-cloud-iap/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-iap/#history
+
 ## [1.17.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-iap-v1.17.0...google-cloud-iap-v1.17.1) (2025-05-29)
 
 

--- a/packages/google-cloud-ids/CHANGELOG.md
+++ b/packages/google-cloud-ids/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-ids/#history
+
 ## [1.10.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-ids-v1.10.1...google-cloud-ids-v1.10.2) (2025-06-11)
 
 

--- a/packages/google-cloud-kms-inventory/CHANGELOG.md
+++ b/packages/google-cloud-kms-inventory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-kms-inventory/#history
+
 ## [0.2.15](https://github.com/googleapis/google-cloud-python/compare/google-cloud-kms-inventory-v0.2.14...google-cloud-kms-inventory-v0.2.15) (2025-06-11)
 
 

--- a/packages/google-cloud-licensemanager/CHANGELOG.md
+++ b/packages/google-cloud-licensemanager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-licensemanager/#history
+
 ## 0.1.0 (2025-07-16)
 
 

--- a/packages/google-cloud-life-sciences/CHANGELOG.md
+++ b/packages/google-cloud-life-sciences/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-life-sciences/#history
+
 ## [0.9.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-life-sciences-v0.9.17...google-cloud-life-sciences-v0.9.18) (2025-06-11)
 
 

--- a/packages/google-cloud-lustre/CHANGELOG.md
+++ b/packages/google-cloud-lustre/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-lustre/#history
+
 ## [0.1.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-lustre-v0.1.1...google-cloud-lustre-v0.1.2) (2025-07-16)
 
 

--- a/packages/google-cloud-maintenance-api/CHANGELOG.md
+++ b/packages/google-cloud-maintenance-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-maintenance-api/#history
+
 ## [0.1.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-maintenance-api-v0.1.0...google-cloud-maintenance-api-v0.1.1) (2025-07-23)
 
 

--- a/packages/google-cloud-managed-identities/CHANGELOG.md
+++ b/packages/google-cloud-managed-identities/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-managed-identities/#history
+
 ## [1.12.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-managed-identities-v1.12.1...google-cloud-managed-identities-v1.12.2) (2025-06-11)
 
 

--- a/packages/google-cloud-managedkafka-schemaregistry/CHANGELOG.md
+++ b/packages/google-cloud-managedkafka-schemaregistry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-managedkafka-schemaregistry/#history
+
 ## 0.1.0 (2025-07-23)
 
 

--- a/packages/google-cloud-managedkafka/CHANGELOG.md
+++ b/packages/google-cloud-managedkafka/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-managedkafka/#history
+
 ## [0.1.12](https://github.com/googleapis/google-cloud-python/compare/google-cloud-managedkafka-v0.1.11...google-cloud-managedkafka-v0.1.12) (2025-07-10)
 
 

--- a/packages/google-cloud-media-translation/CHANGELOG.md
+++ b/packages/google-cloud-media-translation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-media-translation/#history
+
 ## [0.11.17](https://github.com/googleapis/google-cloud-python/compare/google-cloud-media-translation-v0.11.16...google-cloud-media-translation-v0.11.17) (2025-06-11)
 
 

--- a/packages/google-cloud-memcache/CHANGELOG.md
+++ b/packages/google-cloud-memcache/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-memcache/#history
+
 ## [1.12.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-memcache-v1.12.1...google-cloud-memcache-v1.12.2) (2025-06-11)
 
 

--- a/packages/google-cloud-memorystore/CHANGELOG.md
+++ b/packages/google-cloud-memorystore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-memorystore/#history
+
 ## [0.1.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-memorystore-v0.1.2...google-cloud-memorystore-v0.1.3) (2025-05-08)
 
 

--- a/packages/google-cloud-migrationcenter/CHANGELOG.md
+++ b/packages/google-cloud-migrationcenter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-migrationcenter/#history
+
 ## [0.1.15](https://github.com/googleapis/google-cloud-python/compare/google-cloud-migrationcenter-v0.1.14...google-cloud-migrationcenter-v0.1.15) (2025-06-11)
 
 

--- a/packages/google-cloud-modelarmor/CHANGELOG.md
+++ b/packages/google-cloud-modelarmor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-modelarmor/#history
+
 ## [0.2.8](https://github.com/googleapis/google-cloud-python/compare/google-cloud-modelarmor-v0.2.7...google-cloud-modelarmor-v0.2.8) (2025-08-06)
 
 

--- a/packages/google-cloud-monitoring-dashboards/CHANGELOG.md
+++ b/packages/google-cloud-monitoring-dashboards/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-monitoring-dashboards/#history
+
 ## [2.18.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-monitoring-dashboards-v2.18.1...google-cloud-monitoring-dashboards-v2.18.2) (2025-06-11)
 
 

--- a/packages/google-cloud-monitoring-metrics-scopes/CHANGELOG.md
+++ b/packages/google-cloud-monitoring-metrics-scopes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-monitoring-metrics-scopes/#history
+
 ## [1.9.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-monitoring-metrics-scopes-v1.9.1...google-cloud-monitoring-metrics-scopes-v1.9.2) (2025-06-11)
 
 

--- a/packages/google-cloud-netapp/CHANGELOG.md
+++ b/packages/google-cloud-netapp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-netapp/#history
+
 ## [0.3.24](https://github.com/googleapis/google-cloud-python/compare/google-cloud-netapp-v0.3.23...google-cloud-netapp-v0.3.24) (2025-09-04)
 
 

--- a/packages/google-cloud-network-connectivity/CHANGELOG.md
+++ b/packages/google-cloud-network-connectivity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-network-connectivity/#history
+
 ## [2.10.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-network-connectivity-v2.9.0...google-cloud-network-connectivity-v2.10.0) (2025-09-08)
 
 

--- a/packages/google-cloud-network-management/CHANGELOG.md
+++ b/packages/google-cloud-network-management/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-network-management/#history
+
 ## [1.28.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-network-management-v1.27.0...google-cloud-network-management-v1.28.0) (2025-08-10)
 
 

--- a/packages/google-cloud-network-security/CHANGELOG.md
+++ b/packages/google-cloud-network-security/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-network-security/#history
+
 ## [0.9.19](https://github.com/googleapis/google-cloud-python/compare/google-cloud-network-security-v0.9.18...google-cloud-network-security-v0.9.19) (2025-09-04)
 
 

--- a/packages/google-cloud-network-services/CHANGELOG.md
+++ b/packages/google-cloud-network-services/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-network-services/#history
+
 ## [0.5.24](https://github.com/googleapis/google-cloud-python/compare/google-cloud-network-services-v0.5.23...google-cloud-network-services-v0.5.24) (2025-07-10)
 
 

--- a/packages/google-cloud-notebooks/CHANGELOG.md
+++ b/packages/google-cloud-notebooks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-notebooks/#history
+
 ## [1.13.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-notebooks-v1.13.2...google-cloud-notebooks-v1.13.3) (2025-06-11)
 
 

--- a/packages/google-cloud-optimization/CHANGELOG.md
+++ b/packages/google-cloud-optimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-optimization/#history
+
 ## [1.11.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-optimization-v1.11.1...google-cloud-optimization-v1.11.2) (2025-06-11)
 
 

--- a/packages/google-cloud-oracledatabase/CHANGELOG.md
+++ b/packages/google-cloud-oracledatabase/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-oracledatabase/#history
+
 ## [0.1.10](https://github.com/googleapis/google-cloud-python/compare/google-cloud-oracledatabase-v0.1.9...google-cloud-oracledatabase-v0.1.10) (2025-04-29)
 
 

--- a/packages/google-cloud-orchestration-airflow/CHANGELOG.md
+++ b/packages/google-cloud-orchestration-airflow/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-orchestration-airflow/#history
+
 ## [1.17.5](https://github.com/googleapis/google-cloud-python/compare/google-cloud-orchestration-airflow-v1.17.4...google-cloud-orchestration-airflow-v1.17.5) (2025-04-15)
 
 

--- a/packages/google-cloud-org-policy/CHANGELOG.md
+++ b/packages/google-cloud-org-policy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-org-policy/#history
+
 ## [1.14.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-org-policy-v1.13.1...google-cloud-org-policy-v1.14.0) (2025-04-17)
 
 

--- a/packages/google-cloud-os-config/CHANGELOG.md
+++ b/packages/google-cloud-os-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-os-config/#history
+
 ## [1.21.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-os-config-v1.20.2...google-cloud-os-config-v1.21.0) (2025-08-10)
 
 

--- a/packages/google-cloud-os-login/CHANGELOG.md
+++ b/packages/google-cloud-os-login/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [PyPI History][1]
 
+[1]: https://pypi.org/project/google-cloud-os-login/#history
+
+[PyPI History][1]
+
 [1]: https://pypi.org/project/google-cloud-oslogin/#history
 
 ## [2.17.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-os-login-v2.17.1...google-cloud-os-login-v2.17.2) (2025-06-11)

--- a/packages/google-cloud-parallelstore/CHANGELOG.md
+++ b/packages/google-cloud-parallelstore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-parallelstore/#history
+
 ## [0.2.15](https://github.com/googleapis/google-cloud-python/compare/google-cloud-parallelstore-v0.2.14...google-cloud-parallelstore-v0.2.15) (2025-06-03)
 
 

--- a/packages/google-cloud-parametermanager/CHANGELOG.md
+++ b/packages/google-cloud-parametermanager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-parametermanager/#history
+
 ## [0.1.5](https://github.com/googleapis/google-cloud-python/compare/google-cloud-parametermanager-v0.1.4...google-cloud-parametermanager-v0.1.5) (2025-06-23)
 
 

--- a/packages/google-cloud-policy-troubleshooter/CHANGELOG.md
+++ b/packages/google-cloud-policy-troubleshooter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-policy-troubleshooter/#history
+
 ## [1.13.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-policy-troubleshooter-v1.13.2...google-cloud-policy-troubleshooter-v1.13.3) (2025-06-11)
 
 

--- a/packages/google-cloud-policysimulator/CHANGELOG.md
+++ b/packages/google-cloud-policysimulator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-policysimulator/#history
+
 ## [0.1.15](https://github.com/googleapis/google-cloud-python/compare/google-cloud-policysimulator-v0.1.14...google-cloud-policysimulator-v0.1.15) (2025-07-23)
 
 

--- a/packages/google-cloud-policytroubleshooter-iam/CHANGELOG.md
+++ b/packages/google-cloud-policytroubleshooter-iam/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-policytroubleshooter-iam/#history
+
 ## [0.1.13](https://github.com/googleapis/google-cloud-python/compare/google-cloud-policytroubleshooter-iam-v0.1.12...google-cloud-policytroubleshooter-iam-v0.1.13) (2025-06-11)
 
 

--- a/packages/google-cloud-private-ca/CHANGELOG.md
+++ b/packages/google-cloud-private-ca/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-private-ca/#history
+
 ## [1.15.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-private-ca-v1.14.3...google-cloud-private-ca-v1.15.0) (2025-07-10)
 
 

--- a/packages/google-cloud-private-catalog/CHANGELOG.md
+++ b/packages/google-cloud-private-catalog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-private-catalog/#history
+
 ## [0.9.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-private-catalog-v0.9.17...google-cloud-private-catalog-v0.9.18) (2025-06-11)
 
 

--- a/packages/google-cloud-privilegedaccessmanager/CHANGELOG.md
+++ b/packages/google-cloud-privilegedaccessmanager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-privilegedaccessmanager/#history
+
 ## [0.1.9](https://github.com/googleapis/google-cloud-python/compare/google-cloud-privilegedaccessmanager-v0.1.8...google-cloud-privilegedaccessmanager-v0.1.9) (2025-08-06)
 
 

--- a/packages/google-cloud-public-ca/CHANGELOG.md
+++ b/packages/google-cloud-public-ca/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-public-ca/#history
+
 ## [0.3.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.17...google-cloud-public-ca-v0.3.18) (2025-06-11)
 
 

--- a/packages/google-cloud-quotas/CHANGELOG.md
+++ b/packages/google-cloud-quotas/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-quotas/#history
+
 ## [0.1.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-quotas-v0.1.17...google-cloud-quotas-v0.1.18) (2025-06-11)
 
 

--- a/packages/google-cloud-rapidmigrationassessment/CHANGELOG.md
+++ b/packages/google-cloud-rapidmigrationassessment/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-rapidmigrationassessment/#history
+
 ## [0.1.16](https://github.com/googleapis/google-cloud-python/compare/google-cloud-rapidmigrationassessment-v0.1.15...google-cloud-rapidmigrationassessment-v0.1.16) (2025-06-11)
 
 

--- a/packages/google-cloud-recaptcha-enterprise/CHANGELOG.md
+++ b/packages/google-cloud-recaptcha-enterprise/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-recaptcha-enterprise/#history
+
 ## [1.28.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-recaptcha-enterprise-v1.28.1...google-cloud-recaptcha-enterprise-v1.28.2) (2025-06-11)
 
 

--- a/packages/google-cloud-recommendations-ai/CHANGELOG.md
+++ b/packages/google-cloud-recommendations-ai/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-recommendations-ai/#history
+
 ## [0.10.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-recommendations-ai-v0.10.17...google-cloud-recommendations-ai-v0.10.18) (2025-06-11)
 
 

--- a/packages/google-cloud-redis-cluster/CHANGELOG.md
+++ b/packages/google-cloud-redis-cluster/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-redis-cluster/#history
+
 ## [0.1.15](https://github.com/googleapis/google-cloud-python/compare/google-cloud-redis-cluster-v0.1.14...google-cloud-redis-cluster-v0.1.15) (2025-03-15)
 
 

--- a/packages/google-cloud-retail/CHANGELOG.md
+++ b/packages/google-cloud-retail/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-retail/#history
+
 ## [2.6.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-retail-v2.5.0...google-cloud-retail-v2.6.0) (2025-09-08)
 
 

--- a/packages/google-cloud-run/CHANGELOG.md
+++ b/packages/google-cloud-run/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-run/#history
 
 ## [0.11.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-run-v0.10.19...google-cloud-run-v0.11.0) (2025-08-29)
 

--- a/packages/google-cloud-saasplatform-saasservicemgmt/CHANGELOG.md
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-saasplatform-saasservicemgmt/#history
+
 ## 0.1.0 (2025-08-10)
 
 

--- a/packages/google-cloud-secret-manager/CHANGELOG.md
+++ b/packages/google-cloud-secret-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-secret-manager/#history
+
 ## [2.24.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-secret-manager-v2.23.3...google-cloud-secret-manager-v2.24.0) (2025-06-05)
 
 

--- a/packages/google-cloud-securesourcemanager/CHANGELOG.md
+++ b/packages/google-cloud-securesourcemanager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-securesourcemanager/#history
+
 ## [0.1.17](https://github.com/googleapis/google-cloud-python/compare/google-cloud-securesourcemanager-v0.1.16...google-cloud-securesourcemanager-v0.1.17) (2025-08-06)
 
 

--- a/packages/google-cloud-securitycentermanagement/CHANGELOG.md
+++ b/packages/google-cloud-securitycentermanagement/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-securitycentermanagement/#history
+
 ## [0.1.22](https://github.com/googleapis/google-cloud-python/compare/google-cloud-securitycentermanagement-v0.1.21...google-cloud-securitycentermanagement-v0.1.22) (2025-04-12)
 
 

--- a/packages/google-cloud-service-control/CHANGELOG.md
+++ b/packages/google-cloud-service-control/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-service-control/#history
+
 ## [1.16.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-service-control-v1.15.1...google-cloud-service-control-v1.16.0) (2025-07-23)
 
 

--- a/packages/google-cloud-service-directory/CHANGELOG.md
+++ b/packages/google-cloud-service-directory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-service-directory/#history
+
 ## [1.14.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-service-directory-v1.14.1...google-cloud-service-directory-v1.14.2) (2025-03-15)
 
 

--- a/packages/google-cloud-service-management/CHANGELOG.md
+++ b/packages/google-cloud-service-management/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-service-management/#history
+
 ## [1.13.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-service-management-v1.13.1...google-cloud-service-management-v1.13.2) (2025-03-15)
 
 

--- a/packages/google-cloud-service-usage/CHANGELOG.md
+++ b/packages/google-cloud-service-usage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-service-usage/#history
+
 ## [1.13.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-service-usage-v1.13.0...google-cloud-service-usage-v1.13.1) (2025-03-15)
 
 

--- a/packages/google-cloud-servicehealth/CHANGELOG.md
+++ b/packages/google-cloud-servicehealth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-servicehealth/#history
+
 ## [0.1.12](https://github.com/googleapis/google-cloud-python/compare/google-cloud-servicehealth-v0.1.11...google-cloud-servicehealth-v0.1.12) (2025-03-15)
 
 

--- a/packages/google-cloud-shell/CHANGELOG.md
+++ b/packages/google-cloud-shell/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-shell/#history
+
 ## [1.12.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-shell-v1.12.0...google-cloud-shell-v1.12.1) (2025-03-15)
 
 

--- a/packages/google-cloud-source-context/CHANGELOG.md
+++ b/packages/google-cloud-source-context/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-source-context/#history
+
 ## [1.7.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-source-context-v1.7.0...google-cloud-source-context-v1.7.1) (2025-03-15)
 
 

--- a/packages/google-cloud-storage-control/CHANGELOG.md
+++ b/packages/google-cloud-storage-control/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-storage-control/#history
+
 ## [1.6.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-storage-control-v1.6.0...google-cloud-storage-control-v1.6.1) (2025-07-23)
 
 

--- a/packages/google-cloud-storage-transfer/CHANGELOG.md
+++ b/packages/google-cloud-storage-transfer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-storage-transfer/#history
+
 ## [1.17.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-storage-transfer-v1.16.1...google-cloud-storage-transfer-v1.17.0) (2025-05-26)
 
 

--- a/packages/google-cloud-storagebatchoperations/CHANGELOG.md
+++ b/packages/google-cloud-storagebatchoperations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-storagebatchoperations/#history
+
 ## [0.1.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-storagebatchoperations-v0.1.2...google-cloud-storagebatchoperations-v0.1.3) (2025-05-15)
 
 

--- a/packages/google-cloud-storageinsights/CHANGELOG.md
+++ b/packages/google-cloud-storageinsights/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-storageinsights/#history
+
 ## [0.1.16](https://github.com/googleapis/google-cloud-python/compare/google-cloud-storageinsights-v0.1.15...google-cloud-storageinsights-v0.1.16) (2025-05-15)
 
 

--- a/packages/google-cloud-support/CHANGELOG.md
+++ b/packages/google-cloud-support/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-support/#history
+
 ## [0.1.19](https://github.com/googleapis/google-cloud-python/compare/google-cloud-support-v0.1.18...google-cloud-support-v0.1.19) (2025-08-10)
 
 

--- a/packages/google-cloud-telcoautomation/CHANGELOG.md
+++ b/packages/google-cloud-telcoautomation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-telcoautomation/#history
+
 ## [0.2.11](https://github.com/googleapis/google-cloud-python/compare/google-cloud-telcoautomation-v0.2.10...google-cloud-telcoautomation-v0.2.11) (2025-06-11)
 
 

--- a/packages/google-cloud-tpu/CHANGELOG.md
+++ b/packages/google-cloud-tpu/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-tpu/#history
+
 ## [1.23.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-tpu-v1.23.1...google-cloud-tpu-v1.23.2) (2025-06-11)
 
 

--- a/packages/google-cloud-video-live-stream/CHANGELOG.md
+++ b/packages/google-cloud-video-live-stream/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-video-live-stream/#history
+
 ## [1.12.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-video-live-stream-v1.11.1...google-cloud-video-live-stream-v1.12.0) (2025-05-15)
 
 

--- a/packages/google-cloud-video-stitcher/CHANGELOG.md
+++ b/packages/google-cloud-video-stitcher/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-video-stitcher/#history
+
 ## [0.7.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-video-stitcher-v0.7.17...google-cloud-video-stitcher-v0.7.18) (2025-06-11)
 
 

--- a/packages/google-cloud-video-transcoder/CHANGELOG.md
+++ b/packages/google-cloud-video-transcoder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-video-transcoder/#history
+
 ## [1.17.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-video-transcoder-v1.16.0...google-cloud-video-transcoder-v1.17.0) (2025-08-29)
 
 

--- a/packages/google-cloud-visionai/CHANGELOG.md
+++ b/packages/google-cloud-visionai/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-visionai/#history
+
 ## [0.1.10](https://github.com/googleapis/google-cloud-python/compare/google-cloud-visionai-v0.1.9...google-cloud-visionai-v0.1.10) (2025-06-11)
 
 

--- a/packages/google-cloud-vm-migration/CHANGELOG.md
+++ b/packages/google-cloud-vm-migration/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-vm-migration/#history
+
 ## [1.12.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-vm-migration-v1.11.3...google-cloud-vm-migration-v1.12.0) (2025-09-08)
 
 

--- a/packages/google-cloud-vmwareengine/CHANGELOG.md
+++ b/packages/google-cloud-vmwareengine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-vmwareengine/#history
+
 ## [1.8.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-vmwareengine-v1.8.2...google-cloud-vmwareengine-v1.8.3) (2025-06-11)
 
 

--- a/packages/google-cloud-vpc-access/CHANGELOG.md
+++ b/packages/google-cloud-vpc-access/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-vpc-access/#history
+
 ## [1.13.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-vpc-access-v1.13.1...google-cloud-vpc-access-v1.13.2) (2025-06-11)
 
 

--- a/packages/google-cloud-workflows/CHANGELOG.md
+++ b/packages/google-cloud-workflows/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-workflows/#history
+
 ## [1.18.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-workflows-v1.18.1...google-cloud-workflows-v1.18.2) (2025-06-11)
 
 

--- a/packages/google-cloud-workstations/CHANGELOG.md
+++ b/packages/google-cloud-workstations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-workstations/#history
+
 ## [0.5.15](https://github.com/googleapis/google-cloud-python/compare/google-cloud-workstations-v0.5.14...google-cloud-workstations-v0.5.15) (2025-06-11)
 
 

--- a/packages/google-geo-type/CHANGELOG.md
+++ b/packages/google-geo-type/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-geo-type/#history
+
 ## [0.3.13](https://github.com/googleapis/google-cloud-python/compare/google-geo-type-v0.3.12...google-geo-type-v0.3.13) (2025-06-11)
 
 

--- a/packages/google-maps-addressvalidation/CHANGELOG.md
+++ b/packages/google-maps-addressvalidation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-maps-addressvalidation/#history
+
 ## [0.3.20](https://github.com/googleapis/google-cloud-python/compare/google-maps-addressvalidation-v0.3.19...google-maps-addressvalidation-v0.3.20) (2025-07-16)
 
 

--- a/packages/google-maps-areainsights/CHANGELOG.md
+++ b/packages/google-maps-areainsights/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-maps-areainsights/#history
+
 ## [0.1.8](https://github.com/googleapis/google-cloud-python/compare/google-maps-areainsights-v0.1.7...google-maps-areainsights-v0.1.8) (2025-04-24)
 
 

--- a/packages/google-maps-fleetengine-delivery/CHANGELOG.md
+++ b/packages/google-maps-fleetengine-delivery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-maps-fleetengine-delivery/#history
+
 ## [0.2.13](https://github.com/googleapis/google-cloud-python/compare/google-maps-fleetengine-delivery-v0.2.12...google-maps-fleetengine-delivery-v0.2.13) (2025-07-10)
 
 

--- a/packages/google-maps-fleetengine/CHANGELOG.md
+++ b/packages/google-maps-fleetengine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-maps-fleetengine/#history
+
 ## [0.2.11](https://github.com/googleapis/google-cloud-python/compare/google-maps-fleetengine-v0.2.10...google-maps-fleetengine-v0.2.11) (2025-07-10)
 
 

--- a/packages/google-maps-mapsplatformdatasets/CHANGELOG.md
+++ b/packages/google-maps-mapsplatformdatasets/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-maps-mapsplatformdatasets/#history
+
 ## [0.4.8](https://github.com/googleapis/google-cloud-python/compare/google-maps-mapsplatformdatasets-v0.4.7...google-maps-mapsplatformdatasets-v0.4.8) (2025-06-11)
 
 

--- a/packages/google-maps-places/CHANGELOG.md
+++ b/packages/google-maps-places/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-maps-places/#history
+
 ## [0.2.2](https://github.com/googleapis/google-cloud-python/compare/google-maps-places-v0.2.1...google-maps-places-v0.2.2) (2025-07-02)
 
 

--- a/packages/google-maps-routeoptimization/CHANGELOG.md
+++ b/packages/google-maps-routeoptimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-maps-routeoptimization/#history
+
 ## [0.1.11](https://github.com/googleapis/google-cloud-python/compare/google-maps-routeoptimization-v0.1.10...google-maps-routeoptimization-v0.1.11) (2025-06-11)
 
 

--- a/packages/google-maps-routing/CHANGELOG.md
+++ b/packages/google-maps-routing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-maps-routing/#history
+
 ## [0.6.16](https://github.com/googleapis/google-cloud-python/compare/google-maps-routing-v0.6.15...google-maps-routing-v0.6.16) (2025-06-11)
 
 

--- a/packages/google-maps-solar/CHANGELOG.md
+++ b/packages/google-maps-solar/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-maps-solar/#history
+
 ## [0.1.9](https://github.com/googleapis/google-cloud-python/compare/google-maps-solar-v0.1.8...google-maps-solar-v0.1.9) (2025-08-29)
 
 

--- a/packages/google-shopping-css/CHANGELOG.md
+++ b/packages/google-shopping-css/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-css/#history
+
 ## [0.1.17](https://github.com/googleapis/google-cloud-python/compare/google-shopping-css-v0.1.16...google-shopping-css-v0.1.17) (2025-06-11)
 
 

--- a/packages/google-shopping-merchant-accounts/CHANGELOG.md
+++ b/packages/google-shopping-merchant-accounts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-accounts/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-accounts-v0.3.6...google-shopping-merchant-accounts-v1.0.0) (2025-08-29)
 
 

--- a/packages/google-shopping-merchant-conversions/CHANGELOG.md
+++ b/packages/google-shopping-merchant-conversions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-conversions/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-conversions-v0.1.10...google-shopping-merchant-conversions-v1.0.0) (2025-08-29)
 
 

--- a/packages/google-shopping-merchant-datasources/CHANGELOG.md
+++ b/packages/google-shopping-merchant-datasources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-datasources/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-datasources-v0.1.11...google-shopping-merchant-datasources-v1.0.0) (2025-08-29)
 
 

--- a/packages/google-shopping-merchant-inventories/CHANGELOG.md
+++ b/packages/google-shopping-merchant-inventories/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-inventories/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-inventories-v0.1.16...google-shopping-merchant-inventories-v1.0.0) (2025-08-29)
 
 

--- a/packages/google-shopping-merchant-issueresolution/CHANGELOG.md
+++ b/packages/google-shopping-merchant-issueresolution/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-issueresolution/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-issueresolution-v0.1.1...google-shopping-merchant-issueresolution-v1.0.0) (2025-08-29)
 
 

--- a/packages/google-shopping-merchant-lfp/CHANGELOG.md
+++ b/packages/google-shopping-merchant-lfp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-lfp/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-lfp-v0.1.11...google-shopping-merchant-lfp-v1.0.0) (2025-08-29)
 
 

--- a/packages/google-shopping-merchant-notifications/CHANGELOG.md
+++ b/packages/google-shopping-merchant-notifications/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-notifications/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-notifications-v0.1.9...google-shopping-merchant-notifications-v1.0.0) (2025-08-29)
 
 

--- a/packages/google-shopping-merchant-ordertracking/CHANGELOG.md
+++ b/packages/google-shopping-merchant-ordertracking/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-ordertracking/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-ordertracking-v0.1.1...google-shopping-merchant-ordertracking-v1.0.0) (2025-08-29)
 
 

--- a/packages/google-shopping-merchant-products/CHANGELOG.md
+++ b/packages/google-shopping-merchant-products/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-products/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-products-v0.2.7...google-shopping-merchant-products-v1.0.0) (2025-08-29)
 
 

--- a/packages/google-shopping-merchant-productstudio/CHANGELOG.md
+++ b/packages/google-shopping-merchant-productstudio/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-productstudio/#history
+
 ## [0.1.1](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-productstudio-v0.1.0...google-shopping-merchant-productstudio-v0.1.1) (2025-07-02)
 
 

--- a/packages/google-shopping-merchant-promotions/CHANGELOG.md
+++ b/packages/google-shopping-merchant-promotions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-promotions/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-promotions-v0.1.9...google-shopping-merchant-promotions-v1.0.0) (2025-08-29)
 
 

--- a/packages/google-shopping-merchant-quota/CHANGELOG.md
+++ b/packages/google-shopping-merchant-quota/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-quota/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-quota-v0.1.9...google-shopping-merchant-quota-v1.0.0) (2025-08-29)
 
 

--- a/packages/google-shopping-merchant-reports/CHANGELOG.md
+++ b/packages/google-shopping-merchant-reports/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-reports/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-reports-v0.1.17...google-shopping-merchant-reports-v1.0.0) (2025-08-29)
 
 

--- a/packages/google-shopping-merchant-reviews/CHANGELOG.md
+++ b/packages/google-shopping-merchant-reviews/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-merchant-reviews/#history
+
 ## [0.2.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-merchant-reviews-v0.1.4...google-shopping-merchant-reviews-v0.2.0) (2025-07-26)
 
 

--- a/packages/google-shopping-type/CHANGELOG.md
+++ b/packages/google-shopping-type/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-shopping-type/#history
+
 ## [1.0.0](https://github.com/googleapis/google-cloud-python/compare/google-shopping-type-v0.1.12...google-shopping-type-v1.0.0) (2025-08-13)
 
 

--- a/packages/googleapis-common-protos/CHANGELOG.md
+++ b/packages/googleapis-common-protos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/googleapis-common-protos/#history
+
 ## [1.70.0](https://github.com/googleapis/google-cloud-python/compare/googleapis-common-protos-v1.69.2...googleapis-common-protos-v1.70.0) (2025-04-12)
 
 

--- a/packages/grpc-google-iam-v1/CHANGELOG.md
+++ b/packages/grpc-google-iam-v1/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/grpc-google-iam-v1/#history
+
 ## [0.14.2](https://github.com/googleapis/google-cloud-python/compare/grpc-google-iam-v1-v0.14.1...grpc-google-iam-v1-v0.14.2) (2025-03-15)
 
 


### PR DESCRIPTION
Fixes https://github.com/googleapis/librarian/issues/2246

```
[PyPI History][1]

[1]: https://pypi.org/project/google-ads-admanager/#history
```

The anchor pattern below needs to be in each CHANGELOG.md to identify the top of a `CHANGELOG` file as per the code below:

https://github.com/googleapis/google-cloud-python/blob/692a39cc973c93c747a767c8b77d65d2c4c7be9b/.generator/cli.py#L766-L767

