### PR TITLE
docs: Update changelog entry for release

### DIFF
--- a/packages/google-cloud-vectorsearch/CHANGELOG.md
+++ b/packages/google-cloud-vectorsearch/CHANGELOG.md
@@ -16,7 +16,6 @@
 
 * Removed field DenseScannParams from SearchHint ([1b21f1285f0f4349e9521e6dbaa96e6524cc378a](https://github.com/googleapis/google-cloud-python/commit/1b21f1285f0f4349e9521e6dbaa96e6524cc378a))
 
-
 ## [0.6.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-vectorsearch-v0.5.0...google-cloud-vectorsearch-v0.6.0) (2026-03-05)
 
 


### PR DESCRIPTION
The last release for `google-cloud-vectorsearch` did not include detailed release notes due to a process issue described in https://github.com/googleapis/librarian/issues/4542. In PR https://github.com/googleapis/google-cloud-python/pull/16053, we only see `generate libraries` instead of the contents in https://github.com/googleapis/google-cloud-python/pull/16052#issue-4045971701. This PR updates the release notes to include detailed information for release 0.7.0.