### PR TITLE
chore(librarian): fix typo

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -209,7 +209,7 @@ libraries:
     last_generated_commit: ""
     apis: []
     source_roots:
-      - packages/google-auth-httplib2/
+      - packages/google-auth-httplib2
     preserve_regex: []
     remove_regex: []
     tag_format: '{id}-v{version}'


### PR DESCRIPTION
Remove trailing `/` under source roots to ensure that changes in the root of `packages/google-auth-httplib2` trigger releases