### PR TITLE
chore(librarian): fix remove_regex for googleapis-common-protos

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -4465,8 +4465,7 @@ libraries:
       - packages/googleapis-common-protos
     preserve_regex: []
     remove_regex:
-      - ^packages/googleapis-common-protos/google/(?:api|logging|rpc|type)/.*(?:\.proto|_pb2\.(?:py|pyi))$
-      - ^packages/googleapis-common-protos/google/cloud/.*/.*(?:\.proto|_pb2\.(?:py|pyi))$
+      - ^packages/googleapis-common-protos/google/(?:api|cloud|logging|rpc|type)/.*(?:\.proto|_pb2\.(?:py|pyi))$
       - .repo-metadata.json
       - README.rst
       - docs/summary_overview.md


### PR DESCRIPTION
This PR resolves the following issues when running `librarian generate` for `googleapis-common-protos`.

- `.repo-metadata.json` is included in the generated output

```
time=2025-11-05T17:00:04.479Z level=ERROR msg="librarian command failed" err="file existed in destination: /usr/local/google/home/partheniou/git/google-cloud-python/packages/googleapis-common-protos/.repo-metadata.json"
```

- `README.rst` is included in the generated output

```
time=2025-11-05T17:03:18.077Z level=ERROR msg="librarian command failed" err="file existed in destination: /usr/local/google/home/partheniou/git/google-cloud-python/packages/googleapis-common-protos/README.rst"
```

- `docs/summary_overview.md` is included in the generated output

```
time=2025-11-05T17:03:56.453Z level=ERROR msg="librarian command failed" err="file existed in destination: /usr/local/google/home/partheniou/git/google-cloud-python/packages/googleapis-common-protos/docs/summary_overview.md"
```

- *.proto files are included in the generated output

```
time=2025-11-05T17:04:30.389Z level=ERROR msg="librarian command failed" err="file existed in destination: /usr/local/google/home/partheniou/git/google-cloud-python/packages/googleapis-common-protos/google/api/annotations.proto"
```

- add `google/logging` which was missed

```
time=2025-11-05T17:07:43.492Z level=ERROR msg="librarian command failed" err="file existed in destination: /usr/local/google/home/partheniou/git/google-cloud-python/packages/googleapis-common-protos/google/logging/type/http_request.proto"
```

This also uncovered an issue where we were not generating code for https://github.com/googleapis/googleapis/blob/master/google/cloud/common_resources.proto. I'll address this in a separate PR