### PR TITLE
chore(librarian): resolve issue where .repo-metadata is not copied

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -382,7 +382,7 @@ def _copy_files_needed_for_post_processing(
     # `.librarian/generator-input`, then we override the generated `.repo-metadata.json`
     # with what we have in `generator-input`. Remove this logic once the
     # generated `.repo-metadata.json` file is completely backfilled.
-    if os.path.exists(repo_metadata_path):
+    if Path(repo_metadata_path).exists():
         shutil.copy(
             repo_metadata_path,
             f"{output}/{path_to_library}/.repo-metadata.json",

--- a/.generator/test_cli.py
+++ b/.generator/test_cli.py
@@ -858,6 +858,7 @@ def test_copy_files_needed_for_post_processing_copies_files_from_generator_input
 ):
     """Tests that .repo-metadata.json is copied if it exists."""
     mock_makedirs = mocker.patch("os.makedirs")
+    mock_shutil_copy = mocker.patch("shutil.copy")
     mock_shutil_copytree = mocker.patch("shutil.copytree")
     mocker.patch("pathlib.Path.exists", return_value=True)
 
@@ -865,6 +866,7 @@ def test_copy_files_needed_for_post_processing_copies_files_from_generator_input
         "output", "input", "library_id", is_mono_repo
     )
 
+    mock_shutil_copy.assert_called()
     mock_shutil_copytree.assert_called()
     mock_makedirs.assert_called()
 


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-python/pull/14827 removed logic to copy `.repo-metadata`. `shutil.copytree` was supposed to take care of that copy but it appears that hidden files are not copied when they live in sub folders. This PR fixes the issue so that `.repo-metadata.json` files are properly copied.

After this is merged, we should follow the steps [here](https://github.com/googleapis/librarian/blob/main/doc/language-onboarding.md#pin-the-language-container-version-in-stateyaml) to pin the container image.