### PR TITLE
chore(librarian): update gapic-generator to 1.30.13

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator==1.30.12 # https://github.com/googleapis/gapic-generator-python/releases/tag/v1.30.12
+gapic-generator==1.30.13 # https://github.com/googleapis/gapic-generator-python/releases/tag/v1.30.13
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
This is needed to unblock https://github.com/googleapis/google-cloud-python/pull/16094