### PR TITLE
chore(librarian): fix typo in state.yaml

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1128,7 +1128,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
       - tests/unit/test_decorators.py
-      - tests/unit/tests_helpers.py
+      - tests/unit/test_helpers.py
     remove_regex:
       - packages/google-cloud-vision
     tag_format: '{id}-v{version}'


### PR DESCRIPTION
This PR fixes a typo in `state.yaml` which caused `tests/unit/test_helpers.py` not to be preserved in `google-cloud-vision`: https://github.com/googleapis/google-cloud-python/blob/main/packages/google-cloud-vision/tests/unit/test_helpers.py