### PR TITLE
chore(librarian): Add forward slash to remove regex

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -17,7 +17,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-dlp
+      - packages/google-cloud-dlp/
     tag_format: '{id}-v{version}'
   - id: google-cloud-eventarc
     version: 1.16.0
@@ -36,7 +36,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-eventarc
+      - packages/google-cloud-eventarc/
     tag_format: '{id}-v{version}'
   - id: google-cloud-video-live-stream
     version: 1.13.0
@@ -55,7 +55,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-video-live-stream
+      - packages/google-cloud-video-live-stream/
     tag_format: '{id}-v{version}'
   - id: google-ads-marketingplatform-admin
     version: 0.1.6
@@ -74,7 +74,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-ads-marketingplatform-admin
+      - packages/google-ads-marketingplatform-admin/
     tag_format: '{id}-v{version}'
   - id: google-ai-generativelanguage
     version: 0.7.0
@@ -101,7 +101,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-ai-generativelanguage
+      - packages/google-ai-generativelanguage/
     tag_format: '{id}-v{version}'
   - id: google-analytics-admin
     version: 0.25.0
@@ -122,7 +122,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-analytics-admin
+      - packages/google-analytics-admin/
     tag_format: '{id}-v{version}'
   - id: google-analytics-data
     version: 0.18.19
@@ -143,7 +143,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-analytics-data
+      - packages/google-analytics-data/
     tag_format: '{id}-v{version}'
   - id: google-ads-admanager
     version: 0.4.0
@@ -162,7 +162,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-ads-admanager
+      - packages/google-ads-admanager/
     tag_format: '{id}-v{version}'
   - id: google-apps-card
     version: 0.1.8
@@ -182,7 +182,7 @@ libraries:
       - tests/system
       - tests/unit/gapic/card_v1/test_card.py
     remove_regex:
-      - packages/google-apps-card
+      - packages/google-apps-card/
     tag_format: '{id}-v{version}'
   - id: google-apps-chat
     version: 0.2.9
@@ -201,7 +201,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-apps-chat
+      - packages/google-apps-chat/
     tag_format: '{id}-v{version}'
   - id: google-apps-events-subscriptions
     version: 0.2.2
@@ -222,7 +222,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-apps-events-subscriptions
+      - packages/google-apps-events-subscriptions/
     tag_format: '{id}-v{version}'
   - id: google-apps-meet
     version: 0.1.16
@@ -243,7 +243,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-apps-meet
+      - packages/google-apps-meet/
     tag_format: '{id}-v{version}'
   - id: google-area120-tables
     version: 0.11.17
@@ -262,7 +262,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-area120-tables
+      - packages/google-area120-tables/
     tag_format: '{id}-v{version}'
   - id: google-cloud-access-approval
     version: 1.16.2
@@ -281,7 +281,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-access-approval
+      - packages/google-cloud-access-approval/
     tag_format: '{id}-v{version}'
   - id: google-cloud-advisorynotifications
     version: 0.3.16
@@ -300,7 +300,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-advisorynotifications
+      - packages/google-cloud-advisorynotifications/
     tag_format: '{id}-v{version}'
   - id: google-cloud-alloydb
     version: 0.4.9
@@ -323,7 +323,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-alloydb
+      - packages/google-cloud-alloydb/
     tag_format: '{id}-v{version}'
   - id: google-cloud-alloydb-connectors
     version: 0.1.11
@@ -347,7 +347,7 @@ libraries:
       - tests/system
       - tests/unit/gapic/connectors_v1/test_connectors.py
     remove_regex:
-      - packages/google-cloud-alloydb-connectors
+      - packages/google-cloud-alloydb-connectors/
     tag_format: '{id}-v{version}'
   - id: google-cloud-api-gateway
     version: 1.12.2
@@ -366,7 +366,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-api-gateway
+      - packages/google-cloud-api-gateway/
     tag_format: '{id}-v{version}'
   - id: google-cloud-api-keys
     version: 0.5.17
@@ -385,7 +385,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-api-keys
+      - packages/google-cloud-api-keys/
     tag_format: '{id}-v{version}'
   - id: google-cloud-apigee-connect
     version: 1.12.2
@@ -403,7 +403,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-apigee-connect
+      - packages/google-cloud-apigee-connect/
     tag_format: '{id}-v{version}'
   - id: google-cloud-apigee-registry
     version: 0.6.18
@@ -421,7 +421,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-apigee-registry
+      - packages/google-cloud-apigee-registry/
     tag_format: '{id}-v{version}'
   - id: google-cloud-appengine-admin
     version: 1.14.2
@@ -439,7 +439,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-appengine-admin
+      - packages/google-cloud-appengine-admin/
     tag_format: '{id}-v{version}'
   - id: google-cloud-appengine-logging
     version: 1.6.2
@@ -458,7 +458,7 @@ libraries:
       - tests/system
       - tests/unit/gapic/appengine_logging_v1/test_appengine_logging_v1.py
     remove_regex:
-      - packages/google-cloud-appengine-logging
+      - packages/google-cloud-appengine-logging/
     tag_format: '{id}-v{version}'
   - id: google-cloud-apphub
     version: 0.1.10
