### PR TITLE
chore: update post processing scripts

### DIFF
--- a/scripts/client-post-processing/add-missing-dependencies-to-setup-py-constraints.yaml
+++ b/scripts/client-post-processing/add-missing-dependencies-to-setup-py-constraints.yaml
@@ -23,7 +23,7 @@ replacements:
           # Exclude incompatible versions of `google-auth`
           # See https://github.com/googleapis/google-cloud-python/issues/12364
           "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-          "proto-plus >= 1.22.3, <2.0.0",
+          "grpcio >= 1.33.2, < 2.0.0",
     after:  |
       dependencies = [
           "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
@@ -31,7 +31,7 @@ replacements:
           # See https://github.com/googleapis/google-cloud-python/issues/12364
           "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
           "grpc-google-iam-v1 >=0.12.4, <1.0.0",
-          "proto-plus >= 1.22.3, <2.0.0",
+          "grpcio >= 1.33.2, < 2.0.0",
     count: 1
   - paths: [
       packages/google-cloud-gke-hub/testing/constraints-3.7.txt
@@ -39,12 +39,10 @@ replacements:
     before: |
       google-api-core==1.34.1
       google-auth==2.14.1
-      proto-plus==1.22.3
     after: |
       google-api-core==1.34.1
-      google-auth==2.14.1
       grpc-google-iam-v1==0.12.4
-      proto-plus==1.22.3
+      google-auth==2.14.1
     count: 1
   - paths: [
       packages/google-cloud-build/setup.py
@@ -116,12 +114,10 @@ replacements:
     before: |
       google-api-core==1.34.1
       google-auth==2.14.1
-      proto-plus==1.22.3
     after: |
       google-api-core==1.34.1
-      google-auth==2.14.1
       grpc-google-iam-v1==0.12.4
-      proto-plus==1.22.3
+      google-auth==2.14.1
     count: 1
   - paths: [
       packages/google-cloud-iam/setup.py
@@ -132,7 +128,7 @@ replacements:
           # Exclude incompatible versions of `google-auth`
           # See https://github.com/googleapis/google-cloud-python/issues/12364
           "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-          "proto-plus >= 1.22.3, <2.0.0",
+          "grpcio >= 1.33.2, < 2.0.0",
     after:  |
       dependencies = [
           "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
@@ -140,7 +136,7 @@ replacements:
           # See https://github.com/googleapis/google-cloud-python/issues/12364
           "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
           "grpc-google-iam-v1 >=0.12.4, <1.0.0",
-          "proto-plus >= 1.22.3, <2.0.0",
+          "grpcio >= 1.33.2, < 2.0.0",
     count: 1
   - paths: [
       packages/google-cloud-policysimulator/setup.py

--- a/scripts/client-post-processing/bigquery-storage-integration.yaml
+++ b/scripts/client-post-processing/bigquery-storage-integration.yaml
@@ -439,17 +439,13 @@ replacements:
     before: |
       google-api-core==1.34.1
       google-auth==2.14.1
-      proto-plus==1.22.3
-      protobuf==3.20.2
     after: |
       google-api-core==1.34.1
-      google-auth==2.14.1
-      proto-plus==1.22.3
       libcst==0.2.5
       fastavro==0.21.2
       pandas==1.0.5
       pyarrow==0.15.0
-      protobuf==3.20.2
+      google-auth==2.14.1
     count: 1
   - paths: [
       packages/google-cloud-bigquery-storage/docs/index.rst,

--- a/scripts/client-post-processing/integrate-isolated-handwritten-code.yaml
+++ b/scripts/client-post-processing/integrate-isolated-handwritten-code.yaml
@@ -154,12 +154,10 @@ replacements:
     before: |
       google-api-core==1.34.1
       google-auth==2.14.1
-      proto-plus==1.22.3
     after: |
       google-api-core==1.34.1
-      google-auth==2.14.1
       pandas==0.23.2
-      proto-plus==1.22.3
+      google-auth==2.14.1
     count: 1
   - paths: [
       packages/google-cloud-monitoring/noxfile.py,


### PR DESCRIPTION
This PR includes post processing changes to support the latest version of the generated code for packages still using the owlbot pipeline https://github.com/googleapis/gapic-generator-python/releases/tag/v1.28.0