### PR TITLE
chore: correct version for google-cloud-firestore in librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1850,7 +1850,7 @@ libraries:
       product_documentation_override: https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
   - name: google-cloud-firestore
-    version: 2.27.0
+    version: 2.26.0
     apis:
       - path: google/firestore/v1
       - path: google/firestore/admin/v1


### PR DESCRIPTION
Fixes b/498958082

See related PR https://github.com/googleapis/google-cloud-python/pull/16519

Without this fix, we see

```
time=2026-04-02T15:25:24.839Z level=ERROR msg="librarian command failed" err="library google-cloud-firestore, version in state, 2.26.0, is smaller than version in librarian.yaml, 2.27.0: version is regression"
```