### PR TITLE
chore: librarian generate pull request: 20251117T234301Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -938,7 +938,7 @@ libraries:
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigquery-storage
     version: 2.34.0
-    last_generated_commit: 0654a03c3f7a6cb46e36227d17cfcc6f4b71fa5a
+    last_generated_commit: 136201b66f70829232b7ec63fa6e35ca765bcacb
     apis:
       - path: google/cloud/bigquery/storage/v1beta2
         service_config: bigquerystorage_v1beta2.yaml

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/async_client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/async_client.py
@@ -466,9 +466,9 @@ class BigQueryReadAsyncClient:
     ) -> Awaitable[AsyncIterable[storage.ReadRowsResponse]]:
         r"""Reads rows from the stream in the format prescribed
         by the ReadSession. Each response contains one or more
-        table rows, up to a maximum of 100 MiB per response;
-        read requests which attempt to read individual rows
-        larger than 100 MiB will fail.
+        table rows, up to a maximum of 128 MB per response; read
+        requests which attempt to read individual rows larger
+        than 128 MB will fail.
 
         Each request also returns a set of stream statistics
         reflecting the current state of the stream.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/client.py
@@ -924,9 +924,9 @@ class BigQueryReadClient(metaclass=BigQueryReadClientMeta):
     ) -> Iterable[storage.ReadRowsResponse]:
         r"""Reads rows from the stream in the format prescribed
         by the ReadSession. Each response contains one or more
-        table rows, up to a maximum of 100 MiB per response;
-        read requests which attempt to read individual rows
-        larger than 100 MiB will fail.
+        table rows, up to a maximum of 128 MB per response; read
+        requests which attempt to read individual rows larger
+        than 128 MB will fail.
 
         Each request also returns a set of stream statistics
         reflecting the current state of the stream.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/grpc.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/grpc.py
@@ -379,9 +379,9 @@ class BigQueryReadGrpcTransport(BigQueryReadTransport):
 
         Reads rows from the stream in the format prescribed
         by the ReadSession. Each response contains one or more
-        table rows, up to a maximum of 100 MiB per response;
-        read requests which attempt to read individual rows
-        larger than 100 MiB will fail.
+        table rows, up to a maximum of 128 MB per response; read
+        requests which attempt to read individual rows larger
+        than 128 MB will fail.
 
         Each request also returns a set of stream statistics
         reflecting the current state of the stream.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/grpc_asyncio.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_read/transports/grpc_asyncio.py
@@ -387,9 +387,9 @@ class BigQueryReadGrpcAsyncIOTransport(BigQueryReadTransport):
 
         Reads rows from the stream in the format prescribed
         by the ReadSession. Each response contains one or more
-        table rows, up to a maximum of 100 MiB per response;
-        read requests which attempt to read individual rows
-        larger than 100 MiB will fail.
+        table rows, up to a maximum of 128 MB per response; read
+        requests which attempt to read individual rows larger
+        than 128 MB will fail.
 
         Each request also returns a set of stream statistics
         reflecting the current state of the stream.

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/arrow.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/arrow.py
@@ -78,6 +78,9 @@ class ArrowSerializationOptions(proto.Message):
         buffer_compression (google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions.CompressionCodec):
             The compression codec to use for Arrow
             buffers in serialized record batches.
