### PR TITLE
chore: set generate_blocked to true for documentai-toolbox

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -9,3 +9,4 @@ libraries:
 # explicitly initiated
   - id: "google-cloud-documentai-toolbox"
     release_blocked: true
+    generate_blocked: true


### PR DESCRIPTION
This PR updates `.librarian/config.yaml` to set `generate_blocked` to true for `google-cloud-documentai-toolbox`. This will unblock generate for `google-cloud-documentai-toolbox`.