### PR TITLE
chore: update system.sh with firestore creds.json path

### DIFF
--- a/.kokoro/system.sh
+++ b/.kokoro/system.sh
@@ -21,6 +21,9 @@ set -eo pipefail
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 
+# Setup firestore account credentials
+export FIRESTORE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/firebase-credentials.json
+
 # Setup service account credentials.
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/service-account.json
 


### PR DESCRIPTION
This is a blocker for the migration of firestore to this repo. Firestore needs access to a project that has firestore native DBs, which precise-truck-742 does not explicitly have.

Fixes failing tests in https://github.com/googleapis/google-cloud-python/pull/15590 🦕