### PR TITLE
chore: librarian release pull request: 20260331T115804Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -27,6 +27,15 @@ libraries:
     preserve_regex: []
     remove_regex: []
     tag_format: '{id}-v{version}'
+  - id: gapic-generator
+    version: 1.30.13
+    last_generated_commit: ""
+    apis: []
+    source_roots:
+      - packages/gapic-generator
+    preserve_regex: []
+    remove_regex: []
+    tag_format: '{id}-v{version}'
   - id: gcp-sphinx-docfx-yaml
     version: 3.2.4
     last_generated_commit: ""
@@ -1683,7 +1692,7 @@ libraries:
       - packages/google-cloud-documentai/
     tag_format: '{id}-v{version}'
   - id: google-cloud-documentai-toolbox
-    version: 0.15.1-alpha.1
+    version: 0.15.2
     last_generated_commit: ""
     apis: []
     source_roots:
@@ -4226,15 +4235,6 @@ libraries:
     apis: []
     source_roots:
       - packages/sqlalchemy-spanner
-    preserve_regex: []
-    remove_regex: []
-    tag_format: '{id}-v{version}'
-  - id: gapic-generator
-    version: 1.30.13
-    last_generated_commit: ""
-    apis: []
-    source_roots:
-      - packages/gapic-generator
     preserve_regex: []
     remove_regex: []
     tag_format: '{id}-v{version}'

--- a/packages/google-cloud-documentai-toolbox/google/cloud/documentai_toolbox/version.py
+++ b/packages/google-cloud-documentai-toolbox/google/cloud/documentai_toolbox/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.15.1-alpha.1"
+__version__ = "0.15.2"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.2-0.20260309131826-42ac5c451239
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-cloud-documentai-toolbox: v0.15.2</summary>

## [v0.15.2](https://github.com/googleapis/google-cloud-python/compare/google-cloud-documentai-toolbox-v0.15.1-alpha.1...google-cloud-documentai-toolbox-v0.15.2) (2026-03-31)

### Chore

* Bump version to 0.15.2 without any other code changes


</details>