### PR TITLE
chore: remove unused snippets readme files

### DIFF
--- a/packages/google-cloud-scheduler/samples/snippets/README.md
+++ b/packages/google-cloud-scheduler/samples/snippets/README.md
@@ -1,4 +1,0 @@
-Samples migrated
-================
-
-The samples have moved to a new location: https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/scheduler/snippets

--- a/packages/google-cloud-securitycenter/samples/snippets/README.md
+++ b/packages/google-cloud-securitycenter/samples/snippets/README.md
@@ -1,1 +1,0 @@
-The snippets have been migrated to GoogleCloudPlatform/python-docs-samples in PR: https://github.com/GoogleCloudPlatform/python-docs-samples/pull/8493


### PR DESCRIPTION
This PR cleans up the unused snippets README files to minimize the diff against the librarian generation.