### PR TITLE
chore: librarian generate pull request: 20260304T223823Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1768,7 +1768,7 @@ libraries:
     tag_format: '{id}-v{version}'
   - id: google-cloud-firestore
     version: 2.23.0
-    last_generated_commit: d420134ab324c0cbe0f4ae06ad9697dac77f26ad
+    last_generated_commit: 572d5d51926dfa9e7509e12ec61e98ce19650f7c
     apis:
       - path: google/firestore/admin/v1
         service_config: firestore_v1.yaml

--- a/packages/google-cloud-firestore/.coveragerc
+++ b/packages/google-cloud-firestore/.coveragerc
@@ -4,8 +4,8 @@ branch = True
 [report]
 show_missing = True
 omit =
-    google/cloud/firestore_admin/__init__.py
-    google/cloud/firestore_admin/gapic_version.py
+    google/cloud/firestore/__init__.py
+    google/cloud/firestore/gapic_version.py
 exclude_lines =
     # Re-enable the standard pragma
     pragma: NO COVER

--- a/packages/google-cloud-firestore/docs/conf.py
+++ b/packages/google-cloud-firestore/docs/conf.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
-# google-cloud-firestore-admin documentation build configuration file
+# google-cloud-firestore documentation build configuration file
 #
 # This file is execfile()d with the current directory set to its
 # containing dir.
@@ -82,7 +82,7 @@ source_suffix = [".rst", ".md"]
 root_doc = "index"
 
 # General information about the project.
-project = "google-cloud-firestore-admin"
+project = "google-cloud-firestore"
 copyright = "2025, Google, LLC"
 author = "Google APIs"
 
@@ -160,7 +160,7 @@ html_theme = "alabaster"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "description": "Google Cloud Client Libraries for google-cloud-firestore-admin",
+    "description": "Google Cloud Client Libraries for google-cloud-firestore",
     "github_user": "googleapis",
     "github_repo": "google-cloud-python",
     "github_banner": True,
@@ -254,7 +254,7 @@ html_static_path = ["_static"]
 # html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = "google-cloud-firestore-admin-doc"
+htmlhelp_basename = "google-cloud-firestore-doc"
 
 # -- Options for warnings ------------------------------------------------------
 
