### PR TITLE
chore: fix the tag format in librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -24,7 +24,7 @@ release:
     - docs/README.rst
 default:
   output: packages
-  tag_format: '{name}: v{version}'
+  tag_format: '{name}-v{version}'
   python:
     common_gapic_paths:
       - samples/generated_samples


### PR DESCRIPTION
This was created by a bug in the migration tool.

Note that this won't have any impact until we're using librarian for releasing, but we should get it fixed ahead of time.

Fixes https://github.com/googleapis/librarian/issues/5341
