### PR TITLE
fix: fix mypy

### DIFF
--- a/.librarian/generator-input/client-post-processing/unique-grafeas-client.yaml
+++ b/.librarian/generator-input/client-post-processing/unique-grafeas-client.yaml
@@ -1957,13 +1957,13 @@ replacements:
           def __init__(
               self,
               *,
-              transport: Union[str, GrafeasTransport] = None,
+              transport: Optional[Union[str, GrafeasTransport]] = None,
               credentials: Optional[ga_credentials.Credentials] = None,
           ) -> None:
               """Instantiate the grafeas client.
 
               Args:
-                  transport (Union[str, ~.GrafeasTransport]): The
+                  transport (Optional[Union[str, ~.GrafeasTransport]]): The
                       transport to use.
                   credentials (Optional[google.auth.credentials.Credentials]): The
                       authorization credentials to attach to requests. These

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/client.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/client.py
@@ -359,13 +359,13 @@ class GrafeasClient(metaclass=GrafeasClientMeta):
     def __init__(
         self,
         *,
-        transport: Union[str, GrafeasTransport] = None,
+        transport: Optional[Union[str, GrafeasTransport]] = None,
         credentials: Optional[ga_credentials.Credentials] = None,
     ) -> None:
         """Instantiate the grafeas client.
 
         Args:
-            transport (Union[str, ~.GrafeasTransport]): The
+            transport (Optional[Union[str, ~.GrafeasTransport]]): The
                 transport to use.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These


### PR DESCRIPTION
Towards https://github.com/googleapis/google-cloud-python/issues/15104

This is needed to unblock https://github.com/googleapis/google-cloud-python/pull/15457 . 

See follow up issue https://github.com/googleapis/proto-plus-python/issues/558 for the `prerelease` presubmit failure.

See the following mypy failure for `grafeas`

```
2026-01-16T22:02:28.7158467Z grafeas/grafeas_v1/services/grafeas/client.py:362: error: Incompatible default for argument "transport" (default has type "None", argument has type "str | GrafeasTransport") 
```