### PR TITLE
chore: remove documentai-toolbox from librarian automation

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1637,15 +1637,6 @@ libraries:
     remove_regex:
       - packages/google-cloud-documentai/
     tag_format: '{id}-v{version}'
-  - id: google-cloud-documentai-toolbox
-    version: 0.15.1-alpha
-    last_generated_commit: ""
-    apis: []
-    source_roots:
-      - packages/google-cloud-documentai-toolbox
-    preserve_regex: []
-    remove_regex: []
-    tag_format: '{id}-v{version}'
   - id: google-cloud-domains
     version: 1.12.0
     last_generated_commit: 3322511885371d2b2253f209ccc3aa60d4100cfd


### PR DESCRIPTION
`google-cloud-documentai-toolbox` is causing librarian automation to fail for `generate` and `release`. Temporarily removing it until we investigate the root cause.

Track https://github.com/googleapis/librarian/issues/4705. We'll add it once the linked issue is resolved.