### PR TITLE
test(spanner): update mock server tests to check for inline begin

### DIFF
--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/mock_server_test_base.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/mock_server_test_base.py
@@ -161,9 +161,12 @@ class MockServerTestBase(fixtures.TestBase):
         MockServerTestBase.database_admin_service.clear_requests()
 
     def create_engine(self) -> Engine:
+        from sqlalchemy.pool import NullPool
+
         return create_engine(
             "spanner:///projects/p/instances/i/databases/d",
             connect_args={"client": self.client, "logger": MockServerTestBase.logger},
+            poolclass=NullPool,  # Disable pooling to force new sessions for every test
         )
 
     @property

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/mock_server_test_base.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/mock_server_test_base.py
@@ -161,12 +161,9 @@ class MockServerTestBase(fixtures.TestBase):
         MockServerTestBase.database_admin_service.clear_requests()
 
     def create_engine(self) -> Engine:
-        from sqlalchemy.pool import NullPool
-
         return create_engine(
             "spanner:///projects/p/instances/i/databases/d",
             connect_args={"client": self.client, "logger": MockServerTestBase.logger},
-            poolclass=NullPool,  # Disable pooling to force new sessions for every test
         )
 
     @property

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_auto_increment.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_auto_increment.py
@@ -19,7 +19,6 @@ from google.cloud.spanner_v1 import (
     CreateSessionRequest,
     ExecuteSqlRequest,
     CommitRequest,
-    BeginTransactionRequest,
 )
 from tests.mockserver_tests.mock_server_test_base import (
     MockServerTestBase,

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_auto_increment.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_auto_increment.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from sqlalchemy.orm import Session
-from sqlalchemy.testing import eq_, is_instance_of
+from sqlalchemy.testing import eq_, is_instance_of, is_not_none
 from google.cloud.spanner_v1 import (
     ResultSet,
     CreateSessionRequest,
@@ -126,11 +126,12 @@ LIMIT 1
             session.commit()
         # Verify the requests that we got.
         requests = self.spanner_service.requests
-        eq_(4, len(requests))
+        # Dialect now inlines BeginTransaction into the first statement.
+        eq_(3, len(requests))
         is_instance_of(requests[0], CreateSessionRequest)
-        is_instance_of(requests[1], BeginTransactionRequest)
-        is_instance_of(requests[2], ExecuteSqlRequest)
-        is_instance_of(requests[3], CommitRequest)
+        is_instance_of(requests[1], ExecuteSqlRequest)
+        is_instance_of(requests[2], CommitRequest)
+        is_not_none(requests[1].transaction.begin)  # First request inlines begin
 
     def test_insert_row_with_pk_value(self):
         from tests.mockserver_tests.auto_increment_model import Singer

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_bit_reversed_sequence.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_bit_reversed_sequence.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from sqlalchemy.orm import Session
-from sqlalchemy.testing import eq_, is_instance_of
+from sqlalchemy.testing import eq_, is_instance_of, is_not_none
 from google.cloud.spanner_v1 import (
     ResultSet,
     CreateSessionRequest,
@@ -119,8 +119,9 @@ LIMIT 1
             session.commit()
         # Verify the requests that we got.
         requests = self.spanner_service.requests
-        eq_(4, len(requests))
+        # Dialect now inlines BeginTransaction into the first statement.
+        eq_(3, len(requests))
         is_instance_of(requests[0], CreateSessionRequest)
-        is_instance_of(requests[1], BeginTransactionRequest)
-        is_instance_of(requests[2], ExecuteSqlRequest)
-        is_instance_of(requests[3], CommitRequest)
+        is_instance_of(requests[1], ExecuteSqlRequest)
+        is_instance_of(requests[2], CommitRequest)
+        is_not_none(requests[1].transaction.begin)  # First request inlines begin

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_bit_reversed_sequence.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_bit_reversed_sequence.py
@@ -19,7 +19,6 @@ from google.cloud.spanner_v1 import (
     CreateSessionRequest,
     ExecuteSqlRequest,
     CommitRequest,
-    BeginTransactionRequest,
 )
 from tests.mockserver_tests.mock_server_test_base import (
     MockServerTestBase,

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_float32.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_float32.py
@@ -24,7 +24,6 @@ from google.cloud.spanner_v1 import (
     ExecuteSqlRequest,
     ResultSet,
     ResultSetStats,
-    BeginTransactionRequest,
     CommitRequest,
     TypeCode,
 )

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_float32.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_float32.py
@@ -17,6 +17,7 @@ from sqlalchemy.testing import (
     eq_,
     is_instance_of,
     is_false,
+    is_not_none,
 )
 from google.cloud.spanner_v1 import (
     CreateSessionRequest,
@@ -58,12 +59,13 @@ class TestFloat32(MockServerTestBase):
             session.commit()
 
             requests = self.spanner_service.requests
-            eq_(4, len(requests))
+            # Dialect now inlines BeginTransaction into the first statement.
+            eq_(3, len(requests))
             is_instance_of(requests[0], CreateSessionRequest)
-            is_instance_of(requests[1], BeginTransactionRequest)
-            is_instance_of(requests[2], ExecuteSqlRequest)
-            is_instance_of(requests[3], CommitRequest)
-            request: ExecuteSqlRequest = requests[2]
+            is_instance_of(requests[1], ExecuteSqlRequest)
+            is_instance_of(requests[2], CommitRequest)
+            is_not_none(requests[1].transaction.begin)  # First request inlines begin
+            request: ExecuteSqlRequest = requests[1]
             eq_(3, len(request.params))
             eq_("1", request.params["a0"])
             eq_("One", request.params["a1"])

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_insertmany.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_insertmany.py
@@ -22,7 +22,6 @@ from google.cloud.spanner_v1 import (
     ExecuteSqlRequest,
     CommitRequest,
     RollbackRequest,
-    BeginTransactionRequest,
     CreateSessionRequest,
 )
 from tests.mockserver_tests.mock_server_test_base import (

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_insertmany.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_insertmany.py
@@ -17,7 +17,7 @@ from unittest import mock
 
 import sqlalchemy
 from sqlalchemy.orm import Session
-from sqlalchemy.testing import eq_, is_instance_of
+from sqlalchemy.testing import eq_, is_instance_of, is_not_none
 from google.cloud.spanner_v1 import (
     ExecuteSqlRequest,
     CommitRequest,
@@ -53,11 +53,12 @@ class TestInsertmany(MockServerTestBase):
 
         # Verify the requests that we got.
         requests = self.spanner_service.requests
-        eq_(4, len(requests))
+        # Dialect now inlines BeginTransaction into the first statement.
+        eq_(3, len(requests))
         is_instance_of(requests[0], CreateSessionRequest)
-        is_instance_of(requests[1], BeginTransactionRequest)
-        is_instance_of(requests[2], ExecuteSqlRequest)
-        is_instance_of(requests[3], CommitRequest)
+        is_instance_of(requests[1], ExecuteSqlRequest)
+        is_instance_of(requests[2], CommitRequest)
+        is_not_none(requests[1].transaction.begin)  # First request inlines begin
 
     def test_no_insertmany_with_bit_reversed_id(self):
         """Ensures we don't try to bulk insert rows with bit-reversed PKs.
@@ -93,12 +94,13 @@ class TestInsertmany(MockServerTestBase):
 
         # Verify the requests that we got.
         requests = self.spanner_service.requests
-        eq_(5, len(requests))
+        # Dialect now inlines BeginTransaction into the first statement.
+        eq_(4, len(requests))
         is_instance_of(requests[0], CreateSessionRequest)
-        is_instance_of(requests[1], BeginTransactionRequest)
+        is_instance_of(requests[1], ExecuteSqlRequest)
         is_instance_of(requests[2], ExecuteSqlRequest)
-        is_instance_of(requests[3], ExecuteSqlRequest)
-        is_instance_of(requests[4], RollbackRequest)
+        is_instance_of(requests[3], RollbackRequest)
+        is_not_none(requests[1].transaction.begin)  # First request inlines begin
 
     def add_uuid_insert_result(self, sql):
         result = result_set.ResultSet(

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_isolation_level.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_isolation_level.py
@@ -19,7 +19,6 @@ from google.cloud.spanner_v1 import (
     CreateSessionRequest,
     ExecuteSqlRequest,
     CommitRequest,
-    BeginTransactionRequest,
     TransactionOptions,
 )
 

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_isolation_level.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_isolation_level.py
@@ -150,12 +150,12 @@ class TestIsolationLevel(MockServerTestBase):
     def verify_isolation_level(self, level):
         # Verify the requests that we got.
         requests = self.spanner_service.requests
-        eq_(4, len(requests))
+        # Dialect now inlines BeginTransaction into the first statement.
+        eq_(3, len(requests))
         is_instance_of(requests[0], CreateSessionRequest)
-        is_instance_of(requests[1], BeginTransactionRequest)
-        is_instance_of(requests[2], ExecuteSqlRequest)
-        is_instance_of(requests[3], CommitRequest)
-        begin_request: BeginTransactionRequest = requests[1]
+        is_instance_of(requests[1], ExecuteSqlRequest)
+        is_instance_of(requests[2], CommitRequest)
+        execute_request: ExecuteSqlRequest = requests[1]
         eq_(
             TransactionOptions(
                 dict(
@@ -163,7 +163,7 @@ class TestIsolationLevel(MockServerTestBase):
                     read_write=TransactionOptions.ReadWrite(),
                 )
             ),
-            begin_request.options,
+            execute_request.transaction.begin,
         )
 
     def add_insert_result(self, sql):

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_json.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_json.py
@@ -20,7 +20,6 @@ from google.cloud.spanner_v1 import (
     CreateSessionRequest,
     ExecuteSqlRequest,
     CommitRequest,
-    BeginTransactionRequest,
     TypeCode,
     JsonObject,
 )

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_json.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_json.py
@@ -14,7 +14,7 @@
 
 from sqlalchemy import func, select, text
 from sqlalchemy.orm import Session
-from sqlalchemy.testing import eq_, is_instance_of
+from sqlalchemy.testing import eq_, is_instance_of, is_not_none
 from google.cloud.spanner_v1 import (
     ResultSet,
     CreateSessionRequest,
@@ -105,12 +105,13 @@ LIMIT 1
 
         # Verify the requests that we got.
         requests = self.spanner_service.requests
-        eq_(4, len(requests))
+        # Dialect now inlines BeginTransaction into the first statement.
+        eq_(3, len(requests))
         is_instance_of(requests[0], CreateSessionRequest)
-        is_instance_of(requests[1], BeginTransactionRequest)
-        is_instance_of(requests[2], ExecuteSqlRequest)
-        is_instance_of(requests[3], CommitRequest)
-        request: ExecuteSqlRequest = requests[2]
+        is_instance_of(requests[1], ExecuteSqlRequest)
+        is_instance_of(requests[2], CommitRequest)
+        is_not_none(requests[1].transaction.begin)  # First request inlines begin
+        request: ExecuteSqlRequest = requests[1]
         eq_(3, len(request.params))
         eq_("1", request.params["a0"])
         eq_("Test", request.params["a1"])

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_pickle_type.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_pickle_type.py
@@ -19,7 +19,6 @@ from google.cloud.spanner_v1 import (
     CreateSessionRequest,
     ExecuteSqlRequest,
     CommitRequest,
-    BeginTransactionRequest,
     TypeCode,
 )
 from tests.mockserver_tests.mock_server_test_base import (

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_pickle_type.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_pickle_type.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from sqlalchemy.orm import Session
-from sqlalchemy.testing import eq_, is_instance_of
+from sqlalchemy.testing import eq_, is_instance_of, is_not_none
 from google.cloud.spanner_v1 import (
     ResultSet,
     CreateSessionRequest,
@@ -85,12 +85,13 @@ LIMIT 1
 
         # Verify the requests that we got.
         requests = self.spanner_service.requests
-        eq_(4, len(requests))
+        # Dialect now inlines BeginTransaction into the first statement.
+        eq_(3, len(requests))
         is_instance_of(requests[0], CreateSessionRequest)
-        is_instance_of(requests[1], BeginTransactionRequest)
-        is_instance_of(requests[2], ExecuteSqlRequest)
-        is_instance_of(requests[3], CommitRequest)
-        request: ExecuteSqlRequest = requests[2]
+        is_instance_of(requests[1], ExecuteSqlRequest)
+        is_instance_of(requests[2], CommitRequest)
+        is_not_none(requests[1].transaction.begin)  # First request inlines begin
+        request: ExecuteSqlRequest = requests[1]
         eq_(4, len(request.params))
         eq_("1", request.params["a0"])
         eq_("test_user", request.params["a1"])

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_quickstart.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_quickstart.py
@@ -19,7 +19,6 @@ from google.cloud.spanner_v1 import (
     CreateSessionRequest,
     ExecuteBatchDmlRequest,
     CommitRequest,
-    BeginTransactionRequest,
 )
 from sqlalchemy.orm import Session
 from sqlalchemy.testing import eq_, is_instance_of, is_not_none

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_quickstart.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_quickstart.py
@@ -115,12 +115,12 @@ LIMIT 1""",
             session.commit()
 
             requests = self.spanner_service.requests
-            eq_(5, len(requests))
+            # Dialect now inlines BeginTransaction into the first statement.
+            eq_(4, len(requests))
             is_instance_of(requests[0], CreateSessionRequest)
-            is_instance_of(requests[1], BeginTransactionRequest)
+            is_instance_of(requests[1], ExecuteBatchDmlRequest)
             is_instance_of(requests[2], ExecuteBatchDmlRequest)
-            is_instance_of(requests[3], ExecuteBatchDmlRequest)
-            is_instance_of(requests[4], CommitRequest)
-            is_not_none(requests[2].transaction.id)
-            eq_(requests[2].transaction.id, requests[3].transaction.id)
-            eq_(requests[2].transaction.id, requests[4].transaction_id)
+            is_instance_of(requests[3], CommitRequest)
+            is_not_none(requests[1].transaction.begin)  # First request inlines begin
+            is_not_none(requests[2].transaction.id)  # Subsequent requests use ID
+            eq_(requests[2].transaction.id, requests[3].transaction_id)

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_tags.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_tags.py
@@ -83,18 +83,18 @@ class TestStaleReads(MockServerTestBase):
 
         # Verify the requests that we got.
         requests = self.spanner_service.requests
-        eq_(6, len(requests))
+        # Dialect now inlines BeginTransaction into the first statement.
+        eq_(5, len(requests))
         is_instance_of(requests[0], CreateSessionRequest)
-        is_instance_of(requests[1], BeginTransactionRequest)
+        is_instance_of(requests[1], ExecuteSqlRequest)
         is_instance_of(requests[2], ExecuteSqlRequest)
         is_instance_of(requests[3], ExecuteSqlRequest)
-        is_instance_of(requests[4], ExecuteSqlRequest)
-        is_instance_of(requests[5], CommitRequest)
-        for request in requests[2:]:
+        is_instance_of(requests[4], CommitRequest)
+        for request in requests[1:]:
             eq_("my-transaction-tag", request.request_options.transaction_tag)
-        eq_("my-tag-1", requests[2].request_options.request_tag)
-        eq_("my-tag-2", requests[3].request_options.request_tag)
-        eq_("insert-singer", requests[4].request_options.request_tag)
+        eq_("my-tag-1", requests[1].request_options.request_tag)
+        eq_("my-tag-2", requests[2].request_options.request_tag)
+        eq_("insert-singer", requests[3].request_options.request_tag)
 
 
 def empty_singer_result_set():


### PR DESCRIPTION
This PR updates the `sqlalchemy-spanner` mock server tests to account for the dialect now inlining `BeginTransaction` requests into the first statement execution.

### Changes
- Updated expected request counts in multiple tests (typically reducing by 1).
- Removed assertions for separate `BeginTransactionRequest` where applicable.
- Added assertions to verify that the first statement request contains `transaction.begin` options.
- Updated assertions to verify that subsequent requests use the transaction ID returned by the mock server.

These changes resolve the off-by-one failures in request counts across multiple mock server tests.
