### PR TITLE
chore(librarian): preserve `test_iam_logging.py`

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2167,6 +2167,7 @@ libraries:
       - scripts/client-post-processing
       - samples/snippets/README.rst
       - tests/system
+      - tests/unit/gapic/iam_logging_v1/test_iam_logging.py
     remove_regex:
       - packages/google-cloud-iam-logging
     tag_format: '{id}-v{version}'


### PR DESCRIPTION
`tests/unit/gapic/iam_logging_v1/test_iam_logging.py` is a handwritten file and needs to be explicitly preserved

https://github.com/googleapis/google-cloud-python/blob/main/packages/google-cloud-iam-logging/tests/unit/gapic/iam_logging_v1/test_iam_logging.py