### PR TITLE
chore: add documentai-toolbox to config.yaml

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -4,3 +4,8 @@ global_files_allowlist:
   # versions which are hardcoded in the file.
   - path: "CHANGELOG.md"
     permissions: "read-write"
+libraries:
+# libraries have "release_blocked: true" so that releases are
+# explicitly initiated
+  - id: "google-cloud-documentai-toolbox"
+    release_blocked: true


### PR DESCRIPTION
Unblock automated release by adding `google-cloud-documentai-toolbox` to `.librarian/config.yaml`.