@@ -476,7 +476,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-apphub
+      - packages/google-cloud-apphub/
     tag_format: '{id}-v{version}'
   - id: google-cloud-artifact-registry
     version: 1.16.1
@@ -495,7 +495,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-artifact-registry
+      - packages/google-cloud-artifact-registry/
     tag_format: '{id}-v{version}'
   - id: google-cloud-automl
     version: 2.16.4
@@ -519,7 +519,7 @@ libraries:
       - tests/unit/test_gcs_client_v1beta1.py
       - tests/unit/test_tables_client_v1beta1.py
     remove_regex:
-      - packages/google-cloud-automl
+      - packages/google-cloud-automl/
     tag_format: '{id}-v{version}'
   - id: google-cloud-backupdr
     version: 0.2.5
@@ -537,7 +537,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-backupdr
+      - packages/google-cloud-backupdr/
     tag_format: '{id}-v{version}'
   - id: google-cloud-bare-metal-solution
     version: 1.10.3
@@ -555,7 +555,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-bare-metal-solution
+      - packages/google-cloud-bare-metal-solution/
     tag_format: '{id}-v{version}'
   - id: google-cloud-batch
     version: 0.17.37
@@ -574,7 +574,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-batch
+      - packages/google-cloud-batch/
     tag_format: '{id}-v{version}'
   - id: google-cloud-support
     version: 0.1.19
@@ -593,7 +593,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-support
+      - packages/google-cloud-support/
     tag_format: '{id}-v{version}'
   - id: google-cloud-talent
     version: 2.17.2
@@ -612,7 +612,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-talent
+      - packages/google-cloud-talent/
     tag_format: '{id}-v{version}'
   - id: google-cloud-tpu
     version: 1.23.2
@@ -632,7 +632,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-tpu
+      - packages/google-cloud-tpu/
     tag_format: '{id}-v{version}'
   - id: google-cloud-video-transcoder
     version: 1.17.0
@@ -650,7 +650,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-video-transcoder
+      - packages/google-cloud-video-transcoder/
     tag_format: '{id}-v{version}'
   - id: google-cloud-visionai
     version: 0.1.10
@@ -669,7 +669,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-visionai
+      - packages/google-cloud-visionai/
     tag_format: '{id}-v{version}'
   - id: google-cloud-vm-migration
     version: 1.12.0
@@ -687,7 +687,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-vm-migration
+      - packages/google-cloud-vm-migration/
     tag_format: '{id}-v{version}'
   - id: google-cloud-vmwareengine
     version: 1.8.3
@@ -705,7 +705,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-vmwareengine
+      - packages/google-cloud-vmwareengine/
     tag_format: '{id}-v{version}'
   - id: google-cloud-vpc-access
     version: 1.13.2
@@ -723,7 +723,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-vpc-access
+      - packages/google-cloud-vpc-access/
     tag_format: '{id}-v{version}'
   - id: google-cloud-websecurityscanner
     version: 1.17.3
@@ -743,7 +743,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-websecurityscanner
+      - packages/google-cloud-websecurityscanner/
     tag_format: '{id}-v{version}'
   - id: google-cloud-workstations
     version: 0.5.15
@@ -762,7 +762,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-workstations
+      - packages/google-cloud-workstations/
     tag_format: '{id}-v{version}'
   - id: google-cloud-apihub
     version: 0.2.7
@@ -780,7 +780,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-apihub
+      - packages/google-cloud-apihub/
     tag_format: '{id}-v{version}'
   - id: google-cloud-asset
     version: 3.30.1
@@ -801,7 +801,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-asset
+      - packages/google-cloud-asset/
     tag_format: '{id}-v{version}'
   - id: google-cloud-assured-workloads
     version: 1.15.2
@@ -820,7 +820,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-assured-workloads
+      - packages/google-cloud-assured-workloads/
     tag_format: '{id}-v{version}'
   - id: google-cloud-beyondcorp-appconnections
     version: 0.4.18
@@ -838,7 +838,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-beyondcorp-appconnections
+      - packages/google-cloud-beyondcorp-appconnections/
     tag_format: '{id}-v{version}'
   - id: google-cloud-beyondcorp-appconnectors
     version: 0.4.18
@@ -856,7 +856,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-beyondcorp-appconnectors
+      - packages/google-cloud-beyondcorp-appconnectors/
     tag_format: '{id}-v{version}'
   - id: google-cloud-beyondcorp-appgateways
     version: 0.4.18
@@ -874,7 +874,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-beyondcorp-appgateways
+      - packages/google-cloud-beyondcorp-appgateways/
     tag_format: '{id}-v{version}'
   - id: google-cloud-beyondcorp-clientconnectorservices
     version: 0.4.18
@@ -892,7 +892,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-beyondcorp-clientconnectorservices
+      - packages/google-cloud-beyondcorp-clientconnectorservices/
     tag_format: '{id}-v{version}'
   - id: google-cloud-beyondcorp-clientgateways
     version: 0.4.17
@@ -910,7 +910,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-beyondcorp-clientgateways
+      - packages/google-cloud-beyondcorp-clientgateways/
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigquery-analyticshub
     version: 0.4.20
@@ -928,7 +928,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-bigquery-analyticshub
+      - packages/google-cloud-bigquery-analyticshub/
     tag_format: '{id}-v{version}'
   - id: googleapis-common-protos
     version: 1.70.0
