### PR TITLE
chores: add .repo-metadata.json for google-cloud-vectorsearch

### DIFF
--- a/.librarian/generator-input/packages/google-cloud-vectorsearch/.repo-metadata.json
+++ b/.librarian/generator-input/packages/google-cloud-vectorsearch/.repo-metadata.json
@@ -3,7 +3,7 @@
   "api_id": "vectorsearch.googleapis.com",
   "api_shortname": "vectorsearch",
   "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-vectorsearch/latest",
-  "default_version": "v1beta",
+  "default_version": "v1",
   "distribution_name": "google-cloud-vectorsearch",
   "issue_tracker": "https://issuetracker.google.com/issues/new?component=1899904",
   "language": "python",


### PR DESCRIPTION
Need to add the file before generating due to the following error:

```
LIBRARIAN_GITHUB_TOKEN=$(gh auth token) legacylibrarian generate -api=google/cloud/vectorsearch/v1 -library=google-cloud-vectorsearch -push
go: github.com/googleapis/librarian@v0.8.0 requires go >= 1.25.5; switching to go1.25.7
time=2026-02-18T01:01:32.302Z level=INFO msg="temporary working directory" dir=/tmp/librarian-1186255432
time=2026-02-18T01:01:32.302Z level=INFO msg="repo not specified, using current working directory as repo root" path=/usr/local/google/home/lingqinggan/temp/google-cloud-python
time=2026-02-18T01:01:32.302Z level=INFO msg="opening repository" dir=/usr/local/google/home/lingqinggan/temp/google-cloud-python
time=2026-02-18T01:01:39.242Z level=ERROR msg="librarian command failed" err="/usr/local/google/home/lingqinggan/temp/google-cloud-python repo must be clean"
exit status 1
```