### PR TITLE
chore: remove google-cloud-network-connectivity from state.yaml

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2451,24 +2451,6 @@ libraries:
     remove_regex:
       - packages/google-cloud-netapp/
     tag_format: '{id}-v{version}'
-  - id: google-cloud-network-connectivity
-    version: 2.13.0
-    last_generated_commit: d252e591a655910c3d1b581aadfb11e68c8ff294
-    apis:
-      - path: google/cloud/networkconnectivity/v1
-        service_config: networkconnectivity_v1.yaml
-      - path: google/cloud/networkconnectivity/v1alpha1
-        service_config: networkconnectivity_v1alpha1.yaml
-      - path: google/cloud/networkconnectivity/v1beta
-        service_config: networkconnectivity_v1beta.yaml
-    source_roots:
-      - packages/google-cloud-network-connectivity
-    preserve_regex:
-      - packages/google-cloud-network-connectivity/CHANGELOG.md
-      - docs/CHANGELOG.md
-    remove_regex:
-      - packages/google-cloud-network-connectivity/
-    tag_format: '{id}-v{version}'
   - id: google-cloud-network-management
     version: 1.33.0
     last_generated_commit: 6df3ecf4fd43b64826de6a477d1a535ec18b0d7c


### PR DESCRIPTION
Remove `google-cloud-network-connectivity` from the state.yaml file to avoid librarian automation from regenerating and releasing this package.

This package is currently not ready to be released. Wait for [cl/882798624](https://cl.corp.google.com/882798624).