@@ -950,7 +950,7 @@ libraries:
       - packages/googleapis-common-protos
     preserve_regex: []
     remove_regex:
-      - ^packages/googleapis-common-protos/google/(?:api|cloud|rpc|type)/.*/.*_pb2\.(?:py|pyi)$
+      - ^packages/googleapis-common-protos/google/(?:api|cloud|rpc|type)/.*/.*_pb2\.(?:py|pyi)$/
     tag_format: '{id}-v{version}'
   - id: google-cloud-storagebatchoperations
     version: 0.1.3
@@ -968,7 +968,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-storagebatchoperations
+      - packages/google-cloud-storagebatchoperations/
     tag_format: '{id}-v{version}'
   - id: google-cloud-storageinsights
     version: 0.1.16
@@ -986,7 +986,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-storageinsights
+      - packages/google-cloud-storageinsights/
     tag_format: '{id}-v{version}'
   - id: google-cloud-tasks
     version: 2.19.3
@@ -1007,7 +1007,7 @@ libraries:
       - snippets/README.md
       - tests/system
     remove_regex:
-      - packages/google-cloud-tasks
+      - packages/google-cloud-tasks/
     tag_format: '{id}-v{version}'
   - id: google-cloud-telcoautomation
     version: 0.2.11
@@ -1027,7 +1027,7 @@ libraries:
       - snippets/README.md
       - tests/system
     remove_regex:
-      - packages/google-cloud-telcoautomation
+      - packages/google-cloud-telcoautomation/
     tag_format: '{id}-v{version}'
   - id: google-cloud-texttospeech
     version: 2.31.0
@@ -1046,7 +1046,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-texttospeech
+      - packages/google-cloud-texttospeech/
     tag_format: '{id}-v{version}'
   - id: google-cloud-trace
     version: 1.16.2
@@ -1065,7 +1065,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-trace
+      - packages/google-cloud-trace/
     tag_format: '{id}-v{version}'
   - id: google-cloud-videointelligence
     version: 2.16.2
@@ -1087,7 +1087,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-videointelligence
+      - packages/google-cloud-videointelligence/
     tag_format: '{id}-v{version}'
   - id: google-cloud-vision
     version: 3.10.2
@@ -1112,7 +1112,7 @@ libraries:
       - tests/unit/test_decorators.py
       - tests/unit/test_helpers.py
     remove_regex:
-      - packages/google-cloud-vision
+      - packages/google-cloud-vision/
     tag_format: '{id}-v{version}'
   - id: google-cloud-webrisk
     version: 1.18.1
@@ -1131,7 +1131,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-webrisk
+      - packages/google-cloud-webrisk/
     tag_format: '{id}-v{version}'
   - id: google-cloud-access-context-manager
     version: 0.2.2
@@ -1145,7 +1145,7 @@ libraries:
       - packages/google-cloud-access-context-manager
     preserve_regex: []
     remove_regex:
-      - ^packages/google-cloud-access-context-manager/google/.*/.*_pb2\.(?:py|pyi)$
+      - ^packages/google-cloud-access-context-manager/google/.*/.*_pb2\.(?:py|pyi)$/
     tag_format: '{id}-v{version}'
   - id: google-cloud-audit-log
     version: 0.3.2
@@ -1156,7 +1156,7 @@ libraries:
       - packages/google-cloud-audit-log
     preserve_regex: []
     remove_regex:
-      - ^packages/google-cloud-audit-log/google/.*/.*_pb2\.(?:py|pyi)$
+      - ^packages/google-cloud-audit-log/google/.*/.*_pb2\.(?:py|pyi)$/
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigquery-biglake
     version: 0.4.15
@@ -1175,7 +1175,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-bigquery-biglake
+      - packages/google-cloud-bigquery-biglake/
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigquery-connection
     version: 1.18.3
@@ -1193,7 +1193,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-bigquery-connection
+      - packages/google-cloud-bigquery-connection/
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigquery-data-exchange
     version: 0.5.20
@@ -1211,7 +1211,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-bigquery-data-exchange
+      - packages/google-cloud-bigquery-data-exchange/
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigquery-datapolicies
     version: 0.6.16
@@ -1232,7 +1232,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-bigquery-datapolicies
+      - packages/google-cloud-bigquery-datapolicies/
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigquery-datatransfer
     version: 3.19.2
@@ -1250,7 +1250,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-bigquery-datatransfer
+      - packages/google-cloud-bigquery-datatransfer/
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigquery-logging
     version: 1.6.3
@@ -1269,7 +1269,7 @@ libraries:
       - tests/system
       - tests/unit/gapic/bigquery_logging_v1/test_bigquery_logging_v1.py
     remove_regex:
-      - packages/google-cloud-bigquery-logging
+      - packages/google-cloud-bigquery-logging/
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigquery-migration
     version: 0.11.15
@@ -1288,7 +1288,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-bigquery-migration
+      - packages/google-cloud-bigquery-migration/
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigquery-reservation
     version: 1.19.0
@@ -1306,7 +1306,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-bigquery-reservation
+      - packages/google-cloud-bigquery-reservation/
     tag_format: '{id}-v{version}'
   - id: google-cloud-billing
     version: 1.16.3
