### PR TITLE
chore(librarian): update configuration for google-cloud-firestore

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1770,12 +1770,12 @@ libraries:
     version: 2.23.0
     last_generated_commit: d420134ab324c0cbe0f4ae06ad9697dac77f26ad
     apis:
-      - path: google/firestore/v1
-        service_config: firestore_v1.yaml
       - path: google/firestore/admin/v1
         service_config: firestore_v1.yaml
       - path: google/firestore/bundle
         service_config: ""
+      - path: google/firestore/v1
+        service_config: firestore_v1.yaml
     source_roots:
       - packages/google-cloud-firestore
     preserve_regex:


### PR DESCRIPTION
Generation for `google-cloud-firestore` failed in https://github.com/googleapis/google-cloud-python/pull/16023 because of failed check that was added in https://github.com/googleapis/google-cloud-python/pull/14441. The library had an incorrect distribution name in `setup.py`. The generation process for google-cloud-python packages with multiple API versions/sub-packages relies on the order of entries in the apis list. Since each API path generates a setup.py and the last one processed takes precedence, the previous ordering caused the package to be incorrectly named google-cloud-firestore-admin instead of the expected google-cloud-firestore.

This PR moves google/firestore/v1 to the bottom of the apis list, resulting in the correct package name in the generated setup.py.

See related issue https://github.com/googleapis/librarian/issues/4205