### PR TITLE
chore(librarian): fix generation for google-cloud-common

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -694,9 +694,12 @@ def _get_staging_child_directory(api_path: str, is_proto_only_library: bool) -> 
     version_candidate = api_path.split("/")[-1]
     if version_candidate.startswith("v") and not is_proto_only_library:
         return version_candidate
-    else:
-        # Fallback for non-'v' version segment
+    elif is_proto_only_library:
+        # Fallback for non-'v' version segment for proto-only library
         return f"{os.path.basename(api_path)}-py/{api_path}"
+    else:
+        # Fallback for non-'v' version segment for GAPIC
+        return f"{os.path.basename(api_path)}-py"
 
 
 def _stage_proto_only_library(

--- a/.generator/test_cli.py
+++ b/.generator/test_cli.py
@@ -1357,7 +1357,7 @@ def test_verify_library_namespace_error_no_gapic_file(mocker, mock_path_class):
     mock_path_class.assert_called_once_with("repo/packages/my-lib")
 
 
-def test_get_staging_child_directory_gapic():
+def test_get_staging_child_directory_gapic_versioned():
     """
     Tests the behavior for GAPIC clients with standard 'v' prefix versioning.
     Should return only the version segment (e.g., 'v1').
@@ -1365,6 +1365,15 @@ def test_get_staging_child_directory_gapic():
     # Standard v1
     api_path = "google/cloud/language/v1"
     expected = "v1"
+    assert _get_staging_child_directory(api_path, False) == expected
+
+def test_get_staging_child_directory_gapic_non_versioned():
+    """
+    Tests the behavior for GAPIC clients with no standard 'v' prefix versioning.
+    Should return library-py
+    """
+    api_path = "google/cloud/language"
+    expected = "language-py"
     assert _get_staging_child_directory(api_path, False) == expected
 
 

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1569,6 +1569,7 @@ libraries:
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
+      - tests/unit/gapic/common/test_common.py
     remove_regex:
       - packages/google-cloud-common
     tag_format: '{id}-v{version}'


### PR DESCRIPTION
This fixes the following stack trace with generation for `google-cloud-common` which caused generation to fail

```
2025-10-01 16:23:35,628 synthtool [WARNING] > No replacements made in packages/google-cloud-common/docs/index.rst for pattern API Reference
-------------
.. toctree::
    :maxdepth: 2

    common/services_
    common/types_
, maybe replacement is no longer needed?
2025-10-01 16:23:35,628 synthtool [WARNING] > No replacements made in packages/google-cloud-common/docs/index.rst for pattern API Reference
-------------
.. toctree::
    :maxdepth: 2

    common/services_
    common/types_
, maybe replacement is no longer needed?
README.rst
Skipping: docs/index.rst
docs/summary_overview.md
Traceback (most recent call last):
  File "/app/./cli.py", line 535, in handle_generate
    _run_post_processor(output, library_id)
  File "/app/./cli.py", line 300, in _run_post_processor
    python_mono_repo.owlbot_main(path_to_library)
  File "/usr/local/lib/python3.9/site-packages/synthtool/languages/python_mono_repo.py", line 329, in owlbot_main
    apply_client_specific_post_processing(
  File "/usr/local/lib/python3.9/site-packages/synthtool/languages/python_mono_repo.py", line 213, in apply_client_specific_post_processing
    assert (
AssertionError: Replaced 0 rather than 1 instances

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/./cli.py", line 1406, in <module>
    args.func(
  File "/app/./cli.py", line 538, in handle_generate
    raise ValueError("Generation failed.") from e
ValueError: Generation failed.
```