### PR TITLE
chore(librarian): temporarily switch protobuf backend from upb to python

### DIFF
--- a/.generator/cli.py
+++ b/.generator/cli.py
@@ -996,8 +996,11 @@ def _run_nox_sessions(library_id: str, repo: str, is_mono_repo: bool):
         is_mono_repo(bool): True if the current repository is a mono-repo.
     """
     session_runtime = "3.14"
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/14992): Switch the protobuf
+    # implementation back to upb once we identify the root cause of the crash that occurs during testing.
+    # It's not trivial to debug this since it only happens in cloud build.
     sessions = [
-        f"unit-{session_runtime}(protobuf_implementation='upb')",
+        f"unit-{session_runtime}(protobuf_implementation='python')",
     ]
     current_session = None
     try:

--- a/.generator/test_cli.py
+++ b/.generator/test_cli.py
@@ -794,7 +794,7 @@ def test_run_nox_sessions_success(
     mock_run_individual_session = mocker.patch("cli._run_individual_session")
 
     sessions_to_run = [
-        f"unit-{nox_session_python_runtime}(protobuf_implementation='upb')",
+        f"unit-{nox_session_python_runtime}(protobuf_implementation='python')",
     ]
     _run_nox_sessions("mock-library", "repo", is_mono_repo)
 
@@ -802,7 +802,7 @@ def test_run_nox_sessions_success(
     mock_run_individual_session.assert_has_calls(
         [
             mocker.call(
-                f"unit-{nox_session_python_runtime}(protobuf_implementation='upb')",
+                f"unit-{nox_session_python_runtime}(protobuf_implementation='python')",
                 "mock-library",
                 "repo",
                 is_mono_repo,


### PR DESCRIPTION
This is a temporary workaround to address https://github.com/googleapis/google-cloud-python/issues/14992 where a crash happens during unit testing of `google-cloud-compute` until we can identify the root cause. This is not trivial to debug since I don't see the problem locally. It only happens in cloud build.