### PR TITLE
chore(librarian): update preserve_regex for google-cloud-bigquery-storage

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -969,7 +969,8 @@ libraries:
       - scripts/readme-gen
       - testing/.gitignore
       - tests/system
-      - tests/unit/.*.py
+      - tests/unit/helpers.py
+      - tests/unit/test_.*.py
     remove_regex:
       - packages/google-cloud-bigquery-storage
     tag_format: '{id}-v{version}'


### PR DESCRIPTION
This PR resolves the following issue when running `librarian generate` for `google-cloud-bigquery-storage`

```
time=2025-11-05T14:28:05.854Z level=ERROR msg="librarian command failed" err="file existed in destination: /usr/local/google/home/partheniou/git/google-cloud-python/packages/google-cloud-bigquery-storage/tests/unit/__init__.py"
```

`packages/google-cloud-bigquery-storage/tests/unit/__init__.py` is a generated file and should be omitted from the `preserve_regex` to avoid the above error