### PR TITLE
fix(auth): fix request session error 

### DIFF
--- a/packages/google-auth/google/auth/compute_engine/_metadata.py
+++ b/packages/google-auth/google/auth/compute_engine/_metadata.py
@@ -166,16 +166,17 @@ def _prepare_request_for_mds(request, use_mtls=False) -> None:
 
     Args:
         request (google.auth.transport.Request): A callable used to make
-            HTTP requests. If mTLS is enabled, the request will have the mTLS
-            adapter mounted. Otherwise, there will be no change.
+            HTTP requests. If mTLS is enabled, and the request supports sessions,
+            the request will have the mTLS adapter mounted. Otherwise, there
+            will be no change.
         use_mtls (bool): Whether to use mTLS for the request.
 
 
     """
-    # Only modify the request if mTLS is enabled.
-    if use_mtls:
+    # Only modify the request if mTLS is enabled, and request supports sessions.
+    if use_mtls and hasattr(request, "session"):
         # Ensure the request has a session to mount the adapter to.
-        if not getattr(request, "session", None):
+        if not request.session:
             request.session = requests.Session()
 
         adapter = _mtls.MdsMtlsAdapter()

--- a/packages/google-auth/tests/compute_engine/test__metadata.py
+++ b/packages/google-auth/tests/compute_engine/test__metadata.py
@@ -958,14 +958,14 @@ def test__prepare_request_for_mds_mtls_no_session(mock_mds_mtls_adapter):
 
 
 @mock.patch("google.auth.compute_engine._mtls.MdsMtlsAdapter")
-def test__prepare_request_for_mds_mtls_attribute_error(mock_mds_mtls_adapter):
-    # Regression test for https://github.com/googleapis/google-cloud-python/issues/16035
+def test__prepare_request_for_mds_mtls_http_request(mock_mds_mtls_adapter):
+    """
+    http requests should be ignored.
+    Regression test for https://github.com/googleapis/google-cloud-python/issues/16035
+    """
     from google.auth.transport import _http_client
 
     request = _http_client.Request()
-    with mock.patch("requests.Session") as mock_session_class:
-        _metadata._prepare_request_for_mds(request, use_mtls=True)
+    _metadata._prepare_request_for_mds(request, use_mtls=True)
 
-        mock_session_class.assert_called_once()
-        mock_mds_mtls_adapter.assert_called_once()
-        assert request.session.mount.call_count == len(_metadata._GCE_DEFAULT_MDS_HOSTS)
+    assert mock_mds_mtls_adapter.call_count == 0


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-python/issues/16035

only google.auth.transport.**requests**.Request objects have a session attached. Other Request subclasses don't so they raise an error when mts is enabled.

This PR ignores unsupported request types, instead of raising an exception

Thanks @sakshamgoyal-01 for the detailed bug report!