### PR TITLE
feat: enable mypy session for db-dtypes

### DIFF
--- a/packages/db-dtypes/db_dtypes/__init__.py
+++ b/packages/db-dtypes/db_dtypes/__init__.py
@@ -55,7 +55,8 @@ class TimeDtype(core.BaseDatetimeDtype):
     name = time_dtype_name
     type = datetime.time
 
-    def construct_array_type(self):
+    @classmethod
+    def construct_array_type(cls):
         return TimeArray
 
     @staticmethod
@@ -213,7 +214,8 @@ class DateDtype(core.BaseDatetimeDtype):
     name = date_dtype_name
     type = datetime.date
 
-    def construct_array_type(self):
+    @classmethod
+    def construct_array_type(cls):
         return DateArray
 
     @staticmethod
@@ -322,7 +324,7 @@ class DateArray(core.BaseDatetimeArray):
         if isinstance(other, TimeArray):
             return (other._ndarray - _NPEPOCH) + self._ndarray
 
-        return super().__add__(other)
+        return super().__add__(other)  # type: ignore[misc]
 
     def __radd__(self, other):
         return self.__add__(other)
@@ -334,7 +336,7 @@ class DateArray(core.BaseDatetimeArray):
         if isinstance(other, self.__class__):
             return self._ndarray - other._ndarray
 
-        return super().__sub__(other)
+        return super().__sub__(other)  # type: ignore[misc]
 
 
 def _check_python_version():

--- a/packages/db-dtypes/db_dtypes/core.py
+++ b/packages/db-dtypes/db_dtypes/core.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, Callable, Any
 
 import numpy
 import pandas
@@ -49,6 +49,13 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
     # be exactly locations in self._ndarray with _internal_fill_value. See:
     # https://github.com/pandas-dev/pandas/blob/main/pandas/core/arrays/_mixins.py
     _internal_fill_value = numpy.datetime64("NaT")
+
+    _box_func: Callable[[Any], Any]
+    _from_backing_data: Callable[[Any], Any]
+
+    @classmethod
+    def _datetime(cls, value: Any) -> Any:
+        raise NotImplementedError
 
     def __init__(self, values, dtype=None, copy: bool = False):
         if not (
@@ -164,8 +171,8 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
             values=self._ndarray, axis=axis, mask=self.isna(), skipna=skipna
         )
         if axis is None or self.ndim == 1:
-            return self._box_func(result)  # type: ignore[attr-defined]
-        return self._from_backing_data(result)  # type: ignore[attr-defined]
+            return self._box_func(result)
+        return self._from_backing_data(result)
 
     def max(self, *, axis: Optional[int] = None, skipna: bool = True, **kwargs):
         pandas_backports.numpy_validate_max((), kwargs)
@@ -173,8 +180,8 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
             values=self._ndarray, axis=axis, mask=self.isna(), skipna=skipna
         )
         if axis is None or self.ndim == 1:
-            return self._box_func(result)  # type: ignore[attr-defined]
-        return self._from_backing_data(result)  # type: ignore[attr-defined]
+            return self._box_func(result)
+        return self._from_backing_data(result)
 
     def median(
         self,
@@ -191,5 +198,5 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
         )
         result = pandas_backports.nanmedian(self._ndarray, axis=axis, skipna=skipna)
         if axis is None or self.ndim == 1:
-            return self._box_func(result)  # type: ignore[attr-defined]
-        return self._from_backing_data(result)  # type: ignore[attr-defined]
+            return self._box_func(result)
+        return self._from_backing_data(result)

--- a/packages/db-dtypes/db_dtypes/core.py
+++ b/packages/db-dtypes/db_dtypes/core.py
@@ -57,7 +57,7 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
     def _datetime(cls, value: Any) -> Any:
         raise NotImplementedError
 
-    def __init__(self, values, dtype=None, copy: bool = False):
+def __init__(self, values, dtype=None, copy: bool = False):
         if not (
             isinstance(values, numpy.ndarray) and values.dtype == numpy.dtype("<M8[ns]")
         ):
@@ -65,7 +65,12 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
         elif copy:
             values = values.copy()
 
-        super().__init__(values=values, dtype=values.dtype)  # type: ignore[call-arg]
+        # 1. Assign the internal attributes required by NDArrayBackedExtensionArray
+        self._ndarray = values
+        self._dtype = values.dtype
+
+        # 2. Call super() without arguments to initialize PandasObject/ExtensionArray
+        super().__init__()
 
     @classmethod
     def __ndarray(cls, scalars):

