### PR TITLE
feat: create repo-metadata during generation

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -418,6 +418,13 @@ def _generate_repo_metadata_file(
     path_to_library = f"packages/{library_id}"
     output_repo_metadata = f"{output}/{path_to_library}/.repo-metadata.json"
 
+    # TODO(https://github.com/googleapis/librarian/issues/2334)): If `.repo-metadata.json`
+    # already exists in the `output` dir, then this means that it has been successfully copied
+    # over from the `input` dir and we can skip the logic here. Remove the following logic
+    # once we clean up all the `.repo-metadata.json` files from `.librarian/generator-input`.
+    if os.path.exists(output_repo_metadata):
+        return
+
     os.makedirs(f"{output}/{path_to_library}", exist_ok=True)
 
     # TODO(https://github.com/googleapis/librarian/issues/2333): Programatically
@@ -472,8 +479,8 @@ def handle_generate(
             api_path = api.get("path")
             if api_path:
                 _generate_api(api_path, library_id, source, output)
-        _generate_repo_metadata_file(output, library_id, source, apis_to_generate)
         _copy_files_needed_for_post_processing(output, input, library_id)
+        _generate_repo_metadata_file(output, library_id, source, apis_to_generate)
         _run_post_processor(output, library_id)
         _clean_up_files_after_post_processing(output, library_id)
     except Exception as e:

--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -115,6 +115,7 @@ def _write_json_file(path: str, updated_content: Dict):
         json.dump(updated_content, f, indent=2)
         f.write("\n")
 
+
 def _add_new_library_source_roots(library_config: Dict, library_id: str) -> None:
     """Adds the default source_roots to the library configuration if not present.
 
@@ -313,8 +314,9 @@ def _copy_files_needed_for_post_processing(output: str, input: str, library_id: 
     os.makedirs(
         f"{output}/{path_to_library}/scripts/client-post-processing", exist_ok=True
     )
-    # TODO(ohmayr): if `.repo-metadata.json` for a library exists in
-    # ``.librarian/generator-input`, then we override the generated `.repo-metadata.json`
+    # TODO(https://github.com/googleapis/librarian/issues/2334):
+    # if `.repo-metadata.json` for a library exists in
+    # `.librarian/generator-input`, then we override the generated `.repo-metadata.json`
     # with what we have in `generator-input`. Remove this logic once the
     # generated `.repo-metadata.json` file is completely backfilled.
     if os.path.exists(repo_metadata_path):
@@ -367,6 +369,7 @@ def _clean_up_files_after_post_processing(output: str, library_id: str):
     ):  # pragma: NO COVER
         os.remove(gapic_version_file)
 
+
 def _create_repo_metadata_from_service_config(
     service_config_name: str, api_path: str, source: str, library_id: str
 ) -> Dict:
@@ -383,7 +386,8 @@ def _create_repo_metadata_from_service_config(
     """
     full_service_config_path = f"{source}/{api_path}/{service_config_name}"
 
-    # TODO(ohmayr): Read the api service config to backfill .repo-metadata.json
+    # TODO(https://github.com/googleapis/librarian/issues/2332): Read the api
+    # service config to backfill `.repo-metadata.json`.
     return {
         "api_shortname": "",
         "name_pretty": "",
@@ -416,7 +420,8 @@ def _generate_repo_metadata_file(
 
     os.makedirs(f"{output}/{path_to_library}", exist_ok=True)
 
-    # TODO(ohmayr): Programatically determine the primary api to be used to
+    # TODO(https://github.com/googleapis/librarian/issues/2333): Programatically
+    # determine the primary api to be used to
     # to determine the information for metadata. For now, let's use the first
     # api in the list.
     primary_api = apis[0]
@@ -1019,7 +1024,9 @@ def _process_changelog(
             entry_parts.append(f"\n\n### {change_type_map[adjusted_change_type]}\n")
             for change in library_changes:
                 commit_link = f"([{change[source_commit_hash_key]}]({_REPO_URL}/commit/{change[source_commit_hash_key]}))"
-                entry_parts.append(f"* {change[subject_key]} {change[body_key]} {commit_link}")
+                entry_parts.append(
+                    f"* {change[subject_key]} {change[body_key]} {commit_link}"
+                )
 
     new_entry_text = "\n".join(entry_parts)
     anchor_pattern = re.compile(

--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -307,13 +307,21 @@ def _copy_files_needed_for_post_processing(output: str, input: str, library_id: 
     """
 
     path_to_library = f"packages/{library_id}"
+    repo_metadata_path = f"{input}/{path_to_library}/.repo-metadata.json"
 
     # We need to create these directories so that we can copy files necessary for post-processing.
-    os.makedirs(f"{output}/{path_to_library}/scripts/client-post-processing", exist_ok=True)
-    shutil.copy(
-        f"{input}/{path_to_library}/.repo-metadata.json",
-        f"{output}/{path_to_library}/.repo-metadata.json",
+    os.makedirs(
+        f"{output}/{path_to_library}/scripts/client-post-processing", exist_ok=True
     )
+    # TODO(ohmayr): if `.repo-metadata.json` for a library exists in
+    # ``.librarian/generator-input`, then we override the generated `.repo-metadata.json`
+    # with what we have in `generator-input`. Remove this logic once the
+    # generated `.repo-metadata.json` file is completely backfilled.
+    if os.path.exists(repo_metadata_path):
+        shutil.copy(
+            repo_metadata_path,
+            f"{output}/{path_to_library}/.repo-metadata.json",
+        )
 
     # copy post-procesing files
     for post_processing_file in glob.glob(

--- a/.generator/test_cli.py
+++ b/.generator/test_cli.py
@@ -1134,6 +1134,18 @@ def test_generate_repo_metadata_file(mocker):
     )
 
 
+def test_generate_repo_metadata_file_skips_if_exists(mocker):
+    """Tests that the generation of the .repo-metadata.json file is skipped if it already exists."""
+    mock_write_json = mocker.patch("cli._write_json_file")
+    mock_create_metadata = mocker.patch("cli._create_repo_metadata_from_service_config")
+    mocker.patch("os.path.exists", return_value=True)
+
+    _generate_repo_metadata_file("output", "library_id", "source", [])
+
+    mock_create_metadata.assert_not_called()
+    mock_write_json.assert_not_called()
+
+
 def test_determine_library_namespace_fails_not_subpath():
     """Tests that a ValueError is raised if the gapic path is not inside the package root."""
     pkg_root_path = Path("repo/packages/my-lib")

--- a/.generator/test_cli.py
+++ b/.generator/test_cli.py
@@ -724,13 +724,28 @@ def test_invalid_json(mocker):
         _read_json_file("fake/path.json")
 
 
-def test_copy_files_needed_for_post_processing_success(mocker):
+def test_copy_files_needed_for_post_processing_copies_metadata_if_exists(mocker):
+    """Tests that .repo-metadata.json is copied if it exists."""
     mock_makedirs = mocker.patch("os.makedirs")
     mock_shutil_copy = mocker.patch("shutil.copy")
+    mocker.patch("os.path.exists", return_value=True)
+
     _copy_files_needed_for_post_processing("output", "input", "library_id")
 
-    mock_makedirs.assert_called()
     mock_shutil_copy.assert_called_once()
+    mock_makedirs.assert_called()
+
+
+def test_copy_files_needed_for_post_processing_skips_metadata_if_not_exists(mocker):
+    """Tests that .repo-metadata.json is not copied if it does not exist."""
+    mock_makedirs = mocker.patch("os.makedirs")
+    mock_shutil_copy = mocker.patch("shutil.copy")
+    mocker.patch("os.path.exists", return_value=False)
+
+    _copy_files_needed_for_post_processing("output", "input", "library_id")
+
+    mock_shutil_copy.assert_not_called()
+    mock_makedirs.assert_called()
 
 
 def test_clean_up_files_after_post_processing_success(mocker):


### PR DESCRIPTION
This PR creates a basic `.repo-metadata.json` file for a package that is to be generated using librarian. Note that if a `.repo-metadata.json` file for a package exists in `generator-input`, then the generated metadata file will be overriden.

There will be follow up PRs to address the TODO comments.

Towards https://github.com/googleapis/librarian/issues/2262 🦕