### PR TITLE
chore(librarian): fix .repo-metadata.json in googleapis-common-protos

### DIFF
--- a/.librarian/generator-input/packages/googleapis-common-protos/.repo-metadata.json
+++ b/.librarian/generator-input/packages/googleapis-common-protos/.repo-metadata.json
@@ -9,5 +9,5 @@
     "library_type": "CORE",
     "repo": "googleapis/google-cloud-python",
     "distribution_name": "googleapis-common-protos",
-    "default_version": "apiVersion",
+    "default_version": "apiVersion"
 }


### PR DESCRIPTION
This PR fixes the following stack trace which caused generation to fail for `googleapis-common-protos`

```
Traceback (most recent call last):
  File "/app/./cli.py", line 535, in handle_generate
    _run_post_processor(output, library_id)
  File "/app/./cli.py", line 300, in _run_post_processor
    python_mono_repo.owlbot_main(path_to_library)
  File "/usr/local/lib/python3.9/site-packages/synthtool/languages/python_mono_repo.py", line 256, in owlbot_main
    default_version = json.load(
  File "/usr/local/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/usr/local/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.9/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 13 column 1 (char 609)
```