### PR TITLE
chore(librarian): enable pytest debug logging for google-cloud-compute-v1beta

### DIFF
--- a/.librarian/generator-input/client-post-processing/debugging.yaml
+++ b/.librarian/generator-input/client-post-processing/debugging.yaml
@@ -1,0 +1,29 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: debugging issue 14882
+url: https://github.com/googleapis/google-cloud-python/issues/14882
+replacements:
+  - paths: [
+      packages/google-cloud-compute-v1beta/noxfile.py
+    ]
+    before: |
+      session.run\(
+      \        "py.test",
+      \        "--quiet",
+    after: |
+      session.run(
+              "py.test",
+              "-vvv",
+              "--quiet",
+    count: 1


### PR DESCRIPTION
This PR is used for debugging https://github.com/googleapis/google-cloud-python/issues/14882