### PR TITLE
chore(librarian): fix docs in google-maps-routeoptimization

### DIFF
--- a/.librarian/generator-input/client-post-processing/doc-formatting.yaml
+++ b/.librarian/generator-input/client-post-processing/doc-formatting.yaml
@@ -576,3 +576,17 @@ replacements:
                   organizations/{organization}/locations/{location}
                   or folders/{folder}/locations/{location}
     count: 4
+  - paths: [
+      packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/types/route_optimization_service.py,
+    ]
+    before: |
+      The ratio \(vehicle_end_time - vehicle_start_time\) / \(latest_vehicle_end_time - earliest_vehicle_start_time\) for a given vehicle. If the denominator is not present, it uses \(\[ShipmentModel.global_end_time\]\[google.maps.routeoptimization.v1.ShipmentModel.global_end_time\]
+      \            ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n
+      \            \[ShipmentModel.global_start_time\]\[google.maps.routeoptimization.v1.ShipmentModel.global_start_time\]\)
+      \            instead.
+    after: |
+      The ratio (vehicle_end_time - vehicle_start_time) / (latest_vehicle_end_time - earliest_vehicle_start_time) for a given vehicle. If the denominator is not present, it uses
+                  ([ShipmentModel.global_end_time][google.maps.routeoptimization.v1.ShipmentModel.global_end_time] -
+                  [ShipmentModel.global_start_time][google.maps.routeoptimization.v1.ShipmentModel.global_start_time])
+                  instead.
+    count: 1


### PR DESCRIPTION
Fix issue in `google-maps-routeoptimization` which causes the docs build to fail. The root cause of this issue is likely the use of `pandoc` as the problem doesn't appear in the protos as this problem doesn't appear in the [upstream protos](https://github.com/googleapis/googleapis/blob/master/google/maps/routeoptimization/v1/route_optimization_service.proto).

https://github.com/googleapis/googleapis-gen/blob/1d97debfe55a705717024c2103f1cdbda443ca12/google/maps/routeoptimization/v1/maps-routeoptimization-v1-py/google/maps/routeoptimization_v1/types/route_optimization_service.py#L3996

Filed https://github.com/googleapis/google-cloud-python/issues/16214 to follow up on this issue