@@ -1324,7 +1324,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-billing
+      - packages/google-cloud-billing/
     tag_format: '{id}-v{version}'
   - id: google-cloud-billing-budgets
     version: 1.17.2
@@ -1343,7 +1343,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-billing-budgets
+      - packages/google-cloud-billing-budgets/
     tag_format: '{id}-v{version}'
   - id: google-cloud-translate
     version: 3.21.1
@@ -1368,7 +1368,7 @@ libraries:
       - tests/system
       - tests/unit/v2
     remove_regex:
-      - packages/google-cloud-translate
+      - packages/google-cloud-translate/
     tag_format: '{id}-v{version}'
   - id: google-cloud-binary-authorization
     version: 1.13.2
@@ -1387,7 +1387,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-binary-authorization
+      - packages/google-cloud-binary-authorization/
     tag_format: '{id}-v{version}'
   - id: google-cloud-build
     version: 3.32.0
@@ -1406,7 +1406,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-build
+      - packages/google-cloud-build/
     tag_format: '{id}-v{version}'
   - id: google-cloud-capacityplanner
     version: 0.1.0
@@ -1424,7 +1424,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-capacityplanner
+      - packages/google-cloud-capacityplanner/
     tag_format: '{id}-v{version}'
   - id: google-cloud-certificate-manager
     version: 1.10.2
@@ -1442,7 +1442,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-certificate-manager
+      - packages/google-cloud-certificate-manager/
     tag_format: '{id}-v{version}'
   - id: google-cloud-channel
     version: 1.23.0
@@ -1460,7 +1460,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-channel
+      - packages/google-cloud-channel/
     tag_format: '{id}-v{version}'
   - id: google-cloud-chronicle
     version: 0.1.0
@@ -1478,7 +1478,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-chronicle
+      - packages/google-cloud-chronicle/
     tag_format: '{id}-v{version}'
   - id: google-cloud-cloudcontrolspartner
     version: 0.2.7
@@ -1497,7 +1497,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-cloudcontrolspartner
+      - packages/google-cloud-cloudcontrolspartner/
     tag_format: '{id}-v{version}'
   - id: google-cloud-cloudsecuritycompliance
     version: 0.2.0
@@ -1515,7 +1515,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-cloudsecuritycompliance
+      - packages/google-cloud-cloudsecuritycompliance/
     tag_format: '{id}-v{version}'
   - id: google-cloud-commerce-consumer-procurement
     version: 0.2.0
@@ -1534,7 +1534,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-commerce-consumer-procurement
+      - packages/google-cloud-commerce-consumer-procurement/
     tag_format: '{id}-v{version}'
   - id: google-cloud-common
     version: 1.5.2
@@ -1553,7 +1553,7 @@ libraries:
       - tests/system
       - tests/unit/gapic/common/test_common.py
     remove_regex:
-      - packages/google-cloud-common
+      - packages/google-cloud-common/
     tag_format: '{id}-v{version}'
   - id: google-cloud-compute
     version: 1.38.0
@@ -1571,7 +1571,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-compute
+      - packages/google-cloud-compute/
     tag_format: '{id}-v{version}'
   - id: google-cloud-compute-v1beta
     version: 0.1.8
@@ -1589,7 +1589,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-compute-v1beta
+      - packages/google-cloud-compute-v1beta/
     tag_format: '{id}-v{version}'
   - id: google-cloud-confidentialcomputing
     version: 0.5.0
@@ -1607,7 +1607,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-confidentialcomputing
+      - packages/google-cloud-confidentialcomputing/
     tag_format: '{id}-v{version}'
   - id: google-cloud-config
     version: 0.1.21
@@ -1625,7 +1625,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-config
+      - packages/google-cloud-config/
     tag_format: '{id}-v{version}'
   - id: google-cloud-configdelivery
     version: 0.1.3
@@ -1645,7 +1645,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-configdelivery
+      - packages/google-cloud-configdelivery/
     tag_format: '{id}-v{version}'
   - id: google-cloud-contact-center-insights
     version: 1.23.3
@@ -1663,7 +1663,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-contact-center-insights
+      - packages/google-cloud-contact-center-insights/
     tag_format: '{id}-v{version}'
   - id: google-cloud-container
     version: 2.59.0
@@ -1682,7 +1682,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-container
+      - packages/google-cloud-container/
     tag_format: '{id}-v{version}'
   - id: google-cloud-containeranalysis
     version: 2.18.1
@@ -1701,7 +1701,7 @@ libraries:
       - tests/system
       - tests/unit/test_get_grafeas_client.py
     remove_regex:
-      - packages/google-cloud-containeranalysis
+      - packages/google-cloud-containeranalysis/
     tag_format: '{id}-v{version}'
   - id: google-cloud-contentwarehouse
     version: 0.7.16
@@ -1719,7 +1719,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-contentwarehouse
+      - packages/google-cloud-contentwarehouse/
     tag_format: '{id}-v{version}'
   - id: google-cloud-data-fusion
     version: 1.13.3
@@ -1737,7 +1737,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-data-fusion
+      - packages/google-cloud-data-fusion/
     tag_format: '{id}-v{version}'
   - id: google-cloud-workflows
     version: 1.18.2
@@ -1758,7 +1758,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-workflows
+      - packages/google-cloud-workflows/
     tag_format: '{id}-v{version}'
   - id: google-cloud-video-stitcher
     version: 0.7.18
