### PR TITLE
chore: remove tar.gz file from preserve_regex

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -13,7 +13,6 @@ libraries:
       - docs/CHANGELOG.md
       - docs/README.rst
       - samples/README.txt
-      - tar.gz
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -33,7 +32,6 @@ libraries:
       - docs/CHANGELOG.md
       - docs/README.rst
       - samples/README.txt
-      - tar.gz
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -53,7 +51,6 @@ libraries:
       - docs/CHANGELOG.md
       - docs/README.rst
       - samples/README.txt
-      - tar.gz
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -73,7 +70,6 @@ libraries:
       - docs/CHANGELOG.md
       - docs/README.rst
       - samples/README.txt
-      - tar.gz
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -101,7 +97,6 @@ libraries:
       - docs/CHANGELOG.md
       - docs/README.rst
       - samples/README.txt
-      - tar.gz
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -123,7 +118,6 @@ libraries:
       - docs/CHANGELOG.md
       - docs/README.rst
       - samples/README.txt
-      - tar.gz
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -145,7 +139,6 @@ libraries:
       - docs/CHANGELOG.md
       - docs/README.rst
       - samples/README.txt
-      - tar.gz
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -165,7 +158,6 @@ libraries:
       - docs/CHANGELOG.md
       - docs/README.rst
       - samples/README.txt
-      - tar.gz
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -185,7 +177,6 @@ libraries:
       - docs/CHANGELOG.md
       - docs/README.rst
       - samples/README.txt
-      - tar.gz
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
@@ -206,7 +197,6 @@ libraries:
       - docs/CHANGELOG.md
       - docs/README.rst
       - samples/README.txt
-      - tar.gz
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system


### PR DESCRIPTION
This PR removes `tar.gz` from the state.yaml file for all the onboarded libraries.