### PR TITLE
perf(storage): implement fast-path for queue delivery in _StreamMultiplexer

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/asyncio/_stream_multiplexer.py
+++ b/packages/google-cloud-storage/google/cloud/storage/asyncio/_stream_multiplexer.py
@@ -88,6 +88,11 @@ class _StreamMultiplexer:
         return set(self._queues.values())
 
     async def _put_with_timeout(self, queue: asyncio.Queue, item) -> None:
+        """Slow-path put: wait up to _DEFAULT_PUT_TIMEOUT_SECONDS, else drop.
+
+        Callers should attempt ``queue.put_nowait(item)`` first and only call
+        this when it raises :class:`asyncio.QueueFull`.
+        """
         try:
             await asyncio.wait_for(
                 queue.put(item), timeout=_DEFAULT_PUT_TIMEOUT_SECONDS
@@ -99,6 +104,32 @@ class _StreamMultiplexer:
                 logger.warning(
                     "Queue full for too long. Dropping item to prevent multiplexer hang."
                 )
+
+    async def _put_to_queues(self, queues, item) -> None:
+        """Deliver ``item`` to each queue.
+
+        Fast path: ``put_nowait`` for queues with capacity (no Task, no
+        timer handle, no coroutine yield). Slow path: ``_put_with_timeout``
+        only for queues that were full, and a single direct ``await`` when
+        exactly one queue needs the slow path (skips ``asyncio.gather``).
+        """
+        slow_queues = None
+        for q in queues:
+            try:
+                q.put_nowait(item)
+            except asyncio.QueueFull:
+                if slow_queues is None:
+                    slow_queues = [q]
+                else:
+                    slow_queues.append(q)
+        if slow_queues is None:
+            return
+        if len(slow_queues) == 1:
+            await self._put_with_timeout(slow_queues[0], item)
+        else:
+            await asyncio.gather(
+                *(self._put_with_timeout(q, item) for q in slow_queues)
+            )
 
     def _ensure_recv_loop(self) -> None:
         if self._recv_task is None or self._recv_task.done():
@@ -124,13 +155,7 @@ class _StreamMultiplexer:
             while True:
                 response = await self._stream.recv()
                 if response == grpc.aio.EOF:
-                    sentinel = _StreamEnd()
-                    await asyncio.gather(
-                        *(
-                            self._put_with_timeout(queue, sentinel)
-                            for queue in self._get_unique_queues()
-                        )
-                    )
+                    await self._put_to_queues(self._get_unique_queues(), _StreamEnd())
                     return
 
                 if response.object_data_ranges:
@@ -144,19 +169,9 @@ class _StreamMultiplexer:
                             logger.warning(
                                 f"Received data for unregistered read_id: {read_id}"
                             )
-                    await asyncio.gather(
-                        *(
-                            self._put_with_timeout(queue, response)
-                            for queue in queues_to_notify
-                        )
-                    )
+                    await self._put_to_queues(queues_to_notify, response)
                 else:
-                    await asyncio.gather(
-                        *(
-                            self._put_with_timeout(queue, response)
-                            for queue in self._get_unique_queues()
-                        )
-                    )
+                    await self._put_to_queues(self._get_unique_queues(), response)
         except asyncio.CancelledError:
             raise
         except Exception as e:


### PR DESCRIPTION
## Summary
This PR optimizes the message delivery logic in `_StreamMultiplexer` to reduce latency and event loop overhead.

### Performance Improvements:
1. **Fast-path Delivery**: Implemented a "fast-path" that attempts `queue.put_nowait(item)` for all target queues. For queues with available capacity, this is a synchronous operation that avoids:
    - Creating and scheduling a coroutine.
    - Yielding to the event loop.
    - Overhead associated with `asyncio.wait_for`.
2. **Single-Queue Slow-path Optimization**: In cases where exactly one queue is full, the multiplexer now directly awaits the `_put_with_timeout` coroutine. This bypasses the overhead of `asyncio.gather`, which is now only used when multiple queues are full simultaneously.
3. **Reduced Event Loop Pressure**: By minimizing the number of tasks created and yields performed during high-throughput streaming, these changes help the multiplexer keep up with fast-arriving gRPC responses.
