### PR TITLE
feat: add ECS container credentials support for AWS workload identity federation

### DIFF
--- a/packages/google-auth/google/auth/aws.py
+++ b/packages/google-auth/google/auth/aws.py
@@ -43,6 +43,7 @@ from dataclasses import dataclass
 import hashlib
 import hmac
 import http.client as http_client
+import ipaddress
 import json
 import os
 import posixpath
@@ -71,6 +72,10 @@ _DEFAULT_AWS_REGIONAL_CREDENTIAL_VERIFICATION_URL = (
 )
 # IMDSV2 session token lifetime. This is set to a low value because the session token is used immediately.
 _IMDSV2_SESSION_TOKEN_TTL_SECONDS = "300"
+# Base URL for ECS container credentials endpoint (relative URI).
+_ECS_CONTAINER_CREDENTIALS_BASE_URL = "http://169.254.170.2"
+# Known ECS metadata IPs that are allowed without an authorization token.
+_ALLOWED_CONTAINER_METADATA_IPS = frozenset(["169.254.170.2", "169.254.170.23"])
 
 
 class RequestSigner(object):
@@ -433,6 +438,11 @@ class _DefaultAwsSecurityCredentialsSupplier(AwsSecurityCredentialsSupplier):
                 env_aws_access_key_id, env_aws_secret_access_key, env_aws_session_token
             )
 
+        # Check for ECS container credentials before falling back to IMDS.
+        ecs_credentials = self._get_ecs_security_credentials(request)
+        if ecs_credentials is not None:
+            return ecs_credentials
+
         imdsv2_session_token = self._get_imdsv2_session_token(request)
         role_name = self._get_metadata_role_name(request, imdsv2_session_token)
 
@@ -485,6 +495,87 @@ class _DefaultAwsSecurityCredentialsSupplier(AwsSecurityCredentialsSupplier):
         # This endpoint will return the region in format: us-east-2b.
         # Only the us-east-2 part should be used.
         return response_body[:-1]
+
+    def _get_ecs_security_credentials(self, request):
+        """Retrieves AWS security credentials from the ECS container credentials
+        endpoint if available.
+
+        Args:
+            request (google.auth.transport.Request): A callable used to make
+                HTTP requests.
+
+        Returns:
+            Optional[AwsSecurityCredentials]: The AWS security credentials from
+                ECS, or None if ECS environment variables are not set.
+
+        Raises:
+            google.auth.exceptions.RefreshError: If an error occurs while
+                retrieving credentials from the ECS endpoint.
+        """
+        # Check full URI first, then relative URI.
+        full_uri = os.environ.get(
+            environment_vars.AWS_CONTAINER_CREDENTIALS_FULL_URI
+        )
+        relative_uri = os.environ.get(
+            environment_vars.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+        )
+
+        if full_uri:
+            url = full_uri
+            # Validate the full URI host for security.
+            parsed = urllib.parse.urlparse(url)
+            hostname = parsed.hostname
+            try:
+                addr = ipaddress.ip_address(hostname)
+                is_allowed = addr.is_loopback or str(addr) in _ALLOWED_CONTAINER_METADATA_IPS
+            except ValueError:
+                # Not an IP address (e.g., a hostname). Treat as non-loopback.
+                is_allowed = False
+
+            if not is_allowed:
+                # Non-loopback, non-ECS IP requires an authorization token.
+                auth_token = os.environ.get(
+                    environment_vars.AWS_CONTAINER_AUTHORIZATION_TOKEN
+                )
+                if not auth_token:
+                    raise exceptions.RefreshError(
+                        "AWS_CONTAINER_CREDENTIALS_FULL_URI is set to a non-loopback "
+                        "address but AWS_CONTAINER_AUTHORIZATION_TOKEN is not set."
+                    )
+        elif relative_uri:
+            url = _ECS_CONTAINER_CREDENTIALS_BASE_URL + relative_uri
+        else:
+            return None
+
+        headers = {}
+        auth_token = os.environ.get(
+            environment_vars.AWS_CONTAINER_AUTHORIZATION_TOKEN
+        )
+        if auth_token:
+            headers["Authorization"] = auth_token
+
+        response = request(url=url, method="GET", headers=headers or None)
+
+        response_body = (
+            response.data.decode("utf-8")
+            if hasattr(response.data, "decode")
+            else response.data
+        )
+
+        if response.status != http_client.OK:
+            raise exceptions.RefreshError(
+                "Unable to retrieve AWS security credentials from ECS: {}".format(
+                    response_body
+                )
+            )
+
+        credentials_response = json.loads(response_body)
+
+        return AwsSecurityCredentials(
+            credentials_response.get("AccessKeyId"),
+            credentials_response.get("SecretAccessKey"),
+            credentials_response.get("Token"),
+        )
 
     def _get_imdsv2_session_token(self, request):
         if request is not None and self._imdsv2_session_token_url is not None:

