### PR TITLE
chore(librarian): update Python librarian generator SHA

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,4 +1,4 @@
-image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:97c3041de740f26b132d3c5d43f0097f990e8b0d1f2e6707054840024c20ab0c
+image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:72e9b62c0f8f3799651ee62d777a2905f5b72ff19ea46f2e7b7d682d7d1e9414
 libraries:
   - id: google-ads-admanager
     version: 0.6.0


### PR DESCRIPTION
After running the following command, there are no changes to generated libraries. IOW, this newer version of the generator does not introduce any package level diff.

```
librarian update-image -image=us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:72e9b62c0f8f3799651ee62d777a2905f5b72ff19ea46f2e7b7d682d7d1e9414
```

This newer SHA is needed to pull in the changes from https://github.com/googleapis/google-cloud-python/pull/14885