### PR TITLE
chore(librarian): offboard google-cloud-biglake

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -912,24 +912,6 @@ libraries:
     remove_regex:
       - packages/google-cloud-beyondcorp-clientgateways
     tag_format: '{id}-v{version}'
-  - id: google-cloud-biglake
-    version: 0.1.0
-    last_generated_commit: d300b151a973ce0425ae4ad07b3de957ca31bec6
-    apis:
-      - path: google/cloud/biglake/v1
-    source_roots:
-      - packages/google-cloud-biglake
-    preserve_regex:
-      - packages/google-cloud-biglake/CHANGELOG.md
-      - docs/CHANGELOG.md
-      - docs/README.rst
-      - samples/README.txt
-      - scripts/client-post-processing
-      - samples/snippets/README.rst
-      - tests/system
-    remove_regex:
-      - packages/google-cloud-biglake
-    tag_format: '{id}-v{version}'
   - id: google-cloud-bigquery-analyticshub
     version: 0.4.20
     last_generated_commit: d300b151a973ce0425ae4ad07b3de957ca31bec6

--- a/scripts/configure_state_yaml/packages_to_onboard.yaml
+++ b/scripts/configure_state_yaml/packages_to_onboard.yaml
@@ -51,7 +51,6 @@ packages_to_onboard: [
   "google-cloud-beyondcorp-appgateways",
   "google-cloud-beyondcorp-clientconnectorservices",
   "google-cloud-beyondcorp-clientgateways",
-  "google-cloud-biglake",
   "google-cloud-bigquery-analyticshub",
   "google-cloud-bigquery-biglake",
   "google-cloud-bigquery-connection",


### PR DESCRIPTION
Temporarily offboard `google-cloud-biglake` as there is an unexpected diff where the version is being reset to `0.0.0`. I've created https://github.com/googleapis/librarian/issues/2486 to follow up on this