--- a/packages/google-auth/google/auth/environment_vars.py
+++ b/packages/google-auth/google/auth/environment_vars.py
@@ -105,6 +105,13 @@ AWS_SESSION_TOKEN = "AWS_SESSION_TOKEN"
 AWS_REGION = "AWS_REGION"
 AWS_DEFAULT_REGION = "AWS_DEFAULT_REGION"
 
+# AWS ECS container credentials environment variables.
+# These are used to retrieve temporary AWS credentials from the ECS container
+# credentials endpoint when running on AWS ECS.
+AWS_CONTAINER_CREDENTIALS_RELATIVE_URI = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
+AWS_CONTAINER_CREDENTIALS_FULL_URI = "AWS_CONTAINER_CREDENTIALS_FULL_URI"
+AWS_CONTAINER_AUTHORIZATION_TOKEN = "AWS_CONTAINER_AUTHORIZATION_TOKEN"
+
 GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED = "GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED"
 """Environment variable controlling whether to enable trust boundary feature.
 The default value is false. Users have to explicitly set this value to true."""

--- a/packages/google-auth/tests/test_aws.py
+++ b/packages/google-auth/tests/test_aws.py
@@ -2456,3 +2456,256 @@ class TestCredentials(object):
         assert credentials.quota_project_id == QUOTA_PROJECT_ID
         assert credentials.scopes == SCOPES
         assert credentials.default_scopes == ["ignored"]
