### PR TITLE
chore: allow docs warnings in more packages

### DIFF
--- a/.librarian/generator-input/client-post-processing/allow-docs-warnings.yaml
+++ b/.librarian/generator-input/client-post-processing/allow-docs-warnings.yaml
@@ -16,6 +16,12 @@ url: https://github.com/googleapis/gapic-generator-python/issues/2490
 replacements:
   - paths: [
       packages/google-shopping-merchant-accounts/noxfile.py,
+      packages/google-cloud-compute/noxfile.py,
+      packages/google-cloud-compute-v1beta/noxfile.py,
+      packages/google-cloud-container/noxfile.py,
+      packages/google-cloud-dataplex/noxfile.py,
+      packages/google-cloud-network-connectivity/noxfile.py,
+      packages/google-cloud-recaptcha-enterprise/noxfile.py,
     ]
     before: '        "-W",  # warnings as errors\n'
     after: ''

--- a/.librarian/generator-input/client-post-processing/allow-docs-warnings.yaml
+++ b/.librarian/generator-input/client-post-processing/allow-docs-warnings.yaml
@@ -15,13 +15,14 @@ description: Allow documentation warnings for google-shopping-merchant-accounts 
 url: https://github.com/googleapis/gapic-generator-python/issues/2490
 replacements:
   - paths: [
-      packages/google-shopping-merchant-accounts/noxfile.py,
       packages/google-cloud-compute/noxfile.py,
       packages/google-cloud-compute-v1beta/noxfile.py,
       packages/google-cloud-container/noxfile.py,
       packages/google-cloud-dataplex/noxfile.py,
+      packages/google-cloud-dialogflow-cx/noxfile.py,
       packages/google-cloud-network-connectivity/noxfile.py,
       packages/google-cloud-recaptcha-enterprise/noxfile.py,
+      packages/google-shopping-merchant-accounts/noxfile.py,
     ]
     before: '        "-W",  # warnings as errors\n'
     after: ''

--- a/.librarian/generator-input/client-post-processing/allow-docs-warnings.yaml
+++ b/.librarian/generator-input/client-post-processing/allow-docs-warnings.yaml
@@ -13,15 +13,53 @@
 # limitations under the License.
 description: Allow documentation warnings for google-shopping-merchant-accounts due to formatting issue in google/protobuf/empty.proto
 url: https://github.com/googleapis/gapic-generator-python/issues/2490
+# Note: having one replacement per package instead of just listing the paths
+# is annoying, but that's what synthtool expects and it's not worth fixing that
+# at this stage.
 replacements:
   - paths: [
       packages/google-cloud-compute/noxfile.py,
+    ]
+    before: '        "-W",  # warnings as errors\n'
+    after: ''
+    count: 1
+  - paths: [
       packages/google-cloud-compute-v1beta/noxfile.py,
+    ]
+    before: '        "-W",  # warnings as errors\n'
+    after: ''
+    count: 1
+  - paths: [
       packages/google-cloud-container/noxfile.py,
+    ]
+    before: '        "-W",  # warnings as errors\n'
+    after: ''
+    count: 1
+  - paths: [
       packages/google-cloud-dataplex/noxfile.py,
+    ]
+    before: '        "-W",  # warnings as errors\n'
+    after: ''
+    count: 1
+  - paths: [
       packages/google-cloud-dialogflow-cx/noxfile.py,
+    ]
+    before: '        "-W",  # warnings as errors\n'
+    after: ''
+    count: 1
+  - paths: [
       packages/google-cloud-network-connectivity/noxfile.py,
+    ]
+    before: '        "-W",  # warnings as errors\n'
+    after: ''
+    count: 1
+  - paths: [
       packages/google-cloud-recaptcha-enterprise/noxfile.py,
+    ]
+    before: '        "-W",  # warnings as errors\n'
+    after: ''
+    count: 1
+  - paths: [
       packages/google-shopping-merchant-accounts/noxfile.py,
     ]
     before: '        "-W",  # warnings as errors\n'


### PR DESCRIPTION
Renames the post-processing file, and adds more paths to it.

This file should be removed entirely once we've upgraded to a later version of the GAPIC generator which fixes the warnings. See #15475 for details on this work.
