### PR TITLE
chore(librarian): update gapic-generator

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -802,7 +802,7 @@ def _run_nox_sessions(library_id: str, repo: str):
             the config.yaml.
     """
     sessions = [
-        "unit-3.14(protobuf_implementation='upb')",
+        "unit-3.13(protobuf_implementation='upb')",
     ]
     current_session = None
     try:

--- a/.generator/test_cli.py
+++ b/.generator/test_cli.py
@@ -702,7 +702,7 @@ def test_run_nox_sessions_success(mocker, mock_generate_request_data_for_nox):
     mock_run_individual_session = mocker.patch("cli._run_individual_session")
 
     sessions_to_run = [
-        "unit-3.14(protobuf_implementation='upb')",
+        "unit-3.13(protobuf_implementation='upb')",
     ]
     _run_nox_sessions("mock-library", "repo")
 
@@ -710,7 +710,7 @@ def test_run_nox_sessions_success(mocker, mock_generate_request_data_for_nox):
     mock_run_individual_session.assert_has_calls(
         [
             mocker.call(
-                "unit-3.14(protobuf_implementation='upb')", "mock-library", "repo"
+                "unit-3.13(protobuf_implementation='upb')", "mock-library", "repo"
             ),
         ]
     )


### PR DESCRIPTION
Revert https://github.com/googleapis/google-cloud-python/pull/14643

https://github.com/googleapis/gapic-generator-python/releases/tag/v1.28.0

Version 1.28.0 includes support for Python 3.14