### PR TITLE
docs: fix formatting for BgpPeerStatus uptime in edgenetwork

### DIFF
--- a/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/resources.py
+++ b/packages/google-cloud-edgenetwork/google/cloud/edgenetwork_v1/types/resources.py
@@ -1045,8 +1045,7 @@ class RouterStatus(proto.Message):
                 Time this session has been up.
                 Format:
 
-                14 years, 51 weeks, 6 days, 23 hours, 59
-                minutes, 59 seconds
+                14 years, 51 weeks, 6 days, 23 hours, 59 minutes, 59 seconds
             uptime_seconds (int):
                 Time this session has been up, in seconds.
             prefix_counter (google.cloud.edgenetwork_v1.types.RouterStatus.PrefixCounter):


### PR DESCRIPTION
This PR fixes a formatting error in the BgpPeerStatus docstring within edgenetwork.

By correcting the line break in the uptime attribute, we can move toward removing the corresponding post-processing hack in doc-formatting.yaml. Part of #15478.