### PR TITLE
chore(google-cloud-vectorsearch): create a release

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -3684,7 +3684,7 @@ libraries:
       - packages/google-cloud-translate/
     tag_format: '{id}-v{version}'
   - id: google-cloud-vectorsearch
-    version: 0.9.0
+    version: 0.10.0
     last_generated_commit: 38ed7d6ba66a774924722146f054d12b4487a89f
     apis:
       - path: google/cloud/vectorsearch/v1beta

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch/gapic_version.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.9.0"  # {x-release-please-version}
+__version__ = "0.10.0"  # {x-release-please-version}

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/gapic_version.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.9.0"  # {x-release-please-version}
+__version__ = "0.10.0"  # {x-release-please-version}

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/gapic_version.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.9.0"  # {x-release-please-version}
+__version__ = "0.10.0"  # {x-release-please-version}

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/snippet_metadata_google.cloud.vectorsearch.v1.json
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/snippet_metadata_google.cloud.vectorsearch.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-vectorsearch",
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/snippet_metadata_google.cloud.vectorsearch.v1beta.json
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/snippet_metadata_google.cloud.vectorsearch.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-vectorsearch",
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.2-0.20260325150042-e450f8f7dcab
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-cloud-vectorsearch: v0.10.0</summary>

## [v0.10.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-vectorsearch-v0.9.0...google-cloud-vectorsearch-v0.10.0) (2026-04-13)

</details>