### PR TITLE
chore(librarian): temporarily pin GAPIC generator

### DIFF
--- a/.generator/Dockerfile
+++ b/.generator/Dockerfile
@@ -86,6 +86,9 @@ ENV SYNTHTOOL_TEMPLATES="/synthtool/synthtool/gcp/templates"
 # These are the non "-dev" versions of the libraries used in the builder.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    # Temporarily include git and ca-certificates to download gapic-generator from Github
+    ca-certificates \
+    git \
     # This is needed to avoid the following error:
     # `ImportError: libsqlite3.so.0: cannot open shared object file: No such file or directory`.
     # `libsqlite3-0` is used by the `coverage` PyPI package which is used when testing libraries

--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,7 @@
 click
-gapic-generator>=1.27.2
+# Temporarily use a patched version of the generator to avoid getting
+# new features/fixes for GAPIC libraries for the purposes of onboarding to librarian
+gapic-generator @ git+https://github.com/googleapis/gapic-generator-python@librarian-patch-v1.27.0
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
Temporarily pin `gapic-generator` to reduce the diff for libraries being onboarded to librarian

 