### PR TITLE
chore(librarian): bump gapic-generator to 1.28.1

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator>=1.28.0 # Python 3.14 support
+gapic-generator>=1.28.1 # Python 3.14 support, gapic-version support
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
See related issue : https://github.com/googleapis/librarian/issues/2486

1.28.1 is needed to resolve an issue with `gapic-version` option not working for `google-cloud-biglake`. An issue was fixed in `gapic-generator==1.28.1` https://github.com/googleapis/gapic-generator-python/releases/tag/v1.28.1 via https://github.com/googleapis/gapic-generator-python/pull/2460