### PR TITLE
chore(librarian): fix formatting in google-cloud-capacityplanner

### DIFF
--- a/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/usage_service.py
+++ b/packages/google-cloud-capacityplanner/google/cloud/capacityplanner_v1beta/types/usage_service.py
@@ -59,7 +59,11 @@ class QueryUsageHistoriesRequest(proto.Message):
         parent (str):
             Required. The compute engine resource and
             location for the time series values to return.
-            The format is: projects/{project}/locations/{location} or organizations/{organization}/locations/{location} or folders/{folder}/locations/{location}
+            The format is:
+
+            projects/{project}/locations/{location} or
+            organizations/{organization}/locations/{location}
+            or folders/{folder}/locations/{location}
         location_level (google.cloud.capacityplanner_v1beta.types.TimeSeries.LocationType):
             Optional. The location level of the
             reservations usage timeseries.
@@ -190,7 +194,11 @@ class QueryForecastsRequest(proto.Message):
         parent (str):
             Required. The compute engine resource and
             location for the time series values to return.
-            The format is: projects/{project}/locations/{location} or organizations/{organization}/locations/{location} or folders/{folder}/locations/{location}
+            The format is:
+
+            projects/{project}/locations/{location} or
+            organizations/{organization}/locations/{location}
+            or folders/{folder}/locations/{location}
         machine_family (str):
             The machine family to use to select the ``Forecast`` values
             to return. Possible values include "n1", and "n2d". Empty
@@ -307,7 +315,11 @@ class QueryReservationsRequest(proto.Message):
         parent (str):
             Required. The compute engine resource and
             location for the time series values to return.
-            The format is: projects/{project}/locations/{location} or organizations/{organization}/locations/{location} or folders/{folder}/locations/{location}
+            The format is:
+
+            projects/{project}/locations/{location} or
+            organizations/{organization}/locations/{location}
+            or folders/{folder}/locations/{location}
         location_level (google.cloud.capacityplanner_v1beta.types.TimeSeries.LocationType):
             Optional. The location level of the
             reservations usage timeseries.
@@ -987,7 +999,11 @@ class ExportUsageHistoriesRequest(proto.Message):
         parent (str):
             Required. The compute engine resource and
             location for the time series values to return.
-            The format is: projects/{project}/locations/{location} or organizations/{organization}/locations/{location} or folders/{folder}/locations/{location}
+            The format is:
+
+            projects/{project}/locations/{location} or
+            organizations/{organization}/locations/{location}
+            or folders/{folder}/locations/{location}
         is_spot (bool):
             Optional. Set true to export usage for spot
             resources.
@@ -1095,7 +1111,11 @@ class ExportForecastsRequest(proto.Message):
         parent (str):
             Required. The compute engine resource and
             location for the time series values to return.
-            The format is: projects/{project}/locations/{location} or organizations/{organization}/locations/{location} or folders/{folder}/locations/{location}
+            The format is:
+
+            projects/{project}/locations/{location} or
+            organizations/{organization}/locations/{location}
+            or folders/{folder}/locations/{location}
         machine_family (str):
             Optional. The machine family to use to select the
             ``Forecast`` values to return. Possible values include "n1",
@@ -1223,8 +1243,11 @@ class ExportReservationsUsageRequest(proto.Message):
             This field is a member of `oneof`_ ``resource``.
         parent (str):
             Required. The compute engine resource and
-            location of the reservationsusage. The format
-            is: projects/{project}/locations/{location} or organizations/{organization}/locations/{location} or folders/{folder}/locations/{location}
+            location of the reservationsusage. The format is:
+
+            projects/{project}/locations/{location} or
+            organizations/{organization}/locations/{location}
+            or folders/{folder}/locations/{location}
         location_level (google.cloud.capacityplanner_v1beta.types.TimeSeries.LocationType):
             Optional. The location level of the
             reservations usage timeseries.


### PR DESCRIPTION
These changes reflect the current state of generation using `librarian`