### PR TITLE
chore: add repo-metadata for locationfinder

### DIFF
--- a/.librarian/generator-input/packages/google-cloud-locationfinder/.repo-metadata.json
+++ b/.librarian/generator-input/packages/google-cloud-locationfinder/.repo-metadata.json
@@ -1,0 +1,16 @@
+{
+    "name": "google-cloud-locationfinder",
+    "name_pretty": "Cloud Location Finder API",
+    "api_description": "Cloud Location Finder lets you identify and filter cloud locations in regions and zones across Google Cloud, Google Distributed Cloud, Microsoft Azure, Amazon Web Services, and Oracle Cloud Infrastructure based on proximity, geographic location, and carbon footprint.",
+    "product_documentation": "https://issuetracker.google.com/issues/new?component=1569265&template=1988535",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-locationfinder/latest",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1569265&template=1988535",
+    "release_level": "preview",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/google-cloud-python",
+    "distribution_name": "google-cloud-locationfinder",
+    "api_id": "locationfinder.googleapis.com",
+    "default_version": "v1",
+    "api_shortname": "locationfinder"
+}


### PR DESCRIPTION
This PR add `.repo-metadata.json` file to the `generator-input` folder to unblock onboarding `google-cloud-locationfinder` to librarian