@@ -1776,7 +1776,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-video-stitcher
+      - packages/google-cloud-video-stitcher/
     tag_format: '{id}-v{version}'
   - id: google-cloud-redis-cluster
     version: 0.1.15
@@ -1795,7 +1795,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-redis-cluster
+      - packages/google-cloud-redis-cluster/
     tag_format: '{id}-v{version}'
   - id: google-cloud-resource-manager
     version: 1.14.2
@@ -1813,7 +1813,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-resource-manager
+      - packages/google-cloud-resource-manager/
     tag_format: '{id}-v{version}'
   - id: google-cloud-retail
     version: 2.6.0
@@ -1833,7 +1833,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-retail
+      - packages/google-cloud-retail/
     tag_format: '{id}-v{version}'
   - id: google-cloud-run
     version: 0.11.0
@@ -1851,7 +1851,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-run
+      - packages/google-cloud-run/
     tag_format: '{id}-v{version}'
   - id: google-cloud-saasplatform-saasservicemgmt
     version: 0.1.0
@@ -1869,7 +1869,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-saasplatform-saasservicemgmt
+      - packages/google-cloud-saasplatform-saasservicemgmt/
     tag_format: '{id}-v{version}'
   - id: google-cloud-scheduler
     version: 2.16.1
@@ -1888,7 +1888,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-scheduler
+      - packages/google-cloud-scheduler/
     tag_format: '{id}-v{version}'
   - id: google-cloud-securesourcemanager
     version: 0.1.17
@@ -1906,7 +1906,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-securesourcemanager
+      - packages/google-cloud-securesourcemanager/
     tag_format: '{id}-v{version}'
   - id: google-cloud-securitycenter
     version: 1.40.0
@@ -1927,7 +1927,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-securitycenter
+      - packages/google-cloud-securitycenter/
     tag_format: '{id}-v{version}'
   - id: google-cloud-securitycentermanagement
     version: 0.1.22
@@ -1945,7 +1945,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-securitycentermanagement
+      - packages/google-cloud-securitycentermanagement/
     tag_format: '{id}-v{version}'
   - id: google-cloud-service-control
     version: 1.16.0
@@ -1964,7 +1964,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-service-control
+      - packages/google-cloud-service-control/
     tag_format: '{id}-v{version}'
   - id: google-cloud-service-directory
     version: 1.14.2
@@ -1983,7 +1983,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-service-directory
+      - packages/google-cloud-service-directory/
     tag_format: '{id}-v{version}'
   - id: google-cloud-service-management
     version: 1.13.2
@@ -2001,7 +2001,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-service-management
+      - packages/google-cloud-service-management/
     tag_format: '{id}-v{version}'
   - id: google-cloud-service-usage
     version: 1.13.1
@@ -2019,7 +2019,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-service-usage
+      - packages/google-cloud-service-usage/
     tag_format: '{id}-v{version}'
   - id: google-cloud-servicehealth
     version: 0.1.12
@@ -2037,7 +2037,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-servicehealth
+      - packages/google-cloud-servicehealth/
     tag_format: '{id}-v{version}'
   - id: google-cloud-shell
     version: 1.12.1
@@ -2055,7 +2055,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-shell
+      - packages/google-cloud-shell/
     tag_format: '{id}-v{version}'
   - id: google-cloud-source-context
     version: 1.7.1
@@ -2074,7 +2074,7 @@ libraries:
       - tests/system
       - tests/unit/gapic/source_context_v1/test_source_context_v1.py
     remove_regex:
-      - packages/google-cloud-source-context
+      - packages/google-cloud-source-context/
     tag_format: '{id}-v{version}'
   - id: google-cloud-speech
     version: 2.33.0
@@ -2096,7 +2096,7 @@ libraries:
       - tests/system
       - tests/unit/test_helpers.py
     remove_regex:
-      - packages/google-cloud-speech
+      - packages/google-cloud-speech/
     tag_format: '{id}-v{version}'
   - id: google-cloud-storage-control
     version: 1.7.0
@@ -2114,7 +2114,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-storage-control
+      - packages/google-cloud-storage-control/
     tag_format: '{id}-v{version}'
   - id: google-cloud-storage-transfer
     version: 1.17.0
@@ -2132,7 +2132,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-storage-transfer
+      - packages/google-cloud-storage-transfer/
     tag_format: '{id}-v{version}'
   - id: google-cloud-iam-logging
     version: 1.4.3
@@ -2151,7 +2151,7 @@ libraries:
       - tests/system
       - tests/unit/gapic/iam_logging_v1/test_iam_logging.py
     remove_regex:
-      - packages/google-cloud-iam-logging
+      - packages/google-cloud-iam-logging/
     tag_format: '{id}-v{version}'
   - id: google-cloud-iap
     version: 1.17.1
@@ -2169,7 +2169,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-iap
+      - packages/google-cloud-iap/
     tag_format: '{id}-v{version}'
   - id: google-cloud-ids
     version: 1.10.2
@@ -2187,7 +2187,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-ids
+      - packages/google-cloud-ids/
     tag_format: '{id}-v{version}'
   - id: google-cloud-kms
     version: 3.6.0
