### PR TITLE
chore: librarian release pull request: 20250923T174625Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -22,7 +22,7 @@ libraries:
       - packages/google-cloud-dlp
     tag_format: '{id}-v{version}'
   - id: google-cloud-eventarc
-    version: 1.15.3
+    version: 1.16.0
     last_generated_commit: d89b4d093fa1526255dbc724495c3bdb0e5dd384
     apis:
       - path: google/cloud/eventarc/v1
@@ -43,7 +43,7 @@ libraries:
       - packages/google-cloud-eventarc
     tag_format: '{id}-v{version}'
   - id: google-cloud-video-live-stream
-    version: 1.12.0
+    version: 1.13.0
     last_generated_commit: d89b4d093fa1526255dbc724495c3bdb0e5dd384
     apis:
       - path: google/cloud/video/livestream/v1
@@ -160,7 +160,7 @@ libraries:
       - packages/google-analytics-data
     tag_format: '{id}-v{version}'
   - id: google-ads-admanager
-    version: 0.3.0
+    version: 0.4.0
     last_generated_commit: d89b4d093fa1526255dbc724495c3bdb0e5dd384
     apis:
       - path: google/ads/admanager/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Please refer to each API's `CHANGELOG.md` file under the `packages/` directory
 
 Changelogs
 -----
-- [google-ads-admanager==0.3.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-ads-admanager/CHANGELOG.md)
+- [google-ads-admanager==0.4.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-ads-admanager/CHANGELOG.md)
 - [google-ads-marketingplatform-admin==0.1.6](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-ads-marketingplatform-admin/CHANGELOG.md)
 - [google-ai-generativelanguage==0.6.18](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-ai-generativelanguage/CHANGELOG.md)
 - [google-analytics-admin==0.24.1](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-analytics-admin/CHANGELOG.md)
@@ -93,7 +93,7 @@ Changelogs
 - [google-cloud-enterpriseknowledgegraph==0.3.17](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-enterpriseknowledgegraph/CHANGELOG.md)
 - [google-cloud-essential-contacts==1.10.2](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-essential-contacts/CHANGELOG.md)
 - [google-cloud-eventarc-publishing==0.6.19](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-eventarc-publishing/CHANGELOG.md)
-- [google-cloud-eventarc==1.15.3](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-eventarc/CHANGELOG.md)
+- [google-cloud-eventarc==1.16.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-eventarc/CHANGELOG.md)
 - [google-cloud-filestore==1.13.2](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-filestore/CHANGELOG.md)
 - [google-cloud-financialservices==0.1.2](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-financialservices/CHANGELOG.md)
 - [google-cloud-functions==1.20.4](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-functions/CHANGELOG.md)
@@ -184,7 +184,7 @@ Changelogs
 - [google-cloud-tpu==1.23.2](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-tpu/CHANGELOG.md)
 - [google-cloud-trace==1.16.2](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-trace/CHANGELOG.md)
 - [google-cloud-translate==3.21.1](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-translate/CHANGELOG.md)
-- [google-cloud-video-live-stream==1.12.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-video-live-stream/CHANGELOG.md)
+- [google-cloud-video-live-stream==1.13.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-video-live-stream/CHANGELOG.md)
 - [google-cloud-video-stitcher==0.7.18](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-video-stitcher/CHANGELOG.md)
 - [google-cloud-video-transcoder==1.16.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-video-transcoder/CHANGELOG.md)
 - [google-cloud-videointelligence==2.16.2](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-videointelligence/CHANGELOG.md)

--- a/packages/google-ads-admanager/CHANGELOG.md
+++ b/packages/google-ads-admanager/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-ads-admanager/#history
 
