### PR TITLE
chore(bigquery-magics): create a release

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -24,7 +24,7 @@ libraries:
     remove_regex: []
     tag_format: '{id}-v{version}'
   - id: bigquery-magics
-    version: 0.13.0
+    version: 0.14.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/packages/bigquery-magics/bigquery_magics/version.py
+++ b/packages/bigquery-magics/bigquery_magics/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.2-0.20260325150042-e450f8f7dcab
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>bigquery-magics: v0.14.0</summary>

## [v0.14.0](https://github.com/googleapis/google-cloud-python/compare/bigquery-magics-v0.13.0...bigquery-magics-v0.14.0) (2026-04-14)

</details>