+        picos_timestamp_precision (google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions.PicosTimestampPrecision):
+            Optional. Set timestamp precision option. If
+            not set, the default precision is microseconds.
     """
 
     class CompressionCodec(proto.Enum):
@@ -96,10 +99,44 @@ class ArrowSerializationOptions(proto.Message):
         LZ4_FRAME = 1
         ZSTD = 2
 
+    class PicosTimestampPrecision(proto.Enum):
+        r"""The precision of the timestamp value in the Avro message. This
+        precision will **only** be applied to the column(s) with the
+        ``TIMESTAMP_PICOS`` type.
+
+        Values:
+            PICOS_TIMESTAMP_PRECISION_UNSPECIFIED (0):
+                Unspecified timestamp precision. The default
+                precision is microseconds.
+            TIMESTAMP_PRECISION_MICROS (1):
+                Timestamp values returned by Read API will be
+                truncated to microsecond level precision. The
+                value will be encoded as Arrow TIMESTAMP type in
+                a 64 bit integer.
+            TIMESTAMP_PRECISION_NANOS (2):
+                Timestamp values returned by Read API will be
+                truncated to nanosecond level precision. The
+                value will be encoded as Arrow TIMESTAMP type in
+                a 64 bit integer.
+            TIMESTAMP_PRECISION_PICOS (3):
+                Read API will return full precision
+                picosecond value. The value will be encoded as a
+                string which conforms to ISO 8601 format.
+        """
+        PICOS_TIMESTAMP_PRECISION_UNSPECIFIED = 0
+        TIMESTAMP_PRECISION_MICROS = 1
+        TIMESTAMP_PRECISION_NANOS = 2
+        TIMESTAMP_PRECISION_PICOS = 3
+
     buffer_compression: CompressionCodec = proto.Field(
         proto.ENUM,
         number=2,
         enum=CompressionCodec,
+    )
+    picos_timestamp_precision: PicosTimestampPrecision = proto.Field(
+        proto.ENUM,
+        number=3,
+        enum=PicosTimestampPrecision,
     )
 
 

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/avro.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/avro.py
@@ -84,11 +84,48 @@ class AvroSerializationOptions(proto.Message):
             names with a placeholder value and populates a
             "displayName" attribute for every avro field
             with the original column name.
+        picos_timestamp_precision (google.cloud.bigquery_storage_v1.types.AvroSerializationOptions.PicosTimestampPrecision):
+            Optional. Set timestamp precision option. If
+            not set, the default precision is microseconds.
     """
+
+    class PicosTimestampPrecision(proto.Enum):
+        r"""The precision of the timestamp value in the Avro message. This
+        precision will **only** be applied to the column(s) with the
+        ``TIMESTAMP_PICOS`` type.
+
+        Values:
+            PICOS_TIMESTAMP_PRECISION_UNSPECIFIED (0):
+                Unspecified timestamp precision. The default
+                precision is microseconds.
+            TIMESTAMP_PRECISION_MICROS (1):
+                Timestamp values returned by Read API will be
+                truncated to microsecond level precision. The
+                value will be encoded as Avro TIMESTAMP type in
+                a 64 bit integer.
+            TIMESTAMP_PRECISION_NANOS (2):
+                Timestamp values returned by Read API will be
+                truncated to nanosecond level precision. The
+                value will be encoded as Avro TIMESTAMP type in
+                a 64 bit integer.
+            TIMESTAMP_PRECISION_PICOS (3):
+                Read API will return full precision
+                picosecond value. The value will be encoded as a
+                string which conforms to ISO 8601 format.
+        """
+        PICOS_TIMESTAMP_PRECISION_UNSPECIFIED = 0
+        TIMESTAMP_PRECISION_MICROS = 1
+        TIMESTAMP_PRECISION_NANOS = 2
+        TIMESTAMP_PRECISION_PICOS = 3
 
     enable_display_name_attribute: bool = proto.Field(
         proto.BOOL,
         number=1,
+    )
+    picos_timestamp_precision: PicosTimestampPrecision = proto.Field(
+        proto.ENUM,
+        number=2,
+        enum=PicosTimestampPrecision,
     )
 
 

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/storage.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/storage.py
@@ -442,8 +442,7 @@ class AppendRowsRequest(proto.Message):
 
             This field is a member of `oneof`_ ``rows``.
         arrow_rows (google.cloud.bigquery_storage_v1.types.AppendRowsRequest.ArrowData):
-            Rows in arrow format. This is an experimental
-            feature only selected for allowlisted customers.
+            Rows in arrow format.
 
             This field is a member of `oneof`_ ``rows``.
         trace_id (str):
@@ -471,9 +470,9 @@ class AppendRowsRequest(proto.Message):
         default_missing_value_interpretation (google.cloud.bigquery_storage_v1.types.AppendRowsRequest.MissingValueInterpretation):
             Optional. Default missing value interpretation for all
             columns in the table. When a value is specified on an
-            ``AppendRowsRequest``, it is applied to all requests on the
-            connection from that point forward, until a subsequent
-            ``AppendRowsRequest`` sets it to a different value.
+            ``AppendRowsRequest``, it is applied to all requests from
+            that point forward, until a subsequent ``AppendRowsRequest``
+            sets it to a different value.
             ``missing_value_interpretation`` can override
             ``default_missing_value_interpretation``. For example, if
             you want to write ``NULL`` instead of using default values
