### PR TITLE
chore: Update single-library.git-migrate-history.sh to support git submodules

### DIFF
--- a/scripts/split_repo_migration/single-library.git-migrate-history.sh
+++ b/scripts/split_repo_migration/single-library.git-migrate-history.sh
@@ -142,7 +142,7 @@ echo "Success"
 popd # back to workdir
 
 # Do a diff between source code split repo and migrated code.
-git clone --recurse-submodules --recurse-submodules --recurse-submodules "git@github.com:${SOURCE_REPO}.git" source-repo-validation  # Not ideal to clone again.
+git clone --recurse-submodules "git@github.com:${SOURCE_REPO}.git" source-repo-validation  # Not ideal to clone again.
 find source-repo-validation -name .git -exec rm -rf {} +  # That folder is not needed for validation.
 
 DIFF_FILE="${WORKDIR}/diff.txt"


### PR DESCRIPTION
This PR includes a minor tweak to the migration scripts, specifically `scripts/split_repo_migration/single-library.git-migrate-history.sh`, to support migrating git submodules