### PR TITLE
chore(librarian): Only add header to files in .librarian/generator-input

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -413,13 +413,19 @@ def _copy_files_needed_for_post_processing(
     destination_dir = f"{output}/{path_to_library}"
 
     if Path(source_dir).exists():
-        shutil.copytree(
-            source_dir,
-            destination_dir,
-            dirs_exist_ok=True,
-        )
-        # Apply headers only to the generator-input files copied above.
-        _add_header_to_files(destination_dir)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            shutil.copytree(
+                source_dir,
+                tmp_dir,
+                dirs_exist_ok=True,
+            )
+            # Apply headers only to the generator-input files copied above.
+            _add_header_to_files(tmp_dir)
+            shutil.copytree(
+                tmp_dir,
+                destination_dir,
+                dirs_exist_ok=True,
+            )
 
     # We need to create these directories so that we can copy files necessary for post-processing.
     os.makedirs(


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/googleapis/google-cloud-python/pull/14901 which adds the following text to all generated files. We only want this text added to `.librarian/generator-input`

```
# DO NOT EDIT THIS FILE OUTSIDE OF `.librarian/generator-input`
# The source of truth for this file is `.librarian/generator-input`
```