### PR TITLE
chore(google-cloud-spanner): create a release

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -3339,7 +3339,7 @@ libraries:
       - packages/google-cloud-source-context/
     tag_format: '{id}-v{version}'
   - id: google-cloud-spanner
-    version: 3.64.0
+    version: 3.65.0
     last_generated_commit: 3e09ac03bab9dba5b8800248cf10190219938a26
     apis:
       - path: google/spanner/admin/instance/v1

--- a/packages/google-cloud-spanner/google/cloud/spanner/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.64.0"  # {x-release-please-version}
+__version__ = "3.65.0"  # {x-release-please-version}

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.64.0"  # {x-release-please-version}
+__version__ = "3.65.0"  # {x-release-please-version}

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.64.0"  # {x-release-please-version}
+__version__ = "3.65.0"  # {x-release-please-version}

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.64.0"  # {x-release-please-version}
+__version__ = "3.65.0"  # {x-release-please-version}

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.64.0"  # {x-release-please-version}
+__version__ = "3.65.0"  # {x-release-please-version}

--- a/packages/google-cloud-spanner/google/cloud/spanner_dbapi/version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_dbapi/version.py
@@ -15,6 +15,6 @@
 import platform
 
 PY_VERSION = platform.python_version()
-__version__ = "3.64.0"
+__version__ = "3.65.0"
 VERSION = __version__
 DEFAULT_USER_AGENT = "gl-dbapi/" + VERSION

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.64.0"  # {x-release-please-version}
+__version__ = "3.65.0"  # {x-release-please-version}

--- a/packages/google-cloud-spanner/samples/generated_samples/snippet_metadata_google.spanner.admin.database.v1.json
+++ b/packages/google-cloud-spanner/samples/generated_samples/snippet_metadata_google.spanner.admin.database.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-spanner-admin-database",
-    "version": "3.64.0"
+    "version": "3.65.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-spanner/samples/generated_samples/snippet_metadata_google.spanner.admin.instance.v1.json
+++ b/packages/google-cloud-spanner/samples/generated_samples/snippet_metadata_google.spanner.admin.instance.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-spanner-admin-instance",
-    "version": "3.64.0"
+    "version": "3.65.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-spanner/samples/generated_samples/snippet_metadata_google.spanner.v1.json
+++ b/packages/google-cloud-spanner/samples/generated_samples/snippet_metadata_google.spanner.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-spanner",
-    "version": "3.64.0"
+    "version": "3.65.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.2-0.20260325150042-e450f8f7dcab
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-cloud-spanner: v3.65.0</summary>

## [v3.65.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-spanner-v3.64.0...google-cloud-spanner-v3.65.0) (2026-04-13)

</details>