### PR TITLE
chore(librarian): Add exception namespaces for googleapis-common-protos

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -863,7 +863,8 @@ def _determine_library_namespace(
 def _verify_library_namespace(library_id: str, repo: str):
     """
     Verifies that all found package namespaces are one of
-    `google`, `google.cloud`, or `google.ads`.
+    the hardcoded `exception_namespaces` or
+    `valid_namespaces`.
 
     Args:
         library_id (str): The library id under test (e.g., "google-cloud-language").

--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -910,7 +910,7 @@ def _verify_library_namespace(library_id: str, repo: str):
     if not library_path.is_dir():
         raise ValueError(f"Error: Path is not a directory: {library_path}")
 
-    # Use a set to store unique parent directories of relevant files
+    # Use a set to store unique parent directories of relevant directories
     relevant_dirs = set()
 
     # Find all parent directories for 'gapic_version.py' files

--- a/.generator/test_cli.py
+++ b/.generator/test_cli.py
@@ -1321,7 +1321,7 @@ def test_verify_library_namespace_failure_invalid(mocker, mock_path_class):
     mock_instance.rglob.return_value = [mock_file]
 
     mock_determine_ns = mocker.patch(
-        "cli._determine_library_namespace", return_value="google.api"
+        "cli._determine_library_namespace", return_value="google.apis"
     )
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
This PR fixes the following error when running  `librarian generate --build` for a `proto-only` library such as `googleapis-common-protos`  

```
Traceback (most recent call last):
  File "/app/./cli.py", line 977, in handle_build
    _verify_library_namespace(library_id, repo)
  File "/app/./cli.py", line 913, in _verify_library_namespace
    raise ValueError(
ValueError: Error: namespace cannot be determined for googleapis-common-protos. Library is missing a `gapic_version.py`.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/./cli.py", line 1404, in <module>
    args.func(librarian=args.librarian, repo=args.repo)
  File "/app/./cli.py", line 981, in handle_build
    raise ValueError("Build failed.") from e
ValueError: Build failed.
time=2025-09-30T09:00:03.583Z level=INFO
```