--- a/packages/db-dtypes/db_dtypes/core.py
+++ b/packages/db-dtypes/db_dtypes/core.py
@@ -57,7 +57,7 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
     def _datetime(cls, value: Any) -> Any:
         raise NotImplementedError
 
-def __init__(self, values, dtype=None, copy: bool = False):
+    def __init__(self, values, dtype=None, copy: bool = False):
         if not (
             isinstance(values, numpy.ndarray) and values.dtype == numpy.dtype("<M8[ns]")
         ):

--- a/packages/db-dtypes/db_dtypes/core.py
+++ b/packages/db-dtypes/db_dtypes/core.py
@@ -65,12 +65,11 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
         elif copy:
             values = values.copy()
 
-        # We must pass values and dtype to the base constructor. 
-        # Manual assignment (self._ndarray = values) will fail at runtime with 
-        # AttributeError because the base is a Cython-backed 'NDArrayBacked' 
+        # We must pass values and dtype to the base constructor.
+        # Manual assignment (self._ndarray = values) will fail at runtime with
+        # AttributeError because the base is a Cython-backed 'NDArrayBacked'
         # object with non-writable attributes.
         super().__init__(values=values, dtype=values.dtype)  # type: ignore[call-arg]
-
 
     @classmethod
     def __ndarray(cls, scalars):

--- a/packages/db-dtypes/db_dtypes/core.py
+++ b/packages/db-dtypes/db_dtypes/core.py
@@ -65,12 +65,12 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
         elif copy:
             values = values.copy()
 
-        # 1. Assign the internal attributes required by NDArrayBackedExtensionArray
-        self._ndarray = values
-        self._dtype = values.dtype
+        # We must pass values and dtype to the base constructor. 
+        # Manual assignment (self._ndarray = values) will fail at runtime with 
+        # AttributeError because the base is a Cython-backed 'NDArrayBacked' 
+        # object with non-writable attributes.
+        super().__init__(values=values, dtype=values.dtype)  # type: ignore[call-arg]
 
-        # 2. Call super() without arguments to initialize PandasObject/ExtensionArray
-        super().__init__()
 
     @classmethod
     def __ndarray(cls, scalars):

--- a/packages/db-dtypes/db_dtypes/core.py
+++ b/packages/db-dtypes/db_dtypes/core.py
@@ -58,7 +58,7 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
         elif copy:
             values = values.copy()
 
-        super().__init__(values=values, dtype=values.dtype)
+        super().__init__(values=values, dtype=values.dtype)  # type: ignore[call-arg]
 
     @classmethod
     def __ndarray(cls, scalars):
@@ -164,8 +164,8 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
             values=self._ndarray, axis=axis, mask=self.isna(), skipna=skipna
         )
         if axis is None or self.ndim == 1:
-            return self._box_func(result)
-        return self._from_backing_data(result)
+            return self._box_func(result)  # type: ignore[attr-defined]
+        return self._from_backing_data(result)  # type: ignore[attr-defined]
 
     def max(self, *, axis: Optional[int] = None, skipna: bool = True, **kwargs):
         pandas_backports.numpy_validate_max((), kwargs)
@@ -173,8 +173,8 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
             values=self._ndarray, axis=axis, mask=self.isna(), skipna=skipna
         )
         if axis is None or self.ndim == 1:
