### PR TITLE
chore(librarian): update gapic-generator to 1.30.6

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator==1.30.5 # Fix mypy issue https://github.com/googleapis/gapic-generator-python/pull/2536
+gapic-generator==1.30.6 # Fix incorrect REST serialization https://github.com/googleapis/gapic-generator-python/pull/2549
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
This PR is needed to address the issue in https://github.com/googleapis/gapic-generator-python/issues/2548.

See https://github.com/googleapis/gapic-generator-python/pull/2549 for more details. The release notes and changes for generated client libraries will be added in a separate PR.
