### PR TITLE
chore(librarian): update gapic-generator to 1.30.5

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator==1.30.4 # Add cryptography to constraints file https://github.com/googleapis/gapic-generator-python/pull/2527
+gapic-generator==1.30.5 # Fix mypy issue https://github.com/googleapis/gapic-generator-python/pull/2536
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
This PR is needed to address the following failure in PR https://github.com/googleapis/google-cloud-python/pull/15458 when attempting to enable the `mypy` presubmit.


```
.nox/mypy-3-14/lib/python3.14/site-packages/google/cloud/compute_v1beta/services/wire_groups/transports/base.py:88: error: Name "Any" is not defined  [name-defined]
.nox/mypy-3-14/lib/python3.14/site-packages/google/cloud/compute_v1beta/services/wire_groups/transports/base.py:88: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Any")
.nox/mypy-3-14/lib/python3.14/site-packages/google/cloud/compute_v1beta/services/vpn_tunnels/transports/base.py:88: error: Name "Any" is not defined  [name-defined]
```

See https://github.com/googleapis/gapic-generator-python/pull/2536 for more details
