### PR TITLE
fix: update tag_format to the correct format

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -164,7 +164,7 @@ def _add_new_library_tag_format(library_config: Dict) -> None:
         library_config(Dict): The library configuration.
     """
     if "tag_format" not in library_config:
-        library_config["tag_format"] = "{{id}}-v{{version}}"
+        library_config["tag_format"] = "{id}-v{version}"
 
 
 def _get_new_library_config(request_data: Dict) -> Dict:

--- a/.generator/test_cli.py
+++ b/.generator/test_cli.py
@@ -347,7 +347,7 @@ def test_prepare_new_library_config(mocker):
         in prepared_config["preserve_regex"]
     )
     assert prepared_config["remove_regex"] == ["packages/google-cloud-language"]
-    assert prepared_config["tag_format"] == "{{id}}-v{{version}}"
+    assert prepared_config["tag_format"] == "{id}-v{version}"
     assert prepared_config["version"] == "0.0.0"
 
 


### PR DESCRIPTION
Thid PR fixes the the formatting of `tag_format` field of a library in `state.yaml`.