### PR TITLE
chore(librarian): Create package changelog if not present

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -290,9 +290,12 @@ def handle_configure(
         )
         prepared_config = _prepare_new_library_config(new_library_config)
 
-        # Create a `CHANGELOG.md` and `docs/CHANGELOG.md` file for the new library
+        is_mono_repo = _is_mono_repo(input)
         library_id = _get_library_id(prepared_config)
-        _create_new_changelog_for_library(library_id, output)
+        path_to_library = f"packages/{library_id}" if is_mono_repo else "."
+        if not Path(f"{repo}/{path_to_library}").exists():
+            # Create a `CHANGELOG.md` and `docs/CHANGELOG.md` file for the new library
+            _create_new_changelog_for_library(library_id, output)
 
         # Write the new library configuration to configure-response.json.
         _write_json_file(f"{librarian}/configure-response.json", prepared_config)


### PR DESCRIPTION
When adding a new API version to an existing library, the contents of the existing package level `CHANGELOG.md` file is removed. The issue is that a new changelog is created unconditionally here: https://github.com/googleapis/google-cloud-python/blob/c7696a668a405bdafee59a9341f6d04340d0c45e/.generator/cli.py#L295

As an example, the command below adds the client library code for `google/cloud/maintenance/api/v1` to an existing package [google-cloud-maintenance-api](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-maintenance-api)

```
librarian generate -api=google/cloud/maintenance/api/v1 -library=google-cloud-maintenance-api
```

After running the command locally, see that the contents of this [CHANGELOG.md](https://raw.githubusercontent.com/googleapis/google-cloud-python/refs/heads/main/packages/google-cloud-maintenance-api/CHANGELOG.md) is gone. See below

```
(py392) partheniou@partheniou-vm-3:~/git/google-cloud-python$ git diff packages/google-cloud-maintenance-api/CHANGELOG.md
diff --git a/packages/google-cloud-maintenance-api/CHANGELOG.md b/packages/google-cloud-maintenance-api/CHANGELOG.md
index 6436543a6e6..d884ea3cedb 100644
--- a/packages/google-cloud-maintenance-api/CHANGELOG.md
+++ b/packages/google-cloud-maintenance-api/CHANGELOG.md
@@ -3,31 +3,3 @@
 [PyPI History][1]
 
 [1]: https://pypi.org/project/google-cloud-maintenance-api/#history
-
-## [0.2.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-maintenance-api-v0.1.1...google-cloud-maintenance-api-v0.2.0) (2025-10-20)
-
-
-### Features
-
-* Add support for Python 3.14  ([98ee71abc0f97c88239b50bf0e0827df19630def](https://github.com/googleapis/google-cloud-python/commit/98ee71abc0f97c88239b50bf0e0827df19630def))
-
-
-### Bug Fixes
-
-* Deprecate credentials_file argument  ([98ee71abc0f97c88239b50bf0e0827df19630def](https://github.com/googleapis/google-cloud-python/commit/98ee71abc0f97c88239b50bf0e0827df19630def))
-
-## [0.1.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-maintenance-api-v0.1.0...google-cloud-maintenance-api-v0.1.1) (2025-07-23)
-
-
-### Documentation
-
-* Add missing comments for messages ([f955689](https://github.com/googleapis/google-cloud-python/commit/f9556891d9224fefd09202539a7d5830f724e2c4))
-
-## 0.1.0 (2025-06-23)
```

With the fix in this PR, a package level changelog will only be created if it is not present.  An existing changelog will remain untouched.



