### PR TITLE
chore(librarian): onboard `google-cloud-locationfinder`

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2960,3 +2960,21 @@ libraries:
     remove_regex:
       - packages/google-cloud-redis
     tag_format: '{id}-v{version}'
+  - id: google-cloud-locationfinder
+    version: 0.1.0
+    last_generated_commit: d300b151a973ce0425ae4ad07b3de957ca31bec6
+    apis:
+      - path: google/cloud/locationfinder/v1
+    source_roots:
+      - packages/google-cloud-locationfinder
+    preserve_regex:
+      - packages/google-cloud-locationfinder/CHANGELOG.md
+      - docs/CHANGELOG.md
+      - docs/README.rst
+      - samples/README.txt
+      - scripts/client-post-processing
+      - samples/snippets/README.rst
+      - tests/system
+    remove_regex:
+      - packages/google-cloud-locationfinder
+    tag_format: '{id}-v{version}'

--- a/scripts/configure_state_yaml/packages_to_onboard.yaml
+++ b/scripts/configure_state_yaml/packages_to_onboard.yaml
@@ -93,6 +93,7 @@ packages_to_onboard: [
   "google-cloud-language",
   "google-cloud-licensemanager",
   "google-cloud-life-sciences",
+  "google-cloud-locationfinder",
   "google-cloud-lustre",
   "google-cloud-maintenance-api",
   "google-cloud-managed-identities",


### PR DESCRIPTION
This PR onboards `google-cloud-locationfinder` to librarian and should be merged after https://github.com/googleapis/google-cloud-python/pull/14625

Towards https://github.com/googleapis/librarian/issues/762