### PR TITLE
chore(librarian): fix issue_tracker in .repo-metadata.json

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -424,7 +424,7 @@ def _create_repo_metadata_from_service_config(
     api_shortname = service_config.get("name", "").split(".")[0]
     documentation = service_config.get("documentation", {})
     api_description = documentation.get("summary", "")
-    issue_tracker = service_config.get(
+    issue_tracker = publishing.get(
         "new_issue_uri", "https://github.com/googleapis/google-cloud-python/issues"
     )
 


### PR DESCRIPTION
This PR fixes a typo when getting the `new_issue_uri`. The `new_issue_uri` exists under the publishing section, not the root `service_config.yaml` file 