### PR TITLE
chore(librarian): fix `proto_library/py_test not found` error

### DIFF
--- a/.generator/parse_googleapis_content.py
+++ b/.generator/parse_googleapis_content.py
@@ -92,7 +92,6 @@ _NOOP_CALLABLES = (
     "alias",
     "py_test",
     "sh_binary",
-    "proto_library",
     "java_proto_library",
     "genrule",
     "gapic_yaml_from_disco",
@@ -130,6 +129,7 @@ def parse_content(content: str) -> dict:
         return []
 
     mod.add_callable("package", noop_bazel_rule)
+    mod.add_callable("proto_library", noop_bazel_rule)
 
     for glob_callable in _GLOB_CALLABLES:
         mod.add_callable(glob_callable, fake_glob)

--- a/.generator/parse_googleapis_content.py
+++ b/.generator/parse_googleapis_content.py
@@ -90,7 +90,6 @@ _CALLABLE_MAP = {
 _NOOP_CALLABLES = (
     "package",
     "alias",
-    "py_test",
     "sh_binary",
     "java_proto_library",
     "genrule",
@@ -130,6 +129,7 @@ def parse_content(content: str) -> dict:
 
     mod.add_callable("package", noop_bazel_rule)
     mod.add_callable("proto_library", noop_bazel_rule)
+    mod.add_callable("py_test", noop_bazel_rule)
 
     for glob_callable in _GLOB_CALLABLES:
         mod.add_callable(glob_callable, fake_glob)


### PR DESCRIPTION
This PR resolves the following stack traces which appear in the last `librarian generate` job

```
Traceback (most recent call last):
  File "/app/./cli.py", line 532, in handle_generate
    _generate_api(api_path, library_id, source, output, version)
  File "/app/./cli.py", line 764, in _generate_api
    py_gapic_config = _read_bazel_build_py_rule(api_path, source)
  File "/app/./cli.py", line 556, in _read_bazel_build_py_rule
    result = parse_googleapis_content.parse_content(content)
  File "/app/parse_googleapis_content.py", line 149, in parse_content
    sl.eval(mod, ast, glb, sl.FileLoader(load))
starlark.StarlarkError: error: Variable `proto_library` not found
  --> BUILD.bazel:28:1
   |
28 | proto_library(
   | ^^^^^^^^^^^^^
   |


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/./cli.py", line 1412, in <module>
    args.func(
  File "/app/./cli.py", line 538, in handle_generate
    raise ValueError("Generation failed.") from e
ValueError: Generation failed.
time=2025-10-02T11:28:44.666Z level=INFO msg="=== Docker end ================================================================="
time=2025-10-02T11:28:44.667Z level=ERROR msg="failed to generate library" id=google-cloud-source-context err="exit status 1"
```
```
Traceback (most recent call last):
  File "/app/./cli.py", line 532, in handle_generate
    _generate_api(api_path, library_id, source, output, version)
  File "/app/./cli.py", line 764, in _generate_api
    py_gapic_config = _read_bazel_build_py_rule(api_path, source)
  File "/app/./cli.py", line 556, in _read_bazel_build_py_rule
    result = parse_googleapis_content.parse_content(content)
  File "/app/parse_googleapis_content.py", line 149, in parse_content
    sl.eval(mod, ast, glb, sl.FileLoader(load))
starlark.StarlarkError: error: Variable `py_test` not found
   --> BUILD.bazel:188:1
    |
188 | py_test(
    | ^^^^^^^
    |


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/./cli.py", line 1412, in <module>
    args.func(
  File "/app/./cli.py", line 538, in handle_generate
    raise ValueError("Generation failed.") from e
ValueError: Generation failed.
time=2025-10-02T12:32:33.921Z level=INFO msg="=== Docker end ================================================================="
time=2025-10-02T12:32:33.921Z level=ERROR msg="failed to generate library" id=google-cloud-recommendations-ai err="exit status 1"
```