+
+    @mock.patch("google.auth._helpers.utcnow")
+    def test_retrieve_subject_token_success_ecs_relative_uri(
+        self, utcnow, monkeypatch
+    ):
+        monkeypatch.setenv(environment_vars.AWS_REGION, self.AWS_REGION)
+        monkeypatch.setenv(
+            environment_vars.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,
+            "/v2/credentials/role-id",
+        )
+        utcnow.return_value = datetime.datetime.strptime(
+            self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
+        )
+        # Mock the ECS credentials endpoint response.
+        ecs_response = mock.create_autospec(transport.Response, instance=True)
+        ecs_response.status = http_client.OK
+        ecs_response.data = json.dumps(
+            self.AWS_SECURITY_CREDENTIALS_RESPONSE
+        ).encode("utf-8")
+        request = mock.create_autospec(transport.Request)
+        request.side_effect = [ecs_response]
+
+        credentials = self.make_credentials(credential_source=self.CREDENTIAL_SOURCE)
+        subject_token = credentials.retrieve_subject_token(request)
+
+        assert subject_token == self.make_serialized_aws_signed_request(
+            aws.AwsSecurityCredentials(ACCESS_KEY_ID, SECRET_ACCESS_KEY, TOKEN)
+        )
+        # Assert ECS credentials request.
+        assert request.call_args_list[0][1]["url"] == (
+            "http://169.254.170.2/v2/credentials/role-id"
+        )
+        assert request.call_args_list[0][1]["method"] == "GET"
+
+    @mock.patch("google.auth._helpers.utcnow")
+    def test_retrieve_subject_token_success_ecs_full_uri_loopback(
+        self, utcnow, monkeypatch
+    ):
+        monkeypatch.setenv(environment_vars.AWS_REGION, self.AWS_REGION)
+        monkeypatch.setenv(
+            environment_vars.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+            "http://127.0.0.1/v2/credentials/role-id",
+        )
+        utcnow.return_value = datetime.datetime.strptime(
+            self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
+        )
+        ecs_response = mock.create_autospec(transport.Response, instance=True)
+        ecs_response.status = http_client.OK
+        ecs_response.data = json.dumps(
+            self.AWS_SECURITY_CREDENTIALS_RESPONSE
+        ).encode("utf-8")
+        request = mock.create_autospec(transport.Request)
+        request.side_effect = [ecs_response]
+
+        credentials = self.make_credentials(credential_source=self.CREDENTIAL_SOURCE)
+        subject_token = credentials.retrieve_subject_token(request)
+
+        assert subject_token == self.make_serialized_aws_signed_request(
+            aws.AwsSecurityCredentials(ACCESS_KEY_ID, SECRET_ACCESS_KEY, TOKEN)
+        )
+        assert request.call_args_list[0][1]["url"] == (
+            "http://127.0.0.1/v2/credentials/role-id"
+        )
+
+    @mock.patch("google.auth._helpers.utcnow")
+    def test_retrieve_subject_token_success_ecs_full_uri_loopback_ipv6(
+        self, utcnow, monkeypatch
+    ):
+        monkeypatch.setenv(environment_vars.AWS_REGION, self.AWS_REGION)
+        monkeypatch.setenv(
+            environment_vars.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+            "http://[::1]/v2/credentials/role-id",
+        )
+        utcnow.return_value = datetime.datetime.strptime(
+            self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
+        )
+        ecs_response = mock.create_autospec(transport.Response, instance=True)
+        ecs_response.status = http_client.OK
+        ecs_response.data = json.dumps(
+            self.AWS_SECURITY_CREDENTIALS_RESPONSE
+        ).encode("utf-8")
+        request = mock.create_autospec(transport.Request)
+        request.side_effect = [ecs_response]
+
+        credentials = self.make_credentials(credential_source=self.CREDENTIAL_SOURCE)
+        subject_token = credentials.retrieve_subject_token(request)
+
+        assert subject_token == self.make_serialized_aws_signed_request(
+            aws.AwsSecurityCredentials(ACCESS_KEY_ID, SECRET_ACCESS_KEY, TOKEN)
+        )
+
+    @mock.patch("google.auth._helpers.utcnow")
+    def test_retrieve_subject_token_success_ecs_full_uri_with_auth_token(
+        self, utcnow, monkeypatch
+    ):
+        monkeypatch.setenv(environment_vars.AWS_REGION, self.AWS_REGION)
+        monkeypatch.setenv(
+            environment_vars.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+            "http://192.168.1.1/v2/credentials/role-id",
+        )
+        monkeypatch.setenv(
+            environment_vars.AWS_CONTAINER_AUTHORIZATION_TOKEN,
+            "my-auth-token",
+        )
+        utcnow.return_value = datetime.datetime.strptime(
+            self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
+        )
+        ecs_response = mock.create_autospec(transport.Response, instance=True)
+        ecs_response.status = http_client.OK
+        ecs_response.data = json.dumps(
+            self.AWS_SECURITY_CREDENTIALS_RESPONSE
+        ).encode("utf-8")
+        request = mock.create_autospec(transport.Request)
+        request.side_effect = [ecs_response]
+
+        credentials = self.make_credentials(credential_source=self.CREDENTIAL_SOURCE)
+        subject_token = credentials.retrieve_subject_token(request)
+
+        assert subject_token == self.make_serialized_aws_signed_request(
+            aws.AwsSecurityCredentials(ACCESS_KEY_ID, SECRET_ACCESS_KEY, TOKEN)
+        )
+        # Assert Authorization header was sent.
+        assert request.call_args_list[0][1]["headers"]["Authorization"] == "my-auth-token"
+
+    @mock.patch("google.auth._helpers.utcnow")
+    def test_retrieve_subject_token_ecs_full_uri_non_loopback_without_token_raises(
+        self, utcnow, monkeypatch
+    ):
+        monkeypatch.setenv(environment_vars.AWS_REGION, self.AWS_REGION)
+        monkeypatch.setenv(
+            environment_vars.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+            "http://192.168.1.1/v2/credentials/role-id",
+        )
+        utcnow.return_value = datetime.datetime.strptime(
+            self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
+        )
+        credentials = self.make_credentials(credential_source=self.CREDENTIAL_SOURCE)
+
+        with pytest.raises(exceptions.RefreshError) as exc_info:
+            credentials.retrieve_subject_token(None)
+
+        assert "AWS_CONTAINER_CREDENTIALS_FULL_URI" in str(exc_info.value)
+        assert "AWS_CONTAINER_AUTHORIZATION_TOKEN" in str(exc_info.value)
+
+    @mock.patch("google.auth._helpers.utcnow")
+    def test_retrieve_subject_token_ecs_full_uri_takes_precedence_over_relative(
+        self, utcnow, monkeypatch
+    ):
+        monkeypatch.setenv(environment_vars.AWS_REGION, self.AWS_REGION)
+        monkeypatch.setenv(
+            environment_vars.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+            "http://127.0.0.1/full-uri-path",
+        )
+        monkeypatch.setenv(
+            environment_vars.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,
+            "/relative-uri-path",
+        )
+        utcnow.return_value = datetime.datetime.strptime(
+            self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
+        )
+        ecs_response = mock.create_autospec(transport.Response, instance=True)
+        ecs_response.status = http_client.OK
+        ecs_response.data = json.dumps(
+            self.AWS_SECURITY_CREDENTIALS_RESPONSE
+        ).encode("utf-8")
+        request = mock.create_autospec(transport.Request)
+        request.side_effect = [ecs_response]
+
+        credentials = self.make_credentials(credential_source=self.CREDENTIAL_SOURCE)
+        credentials.retrieve_subject_token(request)
+
+        # Full URI should be used, not relative URI.
+        assert request.call_args_list[0][1]["url"] == "http://127.0.0.1/full-uri-path"
+
+    @mock.patch("google.auth._helpers.utcnow")
+    def test_retrieve_subject_token_ecs_takes_precedence_over_imds(
+        self, utcnow, monkeypatch
+    ):
+        monkeypatch.setenv(environment_vars.AWS_REGION, self.AWS_REGION)
+        monkeypatch.setenv(
+            environment_vars.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,
+            "/v2/credentials/role-id",
+        )
+        utcnow.return_value = datetime.datetime.strptime(
+            self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
+        )
+        ecs_response = mock.create_autospec(transport.Response, instance=True)
+        ecs_response.status = http_client.OK
+        ecs_response.data = json.dumps(
+            self.AWS_SECURITY_CREDENTIALS_RESPONSE
+        ).encode("utf-8")
+        request = mock.create_autospec(transport.Request)
+        request.side_effect = [ecs_response]
+
+        credentials = self.make_credentials(credential_source=self.CREDENTIAL_SOURCE)
+        subject_token = credentials.retrieve_subject_token(request)
+
+        assert subject_token == self.make_serialized_aws_signed_request(
+            aws.AwsSecurityCredentials(ACCESS_KEY_ID, SECRET_ACCESS_KEY, TOKEN)
+        )
+        # Only 1 request (ECS), no IMDS requests.
+        assert len(request.call_args_list) == 1
+
+    @mock.patch("google.auth._helpers.utcnow")
+    def test_retrieve_subject_token_env_vars_take_precedence_over_ecs(
+        self, utcnow, monkeypatch
+    ):
+        monkeypatch.setenv(environment_vars.AWS_ACCESS_KEY_ID, ACCESS_KEY_ID)
+        monkeypatch.setenv(environment_vars.AWS_SECRET_ACCESS_KEY, SECRET_ACCESS_KEY)
+        monkeypatch.setenv(environment_vars.AWS_SESSION_TOKEN, TOKEN)
+        monkeypatch.setenv(environment_vars.AWS_REGION, self.AWS_REGION)
+        monkeypatch.setenv(
+            environment_vars.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,
+            "/v2/credentials/role-id",
+        )
+        utcnow.return_value = datetime.datetime.strptime(
+            self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
+        )
+        credentials = self.make_credentials(credential_source=self.CREDENTIAL_SOURCE)
+
+        # No request mock needed - env vars should be used directly.
+        subject_token = credentials.retrieve_subject_token(None)
+
+        assert subject_token == self.make_serialized_aws_signed_request(
+            aws.AwsSecurityCredentials(ACCESS_KEY_ID, SECRET_ACCESS_KEY, TOKEN)
+        )
+
+    @mock.patch("google.auth._helpers.utcnow")
+    def test_retrieve_subject_token_ecs_endpoint_error(
+        self, utcnow, monkeypatch
+    ):
+        monkeypatch.setenv(environment_vars.AWS_REGION, self.AWS_REGION)
+        monkeypatch.setenv(
+            environment_vars.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,
+            "/v2/credentials/role-id",
+        )
+        utcnow.return_value = datetime.datetime.strptime(
+            self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
+        )
+        ecs_response = mock.create_autospec(transport.Response, instance=True)
+        ecs_response.status = http_client.UNAUTHORIZED
+        ecs_response.data = b"Unauthorized"
+        request = mock.create_autospec(transport.Request)
+        request.side_effect = [ecs_response]
+
+        credentials = self.make_credentials(credential_source=self.CREDENTIAL_SOURCE)
+
+        with pytest.raises(exceptions.RefreshError) as exc_info:
+            credentials.retrieve_subject_token(request)
+
+        assert "Unable to retrieve AWS security credentials from ECS" in str(
+            exc_info.value
+        )


### PR DESCRIPTION
## Summary
- Add support for AWS ECS container credentials endpoint in `_DefaultAwsSecurityCredentialsSupplier`, which previously only supported EC2 IMDS
- Credential resolution order: static env vars → ECS container credentials → EC2 IMDS
- Full URI validation follows AWS SDK behavior (loopback/ECS metadata IPs allowed without token; other hosts require `AWS_CONTAINER_AUTHORIZATION_TOKEN`)

Fixes #15203
Fixes #15212

## Changes
- `packages/google-auth/google/auth/aws.py`: Add ECS credential fetching logic
- `packages/google-auth/google/auth/environment_vars.py`: Add ECS-related environment variable constants
- `packages/google-auth/tests/test_aws.py`: Add comprehensive tests for ECS credential support

## Test plan
- [x] Unit tests added for ECS container credentials (relative URI, full URI, token auth, validation)
- [ ] Verify CI passes