@@ -287,8 +287,8 @@ latex_elements = {
 latex_documents = [
     (
         root_doc,
-        "google-cloud-firestore-admin.tex",
-        "google-cloud-firestore-admin Documentation",
+        "google-cloud-firestore.tex",
+        "google-cloud-firestore Documentation",
         author,
         "manual",
     )
@@ -322,8 +322,8 @@ latex_documents = [
 man_pages = [
     (
         root_doc,
-        "google-cloud-firestore-admin",
-        "google-cloud-firestore-admin Documentation",
+        "google-cloud-firestore",
+        "google-cloud-firestore Documentation",
         [author],
         1,
     )
@@ -341,11 +341,11 @@ man_pages = [
 texinfo_documents = [
     (
         root_doc,
-        "google-cloud-firestore-admin",
-        "google-cloud-firestore-admin Documentation",
+        "google-cloud-firestore",
+        "google-cloud-firestore Documentation",
         author,
-        "google-cloud-firestore-admin",
-        "google-cloud-firestore-admin Library",
+        "google-cloud-firestore",
+        "google-cloud-firestore Library",
         "APIs",
     )
 ]

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/base.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/base.py
@@ -218,7 +218,6 @@ class FirestoreTransport(abc.ABC):
                     predicate=retries.if_exception_type(
                         core_exceptions.DeadlineExceeded,
                         core_exceptions.InternalServerError,
-                        core_exceptions.ResourceExhausted,
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=300.0,
@@ -284,7 +283,6 @@ class FirestoreTransport(abc.ABC):
                     predicate=retries.if_exception_type(
                         core_exceptions.DeadlineExceeded,
                         core_exceptions.InternalServerError,
-                        core_exceptions.ResourceExhausted,
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=300.0,
@@ -301,7 +299,6 @@ class FirestoreTransport(abc.ABC):
                     predicate=retries.if_exception_type(
                         core_exceptions.DeadlineExceeded,
                         core_exceptions.InternalServerError,
-                        core_exceptions.ResourceExhausted,
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=300.0,
@@ -318,7 +315,6 @@ class FirestoreTransport(abc.ABC):
                     predicate=retries.if_exception_type(
                         core_exceptions.DeadlineExceeded,
                         core_exceptions.InternalServerError,
-                        core_exceptions.ResourceExhausted,
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=300.0,
@@ -335,7 +331,6 @@ class FirestoreTransport(abc.ABC):
                     predicate=retries.if_exception_type(
                         core_exceptions.DeadlineExceeded,
                         core_exceptions.InternalServerError,
-                        core_exceptions.ResourceExhausted,
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=300.0,

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/services/firestore/transports/grpc_asyncio.py
@@ -916,7 +916,6 @@ class FirestoreGrpcAsyncIOTransport(FirestoreTransport):
                     predicate=retries.if_exception_type(
                         core_exceptions.DeadlineExceeded,
                         core_exceptions.InternalServerError,
-                        core_exceptions.ResourceExhausted,
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=300.0,
@@ -982,7 +981,6 @@ class FirestoreGrpcAsyncIOTransport(FirestoreTransport):
                     predicate=retries.if_exception_type(
                         core_exceptions.DeadlineExceeded,
                         core_exceptions.InternalServerError,
-                        core_exceptions.ResourceExhausted,
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=300.0,
@@ -999,7 +997,6 @@ class FirestoreGrpcAsyncIOTransport(FirestoreTransport):
                     predicate=retries.if_exception_type(
                         core_exceptions.DeadlineExceeded,
                         core_exceptions.InternalServerError,
-                        core_exceptions.ResourceExhausted,
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=300.0,
@@ -1016,7 +1013,6 @@ class FirestoreGrpcAsyncIOTransport(FirestoreTransport):
                     predicate=retries.if_exception_type(
                         core_exceptions.DeadlineExceeded,
                         core_exceptions.InternalServerError,
-                        core_exceptions.ResourceExhausted,
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=300.0,
@@ -1033,7 +1029,6 @@ class FirestoreGrpcAsyncIOTransport(FirestoreTransport):
                     predicate=retries.if_exception_type(
                         core_exceptions.DeadlineExceeded,
                         core_exceptions.InternalServerError,
-                        core_exceptions.ResourceExhausted,
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=300.0,

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/types/document.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/types/document.py
@@ -199,6 +199,14 @@ class Value(proto.Message):
             - Not allowed to be used when writing documents.
 
             This field is a member of `oneof`_ ``value_type``.
+        variable_reference_value (str):
+            Pointer to a variable defined elsewhere in a pipeline.
+
+            Unlike ``field_reference_value`` which references a field
+            within a document, this refers to a variable, defined in a
+            separate namespace than the fields of a document.
+
+            This field is a member of `oneof`_ ``value_type``.
         function_value (google.cloud.firestore_v1.types.Function):
             A value that represents an unevaluated expression.
 
@@ -280,6 +288,11 @@ class Value(proto.Message):
     field_reference_value: str = proto.Field(
         proto.STRING,
         number=19,
+        oneof="value_type",
+    )
+    variable_reference_value: str = proto.Field(
+        proto.STRING,
+        number=22,
         oneof="value_type",
     )
     function_value: "Function" = proto.Field(

--- a/packages/google-cloud-firestore/noxfile.py
+++ b/packages/google-cloud-firestore/noxfile.py
@@ -51,7 +51,7 @@ PREVIEW_PYTHON_VERSION = "3.14"
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
-PACKAGE_NAME = "google-cloud-firestore-admin"
+PACKAGE_NAME = "google-cloud-firestore"
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",

--- a/packages/google-cloud-firestore/setup.py
+++ b/packages/google-cloud-firestore/setup.py
@@ -21,16 +21,14 @@ import setuptools  # type: ignore
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 
-name = "google-cloud-firestore-admin"
+name = "google-cloud-firestore"
 
 
-description = "Google Cloud Firestore Admin API client library"
+description = "Google Cloud Firestore API client library"
 
 version = None
 
-with open(
-    os.path.join(package_root, "google/cloud/firestore_admin/gapic_version.py")
-) as fp:
+with open(os.path.join(package_root, "google/cloud/firestore/gapic_version.py")) as fp:
     version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
     assert len(version_candidates) == 1
     version = version_candidates[0]
@@ -53,7 +51,7 @@ dependencies = [
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
 extras = {}
-url = "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-firestore-admin"
+url = "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-firestore"
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
PR created by the Librarian CLI to generate Cloud Client Libraries code from protos.

BEGIN_COMMIT

BEGIN_NESTED_COMMIT
feat: expose the variable definition in the Cloud Firestore API


PiperOrigin-RevId: 877535984
Library-IDs: google-cloud-firestore
Source-link: [googleapis/googleapis@1ccd68a0](https://github.com/googleapis/googleapis/commit/1ccd68a0)
END_NESTED_COMMIT

BEGIN_NESTED_COMMIT
chore: Firestore.executePipeline to not retry on `RESOURCE_EXHAUSTED`


PiperOrigin-RevId: 877535984
Library-IDs: google-cloud-firestore
Source-link: [googleapis/googleapis@1ccd68a0](https://github.com/googleapis/googleapis/commit/1ccd68a0)
END_NESTED_COMMIT

END_COMMIT

This pull request is generated with proto changes between
[googleapis/googleapis@d420134a](https://github.com/googleapis/googleapis/commit/d420134ab324c0cbe0f4ae06ad9697dac77f26ad)
(exclusive) and
[googleapis/googleapis@1ccd68a0](https://github.com/googleapis/googleapis/commit/1ccd68a09ccd14f82d260a8edb96878027295675)
(inclusive).

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:160860d189ff1c2f7515638478823712fa5b243e27ccc33a2728669fa1e2ed0c