+## [0.4.0](https://github.com/googleapis/google-cloud-python/compare/google-ads-admanager-v0.3.0...google-ads-admanager-v0.4.0) (2025-09-23)
+
+
+### Bug Fixes
+
+* Moved Company enums to a separate file (#14455) ([f9fc5fccd48d87af3edb9668e5e962d097457d58](https://github.com/googleapis/google-cloud-python/commit/f9fc5fccd48d87af3edb9668e5e962d097457d58))
+
 ## [0.3.0](https://github.com/googleapis/google-cloud-python/compare/google-ads-admanager-v0.2.6...google-ads-admanager-v0.3.0) (2025-07-02)
 
 

--- a/packages/google-ads-admanager/google/ads/admanager/gapic_version.py
+++ b/packages/google-ads-admanager/google/ads/admanager/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "0.4.0"  # {x-release-please-version}

--- a/packages/google-ads-admanager/google/ads/admanager_v1/gapic_version.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "0.4.0"  # {x-release-please-version}

--- a/packages/google-ads-admanager/samples/generated_samples/snippet_metadata_google.ads.admanager.v1.json
+++ b/packages/google-ads-admanager/samples/generated_samples/snippet_metadata_google.ads.admanager.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-ads-admanager",
-    "version": "0.1.0"
+    "version": "0.4.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-eventarc/CHANGELOG.md
+++ b/packages/google-cloud-eventarc/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 [1]: https://pypi.org/project/google-cloud-eventarc/#history
 
+## [1.16.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-eventarc-v1.15.3...google-cloud-eventarc-v1.16.0) (2025-09-23)
+
+
+### Documentation
+
+* [google-cloud-eventarc] correct some comments ([26730096e491346f02af2a82138224a110485e74](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))
+
+
+### Features
+
+* [google-cloud-eventarc] add new fields to Eventarc resources ([26730096e491346f02af2a82138224a110485e74](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))
+
+
+### Bug Fixes
+
+* [google-cloud-eventarc] upgrade gRPC service registration func ([26730096e491346f02af2a82138224a110485e74](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))
+
 ## [1.15.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-eventarc-v1.15.2...google-cloud-eventarc-v1.15.3) (2025-06-11)
 
 

--- a/packages/google-cloud-eventarc/google/cloud/eventarc/gapic_version.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "1.16.0"  # {x-release-please-version}

--- a/packages/google-cloud-eventarc/google/cloud/eventarc_v1/gapic_version.py
+++ b/packages/google-cloud-eventarc/google/cloud/eventarc_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "1.16.0"  # {x-release-please-version}

--- a/packages/google-cloud-eventarc/samples/generated_samples/snippet_metadata_google.cloud.eventarc.v1.json
+++ b/packages/google-cloud-eventarc/samples/generated_samples/snippet_metadata_google.cloud.eventarc.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-eventarc",
-    "version": "0.1.0"
+    "version": "1.16.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-video-live-stream/CHANGELOG.md
+++ b/packages/google-cloud-video-live-stream/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 [1]: https://pypi.org/project/google-cloud-video-live-stream/#history
 
+## [1.13.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-video-live-stream-v1.12.0...google-cloud-video-live-stream-v1.13.0) (2025-09-23)
+
+
+### Documentation
+
+* [google-cloud-video-live-stream] Update requirements of resource ([26730096e491346f02af2a82138224a110485e74](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))
+
+
+### Features
+
+* [google-cloud-video-live-stream] Added H.265 (HEVC) codec support ([26730096e491346f02af2a82138224a110485e74](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))
+* [google-cloud-video-live-stream] Added UHD (4k) resolution support ([26730096e491346f02af2a82138224a110485e74](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))
+* [google-cloud-video-live-stream] Added Auto Transcription support ([26730096e491346f02af2a82138224a110485e74](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))
+* [google-cloud-video-live-stream] Added ([26730096e491346f02af2a82138224a110485e74](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))
+* [google-cloud-video-live-stream] Added PreviewInput method used ([26730096e491346f02af2a82138224a110485e74](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))
+* [google-cloud-video-live-stream] Added UpdateEncryptions event to ([26730096e491346f02af2a82138224a110485e74](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))
+
 ## [1.12.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-video-live-stream-v1.11.1...google-cloud-video-live-stream-v1.12.0) (2025-05-15)
 
 

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream/gapic_version.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "1.13.0"  # {x-release-please-version}

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/gapic_version.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "1.13.0"  # {x-release-please-version}

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/snippet_metadata_google.cloud.video.livestream.v1.json
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/snippet_metadata_google.cloud.video.livestream.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-video-live-stream",
-    "version": "0.1.0"
+    "version": "1.13.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
Librarian Version: not available
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator:latest
<details><summary>google-cloud-eventarc: 1.16.0</summary>

## [1.16.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-eventarc-v1.15.3...google-cloud-eventarc-v1.16.0) (2025-09-23)

### Features

* [google-cloud-eventarc] add new fields to Eventarc resources  (PiperOrigin-RevId: 807339306
Source-link:
[googleapis/googleapis@dfce92d](https://github.com/googleapis/googleapis/commit/dfce92d6cc82c6dc133a6974b04e827e9fa4511c)) ([2673009](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))

### Bug Fixes

* [google-cloud-eventarc] upgrade gRPC service registration func An update to Go gRPC Protobuf generation will change service
registration function signatures to use an interface instead of a
concrete type in generated .pb.go service files. This change should
affect very few client library users. See release notes advisories in
https://github.com/googleapis/google-cloud-go/pull/11025. (PiperOrigin-RevId: 808289479
Source-link:
[googleapis/googleapis@36533b0](https://github.com/googleapis/googleapis/commit/36533b09a6b383f3c30d13c3c26092154ecf5388)) ([2673009](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))

### Documentation

* [google-cloud-eventarc] correct some comments  (PiperOrigin-RevId: 807339306
Source-link:
[googleapis/googleapis@dfce92d](https://github.com/googleapis/googleapis/commit/dfce92d6cc82c6dc133a6974b04e827e9fa4511c)) ([2673009](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))

</details>


<details><summary>google-cloud-video-live-stream: 1.13.0</summary>

## [1.13.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-video-live-stream-v1.12.0...google-cloud-video-live-stream-v1.13.0) (2025-09-23)

### Features

* [google-cloud-video-live-stream] Added H.265 (HEVC) codec support  (PiperOrigin-RevId: 808091810
Source-link:
[googleapis/googleapis@c4e80cd](https://github.com/googleapis/googleapis/commit/c4e80cd2d3321cc37cf1c3713bb02529857728d1)) ([2673009](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))

* [google-cloud-video-live-stream] Added UHD (4k) resolution support  (PiperOrigin-RevId: 808091810
Source-link:
[googleapis/googleapis@c4e80cd](https://github.com/googleapis/googleapis/commit/c4e80cd2d3321cc37cf1c3713bb02529857728d1)) ([2673009](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))

* [google-cloud-video-live-stream] Added Auto Transcription support  (PiperOrigin-RevId: 808091810
Source-link:
[googleapis/googleapis@c4e80cd](https://github.com/googleapis/googleapis/commit/c4e80cd2d3321cc37cf1c3713bb02529857728d1)) ([2673009](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))

* [google-cloud-video-live-stream] Added StartDistribution/StopDistribution methods and
Distribution/DistributionStream messages used for distributing live
streams to external RTMP/SRT endpoints (PiperOrigin-RevId: 808091810
Source-link:
[googleapis/googleapis@c4e80cd](https://github.com/googleapis/googleapis/commit/c4e80cd2d3321cc37cf1c3713bb02529857728d1)) ([2673009](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))

* [google-cloud-video-live-stream] Added PreviewInput method used for the low latency input monitoring (PiperOrigin-RevId: 808091810
Source-link:
[googleapis/googleapis@c4e80cd](https://github.com/googleapis/googleapis/commit/c4e80cd2d3321cc37cf1c3713bb02529857728d1)) ([2673009](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))

* [google-cloud-video-live-stream] Added UpdateEncryptions event to perform key rotation without restarting a channel (PiperOrigin-RevId: 808091810
Source-link:
[googleapis/googleapis@c4e80cd](https://github.com/googleapis/googleapis/commit/c4e80cd2d3321cc37cf1c3713bb02529857728d1)) ([2673009](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))

### Documentation

* [google-cloud-video-live-stream] Update requirements of resource ID fields to be more clear (PiperOrigin-RevId: 808091810
Source-link:
[googleapis/googleapis@c4e80cd](https://github.com/googleapis/googleapis/commit/c4e80cd2d3321cc37cf1c3713bb02529857728d1)) ([2673009](https://github.com/googleapis/google-cloud-python/commit/26730096e491346f02af2a82138224a110485e74))

</details>


<details><summary>google-ads-admanager: 0.4.0</summary>

## [0.4.0](https://github.com/googleapis/google-cloud-python/compare/google-ads-admanager-v0.3.0...google-ads-admanager-v0.4.0) (2025-09-23)

### Bug Fixes

* Moved Company enums to a separate file (#14455)  ([f9fc5fc](https://github.com/googleapis/google-cloud-python/commit/f9fc5fccd48d87af3edb9668e5e962d097457d58))

</details>