@@ -2205,7 +2205,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-kms
+      - packages/google-cloud-kms/
     tag_format: '{id}-v{version}'
   - id: google-cloud-kms-inventory
     version: 0.2.15
@@ -2223,7 +2223,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-kms-inventory
+      - packages/google-cloud-kms-inventory/
     tag_format: '{id}-v{version}'
   - id: google-cloud-language
     version: 2.17.2
@@ -2243,7 +2243,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-language
+      - packages/google-cloud-language/
     tag_format: '{id}-v{version}'
   - id: google-cloud-licensemanager
     version: 0.1.0
@@ -2261,7 +2261,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-licensemanager
+      - packages/google-cloud-licensemanager/
     tag_format: '{id}-v{version}'
   - id: google-cloud-life-sciences
     version: 0.9.18
@@ -2279,7 +2279,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-life-sciences
+      - packages/google-cloud-life-sciences/
     tag_format: '{id}-v{version}'
   - id: google-cloud-lustre
     version: 0.1.2
@@ -2297,7 +2297,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-lustre
+      - packages/google-cloud-lustre/
     tag_format: '{id}-v{version}'
   - id: google-cloud-maintenance-api
     version: 0.1.1
@@ -2315,7 +2315,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-maintenance-api
+      - packages/google-cloud-maintenance-api/
     tag_format: '{id}-v{version}'
   - id: google-cloud-managed-identities
     version: 1.12.2
@@ -2333,7 +2333,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-managed-identities
+      - packages/google-cloud-managed-identities/
     tag_format: '{id}-v{version}'
   - id: google-cloud-managedkafka
     version: 0.1.12
@@ -2351,7 +2351,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-managedkafka
+      - packages/google-cloud-managedkafka/
     tag_format: '{id}-v{version}'
   - id: google-cloud-managedkafka-schemaregistry
     version: 0.1.0
@@ -2369,7 +2369,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-managedkafka-schemaregistry
+      - packages/google-cloud-managedkafka-schemaregistry/
     tag_format: '{id}-v{version}'
   - id: google-cloud-media-translation
     version: 0.11.17
@@ -2387,7 +2387,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-media-translation
+      - packages/google-cloud-media-translation/
     tag_format: '{id}-v{version}'
   - id: google-cloud-memcache
     version: 1.12.2
@@ -2406,7 +2406,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-memcache
+      - packages/google-cloud-memcache/
     tag_format: '{id}-v{version}'
   - id: google-cloud-memorystore
     version: 0.1.3
@@ -2425,7 +2425,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-memorystore
+      - packages/google-cloud-memorystore/
     tag_format: '{id}-v{version}'
   - id: google-cloud-migrationcenter
     version: 0.1.15
@@ -2443,7 +2443,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-migrationcenter
+      - packages/google-cloud-migrationcenter/
     tag_format: '{id}-v{version}'
   - id: google-cloud-modelarmor
     version: 0.2.8
@@ -2462,7 +2462,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-modelarmor
+      - packages/google-cloud-modelarmor/
     tag_format: '{id}-v{version}'
   - id: google-cloud-monitoring-metrics-scopes
     version: 1.9.2
@@ -2480,7 +2480,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-monitoring-metrics-scopes
+      - packages/google-cloud-monitoring-metrics-scopes/
     tag_format: '{id}-v{version}'
   - id: google-cloud-netapp
     version: 0.3.24
@@ -2498,7 +2498,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-netapp
+      - packages/google-cloud-netapp/
     tag_format: '{id}-v{version}'
   - id: google-cloud-network-connectivity
     version: 2.10.0
@@ -2517,7 +2517,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-network-connectivity
+      - packages/google-cloud-network-connectivity/
     tag_format: '{id}-v{version}'
   - id: google-cloud-network-management
     version: 1.28.0
@@ -2535,7 +2535,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-network-management
+      - packages/google-cloud-network-management/
     tag_format: '{id}-v{version}'
   - id: google-cloud-network-services
     version: 0.5.24
@@ -2553,7 +2553,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-network-services
+      - packages/google-cloud-network-services/
     tag_format: '{id}-v{version}'
   - id: google-cloud-notebooks
     version: 1.13.3
@@ -2573,7 +2573,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-notebooks
+      - packages/google-cloud-notebooks/
     tag_format: '{id}-v{version}'
   - id: google-cloud-optimization
     version: 1.11.2
@@ -2591,7 +2591,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-optimization
+      - packages/google-cloud-optimization/
     tag_format: '{id}-v{version}'
   - id: google-cloud-oracledatabase
     version: 0.1.10
@@ -2609,7 +2609,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-oracledatabase
+      - packages/google-cloud-oracledatabase/
     tag_format: '{id}-v{version}'
   - id: google-cloud-orchestration-airflow
     version: 1.17.5
@@ -2628,7 +2628,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-orchestration-airflow
+      - packages/google-cloud-orchestration-airflow/
     tag_format: '{id}-v{version}'
   - id: google-cloud-os-config
     version: 1.21.0
@@ -2647,7 +2647,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-os-config
+      - packages/google-cloud-os-config/
     tag_format: '{id}-v{version}'
   - id: google-cloud-parallelstore
     version: 0.2.15
