### PR TITLE
chore: complete migration of google-crc32c

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -4024,7 +4024,6 @@ libraries:
       default_version: v1
   - name: google-crc32c
     version: 1.8.0
-    skip_generate: true
     python:
       library_type: OTHER
       name_pretty_override: A python wrapper of the C library 'Google CRC32C'

--- a/packages/google-crc32c/.repo-metadata.json
+++ b/packages/google-crc32c/.repo-metadata.json
@@ -1,14 +1,11 @@
 {
-    "name": "google-crc32c",
-    "name_pretty": "A python wrapper of the C library 'Google CRC32C'",
-    "product_documentation": "",
     "client_documentation": "https://github.com/googleapis/python-crc32c",
+    "distribution_name": "google-crc32c",
     "issue_tracker": "https://github.com/googleapis/python-crc32c/issues",
-    "release_level": "stable",
     "language": "python",
     "library_type": "OTHER",
-    "repo": "googleapis/google-cloud-python",
-    "distribution_name": "google-crc32c",
-    "default_version": "",
-    "codeowner_team": ""
+    "name": "google-crc32c",
+    "name_pretty": "A python wrapper of the C library 'Google CRC32C'",
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-python"
 }


### PR DESCRIPTION
Removed skip_generate and regenerated with Librarian.