### PR TITLE
chore: replace api-bigquery with bigquery-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # Default owner for all directories not owned by others
 *                                             @googleapis/cloud-sdk-python-team @googleapis/cloud-sdk-librarian-team
 
-/packages/google-cloud-bigquery-storage/      @googleapis/api-bigquery @googleapis/cloud-sdk-librarian-team
+/packages/google-cloud-bigquery-storage/      @googleapis/bigquery-team @googleapis/cloud-sdk-librarian-team


### PR DESCRIPTION
This PR replaces the old api-bigquery team with bigquery-team.

b/478003109