### PR TITLE
chore(librarian): Add Python 3.13 to Python librarian generator image

### DIFF
--- a/.generator/Dockerfile
+++ b/.generator/Dockerfile
@@ -40,26 +40,27 @@ RUN apt-get update && \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ENV PYTHON_VERSION=3.14
-
-# The full Python version, including the minor version, is needed for download/install
-ENV PYTHON_VERSION_WITH_MINOR=3.14.0
-
 # `make altinstall` is used to prevent replacing the system's default python binary.
-RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION_WITH_MINOR}/Python-${PYTHON_VERSION_WITH_MINOR}.tgz && \
+# The full Python version, including the minor version, is needed for download/install
+# TODO(https://github.com/googleapis/librarian/issues/2945): Remove `3.13` when the linked issue is resolved.
+RUN for PYTHON_VERSION_WITH_MINOR in 3.13.9 3.14.0; do \
+    wget https://www.python.org/ftp/python/${PYTHON_VERSION_WITH_MINOR}/Python-${PYTHON_VERSION_WITH_MINOR}.tgz && \
     tar -xvf Python-${PYTHON_VERSION_WITH_MINOR}.tgz && \
     cd Python-${PYTHON_VERSION_WITH_MINOR} && \
     ./configure --enable-optimizations --prefix=/usr/local && \
     make -j$(nproc) && \
     make altinstall && \
     cd / && \
-    rm -rf Python-${PYTHON_VERSION_WITH_MINOR}*
+    rm -rf Python-${PYTHON_VERSION_WITH_MINOR}* \
+    ; done
 
 # Install pip for each python version
-# TODO(http://github.com/googleapis/gapic-generator-python/issues/2435): Remove `3.10` when the linked issue is resolved.
-RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' && \
+# TODO(https://github.com/googleapis/librarian/issues/2945): Remove `3.13` when the linked issue is resolved.
+RUN for PYTHON_VERSION in 3.13 3.14; do \
+    wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' && \
     python${PYTHON_VERSION} /tmp/get-pip.py && \
-    rm /tmp/get-pip.py
+    rm /tmp/get-pip.py \
+    ; done
 
 # Download/extract protoc
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-linux-x86_64.zip
@@ -87,7 +88,7 @@ FROM marketplace.gcr.io/google/ubuntu2404
 # the live repo.
 ENV SYNTHTOOL_TEMPLATES="/synthtool/synthtool/gcp/templates"
 
-ENV PYTHON_VERSION=3.14
+ENV PYTHON_VERSION_DEFAULT=3.14
 
 # Install only the essential runtime libraries for Python.
 # These are the non "-dev" versions of the libraries used in the builder.
@@ -108,8 +109,12 @@ COPY --from=builder protoc/include /usr/local/include
 COPY --from=builder pandoc-binary/bin /usr/local/bin
 COPY --from=builder synthtool /synthtool
 
-COPY --from=builder /usr/local/bin/python${PYTHON_VERSION}  /usr/local/bin/
-COPY --from=builder /usr/local/lib/python${PYTHON_VERSION}  /usr/local/lib/python${PYTHON_VERSION}
+COPY --from=builder /usr/local/bin/python${PYTHON_VERSION_DEFAULT}  /usr/local/bin/
+COPY --from=builder /usr/local/lib/python${PYTHON_VERSION_DEFAULT}  /usr/local/lib/python${PYTHON_VERSION_DEFAULT}
+
+# TODO(https://github.com/googleapis/librarian/issues/2945): Remove `3.13` when the linked issue is resolved.
+COPY --from=builder /usr/local/bin/python3.13  /usr/local/bin
+COPY --from=builder /usr/local/lib/python3.13  /usr/local/lib/python3.13
 
 # Set the working directory in the container.
 WORKDIR /app
@@ -119,12 +124,12 @@ WORKDIR /app
 # Install nox which is used for running client library tests.
 # Install starlark-pyo3 which is used to parse BUILD.bazel files.
 COPY .generator/requirements.in .
-RUN python${PYTHON_VERSION} -m pip install -r requirements.in
-RUN python${PYTHON_VERSION} -m pip install /synthtool
+RUN python${PYTHON_VERSION_DEFAULT} -m pip install -r requirements.in
+RUN python${PYTHON_VERSION_DEFAULT} -m pip install /synthtool
 
 # Install build which is used to get the metadata of package config files.
 COPY .generator/requirements.in .
-RUN python${PYTHON_VERSION} -m pip install -r requirements.in
+RUN python${PYTHON_VERSION_DEFAULT} -m pip install -r requirements.in
 
 # Copy the CLI script into the container.
 COPY .generator/cli.py .

--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -942,8 +942,18 @@ def _run_nox_sessions(library_id: str, repo: str, is_mono_repo: bool):
             the config.yaml.
         is_mono_repo(bool): True if the current repository is a mono-repo.
     """
+    path_to_library = f"{repo}/packages/{library_id}" if is_mono_repo else repo
+    _python_314_supported = Path(
+        f"{path_to_library}/testing/constraints-3.14.txt"
+    ).exists()
+
+    if _python_314_supported:
+        session_runtime = "3.14"
+    else:
+        session_runtime = "3.13"
+
     sessions = [
-        "unit-3.14(protobuf_implementation='upb')",
+        f"unit-{session_runtime}(protobuf_implementation='upb')",
     ]
     current_session = None
     try:


### PR DESCRIPTION
This PR is a partial revert of #14826. The reason for the revert is that some split repositories don't support Python 3.14 yet. See follow up issue https://github.com/googleapis/librarian/issues/2945 to remove 3.13 from `.generator/Dockerfile`. The work to add Python 3.14 support in all split repositories is tracked in b/375664027 .