### PR TITLE
chore(librarian): update gapic-generator to 1.30.9

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator==1.30.8 # fix mypy issue for __func__ type https://github.com/googleapis/gapic-generator-python/pull/2562
+gapic-generator==1.30.9 # update repo location for core deps https://github.com/googleapis/gapic-generator-python/pull/2566
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
This PR is needed to update the `core_deps_from_source` nox session to point to the new location for `google-api-core` in the monorepo

https://github.com/googleapis/google-cloud-python/tree/main/packages/google-api-core

https://github.com/googleapis/google-cloud-python/blob/edd2b7ae39899124747ff62769287f4458387e0c/packages/google-apps-meet/noxfile.py#L600

See https://github.com/googleapis/gapic-generator-python/pull/2566