### PR TITLE
chore: fix missing heading in changelog

### DIFF
--- a/packages/google-cloud-documentai-toolbox/CHANGELOG.md
+++ b/packages/google-cloud-documentai-toolbox/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[PyPI History][1]
+
+[1]: https://pypi.org/project/google-cloud-documentai-toolbox/#history
+
 ## [0.15.1-alpha](https://github.com/googleapis/python-documentai-toolbox/compare/v0.15.0-alpha...v0.15.1-alpha) (2026-01-14)
 
 


### PR DESCRIPTION
Verified this fixes creation of the release PR locally.

Related: #16188 