### PR TITLE
chore(librarian): unblock releases for google-cloud-documentai-toolbox

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -4,9 +4,3 @@ global_files_allowlist:
   # versions which are hardcoded in the file.
   - path: "CHANGELOG.md"
     permissions: "read-write"
-libraries:
-# libraries have "release_blocked: true" so that releases are
-# explicitly initiated
-  - id: "google-cloud-documentai-toolbox"
-    release_blocked: true
-    generate_blocked: true


### PR DESCRIPTION
I believe this should be unblocked now. We can revert this PR if we still encounter issues.