### PR TITLE
chore(librarian): resolve issue where generation failed for certain packages

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -369,12 +369,13 @@ def _copy_files_needed_for_post_processing(
     path_to_library = f"packages/{library_id}" if is_mono_repo else "."
     source_dir = f"{input}/{path_to_library}"
 
-    shutil.copytree(
-        source_dir,
-        output,
-        dirs_exist_ok=True,
-        ignore=shutil.ignore_patterns("client-post-processing"),
-    )
+    if Path(source_dir).exists():
+        shutil.copytree(
+            source_dir,
+            output,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns("client-post-processing"),
+        )
 
     # We need to create these directories so that we can copy files necessary for post-processing.
     os.makedirs(

--- a/.generator/test_cli.py
+++ b/.generator/test_cli.py
@@ -859,6 +859,7 @@ def test_copy_files_needed_for_post_processing_copies_files_from_generator_input
     """Tests that .repo-metadata.json is copied if it exists."""
     mock_makedirs = mocker.patch("os.makedirs")
     mock_shutil_copytree = mocker.patch("shutil.copytree")
+    mocker.patch("pathlib.Path.exists", return_value=True)
 
     _copy_files_needed_for_post_processing(
         "output", "input", "library_id", is_mono_repo


### PR DESCRIPTION
This PR fixes an issue where generation fails for libraries when `/input/packages/google-cloud-<api>` does not exist.

```
Traceback (most recent call last):
  File "/app/./cli.py", line 620, in handle_generate
    _copy_files_needed_for_post_processing(output, input, library_id, is_mono_repo)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/./cli.py", line 372, in _copy_files_needed_for_post_processing
    shutil.copytree(
    ~~~~~~~~~~~~~~~^
        source_dir,
        ^^^^^^^^^^^
    ...<2 lines>...
        ignore=shutil.ignore_patterns("client-post-processing"),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.14/shutil.py", line 652, in copytree
    with os.scandir(src) as itr:
         ~~~~~~~~~~^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/input/packages/google-cloud-hypercomputecluster'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/./cli.py", line 1582, in <module>
    args.func(
    ~~~~~~~~~^
        librarian=args.librarian,
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        input=args.input,
        ^^^^^^^^^^^^^^^^^
    )
    ^
  File "/app/./cli.py", line 628, in handle_generate
    raise ValueError("Generation failed.") from e
ValueError: Generation failed.
```