### PR TITLE
chore(librarian): update gapic-generator to 1.30.4

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator==1.30.3 # Fix mypy checks https://github.com/googleapis/gapic-generator-python/pull/2520
+gapic-generator==1.30.4 # Add cryptography to constraints file https://github.com/googleapis/gapic-generator-python/pull/2527
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
This PR is needed to address the following failure in the `Kokoro Deps at HEAD Tests` presubmit in PR https://github.com/googleapis/google-cloud-python/pull/15468


```
________________ ERROR collecting tests/unit/test_writer_v1.py _________________
ImportError while importing test module '/tmpfs/src/github/google-cloud-python/packages/google-cloud-bigquery-storage/tests/unit/test_writer_v1.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/unit/test_writer_v1.py:25: in 
    from google.cloud.bigquery_storage_v1 import exceptions as bqstorage_exceptions
google/cloud/bigquery_storage_v1/__init__.py:31: in 
    from google.cloud.bigquery_storage_v1 import client, types
google/cloud/bigquery_storage_v1/client.py:24: in 
    from google.api_core import gapic_v1
.nox/core_deps_from_source-protobuf_implementation-upb/lib/python3.14/site-packages/google/api_core/gapic_v1/__init__.py:18: in 
    from google.api_core.gapic_v1 import method
.nox/core_deps_from_source-protobuf_implementation-upb/lib/python3.14/site-packages/google/api_core/gapic_v1/method.py:24: in 
    from google.api_core import grpc_helpers
.nox/core_deps_from_source-protobuf_implementation-upb/lib/python3.14/site-packages/google/api_core/grpc_helpers.py:23: in 
    import google.auth.transport.grpc
.nox/core_deps_from_source-protobuf_implementation-upb/lib/python3.14/site-packages/google/auth/transport/grpc.py:23: in 
    from google.oauth2 import service_account
.nox/core_deps_from_source-protobuf_implementation-upb/lib/python3.14/site-packages/google/oauth2/service_account.py:78: in 
    from google.auth import _service_account_info
.nox/core_deps_from_source-protobuf_implementation-upb/lib/python3.14/site-packages/google/auth/_service_account_info.py:20: in 
    from google.auth import crypt
.nox/core_deps_from_source-protobuf_implementation-upb/lib/python3.14/site-packages/google/auth/crypt/__init__.py:41: in 
    from google.auth.crypt import es
.nox/core_deps_from_source-protobuf_implementation-upb/lib/python3.14/site-packages/google/auth/crypt/es.py:21: in 
    import cryptography.exceptions
E   ModuleNotFoundError: No module named 'cryptography'
```

See https://github.com/googleapis/gapic-generator-python/pull/2527 for more details