### PR TITLE
chore: clean up snippets readme file

### DIFF
--- a/packages/google-cloud-datalabeling/samples/snippets/README.md
+++ b/packages/google-cloud-datalabeling/samples/snippets/README.md
@@ -1,5 +1,0 @@
-# Samples for python-datalabeling
-
-The hand-written code samples for the googleapis/python-datalabeling repo have been moved to
-[GoogleCloudPlatform/python-docs-samples](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/datalabeling/snippets).
-

--- a/packages/google-cloud-dataproc/samples/snippets/README.md
+++ b/packages/google-cloud-dataproc/samples/snippets/README.md
@@ -1,4 +1,0 @@
-Samples migrated
-================
-
-New location: https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/dataproc/snippets

--- a/packages/google-cloud-dialogflow-cx/samples/snippets/README.rst
+++ b/packages/google-cloud-dialogflow-cx/samples/snippets/README.rst
@@ -1,1 +1,0 @@
-The samples have migrated, please see the samples on https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/dialogflow-cx.

--- a/packages/google-cloud-dialogflow/samples/snippets/README.rst
+++ b/packages/google-cloud-dialogflow/samples/snippets/README.rst
@@ -1,1 +1,0 @@
-The samples have migrated, please see the samples on https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/dialogflow.

--- a/packages/google-cloud-dlp/samples/snippets/README.rst
+++ b/packages/google-cloud-dlp/samples/snippets/README.rst
@@ -1,2 +1,0 @@
-The DLP samples have moved to a new repository (https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/dlp/snippets) in PR: https://github.com/GoogleCloudPlatform/python-docs-samples/pull/9091
-Moving forward, all DLP samples will be added/ updated in the python-docs-samples repository.

--- a/packages/google-cloud-iam/samples/snippets/README.md
+++ b/packages/google-cloud-iam/samples/snippets/README.md
@@ -1,1 +1,0 @@
-The snippets have been migrated to [GoogleCloudPlatform/python-docs-samples](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/iam/cloud-client/snippets).

--- a/packages/google-cloud-kms/samples/snippets/README.md
+++ b/packages/google-cloud-kms/samples/snippets/README.md
@@ -1,4 +1,0 @@
-Samples migrated
-================
-
-New location: https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/kms/snippets

--- a/packages/google-cloud-private-ca/samples/snippets/README.md
+++ b/packages/google-cloud-private-ca/samples/snippets/README.md
@@ -1,4 +1,0 @@
-Samples migrated
-================
-
-New location: https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/privateca/snippets

--- a/packages/google-cloud-recaptcha-enterprise/samples/snippets/README.md
+++ b/packages/google-cloud-recaptcha-enterprise/samples/snippets/README.md
@@ -1,4 +1,0 @@
-Samples migrated
-================
-
-New location: https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/recaptcha_enterprise/snippets/

--- a/packages/google-cloud-tasks/samples/snippets/README.md
+++ b/packages/google-cloud-tasks/samples/snippets/README.md
@@ -1,4 +1,0 @@
-Samples migrated
-================
-
-New location: https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/cloud_tasks/snippets


### PR DESCRIPTION
This PR removes the snippets README files from the packages to reduce the diff for librarian onboarding.