-            return self._box_func(result)
-        return self._from_backing_data(result)
+            return self._box_func(result)  # type: ignore[attr-defined]
+        return self._from_backing_data(result)  # type: ignore[attr-defined]
 
     def median(
         self,
@@ -191,5 +191,5 @@ class BaseDatetimeArray(pandas_backports.OpsMixin, _mixins.NDArrayBackedExtensio
         )
         result = pandas_backports.nanmedian(self._ndarray, axis=axis, skipna=skipna)
         if axis is None or self.ndim == 1:
-            return self._box_func(result)
-        return self._from_backing_data(result)
+            return self._box_func(result)  # type: ignore[attr-defined]
+        return self._from_backing_data(result)  # type: ignore[attr-defined]

--- a/packages/db-dtypes/db_dtypes/json.py
+++ b/packages/db-dtypes/db_dtypes/json.py
@@ -32,12 +32,12 @@ class JSONDtype(pd.api.extensions.ExtensionDtype):
     name = "dbjson"
 
     @property
-    def na_value(self) -> pd.NA:
+    def na_value(self) -> pd.NA:  # type: ignore[valid-type]
         """Default NA value to use for this type."""
         return pd.NA
 
     @property
-    def type(self) -> type[str]:
+    def type(self) -> type[str]:  # type: ignore[override]
         """
         Return the scalar type for the array elements.
         The standard JSON data types can be one of `dict`, `list`, `str`, `int`, `float`,

--- a/packages/db-dtypes/db_dtypes/json.py
+++ b/packages/db-dtypes/db_dtypes/json.py
@@ -32,7 +32,7 @@ class JSONDtype(pd.api.extensions.ExtensionDtype):
     name = "dbjson"
 
     @property
-    def na_value(self) -> pd.NAType:
+    def na_value(self) -> pd.NAType:  # type: ignore[name-defined]
         """Default NA value to use for this type."""
         return pd.NA
 
@@ -203,7 +203,7 @@ class JSONArray(arrays.ArrowExtensionArray):
                 assert item.dtype.kind == "b"
                 return type(self)(self.pa_data.filter(item))
         elif isinstance(item, tuple):
-            item = indexers.unpack_tuple_and_ellipses(item)
+            item = indexers.unpack_tuple_and_ellipses(item)  # type: ignore[attr-defined]
 
         if common.is_scalar(item) and not common.is_integer(item):
             # e.g. "foo" or 2.5

--- a/packages/db-dtypes/db_dtypes/json.py
+++ b/packages/db-dtypes/db_dtypes/json.py
@@ -32,7 +32,7 @@ class JSONDtype(pd.api.extensions.ExtensionDtype):
     name = "dbjson"
 
     @property
-    def na_value(self) -> pd.NA:  # type: ignore[valid-type]
+    def na_value(self) -> pd.NAType:
         """Default NA value to use for this type."""
         return pd.NA
 

--- a/packages/db-dtypes/db_dtypes/pandas_backports.py
+++ b/packages/db-dtypes/db_dtypes/pandas_backports.py
@@ -26,16 +26,16 @@ import pandas.compat.numpy.function
 pandas_release = packaging.version.parse(pandas.__version__).release
 
 # # Create aliases for private methods in case they move in a future version.
-nanall = pandas.core.nanops.nanall
-nanany = pandas.core.nanops.nanany
-nanmax = pandas.core.nanops.nanmax
-nanmin = pandas.core.nanops.nanmin
+nanall = pandas.core.nanops.nanall  # type: ignore[attr-defined]
+nanany = pandas.core.nanops.nanany  # type: ignore[attr-defined]
+nanmax = pandas.core.nanops.nanmax  # type: ignore[attr-defined]
+nanmin = pandas.core.nanops.nanmin  # type: ignore[attr-defined]
 numpy_validate_all = pandas.compat.numpy.function.validate_all
 numpy_validate_any = pandas.compat.numpy.function.validate_any
 numpy_validate_max = pandas.compat.numpy.function.validate_max
 numpy_validate_min = pandas.compat.numpy.function.validate_min
 
-nanmedian = pandas.core.nanops.nanmedian
+nanmedian = pandas.core.nanops.nanmedian  # type: ignore[attr-defined]
 numpy_validate_median = pandas.compat.numpy.function.validate_median
 
 

--- a/packages/db-dtypes/noxfile.py
+++ b/packages/db-dtypes/noxfile.py
@@ -487,6 +487,18 @@ def core_deps_from_source(session):
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def mypy(session):
     """Run the type checker."""
-    # TODO(https://github.com/googleapis/google-cloud-python/issues/16014):
-    # Add mypy tests
-    session.skip("mypy tests are not yet supported")
+    session.install(
+        "mypy<1.16.0",
+        "types-requests",
+        "types-protobuf",
+        "pandas-stubs",
+    )
+    session.install("-e", ".")
+    session.run(
+        "mypy",
+        "-p",
+        "db_dtypes",
+        "--check-untyped-defs",
+        "--ignore-missing-imports",
+        *session.posargs,
+    )


### PR DESCRIPTION
This PR enables the mypy session in noxfile.py for db-dtypes and aligns it with the GAPIC generator template. It passes with some type ignores added for missing stubs and internal pandas usage.