### PR TITLE
chore: improve typing in api_core.exceptions

### DIFF
--- a/packages/google-api-core/google/api_core/exceptions.py
+++ b/packages/google-api-core/google/api_core/exceptions.py
@@ -23,7 +23,6 @@ from __future__ import unicode_literals
 
 import http.client
 from typing import Optional, Dict
-from typing import Union
 import warnings
 
 from google.rpc import error_details_pb2


### PR DESCRIPTION
GoogleApiCallError.grpc_status_code had no typing, so mypy will assume the value is always None

This PR adds the proper type annotation