### PR TITLE
chore(librarian): add exception for google.iam

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -899,6 +899,7 @@ def _verify_library_namespace(library_id: str, repo: str):
         "google.cloud.security",
         "google.cloud.video",
         "google.cloud.workflows",
+        "google.iam",
         "google.gapic",
         "google.identity.accesscontextmanager",
         "google.logging",


### PR DESCRIPTION
This PR fixes the following stack trace which caused the build to fail for `grpc-google-iam-v1`. 

```
Traceback (most recent call last):
  File "/app/./cli.py", line 1001, in handle_build
    _verify_library_namespace(library_id, repo)
  File "/app/./cli.py", line 950, in _verify_library_namespace
    raise ValueError(
ValueError: The namespace `google.iam` for `grpc-google-iam-v1` must be one of ['google', 'google.ads', 'google.ai', 'google.analytics', 'google.apps', 'google.cloud', 'google.geo', 'google.maps', 'google.shopping', 'grafeas', 'google.area120', 'google.api', 'google.apps.script', 'google.apps.script.type', 'google.cloud.alloydb', 'google.cloud.billing', 'google.cloud.devtools', 'google.cloud.gkeconnect', 'google.cloud.gkehub_v1', 'google.cloud.orchestration.airflow', 'google.cloud.security', 'google.cloud.video', 'google.cloud.workflows', 'google.gapic', 'google.identity.accesscontextmanager', 'google.logging', 'google.monitoring', 'google.rpc'].

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/./cli.py", line 1440, in <module>
    args.func(librarian=args.librarian, repo=args.repo)
  File "/app/./cli.py", line 1005, in handle_build
    raise ValueError("Build failed.") from e
ValueError: Build failed.
```

