### PR TITLE
feat(sqlalchemy-spanner): wire timeout execution option through to DBAPI Connection.timeout

### DIFF
--- a/packages/sqlalchemy-spanner/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/packages/sqlalchemy-spanner/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -72,6 +72,7 @@ def reset_connection(dbapi_conn, connection_record, reset_state=None):
 
         dbapi_conn.staleness = None
         dbapi_conn.read_only = False
+        dbapi_conn.timeout = None
 
 
 # register a method to get a single value of a JSON object
@@ -216,6 +217,10 @@ class SpannerExecutionContext(DefaultExecutionContext):
         request_tag = self.execution_options.get("request_tag")
         if request_tag:
             self.cursor.request_tag = request_tag
+
+        timeout = self.execution_options.get("timeout")
+        if timeout is not None:
+            self._dbapi_connection.connection.timeout = timeout
 
         ignore_transaction_warnings = self.execution_options.get(
             "ignore_transaction_warnings"

--- a/packages/sqlalchemy-spanner/tests/unit/test_sqlalchemy_spanner.py
+++ b/packages/sqlalchemy-spanner/tests/unit/test_sqlalchemy_spanner.py
@@ -1,0 +1,101 @@
+# Copyright 2024 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for SpannerExecutionContext and reset_connection."""
+
+import unittest
+from unittest import mock
+
+from google.cloud import spanner_dbapi
+from google.cloud.sqlalchemy_spanner.sqlalchemy_spanner import (
+    SpannerExecutionContext,
+    reset_connection,
+)
+
+
+class ResetConnectionTest(unittest.TestCase):
+    def test_reset_connection_clears_timeout(self):
+        dbapi_conn = mock.MagicMock(spec=spanner_dbapi.Connection)
+        dbapi_conn.inside_transaction = False
+
+        reset_connection(dbapi_conn, connection_record=None)
+
+        self.assertIsNone(dbapi_conn.staleness)
+        self.assertFalse(dbapi_conn.read_only)
+        self.assertIsNone(dbapi_conn.timeout)
+
+    def test_reset_connection_with_wrapper(self):
+        inner_conn = mock.MagicMock(spec=spanner_dbapi.Connection)
+        inner_conn.inside_transaction = False
+        wrapper = mock.MagicMock()
+        wrapper.connection = inner_conn
+
+        reset_connection(wrapper, connection_record=None)
+
+        self.assertIsNone(inner_conn.staleness)
+        self.assertFalse(inner_conn.read_only)
+        self.assertIsNone(inner_conn.timeout)
+
+
+class SpannerExecutionContextPreExecTest(unittest.TestCase):
+    def _make_context(self, execution_options):
+        ctx = SpannerExecutionContext.__new__(SpannerExecutionContext)
+        ctx.execution_options = execution_options
+
+        dbapi_conn = mock.MagicMock()
+        dbapi_conn.connection = mock.MagicMock()
+        ctx._dbapi_connection = dbapi_conn
+        ctx.cursor = mock.MagicMock()
+
+        return ctx
+
+    @mock.patch(
+        "google.cloud.sqlalchemy_spanner.sqlalchemy_spanner.DefaultExecutionContext.pre_exec"
+    )
+    def test_pre_exec_sets_timeout(self, mock_super_pre_exec):
+        ctx = self._make_context({"timeout": 60})
+        ctx.pre_exec()
+
+        self.assertEqual(ctx._dbapi_connection.connection.timeout, 60)
+
+    @mock.patch(
+        "google.cloud.sqlalchemy_spanner.sqlalchemy_spanner.DefaultExecutionContext.pre_exec"
+    )
+    def test_pre_exec_no_timeout_leaves_connection_unchanged(self, mock_super_pre_exec):
+        ctx = self._make_context({})
+
+        conn = ctx._dbapi_connection.connection
+        conn._mock_children.clear()
+
+        ctx.pre_exec()
+
+        set_attrs = {
+            name
+            for name, _ in conn._mock_children.items()
+            if not name.startswith("_")
+        }
+        self.assertNotIn("timeout", set_attrs)
+
+    @mock.patch(
+        "google.cloud.sqlalchemy_spanner.sqlalchemy_spanner.DefaultExecutionContext.pre_exec"
+    )
+    def test_pre_exec_timeout_with_other_options(self, mock_super_pre_exec):
+        ctx = self._make_context(
+            {"timeout": 30, "read_only": True, "request_priority": 2}
+        )
+        ctx.pre_exec()
+
+        self.assertEqual(ctx._dbapi_connection.connection.timeout, 30)
+        self.assertTrue(ctx._dbapi_connection.connection.read_only)
+        self.assertEqual(ctx._dbapi_connection.connection.request_priority, 2)


### PR DESCRIPTION
## Summary

Add `timeout` handling to `SpannerExecutionContext.pre_exec()` and `reset_connection()` so that users can set a per-statement gRPC deadline via SQLAlchemy's `execution_options(timeout=N)`.

Fixes #16467

## Background

The Spanner SQLAlchemy dialect reads execution options in `SpannerExecutionContext.pre_exec()` and forwards them to the DBAPI connection. Currently handled options: `read_only`, `staleness`, `request_priority`, `transaction_tag`, `request_tag`, `ignore_transaction_warnings`. The `timeout` option is not handled.

The underlying Spanner client's `_SnapshotBase.execute_sql()` accepts a `timeout` parameter that controls the gRPC deadline for `ExecuteStreamingSql`. Without it, all queries use the gRPC default of 3600 seconds.

## Timeline

| Date | Commit | Event |
|---|---|---|
| Apr 2020 | Initial commit | Dialect created — `pre_exec()` handles `read_only` and `staleness` |
| Oct 2021 | `d976fda` (PR googleapis/python-spanner#269) | `request_priority` added to `pre_exec()` |
| Jan 2023 | `5bd5076` (PR googleapis/python-spanner#494) | `transaction_tag` and `request_tag` added to `pre_exec()` |
| Jun 2023 | `66c32a4` (PR googleapis/python-spanner#503) | `ignore_transaction_warnings` added to `pre_exec()` |
| None | N/A | `timeout` was never added to `pre_exec()` or `reset_connection()` |

Each new execution option was added incrementally. `timeout` was not included in any of these additions.

## Changes

### `sqlalchemy_spanner.py`

- Add `timeout` handling in `pre_exec()`: reads `self.execution_options.get("timeout")` and sets `self._dbapi_connection.connection.timeout`
- Add `timeout` reset in `reset_connection()`: sets `dbapi_conn.timeout = None` when connection returns to pool

### Usage

```python
from sqlalchemy import create_engine

engine = create_engine("spanner:///...")

# Per-connection timeout
with engine.connect().execution_options(timeout=60) as conn:
    conn.execute(text("SELECT * FROM my_table"))

# Engine-level default timeout
engine = create_engine("spanner:///...", execution_options={"timeout": 60})
```

## Tests

Added 5 unit tests in `tests/unit/test_sqlalchemy_spanner.py`:

- `test_reset_connection_clears_timeout` — verifies `reset_connection` sets `timeout = None`
- `test_reset_connection_with_wrapper` — verifies reset works through connection wrapper
- `test_pre_exec_sets_timeout` — verifies `timeout` is forwarded to DBAPI connection
- `test_pre_exec_no_timeout_leaves_connection_unchanged` — verifies `timeout` is not set when absent from options
- `test_pre_exec_timeout_with_other_options` — verifies `timeout` coexists with `read_only` and `request_priority`

## Prerequisites

This change depends on the DBAPI `Connection` supporting a `timeout` property: googleapis/google-cloud-python#16492 (PR: googleapis/python-spanner#1535)

## Related

- DBAPI issue: googleapis/google-cloud-python#16492
- DBAPI PR: googleapis/python-spanner#1535
- `_SnapshotBase.execute_sql()` has accepted `timeout=` since November 2018 (PR #6536 in the original monorepo)
- This code was previously in `googleapis/python-spanner-sqlalchemy` (now archived)