### PR TITLE
chore(google-cloud-dataproc): regenerate

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -1,6 +1,5 @@
 # This file is being migrated to librarian@latest, and is no longer maintained by hand.
 
-release_only_mode: true
 global_files_allowlist:
   - path: CHANGELOG.md
     permissions: read-write

--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -1,5 +1,6 @@
 # This file is being migrated to librarian@latest, and is no longer maintained by hand.
 
+release_only_mode: true
 global_files_allowlist:
   - path: CHANGELOG.md
     permissions: read-write

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
 libraries:
   - id: bigframes

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,17 +1,3 @@
-# Copyright 2026 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
 libraries:
   - id: bigframes
@@ -1531,7 +1517,7 @@ libraries:
     tag_format: '{id}-v{version}'
   - id: google-cloud-dataproc
     version: 5.26.0
-    last_generated_commit: 1133adb136f742df62864f1d9d307df25d451880
+    last_generated_commit: 38ed7d6ba66a774924722146f054d12b4487a89f
     apis:
       - path: google/cloud/dataproc/v1
         service_config: dataproc_v1.yaml

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/clusters.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/clusters.py
@@ -183,6 +183,8 @@ class ClusterConfig(proto.Message):
             Optional. The type of the cluster.
         cluster_tier (google.cloud.dataproc_v1.types.ClusterConfig.ClusterTier):
             Optional. The cluster tier.
+        engine (google.cloud.dataproc_v1.types.ClusterConfig.Engine):
+            Optional. The cluster engine.
         config_bucket (str):
             Optional. A Cloud Storage bucket used to stage job
             dependencies, config files, and job driver console output.
@@ -300,6 +302,23 @@ class ClusterConfig(proto.Message):
         CLUSTER_TIER_STANDARD = 1
         CLUSTER_TIER_PREMIUM = 2
 
+    class Engine(proto.Enum):
+        r"""The cluster engine.
+
+        Values:
+            ENGINE_UNSPECIFIED (0):
+                The engine is not specified. Works the same as
+                ENGINE_DEFAULT.
+            DEFAULT (1):
+                The cluster is a default engine cluster.
+            LIGHTNING (2):
+                The cluster is a lightning engine cluster.
+        """
+
+        ENGINE_UNSPECIFIED = 0
+        DEFAULT = 1
+        LIGHTNING = 2
+
     cluster_type: ClusterType = proto.Field(
         proto.ENUM,
         number=27,
@@ -309,6 +328,11 @@ class ClusterConfig(proto.Message):
         proto.ENUM,
         number=29,
         enum=ClusterTier,
+    )
+    engine: Engine = proto.Field(
+        proto.ENUM,
+        number=30,
+        enum=Engine,
     )
     config_bucket: str = proto.Field(
         proto.STRING,
@@ -1911,6 +1935,28 @@ class LifecycleConfig(proto.Message):
             `Duration <https://developers.google.com/protocol-buffers/docs/proto3#json>`__).
 
             This field is a member of `oneof`_ ``ttl``.
+        idle_stop_ttl (google.protobuf.duration_pb2.Duration):
+            Optional. The duration to keep the cluster started while
+            idling (when no jobs are running). Passing this threshold
+            will cause the cluster to be stopped. Minimum value is 5
+            minutes; maximum value is 14 days (see JSON representation
+            of
+            `Duration <https://developers.google.com/protocol-buffers/docs/proto3#json>`__).
+        auto_stop_time (google.protobuf.timestamp_pb2.Timestamp):
+            Optional. The time when cluster will be auto-stopped (see
+            JSON representation of
+            `Timestamp <https://developers.google.com/protocol-buffers/docs/proto3#json>`__).
+
+            This field is a member of `oneof`_ ``stop_ttl``.
+        auto_stop_ttl (google.protobuf.duration_pb2.Duration):
+            Optional. The lifetime duration of the cluster. The cluster
+            will be auto-stopped at the end of this period, calculated
+            from the time of submission of the create or update cluster
+            request. Minimum value is 10 minutes; maximum value is 14
+            days (see JSON representation of
+            `Duration <https://developers.google.com/protocol-buffers/docs/proto3#json>`__).
+
+            This field is a member of `oneof`_ ``stop_ttl``.
         idle_start_time (google.protobuf.timestamp_pb2.Timestamp):
             Output only. The time when cluster became idle (most recent
             job finished) and became eligible for deletion due to
@@ -1933,6 +1979,23 @@ class LifecycleConfig(proto.Message):
         proto.MESSAGE,
         number=3,
         oneof="ttl",
