### PR TITLE
chore(librarian): update gapic-generator to 1.30.3

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator==1.30.2 # remove formatting changes
+gapic-generator==1.30.3 # Fix mypy checks https://github.com/googleapis/gapic-generator-python/pull/2520
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
Mypy checks are currently failing on generated outputs, because the `google-auth` library [recently added some stricter type annotations](https://github.com/googleapis/google-auth-library-python/pull/1588)

For example, see the mypy failure [here](https://github.com/googleapis/python-datastore/actions/runs/20936345326/job/60159796798?pr=660) in `python-datastore`