### PR TITLE
chore(google-cloud-dataproc): create a release

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1530,7 +1530,7 @@ libraries:
       - packages/google-cloud-dataplex/
     tag_format: '{id}-v{version}'
   - id: google-cloud-dataproc
-    version: 5.26.0
+    version: 5.27.0
     last_generated_commit: 38ed7d6ba66a774924722146f054d12b4487a89f
     apis:
       - path: google/cloud/dataproc/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Changelogs
 - [google-cloud-datalabeling==1.16.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-datalabeling/CHANGELOG.md)
 - [google-cloud-dataplex==2.18.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-dataplex/CHANGELOG.md)
 - [google-cloud-dataproc-metastore==1.22.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-dataproc-metastore/CHANGELOG.md)
-- [google-cloud-dataproc==5.26.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-dataproc/CHANGELOG.md)
+- [google-cloud-dataproc==5.27.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-dataproc/CHANGELOG.md)
 - [google-cloud-datastream==1.18.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-datastream/CHANGELOG.md)
 - [google-cloud-deploy==2.10.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-deploy/CHANGELOG.md)
 - [google-cloud-developerconnect==0.5.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-developerconnect/CHANGELOG.md)

--- a/packages/google-cloud-dataproc/google/cloud/dataproc/gapic_version.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "5.26.0"  # {x-release-please-version}
+__version__ = "5.27.0"  # {x-release-please-version}

--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/gapic_version.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "5.26.0"  # {x-release-please-version}
+__version__ = "5.27.0"  # {x-release-please-version}

--- a/packages/google-cloud-dataproc/samples/generated_samples/snippet_metadata_google.cloud.dataproc.v1.json
+++ b/packages/google-cloud-dataproc/samples/generated_samples/snippet_metadata_google.cloud.dataproc.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-dataproc",
-    "version": "5.26.0"
+    "version": "5.27.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.2-0.20260325150042-e450f8f7dcab
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-cloud-dataproc: v5.27.0</summary>

## [v5.27.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-dataproc-v5.26.0...google-cloud-dataproc-v5.27.0) (2026-04-13)

</details>