### PR TITLE
chore: fix sqlalchemy-bigquery librarian config

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -4147,6 +4147,7 @@ libraries:
       - packages/sqlalchemy-bigquery
     preserve_regex: []
     remove_regex: []
+    tag_format: '{id}-v{version}'
   - id: sqlalchemy-spanner
     version: 1.17.2
     last_generated_commit: ""


### PR DESCRIPTION
Without the tag_format librarian was failing to find the tag for this library.

Internal bug: b/494886518