### PR TITLE
chore: run prerelease tests with Python 3.14

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -49,13 +49,45 @@ jobs:
       with:
         name: coverage-artifact-${{ '{{' }} matrix.python {{ '}}' }}
         path: .coverage-${{ matrix.python }}
-  unit-extended:
+  unit-prerelease:
+    name: ${{ matrix.option }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.14"]
+        option: ["prerelease"]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      # Use a fetch-depth of 2 to avoid error `fatal: origin/main...HEAD: no merge base`
+      # See https://github.com/googleapis/google-cloud-python/issues/12013
+      # and https://github.com/actions/checkout#checkout-head.
+      with:
+        fetch-depth: 2
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+        allow-prereleases: true
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run ${{ matrix.option }} tests
+      env:
+        BUILD_TYPE: presubmit
+        TEST_TYPE: ${{ matrix.option }}
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
+        PY_VERSION: "unused"
+      run: |
+        ci/run_conditional_tests.sh
+  unit-core-deps-from-source:
     name: ${{ matrix.option }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python: ["3.13"]
-        option: ["prerelease", "core_deps_from_source"]
+        option: ["core_deps_from_source"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
This PR fixes the error `Python interpreter 3.14 not found.` when running pre-release tests. See https://github.com/googleapis/google-cloud-python/actions/runs/18178779332/job/51750304401?pr=14616