### PR TITLE
test(storage): isolate environment in client tests

### DIFF
--- a/packages/google-cloud-storage/tests/unit/test_client.py
+++ b/packages/google-cloud-storage/tests/unit/test_client.py
@@ -384,9 +384,9 @@ class TestClient(unittest.TestCase):
         custom_endpoint = "storage-example.p.googleapis.com"
         credentials = _make_credentials(project=PROJECT)
         with mock.patch("os.environ", {}):
+        with mock.patch.dict("os.environ", {}, clear=True):
             client = self._make_one(
-                credentials=credentials,
-                client_options={"api_endpoint": custom_endpoint},
+                credentials=credentials, client_options={"api_endpoint": custom_endpoint}
             )
         self.assertEqual(client._connection.API_BASE_URL, custom_endpoint)
         self.assertEqual(client.project, PROJECT)

--- a/packages/google-cloud-storage/tests/unit/test_client.py
+++ b/packages/google-cloud-storage/tests/unit/test_client.py
@@ -369,7 +369,7 @@ class TestClient(unittest.TestCase):
 
     def test_ctor_w_custom_endpoint_bypass_auth(self):
         custom_endpoint = "storage-example.p.googleapis.com"
-        with mock.patch("os.environ", {}):
+        with mock.patch.dict("os.environ", {}, clear=True):
             client = self._make_one(
                 client_options={"api_endpoint": custom_endpoint},
                 use_auth_w_custom_endpoint=False,

--- a/packages/google-cloud-storage/tests/unit/test_client.py
+++ b/packages/google-cloud-storage/tests/unit/test_client.py
@@ -383,10 +383,10 @@ class TestClient(unittest.TestCase):
         PROJECT = "PROJECT"
         custom_endpoint = "storage-example.p.googleapis.com"
         credentials = _make_credentials(project=PROJECT)
-        with mock.patch("os.environ", {}):
         with mock.patch.dict("os.environ", {}, clear=True):
             client = self._make_one(
-                credentials=credentials, client_options={"api_endpoint": custom_endpoint}
+                credentials=credentials,
+                client_options={"api_endpoint": custom_endpoint},
             )
         self.assertEqual(client._connection.API_BASE_URL, custom_endpoint)
         self.assertEqual(client.project, PROJECT)

--- a/packages/google-cloud-storage/tests/unit/test_client.py
+++ b/packages/google-cloud-storage/tests/unit/test_client.py
@@ -300,7 +300,7 @@ class TestClient(unittest.TestCase):
         PROJECT = "PROJECT"
         credentials = _make_credentials(project=PROJECT)
 
-        with mock.patch("os.environ", {}):
+        with mock.patch.dict("os.environ", {}, clear=True):
             client = self._make_one(credentials=credentials)
 
         self.assertEqual(client.project, PROJECT)

--- a/packages/google-cloud-storage/tests/unit/test_client.py
+++ b/packages/google-cloud-storage/tests/unit/test_client.py
@@ -385,7 +385,8 @@ class TestClient(unittest.TestCase):
         credentials = _make_credentials(project=PROJECT)
         with mock.patch("os.environ", {}):
             client = self._make_one(
-                credentials=credentials, client_options={"api_endpoint": custom_endpoint}
+                credentials=credentials,
+                client_options={"api_endpoint": custom_endpoint},
             )
         self.assertEqual(client._connection.API_BASE_URL, custom_endpoint)
         self.assertEqual(client.project, PROJECT)

--- a/packages/google-cloud-storage/tests/unit/test_client.py
+++ b/packages/google-cloud-storage/tests/unit/test_client.py
@@ -300,7 +300,8 @@ class TestClient(unittest.TestCase):
         PROJECT = "PROJECT"
         credentials = _make_credentials(project=PROJECT)
 
-        client = self._make_one(credentials=credentials)
+        with mock.patch("os.environ", {}):
+            client = self._make_one(credentials=credentials)
 
         self.assertEqual(client.project, PROJECT)
         self.assertIsInstance(client._connection, Connection)
@@ -368,10 +369,11 @@ class TestClient(unittest.TestCase):
 
     def test_ctor_w_custom_endpoint_bypass_auth(self):
         custom_endpoint = "storage-example.p.googleapis.com"
-        client = self._make_one(
-            client_options={"api_endpoint": custom_endpoint},
-            use_auth_w_custom_endpoint=False,
-        )
+        with mock.patch("os.environ", {}):
+            client = self._make_one(
+                client_options={"api_endpoint": custom_endpoint},
+                use_auth_w_custom_endpoint=False,
+            )
         self.assertEqual(client._connection.API_BASE_URL, custom_endpoint)
         self.assertEqual(client.project, None)
         self.assertIsInstance(client._connection, Connection)
@@ -381,9 +383,10 @@ class TestClient(unittest.TestCase):
         PROJECT = "PROJECT"
         custom_endpoint = "storage-example.p.googleapis.com"
         credentials = _make_credentials(project=PROJECT)
-        client = self._make_one(
-            credentials=credentials, client_options={"api_endpoint": custom_endpoint}
-        )
+        with mock.patch("os.environ", {}):
+            client = self._make_one(
+                credentials=credentials, client_options={"api_endpoint": custom_endpoint}
+            )
         self.assertEqual(client._connection.API_BASE_URL, custom_endpoint)
         self.assertEqual(client.project, PROJECT)
         self.assertIsInstance(client._connection, Connection)


### PR DESCRIPTION
This PR resolves a unit test failure where the project ID leaked from the local environment into the client constructor tests, causing assertions to fail.

**Problem**: Tests like `test_ctor_wo_project`, `test_ctor_w_custom_endpoint_bypass_auth`, and `test_ctor_w_custom_endpoint_w_credentials` were asserting that `client.project` was `None` or a specific project ID (like `"PROJECT"`). However, they were receiving a project ID set in the user's local environment (e.g., `"precise-truck-742"`), causing an AssertionError.

**Solution**: Wrapped the client creation in these specific tests using a 

```
with mock.patch.dict("os.environ", {}, clear=True):
```

code block to ensure the environment is clean and isolated during test execution.

> [!Note]
`os.environ` is not simply a Python `dict`, it is an `os._Environ` object with special characteristics (i.e. `putenv`, `unsetenv`, enforcing string-only keys/values, handling case-sensitivity in Windows OS).
> 
> The approach in this PR ensures that:
> * we don't just move **this** `os.environ` reference to point at an empty `dict` but rather we replace the existing `dict` _in situ_ so that any other references to those variables that might be been created earlier in code execution will now reference the correct values as well.
> * We ensure we retain access to the characteristics of the `os._Environ` object. 
> * Using `clear=True` we explicitly state that we want a clean slate for this test.