### PR TITLE
chore(librarian): remove support for owlbot.py; prefer librarian.py

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -331,10 +331,10 @@ def _run_post_processor(output: str, library_id: str, is_mono_repo: bool):
         if is_mono_repo:
             python_mono_repo.owlbot_main(path_to_library)
         else:
-            # Some repositories have customizations in `owlbot.py`. If this file exists,
-            # run those customizations instead of `owlbot_main`
-            if Path(f"{output}/owlbot.py").exists():
-                subprocess.run(["python3.14", f"{output}/owlbot.py"])
+            # Some repositories have customizations in `librarian.py`.
+            # If this file exists, run those customizations instead of `owlbot_main`
+            if Path(f"{output}/librarian.py").exists():
+                subprocess.run(["python3.14", f"{output}/librarian.py"])
             else:
                 python.owlbot_main()
     else:


### PR DESCRIPTION
This PR addresses the following section from https://github.com/googleapis/librarian/blob/main/doc/repository-library-onboarding.md#library-setup

```
There is no requirement to stop using library-specific post-processing files as part of this migration. However, any post processing should be included in a file named "librarian.", where corresponds to the script's file extension (e.g., "sh", "py"). While migrating, please also consider opening an issue in your generator repository for any improvements that could reduce your library's post-processing logic.
```

We will need to rename `owlbot.py` to `librarian.py` downstream in the split repositories