### PR TITLE
chore: librarian generate pull request: 20260325T142358Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1567,7 +1567,7 @@ libraries:
     tag_format: '{id}-v{version}'
   - id: google-cloud-discoveryengine
     version: 0.17.0
-    last_generated_commit: 256b575f6915282b20795c13414b21f2c0af65db
+    last_generated_commit: 59d5f2b46924714af627ac29ea6de78641a00835
     apis:
       - path: google/cloud/discoveryengine/v1
         service_config: discoveryengine_v1.yaml

--- a/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/search_service.py
+++ b/packages/google-cloud-discoveryengine/google/cloud/discoveryengine_v1beta/types/search_service.py
@@ -503,11 +503,17 @@ class SearchRequest(proto.Message):
                 [DataStore][google.cloud.discoveryengine.v1beta.DataStore],
                 such as
                 ``projects/{project}/locations/{location}/collections/{collection_id}/dataStores/{data_store_id}``.
+                The path must include the project number, project id is not
+                supported for this field.
             filter (str):
                 Optional. Filter specification to filter documents in the
                 data store specified by data_store field. For more
                 information on filtering, see
                 `Filtering <https://cloud.google.com/generative-ai-app-builder/docs/filter-search-metadata>`__
+            boost_spec (google.cloud.discoveryengine_v1beta.types.SearchRequest.BoostSpec):
+                Optional. Boost specification to boost certain documents.
+                For more information on boosting, see
+                `Boosting <https://cloud.google.com/generative-ai-app-builder/docs/boost-search-results>`__
         """
 
         data_store: str = proto.Field(
@@ -517,6 +523,11 @@ class SearchRequest(proto.Message):
         filter: str = proto.Field(
             proto.STRING,
             number=5,
+        )
+        boost_spec: "SearchRequest.BoostSpec" = proto.Field(
+            proto.MESSAGE,
+            number=6,
+            message="SearchRequest.BoostSpec",
         )
 
     class FacetSpec(proto.Message):

--- a/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1beta/test_evaluation_service.py
+++ b/packages/google-cloud-discoveryengine/tests/unit/gapic/discoveryengine_v1beta/test_evaluation_service.py
@@ -4677,7 +4677,29 @@ def test_create_evaluation_rest_call_success(request_type):
                 "offset": 647,
                 "one_box_page_size": 1792,
                 "data_store_specs": [
-                    {"data_store": "data_store_value", "filter": "filter_value"}
+                    {
+                        "data_store": "data_store_value",
+                        "filter": "filter_value",
+                        "boost_spec": {
+                            "condition_boost_specs": [
+                                {
+                                    "condition": "condition_value",
+                                    "boost": 0.551,
+                                    "boost_control_spec": {
+                                        "field_name": "field_name_value",
+                                        "attribute_type": 1,
+                                        "interpolation_type": 1,
+                                        "control_points": [
+                                            {
+                                                "attribute_value": "attribute_value_value",
+                                                "boost_amount": 0.1306,
+                                            }
+                                        ],
+                                    },
+                                }
+                            ]
+                        },
+                    }
                 ],
                 "filter": "filter_value",
                 "canonical_filter": "canonical_filter_value",
@@ -4717,25 +4739,7 @@ def test_create_evaluation_rest_call_success(request_type):
                         "enable_dynamic_position": True,
                     }
                 ],
-                "boost_spec": {
-                    "condition_boost_specs": [
-                        {
-                            "condition": "condition_value",
-                            "boost": 0.551,
-                            "boost_control_spec": {
-                                "field_name": "field_name_value",
-                                "attribute_type": 1,
-                                "interpolation_type": 1,
-                                "control_points": [
-                                    {
-                                        "attribute_value": "attribute_value_value",
-                                        "boost_amount": 0.1306,
-                                    }
-                                ],
-                            },
-                        }
-                    ]
-                },
+                "boost_spec": {},
                 "params": {},
                 "query_expansion_spec": {
                     "condition": 1,


### PR DESCRIPTION
PR created by the Librarian CLI to generate Cloud Client Libraries code from protos.

BEGIN_COMMIT

BEGIN_NESTED_COMMIT
feat: Update DataStoreSpec and add BoostSpec to SearchService


PiperOrigin-RevId: 886697454
Library-IDs: google-cloud-discoveryengine
Source-link: [googleapis/googleapis@7439b698](https://github.com/googleapis/googleapis/commit/7439b698)
END_NESTED_COMMIT

BEGIN_NESTED_COMMIT
docs: Clarify project number requirement for data_store field


PiperOrigin-RevId: 886697454
Library-IDs: google-cloud-discoveryengine
Source-link: [googleapis/googleapis@7439b698](https://github.com/googleapis/googleapis/commit/7439b698)
END_NESTED_COMMIT

END_COMMIT

This pull request is generated with proto changes between
[googleapis/googleapis@256b575f](https://github.com/googleapis/googleapis/commit/256b575f6915282b20795c13414b21f2c0af65db)
(exclusive) and
[googleapis/googleapis@7439b698](https://github.com/googleapis/googleapis/commit/7439b69835fbb2903d38a87a596ade15b2dafd8f)
(inclusive).

Librarian Version: v1.0.2-0.20260309131826-42ac5c451239
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c5699d10addd7c32f45569a3eddc624bf68731095922cf9db0fda5352f849bf5