@@ -2666,7 +2666,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-parallelstore
+      - packages/google-cloud-parallelstore/
     tag_format: '{id}-v{version}'
   - id: google-cloud-parametermanager
     version: 0.1.5
@@ -2684,7 +2684,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-parametermanager
+      - packages/google-cloud-parametermanager/
     tag_format: '{id}-v{version}'
   - id: google-cloud-phishing-protection
     version: 1.14.2
@@ -2702,7 +2702,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-phishing-protection
+      - packages/google-cloud-phishing-protection/
     tag_format: '{id}-v{version}'
   - id: google-cloud-policy-troubleshooter
     version: 1.13.3
@@ -2720,7 +2720,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-policy-troubleshooter
+      - packages/google-cloud-policy-troubleshooter/
     tag_format: '{id}-v{version}'
   - id: google-cloud-policysimulator
     version: 0.1.15
@@ -2738,7 +2738,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-policysimulator
+      - packages/google-cloud-policysimulator/
     tag_format: '{id}-v{version}'
   - id: google-cloud-policytroubleshooter-iam
     version: 0.1.13
@@ -2756,7 +2756,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-policytroubleshooter-iam
+      - packages/google-cloud-policytroubleshooter-iam/
     tag_format: '{id}-v{version}'
   - id: google-cloud-private-ca
     version: 1.15.0
@@ -2775,7 +2775,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-private-ca
+      - packages/google-cloud-private-ca/
     tag_format: '{id}-v{version}'
   - id: google-cloud-private-catalog
     version: 0.9.18
@@ -2793,7 +2793,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-private-catalog
+      - packages/google-cloud-private-catalog/
     tag_format: '{id}-v{version}'
   - id: google-cloud-privilegedaccessmanager
     version: 0.1.9
@@ -2811,7 +2811,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-privilegedaccessmanager
+      - packages/google-cloud-privilegedaccessmanager/
     tag_format: '{id}-v{version}'
   - id: google-cloud-quotas
     version: 0.1.18
@@ -2830,7 +2830,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-quotas
+      - packages/google-cloud-quotas/
     tag_format: '{id}-v{version}'
   - id: google-cloud-rapidmigrationassessment
     version: 0.1.16
@@ -2848,7 +2848,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-rapidmigrationassessment
+      - packages/google-cloud-rapidmigrationassessment/
     tag_format: '{id}-v{version}'
   - id: google-cloud-recaptcha-enterprise
     version: 1.28.2
@@ -2866,7 +2866,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-recaptcha-enterprise
+      - packages/google-cloud-recaptcha-enterprise/
     tag_format: '{id}-v{version}'
   - id: google-cloud-recommendations-ai
     version: 0.10.18
@@ -2884,7 +2884,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-recommendations-ai
+      - packages/google-cloud-recommendations-ai/
     tag_format: '{id}-v{version}'
   - id: google-cloud-recommender
     version: 2.18.2
@@ -2903,7 +2903,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-recommender
+      - packages/google-cloud-recommender/
     tag_format: '{id}-v{version}'
   - id: google-cloud-redis
     version: 2.18.1
@@ -2922,7 +2922,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-redis
+      - packages/google-cloud-redis/
     tag_format: '{id}-v{version}'
   - id: google-cloud-locationfinder
     version: 0.1.0
@@ -2940,7 +2940,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-locationfinder
+      - packages/google-cloud-locationfinder/
     tag_format: '{id}-v{version}'
   - id: google-cloud-data-qna
     version: 0.10.17
@@ -2958,7 +2958,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-data-qna
+      - packages/google-cloud-data-qna/
     tag_format: '{id}-v{version}'
   - id: google-cloud-datacatalog
     version: 3.27.1
@@ -2977,7 +2977,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-datacatalog
+      - packages/google-cloud-datacatalog/
     tag_format: '{id}-v{version}'
   - id: google-cloud-datacatalog-lineage
     version: 0.3.14
@@ -2995,7 +2995,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-datacatalog-lineage
+      - packages/google-cloud-datacatalog-lineage/
     tag_format: '{id}-v{version}'
   - id: google-cloud-dataflow-client
     version: 0.9.0
@@ -3013,7 +3013,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-dataflow-client
+      - packages/google-cloud-dataflow-client/
     tag_format: '{id}-v{version}'
   - id: google-cloud-dataform
     version: 0.6.2
@@ -3032,7 +3032,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-dataform
+      - packages/google-cloud-dataform/
     tag_format: '{id}-v{version}'
   - id: google-cloud-datalabeling
     version: 1.13.2
@@ -3050,7 +3050,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-datalabeling
+      - packages/google-cloud-datalabeling/
     tag_format: '{id}-v{version}'
   - id: google-cloud-dataplex
     version: 2.12.0
@@ -3068,7 +3068,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-dataplex
+      - packages/google-cloud-dataplex/
     tag_format: '{id}-v{version}'
   - id: google-cloud-dataproc
     version: 5.22.0
@@ -3086,7 +3086,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-dataproc
+      - packages/google-cloud-dataproc/
     tag_format: '{id}-v{version}'
   - id: google-cloud-dataproc-metastore
     version: 1.19.0
@@ -3106,7 +3106,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-dataproc-metastore
+      - packages/google-cloud-dataproc-metastore/
     tag_format: '{id}-v{version}'
   - id: google-cloud-datastream
     version: 1.15.0
