### PR TITLE
chore: Update version for google-cloud-firestore in .librarian/state.yaml

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1884,7 +1884,7 @@ libraries:
       - packages/google-cloud-financialservices/
     tag_format: '{id}-v{version}'
   - id: google-cloud-firestore
-    version: 2.27.0
+    version: 2.26.0
     last_generated_commit: 59d5f2b46924714af627ac29ea6de78641a00835
     apis:
       - path: google/firestore/admin/v1


### PR DESCRIPTION
`google-cloud-firestore` was manually removed from the release PR https://github.com/googleapis/google-cloud-python/pull/16193 but the change to the version for `google-cloud-firestore` was not reverted `.librarian/state.yaml` . This PR fixes the issue.

Without this fix, we see the following error in librarian automation.

```
time=2026-04-01T20:03:38.254Z level=ERROR msg="librarian command failed" err="failed to fetch conventional commits for library, google-cloud-firestore: failed to get commits for library \"google-cloud-firestore\" with source roots [\"packages/google-cloud-firestore\"] at tag \"google-cloud-firestore-v2.27.0\": failed to find tag google-cloud-firestore-v2.27.0: tag not found"
```