### PR TITLE
chore(librarian): delete librarian.py as part of post processor clean up

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -414,6 +414,7 @@ def _clean_up_files_after_post_processing(
     # Safely remove specific files if they exist using pathlib.
     Path(f"{output}/{path_to_library}/CHANGELOG.md").unlink(missing_ok=True)
     Path(f"{output}/{path_to_library}/docs/CHANGELOG.md").unlink(missing_ok=True)
+    Path(f"{output}/{path_to_library}/librarian.py").unlink(missing_ok=True)
 
     # The glob loops are already safe, as they do nothing if no files match.
     for post_processing_file in glob.glob(


### PR DESCRIPTION
This PR cleans ups `librarian.py` if it exists in the generated output since it's not needed after the post processing runs