@@ -507,8 +506,6 @@ class AppendRowsRequest(proto.Message):
 
     class ArrowData(proto.Message):
         r"""Arrow schema and data.
-        Arrow format is an experimental feature only selected for
-        allowlisted customers.
 
         Attributes:
             writer_schema (google.cloud.bigquery_storage_v1.types.ArrowSchema):
@@ -536,8 +533,8 @@ class AppendRowsRequest(proto.Message):
 
         Attributes:
             writer_schema (google.cloud.bigquery_storage_v1.types.ProtoSchema):
-                The protocol buffer schema used to serialize the data.
-                Provide this value whenever:
+                Optional. The protocol buffer schema used to serialize the
+                data. Provide this value whenever:
 
                 - You send the first request of an RPC connection.
 
@@ -545,11 +542,11 @@ class AppendRowsRequest(proto.Message):
 
                 - You specify a new destination table.
             rows (google.cloud.bigquery_storage_v1.types.ProtoRows):
-                Serialized row data in protobuf message
-                format. Currently, the backend expects the
-                serialized rows to adhere to proto2 semantics
-                when appending rows, particularly with respect
-                to how default values are encoded.
+                Required. Serialized row data in protobuf
+                message format. Currently, the backend expects
+                the serialized rows to adhere to proto2
+                semantics when appending rows, particularly with
+                respect to how default values are encoded.
         """
 
         writer_schema: protobuf.ProtoSchema = proto.Field(

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/stream.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/stream.py
@@ -413,8 +413,8 @@ class WriteStream(proto.Message):
         write_mode (google.cloud.bigquery_storage_v1.types.WriteStream.WriteMode):
             Immutable. Mode of the stream.
         location (str):
-            Immutable. The geographic location where the
-            stream's dataset resides. See
+            Output only. The geographic location where
+            the stream's dataset resides. See
             https://cloud.google.com/bigquery/docs/locations
             for supported locations.
     """

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/table.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/types/table.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from typing import MutableMapping, MutableSequence
 
+from google.protobuf import wrappers_pb2  # type: ignore
 import proto  # type: ignore
 
 __protobuf__ = proto.module(
@@ -125,6 +126,14 @@ class TableFieldSchema(proto.Message):
             Optional. A SQL expression to specify the [default value]
             (https://cloud.google.com/bigquery/docs/default-values) for
             this field.
+        timestamp_precision (google.protobuf.wrappers_pb2.Int64Value):
+            Optional. Precision (maximum number of total digits in base
+            10) for seconds of TIMESTAMP type.
+
+            Possible values include:
+
+            - 6 (Default, for TIMESTAMP type with microsecond precision)
+            - 12 (For TIMESTAMP type with picosecond precision)
         range_element_type (google.cloud.bigquery_storage_v1.types.TableFieldSchema.FieldElementType):
             Optional. The subtype of the RANGE, if the type of this
             field is RANGE. If the type is RANGE, this field is
@@ -264,6 +273,11 @@ class TableFieldSchema(proto.Message):
     default_value_expression: str = proto.Field(
         proto.STRING,
         number=10,
+    )
+    timestamp_precision: wrappers_pb2.Int64Value = proto.Field(
+        proto.MESSAGE,
+        number=27,
+        message=wrappers_pb2.Int64Value,
     )
     range_element_type: FieldElementType = proto.Field(
         proto.MESSAGE,


### PR DESCRIPTION
PR created by the Librarian CLI to generate Cloud Client Libraries code from protos.

BEGIN_COMMIT

BEGIN_NESTED_COMMIT
feat: Support picosecond timestamp precision in BigQuery Storage API


PiperOrigin-RevId: 829486853
Library-IDs: google-cloud-bigquery-storage
Source-link: [googleapis/googleapis@04bd623c](https://github.com/googleapis/googleapis/commit/04bd623c)
END_NESTED_COMMIT

END_COMMIT

This pull request is generated with proto changes between
[googleapis/googleapis@0654a03c](https://github.com/googleapis/googleapis/commit/0654a03c3f7a6cb46e36227d17cfcc6f4b71fa5a)
(exclusive) and
[googleapis/googleapis@04bd623c](https://github.com/googleapis/googleapis/commit/04bd623ce9d0c06f1e842a6fc6d5ed7dc9baee13)
(inclusive).

Librarian Version: v0.6.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:97c3041de740f26b132d3c5d43f0097f990e8b0d1f2e6707054840024c20ab0c