### PR TITLE
fix(bigquerystorage): sync `__version__` with PyPI

### DIFF
--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage/gapic_version.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "2.33.1"  # {x-release-please-version}


### PR DESCRIPTION
Out-of-date version is causing issues with prerelease tests.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

See test failures in https://github.com/googleapis/python-bigquery-magics/pull/142

```
               raise exceptions.LegacyBigQueryStorageError(msg)
E               google.cloud.bigquery.exceptions.LegacyBigQueryStorageError: Dependency google-cloud-bigquery-storage is outdated, please upgrade it to version >= 2.0.0 (version found: 0.0.0).
```

🦕