### PR TITLE
Change list_secrets to use async await

### DIFF
--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_async.py
@@ -44,8 +44,8 @@ async def sample_list_secrets():
     )
 
     # Make the request
-    page_result = client.list_secrets(request=request)
-
+    page_result = await client.list_secrets(request=request)
+    
     # Handle the response
     async for response in page_result:
         print(response)


### PR DESCRIPTION
The list_secrets call returns a coroutine that should be awaited, therefore, I am introducing the await instruction, which was absent, to the async secrets getter example.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