### PR TITLE
chore: remove hardcoded maintainer for google-cloud-bigquery-storage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,3 @@
 
 # Default owner for all directories not owned by others
 *                                             @googleapis/cloud-sdk-python-team @googleapis/cloud-sdk-librarian-team
-
-/packages/google-cloud-bigquery-storage/      @googleapis/bigquery-team @googleapis/cloud-sdk-librarian-team


### PR DESCRIPTION
I created https://github.com/googleapis/google-cloud-python/issues/16081 to follow up on ensuring that teams have permissions to maintain to handwritten libraries