### PR TITLE
chore(librarian): bump gapic-generator to 1.28.3

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator>=1.28.2 # Bump `google-apps-card` dep to 0.3.0
+gapic-generator>=1.28.3 # format generated samples
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
1.28.3 is needed to resolve an issue where generation fails for libraries which don't contain samples. See https://github.com/googleapis/gapic-generator-python/releases/tag/v1.28.3 and https://github.com/googleapis/gapic-generator-python/pull/2466

```
Generation failed for
google-apps-card
google-apps-script-type
google-cloud-alloydb-connectors
google-cloud-appengine-logging
google-cloud-bigquery-logging
google-cloud-common
google-cloud-iam-logging
google-cloud-source-context
google-geo-type
google-maps-places
google-shopping-type
```

The specific stack trace is

```
Broken 1 paths
nox > black docs google samples tests noxfile.py setup.py
Usage: black [OPTIONS] SRC ...
Try 'black -h' for help.

Error: Invalid value for 'SRC ...': Path 'samples' does not exist.
nox > Command black docs google samples tests noxfile.py setup.py failed with exit code 2
```

The reason that these libraries do not contain samples is that the APIs do not have any RPCs
