### PR TITLE
chore(librarian): block generation for google-cloud-firestore due to failing system tests

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -24,3 +24,7 @@ libraries:
 # Allow generation for google-cloud-bigtable once this bug is fixed.
   - id: "google-cloud-bigtable"
     generate_blocked: true
+# TODO(https://github.com/googleapis/google-cloud-python/issues/16506):
+# Allow generation for google-cloud-firestore once this bug is fixed.
+  - id: "google-cloud-firestore"
+    generate_blocked: true


### PR DESCRIPTION
This is needed to unblock https://github.com/googleapis/google-cloud-python/pull/16500 which is the weekly librarian generation PR to update generated code in this repository. We can restore generation for google-cloud-firestore once https://github.com/googleapis/google-cloud-python/issues/16506 is fixed.