### PR TITLE
chore: update package name for google-cloud-public-ca to google-cloud-security-publicca

### DIFF
--- a/.librarian/generator-input/packages/google-cloud-security-publicca/.repo-metadata.json
+++ b/.librarian/generator-input/packages/google-cloud-security-publicca/.repo-metadata.json
@@ -8,7 +8,7 @@
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "repo": "googleapis/google-cloud-python",
-    "distribution_name": "google-cloud-public-ca",
+    "distribution_name": "google-cloud-security-publicca",
     "api_id": "publicca.googleapis.com",
     "default_version": "v1",
     "api_shortname": "publicca",

--- a/packages/google-cloud-security-publicca/.repo-metadata.json
+++ b/packages/google-cloud-security-publicca/.repo-metadata.json
@@ -8,7 +8,7 @@
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "repo": "googleapis/google-cloud-python",
-    "distribution_name": "google-cloud-public-ca",
+    "distribution_name": "google-cloud-security-publicca",
     "api_id": "publicca.googleapis.com",
     "default_version": "v1",
     "api_shortname": "publicca",

--- a/packages/google-cloud-security-publicca/CHANGELOG.md
+++ b/packages/google-cloud-security-publicca/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 [PyPI History][1]
 
-[1]: https://pypi.org/project/google-cloud-public-ca/#history
+[1]: https://pypi.org/project/google-cloud-security-publicca/#history
 
