### PR TITLE
chore(librarian): remove commit body from release notes

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -1339,7 +1339,6 @@ def _process_changelog(
     type_key = "type"
     commit_hash_key = "commit_hash"
     subject_key = "subject"
-    body_key = "body"
     library_changes.sort(key=lambda x: x[type_key])
     grouped_changes = itertools.groupby(library_changes, key=lambda x: x[type_key])
 
@@ -1356,7 +1355,7 @@ def _process_changelog(
             for change in library_changes:
                 commit_link = f"([{change[commit_hash_key]}]({_REPO_URL}/commit/{change[commit_hash_key]}))"
                 entry_parts.append(
-                    f"* {change[subject_key]} {change[body_key]} {commit_link}"
+                    f"* {change[subject_key]} {commit_link}"
                 )
 
     new_entry_text = "\n".join(entry_parts)

--- a/.generator/test_cli.py
+++ b/.generator/test_cli.py
@@ -1270,12 +1270,12 @@ def test_process_changelog_success():
     expected_result = f"""# Changelog\n[PyPI History][1]\n[1]: https://pypi.org/project/google-cloud-language/#history\n
 ## [1.2.3](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v1.2.2...google-cloud-language-v1.2.3) ({current_date})\n\n
 ### Documentation\n
-* fix typo in BranchRule comment  ([9461532e7d19c8d71709ec3b502e5d81340fb661](https://github.com/googleapis/google-cloud-python/commit/9461532e7d19c8d71709ec3b502e5d81340fb661))\n\n
+* fix typo in BranchRule comment ([9461532e7d19c8d71709ec3b502e5d81340fb661](https://github.com/googleapis/google-cloud-python/commit/9461532e7d19c8d71709ec3b502e5d81340fb661))\n\n
 ### Features\n
-* add new UpdateRepository API This adds the ability to update a repository's properties. ([9461532e7d19c8d71709ec3b502e5d81340fb661](https://github.com/googleapis/google-cloud-python/commit/9461532e7d19c8d71709ec3b502e5d81340fb661))\n\n
+* add new UpdateRepository API ([9461532e7d19c8d71709ec3b502e5d81340fb661](https://github.com/googleapis/google-cloud-python/commit/9461532e7d19c8d71709ec3b502e5d81340fb661))\n\n
 ### Bug Fixes\n
-* some fix some body ([1231532e7d19c8d71709ec3b502e5d81340fb661](https://github.com/googleapis/google-cloud-python/commit/1231532e7d19c8d71709ec3b502e5d81340fb661))
-* another fix  ([1241532e7d19c8d71709ec3b502e5d81340fb661](https://github.com/googleapis/google-cloud-python/commit/1241532e7d19c8d71709ec3b502e5d81340fb661))\n
+* some fix ([1231532e7d19c8d71709ec3b502e5d81340fb661](https://github.com/googleapis/google-cloud-python/commit/1231532e7d19c8d71709ec3b502e5d81340fb661))
+* another fix ([1241532e7d19c8d71709ec3b502e5d81340fb661](https://github.com/googleapis/google-cloud-python/commit/1241532e7d19c8d71709ec3b502e5d81340fb661))\n
 ## [1.2.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-language-v1.2.1...google-cloud-language-v1.2.2) (2025-06-11)"""
     version = "1.2.3"
     previous_version = "1.2.2"


### PR DESCRIPTION
The commit body is not needed when creating release notes. It was originally added to workaround https://github.com/googleapis/librarian/issues/2234. As per https://github.com/googleapis/librarian/issues/2234#issuecomment-3325613153, we should not include the body in the release notes.

Without the fix in this PR, the changelog for `googleapis-common-protos` looks like this
```

## [1.72.0](https://github.com/googleapis/google-cloud-python/compare/googleapis-common-protos-v1.71.0...googleapis-common-protos-v1.72.0) (2025-11-05)


### Features

* add common_resources.proto (#14851) This PR depends on
https://github.com/googleapis/google-cloud-python/pull/14850
`google/cloud` was not listed as an api path for
`googleapis-common-protos` for code was not being generated for
https://github.com/googleapis/googleapis/blob/master/google/cloud/extended_operations.proto
and
https://github.com/googleapis/googleapis/blob/master/google/cloud/common_resources.proto ([e4e0e2a93c3db14324c1d9f799283ffe4f2bec09](https://github.com/googleapis/google-cloud-python/commit/e4e0e2a93c3db14324c1d9f799283ffe4f2bec09))
* add field api_version to message ServiceForTransport (#14843) This PR was created locally. The reason that this could not be automated
is that the current directory structure
[gapic/metadata](https://github.com/googleapis/googleapis/tree/master/gapic/metadata)
doesn't align with the protobuf package name
[google.gapic.metadata](https://github.com/googleapis/googleapis/blob/53af3b727f84acc34e31c23f3b6e7b8aa4b7e837/gapic/metadata/gapic_metadata.proto#L18).
The expected directory structure for `google.gapic.metadata` is
`google/gapic/metadata`.
In the `googleapis-common-protos` package, the `gencode` is in the
expected location ([81812fde4f1e43d568d53d6a993cf423b38d6728](https://github.com/googleapis/google-cloud-python/commit/81812fde4f1e43d568d53d6a993cf423b38d6728))
```

With the fix, the changelog for `googleapis-common-protos` looks like this

```

## [1.72.0](https://github.com/googleapis/google-cloud-python/compare/googleapis-common-protos-v1.71.0...googleapis-common-protos-v1.72.0) (2025-11-05)


### Features

* add common_resources.proto (#14851) ([e4e0e2a93c3db14324c1d9f799283ffe4f2bec09](https://github.com/googleapis/google-cloud-python/commit/e4e0e2a93c3db14324c1d9f799283ffe4f2bec09))
* add field api_version to message ServiceForTransport (#14843) ([81812fde4f1e43d568d53d6a993cf423b38d6728](https://github.com/googleapis/google-cloud-python/commit/81812fde4f1e43d568d53d6a993cf423b38d6728))
```