### PR TITLE
chore(librarian): add pypi anchor to `CHANGELOG.md`

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -233,11 +233,13 @@ def _create_new_changelog_for_library(library_id: str, output: str):
     package_changelog_path = f"{output}/packages/{library_id}/CHANGELOG.md"
     docs_changelog_path = f"{output}/packages/{library_id}/docs/CHANGELOG.md"
 
+    changelog_content = f"# Changelog\n\n[PyPI History][1]\n\n[1]: https://pypi.org/project/{library_id}/#history\n"
+
     os.makedirs(os.path.dirname(package_changelog_path), exist_ok=True)
-    _write_text_file(package_changelog_path, "# Changelog\n")
+    _write_text_file(package_changelog_path, changelog_content)
 
     os.makedirs(os.path.dirname(docs_changelog_path), exist_ok=True)
-    _write_text_file(docs_changelog_path, "# Changelog\n")
+    _write_text_file(docs_changelog_path, changelog_content)
 
 
 def handle_configure(

--- a/.generator/test_cli.py
+++ b/.generator/test_cli.py
@@ -330,8 +330,9 @@ def test_create_new_changelog_for_library(mocker):
     assert mock_makedirs.call_count == 2
 
     # Check that the files were "written" with the correct content
-    mock_write_text_file.assert_any_call(package_changelog_path, "# Changelog\n")
-    mock_write_text_file.assert_any_call(docs_changelog_path, "# Changelog\n")
+    changelog_content = f"# Changelog\n\n[PyPI History][1]\n\n[1]: https://pypi.org/project/{library_id}/#history\n"
+    mock_write_text_file.assert_any_call(package_changelog_path, changelog_content)
+    mock_write_text_file.assert_any_call(docs_changelog_path, changelog_content)
     assert mock_write_text_file.call_count == 2
 
 


### PR DESCRIPTION
This PR adds the pypi anchor to the `CHANGELOG.md` file and ensures that both `CHANGELOG.md` and `docs/CHANGELOG.md`, if it exists, are updated in release-init.