-## [0.3.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.17...google-cloud-public-ca-v0.3.18) (2025-06-11)
+## [0.3.18](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.17...google-cloud-security-publicca-v0.3.18) (2025-06-11)
 
 
 ### Documentation
 
 * Update import statement example in README ([dfc2cd6](https://github.com/googleapis/google-cloud-python/commit/dfc2cd6be6422baa45dcebc5ff6e7fc846bf5c7d))
 
-## [0.3.17](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.16...google-cloud-public-ca-v0.3.17) (2025-03-15)
+## [0.3.17](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.16...google-cloud-security-publicca-v0.3.17) (2025-03-15)
 
 
 ### Bug Fixes
@@ -19,7 +19,7 @@
 * [Many APIs] Allow Protobuf 6.x ([7295cbb](https://github.com/googleapis/google-cloud-python/commit/7295cbb7c3122eeff1042c3c543bfc9b8b3ca913))
 * remove setup.cfg configuration for creating universal wheels ([#13659](https://github.com/googleapis/google-cloud-python/issues/13659)) ([59bfd42](https://github.com/googleapis/google-cloud-python/commit/59bfd42cf8a2eaeed696a7504890bce5aae815ce))
 
-## [0.3.16](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.15...google-cloud-public-ca-v0.3.16) (2025-02-18)
+## [0.3.16](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.15...google-cloud-security-publicca-v0.3.16) (2025-02-18)
 
 
 ### Features
@@ -27,7 +27,7 @@
 * Add REST Interceptors which support reading metadata ([c8e0760](https://github.com/googleapis/google-cloud-python/commit/c8e0760e8088950c62279335216ad1d17716ce59))
 * Add support for reading selective GAPIC generation methods from service YAML ([c8e0760](https://github.com/googleapis/google-cloud-python/commit/c8e0760e8088950c62279335216ad1d17716ce59))
 
-## [0.3.15](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.14...google-cloud-public-ca-v0.3.15) (2024-12-12)
+## [0.3.15](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.14...google-cloud-security-publicca-v0.3.15) (2024-12-12)
 
 
 ### Features
@@ -39,49 +39,49 @@
 
 * Fix typing issue with gRPC metadata when key ends in -bin ([8e6b0cc](https://github.com/googleapis/google-cloud-python/commit/8e6b0cca8709ae8c7f0c722c5ebf0707358d3359))
 
-## [0.3.14](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.13...google-cloud-public-ca-v0.3.14) (2024-11-11)
+## [0.3.14](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.13...google-cloud-security-publicca-v0.3.14) (2024-11-11)
 
 
 ### Bug Fixes
 
 * disable universe-domain validation  ([#13245](https://github.com/googleapis/google-cloud-python/issues/13245)) ([875f712](https://github.com/googleapis/google-cloud-python/commit/875f712265a36919409964f5ade218330f1d0147))
 
-## [0.3.13](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.12...google-cloud-public-ca-v0.3.13) (2024-10-24)
+## [0.3.13](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.12...google-cloud-security-publicca-v0.3.13) (2024-10-24)
 
 
 ### Features
 
 * Add support for Python 3.13 ([#13208](https://github.com/googleapis/google-cloud-python/issues/13208)) ([a019409](https://github.com/googleapis/google-cloud-python/commit/a019409a5b5a983402301f1ac175d8b7e45c3818))
 
-## [0.3.12](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.11...google-cloud-public-ca-v0.3.12) (2024-07-30)
+## [0.3.12](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.11...google-cloud-security-publicca-v0.3.12) (2024-07-30)
 
 
 ### Bug Fixes
 
 * Retry and timeout values do not propagate in requests during pagination ([52db52e](https://github.com/googleapis/google-cloud-python/commit/52db52ea05c6883b07956d323fdd1d3029806374))
 
-## [0.3.11](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.10...google-cloud-public-ca-v0.3.11) (2024-07-08)
+## [0.3.11](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.10...google-cloud-security-publicca-v0.3.11) (2024-07-08)
 
 
 ### Bug Fixes
 
 * Allow Protobuf 5.x ([#12868](https://github.com/googleapis/google-cloud-python/issues/12868)) ([0e39c1a](https://github.com/googleapis/google-cloud-python/commit/0e39c1a0ab46757bcf80a178d9bd422f6dcb24c6))
 
-## [0.3.10](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.9...google-cloud-public-ca-v0.3.10) (2024-05-16)
+## [0.3.10](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.9...google-cloud-security-publicca-v0.3.10) (2024-05-16)
 
 
 ### Features
 
 * added protos for publicca v1 ([f38aae4](https://github.com/googleapis/google-cloud-python/commit/f38aae4215c47e566742fb94f40ab2cc6e2ba975))
 
-## [0.3.9](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.8...google-cloud-public-ca-v0.3.9) (2024-03-05)
+## [0.3.9](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.8...google-cloud-security-publicca-v0.3.9) (2024-03-05)
 
 
 ### Bug Fixes
 
 * **deps:** Exclude google-auth 2.24.0 and 2.25.0 ([#12386](https://github.com/googleapis/google-cloud-python/issues/12386)) ([edcad16](https://github.com/googleapis/google-cloud-python/commit/edcad1661973ae1677c69b3fc1c03c3069ec0e71))
 
-## [0.3.8](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.7...google-cloud-public-ca-v0.3.8) (2024-02-22)
+## [0.3.8](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.7...google-cloud-security-publicca-v0.3.8) (2024-02-22)
 
 
 ### Bug Fixes
@@ -89,7 +89,7 @@
 * **deps:** [Many APIs] Require `google-api-core&gt;=1.34.1` ([#12308](https://github.com/googleapis/google-cloud-python/issues/12308)) ([74dabeb](https://github.com/googleapis/google-cloud-python/commit/74dabebab206189e649ff6e00f3c7809d96c043b))
 * fix ValueError in test__validate_universe_domain ([89c1b05](https://github.com/googleapis/google-cloud-python/commit/89c1b054f321b90ab4eed0139a3a2a79c369730d))
 
-## [0.3.7](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.6...google-cloud-public-ca-v0.3.7) (2024-02-06)
+## [0.3.7](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.6...google-cloud-security-publicca-v0.3.7) (2024-02-06)
 
 
 ### Bug Fixes
@@ -98,14 +98,14 @@
 * Add staticmethod decorator to _get_client_cert_source and _get_api_endpoint ([e75fcf6](https://github.com/googleapis/google-cloud-python/commit/e75fcf6e389fd2e90ec00b87a625b208837c72dc))
 * Resolve AttributeError 'Credentials' object has no attribute 'universe_domain' ([e75fcf6](https://github.com/googleapis/google-cloud-python/commit/e75fcf6e389fd2e90ec00b87a625b208837c72dc))
 
-## [0.3.6](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.5...google-cloud-public-ca-v0.3.6) (2024-02-01)
+## [0.3.6](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.5...google-cloud-security-publicca-v0.3.6) (2024-02-01)
 
 
 ### Features
 
 * Allow users to explicitly configure universe domain ([4368029](https://github.com/googleapis/google-cloud-python/commit/436802904bfdafa7e90f94b128813506525e1605))
 
-## [0.3.5](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.4...google-cloud-public-ca-v0.3.5) (2023-12-07)
+## [0.3.5](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.4...google-cloud-security-publicca-v0.3.5) (2023-12-07)
 
 
 ### Features
@@ -119,14 +119,14 @@
 * Require proto-plus &gt;= 1.22.3 ([9a629e1](https://github.com/googleapis/google-cloud-python/commit/9a629e1c9f7858f55c82ac21e60f22acf781db15))
 * Use `retry_async` instead of `retry` in async client ([9a629e1](https://github.com/googleapis/google-cloud-python/commit/9a629e1c9f7858f55c82ac21e60f22acf781db15))
 
-## [0.3.4](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.3...google-cloud-public-ca-v0.3.4) (2023-09-19)
+## [0.3.4](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.3...google-cloud-security-publicca-v0.3.4) (2023-09-19)
 
 
 ### Documentation
 
 * Minor formatting ([1ae610b](https://github.com/googleapis/google-cloud-python/commit/1ae610bb3b321ceac7bd23a455a002e39645d84f))
 
-## [0.3.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-public-ca-v0.3.2...google-cloud-public-ca-v0.3.3) (2023-07-05)
+## [0.3.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-security-publicca-v0.3.2...google-cloud-security-publicca-v0.3.3) (2023-07-05)
 
 
 ### Bug Fixes

--- a/packages/google-cloud-security-publicca/README.rst
+++ b/packages/google-cloud-security-publicca/README.rst
@@ -10,10 +10,10 @@ Python Client for Public Certificate Authority
 
 .. |preview| image:: https://img.shields.io/badge/support-preview-orange.svg
    :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#stability-levels
-.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-public-ca.svg
-   :target: https://pypi.org/project/google-cloud-public-ca/
-.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-public-ca.svg
-   :target: https://pypi.org/project/google-cloud-public-ca/
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-security-publicca.svg
+   :target: https://pypi.org/project/google-cloud-security-publicca/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-security-publicca.svg
+   :target: https://pypi.org/project/google-cloud-security-publicca/
 .. _Public Certificate Authority: https://cloud.google.com/certificate-manager/docs/public-ca
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/publicca/latest/summary_overview
 .. _Product Documentation:  https://cloud.google.com/certificate-manager/docs/public-ca
@@ -53,7 +53,7 @@ Code samples and snippets
 
 Code samples and snippets live in the `samples/`_ folder.
 
-.. _samples/: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-public-ca/samples
+.. _samples/: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-security-publicca/samples
 
 
 Supported Python Versions
@@ -82,7 +82,7 @@ Mac/Linux
 
     python3 -m venv <your-env>
     source <your-env>/bin/activate
-    pip install google-cloud-public-ca
+    pip install google-cloud-security-publicca
 
 
 Windows
@@ -92,7 +92,7 @@ Windows
 
     py -m venv <your-env>
     .\<your-env>\Scripts\activate
-    pip install google-cloud-public-ca
+    pip install google-cloud-security-publicca
 
 Next Steps
 ~~~~~~~~~~

--- a/packages/google-cloud-security-publicca/docs/index.rst
+++ b/packages/google-cloud-security-publicca/docs/index.rst
@@ -26,7 +26,7 @@ API Reference
 Changelog
 ---------
 
-For a list of all ``google-cloud-public-ca`` releases:
+For a list of all ``google-cloud-security-publicca`` releases:
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
Follow up to https://github.com/googleapis/google-cloud-python/pull/14634