### PR TITLE
chore(librarian): update synthtool SHA

### DIFF
--- a/.generator/Dockerfile
+++ b/.generator/Dockerfile
@@ -75,7 +75,7 @@ RUN tar -xvf pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -C pandoc-binary --stri
 # This needs to be a single command so that the git clone command is not cached
 RUN git clone https://github.com/googleapis/synthtool.git synthtool && \
     cd synthtool && \
-    git checkout afd7725f32d522a95e964884e0fba6d0d6b4cb6a
+    git checkout 96f416c959fbe8048200b6c16000de32b352902e
 
 # --- Final Stage ---
 # This stage creates the lightweight final image, copying only the


### PR DESCRIPTION
The source of truth for the "generated" `README` for client libraries currently lives at https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_mono_repo_library/README.rst

We recently dropped Python 3.7 and 3.8 in https://github.com/googleapis/google-cloud-python/pull/16150 and https://github.com/googleapis/google-cloud-python/pull/16102. 

The supported Python runtimes was recently updated to reflect this change in https://github.com/googleapis/synthtool/pull/2168 (commit https://github.com/googleapis/synthtool/commit/96f416c959fbe8048200b6c16000de32b352902e).

We need to update the synthtool commit in the python librarian Dockerfile to include the new README.