### PR TITLE
chore: allow cloud-sdk-librarian-team to approve all generated changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # Default owner for all directories not owned by others
 *                                             @googleapis/cloud-sdk-python-team @googleapis/cloud-sdk-librarian-team
 
-/packages/google-cloud-bigquery-storage/      @googleapis/api-bigquery
+/packages/google-cloud-bigquery-storage/      @googleapis/api-bigquery @googleapis/cloud-sdk-librarian-team


### PR DESCRIPTION
This PR unblocks approval for https://github.com/googleapis/google-cloud-python/pull/15527 which was created automatically.