### PR TITLE
chore: update gapic-generator to 1.28.2

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator>=1.28.1 # Python 3.14 support, gapic-version support
+gapic-generator>=1.28.2 # Bump `google-apps-card` dep to 0.3.0
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
1.28.2 is needed to resolve an issue where tests fail for `google-apps-chat` with the following message:

```
tests/unit/gapic/chat_v1/test_chat_service.py:23669: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
google/apps/chat_v1/services/chat_service/client.py:1845: in update_message
    request = gc_message.UpdateMessageRequest(request)
.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/proto/message.py:598: in __init__
    pb_value = marshal.to_proto(pb_type, value)
.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/proto/marshal/marshal.py:228: in to_proto
    pb_value = self.get_rule(proto_type=proto_type).to_proto(value)
.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/proto/marshal/rules/message.py:36: in to_proto
    return self._descriptor(**value)
.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/google/protobuf/internal/python_message.py:535: in init
    copy.add(**val)
.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/google/protobuf/internal/containers.py:276: in add
    new_element = self._message_descriptor._concrete_class(**kwargs)
.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/google/protobuf/internal/python_message.py:548: in init
    new_val = field.message_type._concrete_class(**field_value)
.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/google/protobuf/internal/python_message.py:535: in init
    copy.add(**val)
.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/google/protobuf/internal/containers.py:276: in add
    new_element = self._message_descriptor._concrete_class(**kwargs)
.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/google/protobuf/internal/python_message.py:535: in init
    copy.add(**val)
.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/google/protobuf/internal/containers.py:276: in add
    new_element = self._message_descriptor._concrete_class(**kwargs)
.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/google/protobuf/internal/python_message.py:548: in init
    new_val = field.message_type._concrete_class(**field_value)
.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/google/protobuf/internal/python_message.py:516: in init
    field = _GetFieldByName(message_descriptor, field_name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

message_descriptor = <google.protobuf.descriptor.Descriptor object at 0x7fd5f43f7650>, field_name = 'max_lines'

    def _GetFieldByName(message_descriptor, field_name):
      """Returns a field descriptor by field name.
    
      Args:
        message_descriptor: A Descriptor describing all fields in message.
        field_name: The name of the field to retrieve.
      Returns:
        The field descriptor associated with the field name.
      """
      try:
        return message_descriptor.fields_by_name[field_name]
      except KeyError:
        raise ValueError('Protocol message %s has no "%s" field.' %
>                        (message_descriptor.name, field_name))
E       ValueError: Protocol message TextParagraph has no "max_lines" field.

.nox/unit-3-7-protobuf_implementation-python/lib/python3.7/site-packages/google/protobuf/internal/python_message.py:580: ValueError
```

See PR https://github.com/googleapis/google-cloud-python/pull/14780 where the build/test failed for `google-apps-chat`. The test passes with `google-apps-card` 0.3.0

An issue was fixed in gapic-generator==1.28.2 https://github.com/googleapis/gapic-generator-python/releases/tag/v1.28.2 via https://github.com/googleapis/gapic-generator-python/pull/2464
