### PR TITLE
chore: remove hardcoded python runtime in prerelease presubmit

### DIFF
--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -61,7 +61,7 @@ case ${TEST_TYPE} in
         rm -rf docs/_build
         ;;
     prerelease)
-        nox -s prerelease_deps-3.13
+        nox -s prerelease_deps
         retval=$?
         ;;
     unit)


### PR DESCRIPTION
Remove hardcoded python runtime for the prerelease presubmit to resolve the failure in https://github.com/googleapis/google-cloud-python/pull/14606 where we want to run prerelease tests with python 3.14