### PR TITLE
chore(librarian): update gapic-generator to 1.30.2

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator==1.30.1 # performance improvements
+gapic-generator==1.30.2 # remove formatting changes
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
1.30.2 is needed to remove formatting changes which were introduced in 1.30.1. See https://github.com/googleapis/gapic-generator-python/releases/tag/v1.30.2