+        message=duration_pb2.Duration,
+    )
+    idle_stop_ttl: duration_pb2.Duration = proto.Field(
+        proto.MESSAGE,
+        number=5,
+        message=duration_pb2.Duration,
+    )
+    auto_stop_time: timestamp_pb2.Timestamp = proto.Field(
+        proto.MESSAGE,
+        number=6,
+        oneof="stop_ttl",
+        message=timestamp_pb2.Timestamp,
+    )
+    auto_stop_ttl: duration_pb2.Duration = proto.Field(
+        proto.MESSAGE,
+        number=7,
+        oneof="stop_ttl",
         message=duration_pb2.Duration,
     )
     idle_start_time: timestamp_pb2.Timestamp = proto.Field(

--- a/packages/google-cloud-dataproc/tests/unit/gapic/dataproc_v1/test_cluster_controller.py
+++ b/packages/google-cloud-dataproc/tests/unit/gapic/dataproc_v1/test_cluster_controller.py
@@ -6369,6 +6369,7 @@ def test_create_cluster_rest_call_success(request_type):
         "config": {
             "cluster_type": 1,
             "cluster_tier": 1,
+            "engine": 1,
             "config_bucket": "config_bucket_value",
             "temp_bucket": "temp_bucket_value",
             "gce_cluster_config": {
@@ -6495,6 +6496,9 @@ def test_create_cluster_rest_call_success(request_type):
                 "idle_delete_ttl": {},
                 "auto_delete_time": {"seconds": 751, "nanos": 543},
                 "auto_delete_ttl": {},
+                "idle_stop_ttl": {},
+                "auto_stop_time": {},
+                "auto_stop_ttl": {},
                 "idle_start_time": {},
             },
             "endpoint_config": {"http_ports": {}, "enable_http_port_access": True},
@@ -6785,6 +6789,7 @@ def test_update_cluster_rest_call_success(request_type):
         "config": {
             "cluster_type": 1,
             "cluster_tier": 1,
+            "engine": 1,
             "config_bucket": "config_bucket_value",
             "temp_bucket": "temp_bucket_value",
             "gce_cluster_config": {
@@ -6911,6 +6916,9 @@ def test_update_cluster_rest_call_success(request_type):
                 "idle_delete_ttl": {},
                 "auto_delete_time": {"seconds": 751, "nanos": 543},
                 "auto_delete_ttl": {},
+                "idle_stop_ttl": {},
+                "auto_stop_time": {},
+                "auto_stop_ttl": {},
                 "idle_start_time": {},
             },
             "endpoint_config": {"http_ports": {}, "enable_http_port_access": True},

--- a/packages/google-cloud-dataproc/tests/unit/gapic/dataproc_v1/test_workflow_template_service.py
+++ b/packages/google-cloud-dataproc/tests/unit/gapic/dataproc_v1/test_workflow_template_service.py
@@ -5994,6 +5994,7 @@ def test_create_workflow_template_rest_call_success(request_type):
                 "config": {
                     "cluster_type": 1,
                     "cluster_tier": 1,
+                    "engine": 1,
                     "config_bucket": "config_bucket_value",
                     "temp_bucket": "temp_bucket_value",
                     "gce_cluster_config": {
@@ -6127,6 +6128,9 @@ def test_create_workflow_template_rest_call_success(request_type):
                         "idle_delete_ttl": {},
                         "auto_delete_time": {},
                         "auto_delete_ttl": {},
+                        "idle_stop_ttl": {},
+                        "auto_stop_time": {},
+                        "auto_stop_ttl": {},
                         "idle_start_time": {},
                     },
                     "endpoint_config": {
@@ -6786,6 +6790,7 @@ def test_instantiate_inline_workflow_template_rest_call_success(request_type):
                 "config": {
                     "cluster_type": 1,
                     "cluster_tier": 1,
+                    "engine": 1,
                     "config_bucket": "config_bucket_value",
                     "temp_bucket": "temp_bucket_value",
                     "gce_cluster_config": {
@@ -6919,6 +6924,9 @@ def test_instantiate_inline_workflow_template_rest_call_success(request_type):
                         "idle_delete_ttl": {},
                         "auto_delete_time": {},
                         "auto_delete_ttl": {},
+                        "idle_stop_ttl": {},
+                        "auto_stop_time": {},
+                        "auto_stop_ttl": {},
                         "idle_start_time": {},
                     },
                     "endpoint_config": {
@@ -7296,6 +7304,7 @@ def test_update_workflow_template_rest_call_success(request_type):
                 "config": {
                     "cluster_type": 1,
                     "cluster_tier": 1,
+                    "engine": 1,
                     "config_bucket": "config_bucket_value",
                     "temp_bucket": "temp_bucket_value",
                     "gce_cluster_config": {
@@ -7429,6 +7438,9 @@ def test_update_workflow_template_rest_call_success(request_type):
                         "idle_delete_ttl": {},
                         "auto_delete_time": {},
                         "auto_delete_ttl": {},
+                        "idle_stop_ttl": {},
+                        "auto_stop_time": {},
+                        "auto_stop_ttl": {},
                         "idle_start_time": {},
                     },
                     "endpoint_config": {


### PR DESCRIPTION
PR created by the Librarian CLI to generate Cloud Client Libraries code from protos.

BEGIN_COMMIT

BEGIN_NESTED_COMMIT
feat: Add `Engine` field to support LightningEngine in clusters and add support for stop ttl

PiperOrigin-RevId: 897294662
Library-IDs: google-cloud-dataproc
Source-link: [https://github.com/googleapis/googleapis/commit/2da86587](https://github.com/googleapis/googleapis/commit/2da86587)
END_NESTED_COMMIT

END_COMMIT

This pull request is generated with proto changes between
[https://github.com/googleapis/googleapis/commit/1133adb1](https://github.com/googleapis/googleapis/commit/1133adb136f742df62864f1d9d307df25d451880)
(exclusive) and
[https://github.com/googleapis/googleapis/commit/2da86587](https://github.com/googleapis/googleapis/commit/2da86587126416eb48d561cd800bb03afa2f501a)
(inclusive).

Librarian Version: v1.0.2-0.20260325150042-e450f8f7dcab
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e