### PR TITLE
chore: skip generation of failed packages

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1737,6 +1737,7 @@ libraries:
     keep:
       - CHANGELOG.md
       - docs/CHANGELOG.md
+    skip_generate: true
     python:
       library_type: GAPIC_COMBO
       opt_args_by_api:
@@ -1975,6 +1976,7 @@ libraries:
     keep:
       - CHANGELOG.md
       - docs/CHANGELOG.md
+    skip_generate: true
     python:
       library_type: GAPIC_COMBO
       opt_args_by_api:
@@ -2740,6 +2742,7 @@ libraries:
       default_version: v1
   - name: google-cloud-ndb
     version: 2.4.2
+    skip_generate: true
     python:
       library_type: GAPIC_MANUAL
       name_pretty_override: NDB Client Library for Google Cloud Datastore
@@ -3587,6 +3590,7 @@ libraries:
     keep:
       - CHANGELOG.md
       - docs/CHANGELOG.md
+    skip_generate: true
     python:
       library_type: GAPIC_MANUAL
       opt_args_by_api:


### PR DESCRIPTION
These packages were removed from the migration batches before, due to test failures. They will be restored one at a time, removing skip_generate in the same PR as generating and fixing any issues for each package.