### PR TITLE
chore: complete migration of google-cloud-datastore

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1732,7 +1732,6 @@ libraries:
     keep:
       - CHANGELOG.md
       - docs/CHANGELOG.md
-    skip_generate: true
     python:
       library_type: GAPIC_COMBO
       opt_args_by_api:

--- a/packages/google-cloud-datastore/.repo-metadata.json
+++ b/packages/google-cloud-datastore/.repo-metadata.json
@@ -1,17 +1,16 @@
 {
+    "api_description": "is a fully managed, schemaless database for\nstoring non-relational data. Cloud Datastore automatically scales with\nyour users and supports ACID transactions, high availability of reads and\nwrites, strong consistency for reads and ancestor queries, and eventual\nconsistency for all other queries.",
+    "api_id": "datastore.googleapis.com",
+    "api_shortname": "datastore",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/datastore/latest",
+    "default_version": "v1",
+    "distribution_name": "google-cloud-datastore",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559768",
+    "language": "python",
+    "library_type": "GAPIC_COMBO",
     "name": "datastore",
     "name_pretty": "Google Cloud Datastore API",
     "product_documentation": "https://cloud.google.com/datastore",
-    "client_documentation": "https://cloud.google.com/python/docs/reference/datastore/latest",
-    "issue_tracker": "https://issuetracker.google.com/savedsearches/559768",
     "release_level": "stable",
-    "language": "python",
-    "library_type": "GAPIC_COMBO",
-    "repo": "googleapis/google-cloud-python",
-    "distribution_name": "google-cloud-datastore",
-    "api_id": "datastore.googleapis.com",
-    "default_version": "v1",
-    "codeowner_team": "@googleapis/cloud-native-db-dpes @googleapis/api-datastore-sdk @googleapis/api-firestore-partners",
-    "api_shortname": "datastore",
-    "api_description": "is a fully managed, schemaless database for\nstoring non-relational data. Cloud Datastore automatically scales with\nyour users and supports ACID transactions, high availability of reads and\nwrites, strong consistency for reads and ancestor queries, and eventual\nconsistency for all other queries."
+    "repo": "googleapis/google-cloud-python"
 }


### PR DESCRIPTION
Removed skip_generate and regenerated with Librarian.
