### PR TITLE
chore(librarian): exclude version files under tests directory

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -1199,7 +1199,8 @@ def _update_version_for_library(
 
     # Find and update version.py or gapic_version.py files
     search_base = Path(f"{repo}/{path_to_library}")
-    version_files = list(search_base.rglob("**/gapic_version.py"))
+    version_files = []
+    patterns = ["**/gapic_version.py", "**/version.py"]
     excluded_dirs = {
         ".nox",
         ".venv",
@@ -1209,14 +1210,16 @@ def _update_version_for_library(
         "build",
         "dist",
         "__pycache__",
+        "tests",
     }
-    version_files.extend(
-        [
-            p
-            for p in search_base.rglob("**/version.py")
-            if not any(part in excluded_dirs for part in p.parts)
-        ]
-    )
+    for pattern in patterns:
+        version_files.extend(
+            [
+                p
+                for p in search_base.rglob(pattern)
+                if not any(part in excluded_dirs for part in p.parts)
+            ]
+        )
 
     if not version_files:
         # Fallback to `pyproject.toml`` or `setup.py``. Proto-only libraries have
@@ -1238,8 +1241,8 @@ def _update_version_for_library(
         _write_text_file(output_path, updated_content)
 
     # Find and update snippet_metadata.json files
-    snippet_metadata_files = Path(f"{repo}/{path_to_library}").rglob(
-        "samples/**/*snippet*.json"
+    snippet_metadata_files = Path(f"{repo}/{path_to_library}/samples").rglob(
+        "**/*snippet*.json"
     )
     for metadata_file in snippet_metadata_files:
         output_path = f"{output}/{metadata_file.relative_to(repo)}"

--- a/.generator/test_cli.py
+++ b/.generator/test_cli.py
@@ -1037,18 +1037,19 @@ def test_update_version_for_library_success_gapic(mocker):
 
     mock_rglob = mocker.patch("pathlib.Path.rglob")
     mock_rglob.side_effect = [
-        [pathlib.Path("repo/gapic_version.py")],  # 1st call (gapic_version.py)
+        [pathlib.Path("repo/gapic_version.py"), pathlib.Path("repo/tests/gapic_version.py")],  # 1st call (gapic_version.py)
         [pathlib.Path("repo/types/version.py")],  # 2nd call (types/version.py).
         [pathlib.Path("repo/samples/snippet_metadata.json")],  # 3rd call (snippets)
     ]
-    mock_rglob = mocker.patch("cli._read_text_file")
-    mock_rglob.side_effect = [
+    mock_read_text_file = mocker.patch("cli._read_text_file")
+    mock_read_text_file.side_effect = [
         mock_content,  # 1st call (gapic_version.py)
         # Do not process version files in the `types` directory as some
         # GAPIC libraries have `version.py` which are generated from
         # `version.proto` and do not include SDK versions.
         # Leave the content as empty because it doesn't contain version information
-        "",  # 2nd call (types/version.py)
+        "",  # 2nd call (tests/gapic_version.py)
+        "",  # 3rd call (types/version.py)
     ]
 
     with unittest.mock.patch("cli.open", m):


### PR DESCRIPTION
This PR fixes an issue where `librarian release stage` fails for libraries when version files exist under test directories and are not expected to be updated. See the following stack trace for `gapic-generator-python` when running `librarian release stage`. 

```
partheniou@partheniou-vm-3:~/git/gapic-generator-python$ librarian release stage
time=2025-11-08T14:22:44.752Z level=INFO msg="temporary working directory" dir=/tmp/librarian-1630479680
time=2025-11-08T14:22:44.752Z level=INFO msg="repo not specified, using current working directory as repo root" path=/usr/local/google/home/partheniou/git/gapic-generator-python
time=2025-11-08T14:22:44.752Z level=INFO msg="opening repository" dir=/usr/local/google/home/partheniou/git/gapic-generator-python
time=2025-11-08T14:22:44.956Z level=INFO msg="source not specified, skipping service config population"
time=2025-11-08T14:22:44.956Z level=INFO msg="config.yaml not found, proceeding"
time=2025-11-08T14:22:44.957Z level=INFO msg="staging a release" dir=/tmp/librarian-1630479680/output
time=2025-11-08T14:22:44.973Z level=INFO msg="updating library to the next version" library=gapic-generator currentVersion=1.29.0 nextVersion=1.30.0
time=2025-11-08T14:22:44.974Z level=INFO msg="=== Docker start ==============================================================="
time=2025-11-08T14:22:44.974Z level=INFO msg="/usr/bin/docker run --rm -v /usr/local/google/home/partheniou/git/gapic-generator-python/.librarian:/librarian -v /usr/local/google/home/partheniou/git/gapic-generator-python:/repo:ro -v /tmp/librarian-1630479680/output:/output --user 814163:89939 us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator:latest release-stage --librarian=/librarian --repo=/repo --output=/output"
time=2025-11-08T14:22:44.974Z level=INFO msg=--------------------------------------------------------------------------------
2025-11-08 14:22:45,791 synthtool [CRITICAL] > You are running the synthesis script directly, this will be disabled in a future release of Synthtool. Please use python3 -m synthtool instead.
2025-11-08 14:22:45,990 synthtool [DEBUG] > Using local templates at /synthtool/synthtool/gcp/templates
2025-11-08 14:22:45,997 synthtool [DEBUG] > Using local templates at /synthtool/synthtool/gcp/templates
Traceback (most recent call last):
  File "/app/./cli.py", line 1497, in handle_release_stage
    _update_version_for_library(repo, output, path_to_library, version)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/./cli.py", line 1251, in _update_version_for_library
    _write_json_file(output_path, metadata_contents)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/./cli.py", line 114, in _write_json_file
    with open(path, "w") as f:
         ~~~~^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/output/tests/integration/goldens/redis_selective/samples/generated_samples/snippet_metadata_google.cloud.redis.v1.json'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/./cli.py", line 1592, in <module>
    args.func(librarian=args.librarian, repo=args.repo, output=args.output)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/./cli.py", line 1509, in handle_release_stage
    raise ValueError(f"Release stage failed: {e}") from e
ValueError: Release stage failed: [Errno 13] Permission denied: '/output/tests/integration/goldens/redis_selective/samples/generated_samples/snippet_metadata_google.cloud.redis.v1.json'
time=2025-11-08T14:22:46.419Z level=INFO msg="=== Docker end ================================================================="
time=2025-11-08T14:22:46.419Z level=ERROR msg="librarian command failed" err="exit status 1"
```