### PR TITLE
chore(librarian): bump version for google-cloud-monitoring

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -4288,7 +4288,7 @@ libraries:
       - ^packages/googleapis-common-protos/google/(?:api|cloud|rpc|type)/.*/.*_pb2\.(?:py|pyi)$/
     tag_format: '{id}-v{version}'
   - id: google-cloud-monitoring
-    version: 2.27.2
+    version: 2.28.0
     last_generated_commit: d300b151a973ce0425ae4ad07b3de957ca31bec6
     apis:
       - path: google/monitoring/v3


### PR DESCRIPTION
Bump the version of `google-cloud-monitoring` to reflect the last release

https://pypi.org/project/google-cloud-monitoring/