### PR TITLE
chore(librarian): update gapic-generator to 1.30.1

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator==1.28.3 # format generated samples
+gapic-generator==1.30.1 # performance improvements
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
1.30.1 is needed to improve the performance of the Python GAPIC generator. See https://github.com/googleapis/gapic-generator-python/releases/tag/v1.30.1 and https://github.com/googleapis/gapic-generator-python/pull/2504 