### PR TITLE
chore: simplify making dirs for files

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -309,8 +309,7 @@ def _copy_files_needed_for_post_processing(output: str, input: str, library_id: 
     path_to_library = f"packages/{library_id}"
 
     # We need to create these directories so that we can copy files necessary for post-processing.
-    os.makedirs(f"{output}/{path_to_library}")
-    os.makedirs(f"{output}/{path_to_library}/scripts/client-post-processing")
+    os.makedirs(f"{output}/{path_to_library}/scripts/client-post-processing", exist_ok=True)
     shutil.copy(
         f"{input}/{path_to_library}/.repo-metadata.json",
         f"{output}/{path_to_library}/.repo-metadata.json",


### PR DESCRIPTION
The current logic for making directories can be simplified into a single statement. `exist_ok` also ensures that the command doesn't fail if the directory already exists.