### PR TITLE
fix: allow Protobuf 7.x

### DIFF
--- a/packages/google-api-core/pyproject.toml
+++ b/packages/google-api-core/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 ]
 dependencies = [
   "googleapis-common-protos >= 1.63.2, < 2.0.0",
-  "protobuf >= 4.25.8, < 7.0.0",
+  "protobuf >= 4.25.8, < 8.0.0",
   "proto-plus >= 1.22.3, < 2.0.0",
   "proto-plus >= 1.25.0, < 2.0.0; python_version >= '3.13'",
   "google-auth >= 2.14.1, < 3.0.0",


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-python/issues/16526

See related PR https://github.com/googleapis/google-cloud-python/pull/16102. Note: We're still waiting on a fix for https://github.com/grpc/grpc/issues/41933 