@@ -3125,7 +3125,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-datastream
+      - packages/google-cloud-datastream/
     tag_format: '{id}-v{version}'
   - id: google-cloud-deploy
     version: 2.7.1
@@ -3143,7 +3143,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-deploy
+      - packages/google-cloud-deploy/
     tag_format: '{id}-v{version}'
   - id: google-cloud-developerconnect
     version: 0.1.10
@@ -3161,7 +3161,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-developerconnect
+      - packages/google-cloud-developerconnect/
     tag_format: '{id}-v{version}'
   - id: google-cloud-devicestreaming
     version: 0.1.0
@@ -3179,7 +3179,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-devicestreaming
+      - packages/google-cloud-devicestreaming/
     tag_format: '{id}-v{version}'
   - id: google-cloud-dialogflow
     version: 2.41.2
@@ -3198,7 +3198,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-dialogflow
+      - packages/google-cloud-dialogflow/
     tag_format: '{id}-v{version}'
   - id: google-cloud-discoveryengine
     version: 0.13.12
@@ -3218,7 +3218,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-discoveryengine
+      - packages/google-cloud-discoveryengine/
     tag_format: '{id}-v{version}'
   - id: google-cloud-dms
     version: 1.12.4
@@ -3236,7 +3236,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-dms
+      - packages/google-cloud-dms/
     tag_format: '{id}-v{version}'
   - id: google-cloud-documentai
     version: 3.6.0
@@ -3255,7 +3255,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-documentai
+      - packages/google-cloud-documentai/
     tag_format: '{id}-v{version}'
   - id: google-cloud-domains
     version: 1.10.2
@@ -3274,7 +3274,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-domains
+      - packages/google-cloud-domains/
     tag_format: '{id}-v{version}'
   - id: google-cloud-edgecontainer
     version: 0.5.18
@@ -3292,7 +3292,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-edgecontainer
+      - packages/google-cloud-edgecontainer/
     tag_format: '{id}-v{version}'
   - id: google-cloud-edgenetwork
     version: 0.1.18
@@ -3310,7 +3310,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-edgenetwork
+      - packages/google-cloud-edgenetwork/
     tag_format: '{id}-v{version}'
   - id: google-cloud-enterpriseknowledgegraph
     version: 0.3.17
@@ -3328,7 +3328,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-enterpriseknowledgegraph
+      - packages/google-cloud-enterpriseknowledgegraph/
     tag_format: '{id}-v{version}'
   - id: google-cloud-essential-contacts
     version: 1.10.2
@@ -3346,7 +3346,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-essential-contacts
+      - packages/google-cloud-essential-contacts/
     tag_format: '{id}-v{version}'
   - id: google-cloud-eventarc-publishing
     version: 0.6.19
@@ -3364,7 +3364,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-eventarc-publishing
+      - packages/google-cloud-eventarc-publishing/
     tag_format: '{id}-v{version}'
   - id: google-cloud-filestore
     version: 1.13.2
@@ -3382,7 +3382,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-filestore
+      - packages/google-cloud-filestore/
     tag_format: '{id}-v{version}'
   - id: google-cloud-financialservices
     version: 0.1.3
@@ -3400,7 +3400,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-financialservices
+      - packages/google-cloud-financialservices/
     tag_format: '{id}-v{version}'
   - id: google-cloud-functions
     version: 1.20.4
@@ -3419,7 +3419,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-functions
+      - packages/google-cloud-functions/
     tag_format: '{id}-v{version}'
   - id: google-cloud-gdchardwaremanagement
     version: 0.1.13
@@ -3437,7 +3437,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-gdchardwaremanagement
+      - packages/google-cloud-gdchardwaremanagement/
     tag_format: '{id}-v{version}'
   - id: google-cloud-geminidataanalytics
     version: 0.4.0
@@ -3456,7 +3456,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-geminidataanalytics
+      - packages/google-cloud-geminidataanalytics/
     tag_format: '{id}-v{version}'
   - id: google-cloud-gke-backup
     version: 0.5.19
@@ -3474,7 +3474,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-gke-backup
+      - packages/google-cloud-gke-backup/
     tag_format: '{id}-v{version}'
   - id: google-cloud-gke-connect-gateway
     version: 0.10.4
@@ -3493,7 +3493,7 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-gke-connect-gateway
+      - packages/google-cloud-gke-connect-gateway/
     tag_format: '{id}-v{version}'
   - id: google-cloud-security-publicca
     version: 0.3.18
@@ -3512,5 +3512,5 @@ libraries:
       - samples/snippets/README.rst
       - tests/system
     remove_regex:
-      - packages/google-cloud-security-publicca
+      - packages/google-cloud-security-publicca/
     tag_format: '{id}-v{version}'


### PR DESCRIPTION
This PR adds a forward slash to the `remove_regex` to provide clarity that the regex is for the full directory name not partial name. 
For example, for `google-cloud-compute` , where there also exists `google-cloud-compute-v1beta`

We would have

```
    remove_regex:
      - packages/google-cloud-compute/
```

which would only match `google-cloud-compute`  

instead of

```
    remove_regex:
      - packages/google-cloud-compute
```

Which would match both  `google-cloud-compute`  and `google-cloud-compute-v1beta`