### PR TITLE
chore(librarian): update gapic-generator to 1.30.11

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator==1.30.10 # Allow protobuf 7.x https://github.com/googleapis/gapic-generator-python/pull/2575
+gapic-generator==1.30.11 # Downgrade mypy https://github.com/googleapis/gapic-generator-python/pull/2580
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
This is needed to resolve https://github.com/googleapis/gapic-generator-python/issues/2579 and unblock https://github.com/googleapis/google-cloud-python/pull/16063