### PR TITLE
chore(librarian): remove docs post processing for google-cloud-storagebatchoperations

### DIFF
--- a/.librarian/generator-input/client-post-processing/doc-formatting.yaml
+++ b/.librarian/generator-input/client-post-processing/doc-formatting.yaml
@@ -533,22 +533,6 @@ replacements:
                   proactively before maintenance was scheduled
     count: 1
   - paths: [
-      packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/storage_batch_operations_types.py,
-    ]
-    before: |
-      content_type \(str\):
-      \            Optional. Updates objects Content-Type fixed
-      \            metadata. Unset values will be ignored.
-      \             Set empty values to clear the metadata. Refer
-      \            to documentation in
-    after: |
-      content_type (str):
-                  Optional. Updates objects Content-Type fixed
-                  metadata. Unset values will be ignored.
-                  Set empty values to clear the metadata. Refer
-                  to documentation in
-    count: 1
-  - paths: [
       packages/google-cloud-dataplex/google/cloud/dataplex_v1/types/business_glossary.py,
     ]
     before: |


### PR DESCRIPTION
The documentation post processing for `google-cloud-storagebatchoperations` is no longer needed as the formatting issue was fixed upstream in cl/748036392 (See https://github.com/googleapis/googleapis/commit/8f3e57f09707aeea497c82ba9fa96092c4d67d1c)

<img width="1825" height="300" alt="image" src="https://github.com/user-attachments/assets/f6f3f65d-ad02-4b75-91ad-3b30800ef7ee" />

Towards https://github.com/googleapis/google-cloud-python/issues/14992
