### PR TITLE
chore: complete migration of google-cloud-error-reporting

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1971,7 +1971,6 @@ libraries:
     keep:
       - CHANGELOG.md
       - docs/CHANGELOG.md
-    skip_generate: true
     python:
       library_type: GAPIC_COMBO
       opt_args_by_api:

--- a/packages/google-cloud-error-reporting/.repo-metadata.json
+++ b/packages/google-cloud-error-reporting/.repo-metadata.json
@@ -1,18 +1,16 @@
 {
+    "api_description": "counts, analyzes and aggregates the crashes in your running cloud services.  A centralized error management interface displays the results with sorting and filtering capabilities. A dedicated view shows the error details: time chart, occurrences, affected user count, first and last seen dates and a cleaned exception stack trace. Opt-in to receive email and mobile alerts on new errors.",
+    "api_id": "clouderrorreporting.googleapis.com",
+    "api_shortname": "clouderrorreporting",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/clouderrorreporting/latest",
+    "default_version": "v1beta1",
+    "distribution_name": "google-cloud-error-reporting",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559780",
+    "language": "python",
+    "library_type": "GAPIC_COMBO",
     "name": "clouderrorreporting",
     "name_pretty": "Error Reporting API",
     "product_documentation": "https://cloud.google.com/error-reporting",
-    "client_documentation": "https://cloud.google.com/python/docs/reference/clouderrorreporting/latest",
-    "issue_tracker": "https://issuetracker.google.com/savedsearches/559780",
     "release_level": "preview",
-    "language": "python",
-    "library_type": "GAPIC_COMBO",
-    "repo": "googleapis/google-cloud-python",
-    "distribution_name": "google-cloud-error-reporting",
-    "api_id": "clouderrorreporting.googleapis.com",
-    "requires_billing": false,
-    "codeowner_team": "@googleapis/yoshi-python",
-    "default_version": "v1beta1",
-    "api_shortname": "clouderrorreporting",
-    "api_description": "counts, analyzes and aggregates the crashes in your running cloud services.  A centralized error management interface displays the results with sorting and filtering capabilities. A dedicated view shows the error details: time chart, occurrences, affected user count, first and last seen dates and a cleaned exception stack trace. Opt-in to receive email and mobile alerts on new errors."
+    "repo": "googleapis/google-cloud-python"
 }


### PR DESCRIPTION
Removed skip_generate and regenerated with Librarian.