### PR TITLE
chore(migration): create draft PRs when running scripts in split_repo_migration

### DIFF
--- a/scripts/split_repo_migration/multiple-library.post-process.sh
+++ b/scripts/split_repo_migration/multiple-library.post-process.sh
@@ -116,7 +116,7 @@ echo "Committing changes locally"
 ${GIT} add .
 ${GIT} commit -am "$(echo -e "migration: post-process\n\nThis includes post processing for:\n${*//\"/}")"
 ${GIT} push -u origin "${BRANCH}" --force
-gh pr create --title "chore(migration): Update common files for batch migration" --body "This updates the common files for the migration batch that contains ${*//\"/}"
+gh pr create --draft --title "chore(migration): Update common files for batch migration" --body "This updates the common files for the migration batch that contains ${*//\"/}"
 ${GIT} checkout main # to restore to a known state and allow reruns
 ## END commit changes
 

--- a/scripts/split_repo_migration/single-library.git-migrate-history.sh
+++ b/scripts/split_repo_migration/single-library.git-migrate-history.sh
@@ -166,12 +166,12 @@ git push -u origin "${BRANCH}" --force
 # create pull request
 if which gh > /dev/null
 then
-  while ! gh pr create --title "chore(migration): Migrate code from ${SOURCE_REPO} into ${TARGET_PATH}" --body "$(echo -e "See #${ISSUE_NUMBER}. \n\nThis PR should be merged with a merge-commit, not a squash-commit, in order to preserve the git history.")" ; do
+  while ! gh pr create --draft --title "chore(migration): Migrate code from ${SOURCE_REPO} into ${TARGET_PATH}" --body "$(echo -e "See #${ISSUE_NUMBER}. \n\nThis PR should be merged with a merge-commit, not a squash-commit, in order to preserve the git history.")" ; do
     echo "** PR creation command FAILED (${SOURCE_REPO} --> ${TARGET_PATH}) : sleeping & retrying"
     sleep 30s
   done
 else
-  hub pull-request -m "migrate code from ${SOURCE_REPO}"
+  hub pull-request --draft -m "migrate code from ${SOURCE_REPO}"
 fi
 
 popd >& /dev/null


### PR DESCRIPTION
The scripts in [split_repo_migration](https://github.com/googleapis/google-cloud-python/tree/main/scripts/split_repo_migration) create migration PRs in non-draft state. This is not desired because there is still work to be done before the PRs can be sent for review. 