### PR TITLE
chore(google-cloud-firestore): create a release

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1960,7 +1960,7 @@ libraries:
       - packages/google-cloud-financialservices/
     tag_format: '{id}-v{version}'
   - id: google-cloud-firestore
-    version: 2.26.0
+    version: 2.27.0
     last_generated_commit: 59d5f2b46924714af627ac29ea6de78641a00835
     apis:
       - path: google/firestore/admin/v1

--- a/packages/google-cloud-firestore/google/cloud/firestore/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.26.0"  # {x-release-please-version}
+__version__ = "2.27.0"  # {x-release-please-version}

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.26.0"  # {x-release-please-version}
+__version__ = "2.27.0"  # {x-release-please-version}

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.26.0"  # {x-release-please-version}
+__version__ = "2.27.0"  # {x-release-please-version}

--- a/packages/google-cloud-firestore/google/cloud/firestore_bundle/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_bundle/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.26.0"  # {x-release-please-version}
+__version__ = "2.27.0"  # {x-release-please-version}

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/gapic_version.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.26.0"  # {x-release-please-version}
+__version__ = "2.27.0"  # {x-release-please-version}

--- a/packages/google-cloud-firestore/samples/generated_samples/snippet_metadata_google.firestore.admin.v1.json
+++ b/packages/google-cloud-firestore/samples/generated_samples/snippet_metadata_google.firestore.admin.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-firestore-admin",
-    "version": "2.26.0"
+    "version": "2.27.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-firestore/samples/generated_samples/snippet_metadata_google.firestore.v1.json
+++ b/packages/google-cloud-firestore/samples/generated_samples/snippet_metadata_google.firestore.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-firestore",
-    "version": "2.26.0"
+    "version": "2.27.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.2-0.20260325150042-e450f8f7dcab
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-cloud-firestore: v2.27.0</summary>

## [v2.27.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-firestore-v2.26.0...google-cloud-firestore-v2.27.0) (2026-04-13)

</details>