### PR TITLE
feat(auth): Add blocking Regional Access Boundary Lookup and Seed Support

### DIFF
--- a/packages/google-auth/google/auth/_helpers.py
+++ b/packages/google-auth/google/auth/_helpers.py
@@ -21,6 +21,7 @@ from email.message import Message
 import hashlib
 import json
 import logging
+import os
 import sys
 from typing import Any, Dict, Mapping, Optional, Union
 import urllib
@@ -305,6 +306,46 @@ def unpadded_urlsafe_b64encode(value):
         Union[str|bytes]: The encoded value
     """
     return base64.urlsafe_b64encode(value).rstrip(b"=")
+
+
+def get_bool_from_env(variable_name, default=False):
+    """Gets a boolean value from an environment variable.
+
+    The environment variable is interpreted as a boolean with the following
+    (case-insensitive) rules:
+    - "true", "1" are considered true.
+    - "false", "0" are considered false.
+    Any other values will raise an exception.
+
+    Args:
+        variable_name (str): The name of the environment variable.
+        default (bool): The default value if the environment variable is not
+            set.
+
+    Returns:
+        bool: The boolean value of the environment variable.
+
+    Raises:
+        google.auth.exceptions.InvalidValue: If the environment variable is
+            set to a value that can not be interpreted as a boolean.
+    """
+    value = os.environ.get(variable_name)
+
+    if value is None:
+        return default
+
+    value = value.lower()
+
+    if value in ("true", "1"):
+        return True
+    elif value in ("false", "0"):
+        return False
+    else:
+        raise exceptions.InvalidValue(
+            'Environment variable "{}" must be one of "true", "false", "1", or "0".'.format(
+                variable_name
+            )
+        )
 
 
 def is_python_3():

--- a/packages/google-auth/google/auth/_helpers.py
+++ b/packages/google-auth/google/auth/_helpers.py
@@ -21,7 +21,6 @@ from email.message import Message
 import hashlib
 import json
 import logging
-import os
 import sys
 from typing import Any, Dict, Mapping, Optional, Union
 import urllib
@@ -307,45 +306,6 @@ def unpadded_urlsafe_b64encode(value):
     """
     return base64.urlsafe_b64encode(value).rstrip(b"=")
 
-
-def get_bool_from_env(variable_name, default=False):
-    """Gets a boolean value from an environment variable.
-
-    The environment variable is interpreted as a boolean with the following
-    (case-insensitive) rules:
-    - "true", "1" are considered true.
-    - "false", "0" are considered false.
-    Any other values will raise an exception.
-
-    Args:
-        variable_name (str): The name of the environment variable.
-        default (bool): The default value if the environment variable is not
-            set.
-
-    Returns:
-        bool: The boolean value of the environment variable.
-
-    Raises:
-        google.auth.exceptions.InvalidValue: If the environment variable is
-            set to a value that can not be interpreted as a boolean.
-    """
-    value = os.environ.get(variable_name)
-
-    if value is None:
-        return default
-
-    value = value.lower()
-
-    if value in ("true", "1"):
-        return True
-    elif value in ("false", "0"):
-        return False
-    else:
-        raise exceptions.InvalidValue(
-            'Environment variable "{}" must be one of "true", "false", "1", or "0".'.format(
-                variable_name
-            )
-        )
 
 
 def is_python_3():

--- a/packages/google-auth/google/auth/_helpers.py
+++ b/packages/google-auth/google/auth/_helpers.py
@@ -307,7 +307,6 @@ def unpadded_urlsafe_b64encode(value):
     return base64.urlsafe_b64encode(value).rstrip(b"=")
 
 
-
 def is_python_3():
     """Check if the Python interpreter is Python 2 or 3.
 

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -226,7 +226,9 @@ class _RegionalAccessBoundaryManager(object):
 
             if regional_access_boundary_info:
                 # On success, update the boundary and its expiry, and clear any cooldown.
-                encoded_locations = regional_access_boundary_info.get("encodedLocations")
+                encoded_locations = regional_access_boundary_info.get(
+                    "encodedLocations"
+                )
                 updated_data = _RegionalAccessBoundaryData(
                     encoded_locations=encoded_locations,
                     expiry=_helpers.utcnow() + DEFAULT_REGIONAL_ACCESS_BOUNDARY_TTL,
@@ -242,7 +244,9 @@ class _RegionalAccessBoundaryManager(object):
                         "Regional Access Boundary lookup failed. Entering cooldown."
                     )
 
-                next_cooldown_expiry = _helpers.utcnow() + current_data.cooldown_duration
+                next_cooldown_expiry = (
+                    _helpers.utcnow() + current_data.cooldown_duration
+                )
                 next_cooldown_duration = min(
                     current_data.cooldown_duration * 2,
                     MAX_REGIONAL_ACCESS_BOUNDARY_COOLDOWN,
@@ -266,8 +270,6 @@ class _RegionalAccessBoundaryManager(object):
 
             # Perform the atomic swap of the state object.
             self._data = updated_data
-
-
 
 
 class _RegionalAccessBoundaryRefreshThread(threading.Thread):

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -110,6 +110,16 @@ class _RegionalAccessBoundaryManager(object):
         self.__dict__.update(state)
         self._update_lock = threading.Lock()
 
+    def __eq__(self, other):
+        """Checks if two managers are equal."""
+        if not isinstance(other, _RegionalAccessBoundaryManager):
+            return NotImplemented
+        return (
+            self._data == other._data
+            and self._use_blocking_regional_access_boundary_lookup
+            == other._use_blocking_regional_access_boundary_lookup
+        )
+
     def use_blocking_regional_access_boundary_lookup(self):
         """Enables blocking regional access boundary lookup to true"""
         self._use_blocking_regional_access_boundary_lookup = True

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -110,15 +110,6 @@ class _RegionalAccessBoundaryManager(object):
         self.__dict__.update(state)
         self._update_lock = threading.Lock()
 
-    def __eq__(self, other):
-        if not isinstance(other, _RegionalAccessBoundaryManager):
-            return False
-        return (
-            self._data == other._data
-            and self.refresh_manager == other.refresh_manager
-            and self._use_blocking_regional_access_boundary_lookup
-            == other._use_blocking_regional_access_boundary_lookup
-        )
 
     def use_blocking_regional_access_boundary_lookup(self):
         """Enables blocking regional access boundary lookup to true"""
@@ -332,12 +323,6 @@ class _RegionalAccessBoundaryRefreshManager(object):
         self.__dict__.update(state)
         self._lock = threading.Lock()
         self._worker = None
-
-    def __eq__(self, other):
-        if not isinstance(other, _RegionalAccessBoundaryRefreshManager):
-            return False
-        # Note: We only compare public/pickled properties.
-        return self._worker == other._worker
 
     def start_refresh(self, credentials, request, rab_manager):
         """

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -120,22 +120,29 @@ class _RegionalAccessBoundaryManager(object):
             == other._use_blocking_regional_access_boundary_lookup
         )
 
-    def use_blocking_regional_access_boundary_lookup(self):
-        """Enables blocking regional access boundary lookup to true"""
+    def enable_blocking_lookup(self):
+        """Enables blocking Regional Access Boundary lookup.
+
+        When enabled, the Regional Access Boundary lookup will be performed
+        synchronously in the calling thread instead of asynchronously in a
+        background thread.
+        """
         self._use_blocking_regional_access_boundary_lookup = True
 
-    def set_initial_regional_access_boundary(self, seed):
-        """Manually sets the regional access boundary to the client provided seed
+    def set_initial_regional_access_boundary(self, encoded_locations=None, expiry=None):
+        """Manually sets the regional access boundary to the client provided seed.
 
         Args:
-            seed (Mapping[str, str]): The regional access boundary to use for the
-                credential. This should be a map with, at a minimum, an "encodedLocations"
-                key that maps to a hex string and an "expiry" key which maps to a
-                datetime.datetime.
+            encoded_locations (Optional[str]): The encoded locations string.
+            expiry (Optional[datetime.datetime]): The expiry time for the boundary.
+                If encoded_locations is not provided, expiry is ignored.
         """
+        if not encoded_locations:
+            expiry = None
+
         self._data = _RegionalAccessBoundaryData(
-            encoded_locations=seed.get("encodedLocations", None),
-            expiry=seed.get("expiry", None),
+            encoded_locations=encoded_locations,
+            expiry=expiry,
             cooldown_expiry=None,
             cooldown_duration=DEFAULT_REGIONAL_ACCESS_BOUNDARY_COOLDOWN,
         )
@@ -190,17 +197,20 @@ class _RegionalAccessBoundaryManager(object):
     def start_blocking_refresh(self, credentials, request):
         """Initiates a blocking lookup of the Regional Access Boundary.
 
+        If the lookup raises an exception, it is caught and logged as a warning,
+        and the lookup is treated as a failure (entering cooldown). Exceptions
+        are not propagated to the caller.
+
         Args:
             credentials (google.auth.credentials.Credentials): The credentials to refresh.
             request (google.auth.transport.Request): The object used to make HTTP requests.
         """
         try:
-            # A blocking parameter is passed here to indicate this is a blocking lookup,
-            # which in turn will do two things: 1) set a timeout to 3s instead of the
-            # default 120s and 2) ensure we do not retry at all
-            blocking = True
+            # The fail_fast parameter is set to True to ensure we don't block the calling
+            # thread for too long. This will do two things: 1) set a timeout to 3s
+            # instead of the default 120s and 2) ensure we do not retry at all
             regional_access_boundary_info = (
-                credentials._lookup_regional_access_boundary(request, blocking)
+                credentials._lookup_regional_access_boundary(request, fail_fast=True)
             )
         except Exception as e:
             if _helpers.is_logging_enabled(_LOGGER):
@@ -275,7 +285,12 @@ class _RegionalAccessBoundaryManager(object):
 class _RegionalAccessBoundaryRefreshThread(threading.Thread):
     """Thread for background refreshing of the Regional Access Boundary."""
 
-    def __init__(self, credentials, request, rab_manager):
+    def __init__(
+        self,
+        credentials: "google.auth.credentials.CredentialsWithRegionalAccessBoundary",  # noqa: F821
+        request: "google.auth.transport.Request",  # noqa: F821
+        rab_manager: "_RegionalAccessBoundaryManager",
+    ):
         super().__init__()
         self.daemon = True
         self._credentials = credentials

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -97,6 +97,7 @@ class _RegionalAccessBoundaryManager(object):
         )
         self.refresh_manager = _RegionalAccessBoundaryRefreshManager()
         self._update_lock = threading.Lock()
+        self._use_blocking_regional_access_boundary_lookup = False
 
     def __getstate__(self):
         """Pickle helper that serializes the _update_lock attribute."""
@@ -108,6 +109,36 @@ class _RegionalAccessBoundaryManager(object):
         """Pickle helper that deserializes the _update_lock attribute."""
         self.__dict__.update(state)
         self._update_lock = threading.Lock()
+
+    def __eq__(self, other):
+        if not isinstance(other, _RegionalAccessBoundaryManager):
+            return False
+        return (
+            self._data == other._data
+            and self.refresh_manager == other.refresh_manager
+            and self._use_blocking_regional_access_boundary_lookup
+            == other._use_blocking_regional_access_boundary_lookup
+        )
+
+    def use_blocking_regional_access_boundary_lookup(self):
+        """Enables blocking regional access boundary lookup to true"""
+        self._use_blocking_regional_access_boundary_lookup = True
+
+    def set_initial_regional_access_boundary(self, seed):
+        """Manually sets the regional access boundary to the client provided seed
+
+        Args:
+            seed (Mapping[str, str]): The regional access boundary to use for the
+                credential. This should be a map with, at a minimum, an "encodedLocations"
+                key that maps to a hex string and an "expiry" key which maps to a
+                datetime.datetime.
+        """
+        self._data = _RegionalAccessBoundaryData(
+            encoded_locations=seed.get("encodedLocations", None),
+            expiry=seed.get("expiry", None),
+            cooldown_expiry=None,
+            cooldown_duration=DEFAULT_REGIONAL_ACCESS_BOUNDARY_COOLDOWN,
+        )
 
     def apply_headers(self, headers):
         """Applies the Regional Access Boundary header to the provided dictionary.
@@ -151,7 +182,92 @@ class _RegionalAccessBoundaryManager(object):
             return
 
         # If all checks pass, start the background refresh.
-        self.refresh_manager.start_refresh(credentials, request, self)
+        if self._use_blocking_regional_access_boundary_lookup:
+            self.start_blocking_refresh(credentials, request)
+        else:
+            self.refresh_manager.start_refresh(credentials, request, self)
+
+    def start_blocking_refresh(self, credentials, request):
+        """Initiates a blocking lookup of the Regional Access Boundary.
+
+        Args:
+            credentials (google.auth.credentials.Credentials): The credentials to refresh.
+            request (google.auth.transport.Request): The object used to make HTTP requests.
+        """
+        try:
+            # A blocking parameter is passed here to indicate this is a blocking lookup,
+            # which in turn will do two things: 1) set a timeout to 3s instead of the
+            # default 120s and 2) ensure we do not retry at all
+            blocking = True
+            regional_access_boundary_info = (
+                credentials._lookup_regional_access_boundary(request, blocking)
+            )
+        except Exception as e:
+            if _helpers.is_logging_enabled(_LOGGER):
+                _LOGGER.warning(
+                    "Blocking Regional Access Boundary lookup raised an exception: %s",
+                    e,
+                    exc_info=True,
+                )
+            regional_access_boundary_info = None
+
+        self.process_regional_access_boundary_info(regional_access_boundary_info)
+
+    def process_regional_access_boundary_info(self, regional_access_boundary_info):
+        """Processes the regional access boundary info and updates the state.
+
+        Args:
+            regional_access_boundary_info (Optional[Mapping[str, str]]): The regional access
+                boundary info to process.
+        """
+        with self._update_lock:
+            # Capture the current state before calculating updates.
+            current_data = self._data
+
+            if regional_access_boundary_info:
+                # On success, update the boundary and its expiry, and clear any cooldown.
+                encoded_locations = regional_access_boundary_info.get("encodedLocations")
+                updated_data = _RegionalAccessBoundaryData(
+                    encoded_locations=encoded_locations,
+                    expiry=_helpers.utcnow() + DEFAULT_REGIONAL_ACCESS_BOUNDARY_TTL,
+                    cooldown_expiry=None,
+                    cooldown_duration=DEFAULT_REGIONAL_ACCESS_BOUNDARY_COOLDOWN,
+                )
+                if _helpers.is_logging_enabled(_LOGGER):
+                    _LOGGER.debug("Regional Access Boundary lookup successful.")
+            else:
+                # On failure, calculate cooldown and update state.
+                if _helpers.is_logging_enabled(_LOGGER):
+                    _LOGGER.warning(
+                        "Regional Access Boundary lookup failed. Entering cooldown."
+                    )
+
+                next_cooldown_expiry = _helpers.utcnow() + current_data.cooldown_duration
+                next_cooldown_duration = min(
+                    current_data.cooldown_duration * 2,
+                    MAX_REGIONAL_ACCESS_BOUNDARY_COOLDOWN,
+                )
+
+                # If the refresh failed, we keep reusing the existing data unless
+                # it has reached its hard expiration time.
+                if current_data.expiry and _helpers.utcnow() > current_data.expiry:
+                    next_encoded_locations = None
+                    next_expiry = None
+                else:
+                    next_encoded_locations = current_data.encoded_locations
+                    next_expiry = current_data.expiry
+
+                updated_data = _RegionalAccessBoundaryData(
+                    encoded_locations=next_encoded_locations,
+                    expiry=next_expiry,
+                    cooldown_expiry=next_cooldown_expiry,
+                    cooldown_duration=next_cooldown_duration,
+                )
+
+            # Perform the atomic swap of the state object.
+            self._data = updated_data
+
+
 
 
 class _RegionalAccessBoundaryRefreshThread(threading.Thread):
@@ -190,58 +306,9 @@ class _RegionalAccessBoundaryRefreshThread(threading.Thread):
                 )
             regional_access_boundary_info = None
 
-        with self._rab_manager._update_lock:
-            # Capture the current state before calculating updates.
-            current_data = self._rab_manager._data
-
-            if regional_access_boundary_info:
-                # On success, update the boundary and its expiry, and clear any cooldown.
-                encoded_locations = regional_access_boundary_info.get(
-                    "encodedLocations"
-                )
-                updated_data = _RegionalAccessBoundaryData(
-                    encoded_locations=encoded_locations,
-                    expiry=_helpers.utcnow() + DEFAULT_REGIONAL_ACCESS_BOUNDARY_TTL,
-                    cooldown_expiry=None,
-                    cooldown_duration=DEFAULT_REGIONAL_ACCESS_BOUNDARY_COOLDOWN,
-                )
-                if _helpers.is_logging_enabled(_LOGGER):
-                    _LOGGER.debug(
-                        "Asynchronous Regional Access Boundary lookup successful."
-                    )
-            else:
-                # On failure, calculate cooldown and update state.
-                if _helpers.is_logging_enabled(_LOGGER):
-                    _LOGGER.warning(
-                        "Asynchronous Regional Access Boundary lookup failed. Entering cooldown."
-                    )
-
-                next_cooldown_expiry = (
-                    _helpers.utcnow() + current_data.cooldown_duration
-                )
-                next_cooldown_duration = min(
-                    current_data.cooldown_duration * 2,
-                    MAX_REGIONAL_ACCESS_BOUNDARY_COOLDOWN,
-                )
-
-                # If the refresh failed, we keep reusing the existing data unless
-                # it has reached its hard expiration time.
-                if current_data.expiry and _helpers.utcnow() > current_data.expiry:
-                    next_encoded_locations = None
-                    next_expiry = None
-                else:
-                    next_encoded_locations = current_data.encoded_locations
-                    next_expiry = current_data.expiry
-
-                updated_data = _RegionalAccessBoundaryData(
-                    encoded_locations=next_encoded_locations,
-                    expiry=next_expiry,
-                    cooldown_expiry=next_cooldown_expiry,
-                    cooldown_duration=next_cooldown_duration,
-                )
-
-            # Perform the atomic swap of the state object.
-            self._rab_manager._data = updated_data
+        self._rab_manager.process_regional_access_boundary_info(
+            regional_access_boundary_info
+        )
 
 
 class _RegionalAccessBoundaryRefreshManager(object):
@@ -263,6 +330,12 @@ class _RegionalAccessBoundaryRefreshManager(object):
         self.__dict__.update(state)
         self._lock = threading.Lock()
         self._worker = None
+
+    def __eq__(self, other):
+        if not isinstance(other, _RegionalAccessBoundaryRefreshManager):
+            return False
+        # Note: We only compare public/pickled properties.
+        return self._worker == other._worker
 
     def start_refresh(self, credentials, request, rab_manager):
         """

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -20,10 +20,14 @@ import functools
 import logging
 import os
 import threading
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, TYPE_CHECKING
 
 from google.auth import _helpers
 from google.auth import environment_vars
+
+if TYPE_CHECKING:
+    import google.auth.credentials
+    import google.auth.transport
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -110,7 +110,6 @@ class _RegionalAccessBoundaryManager(object):
         self.__dict__.update(state)
         self._update_lock = threading.Lock()
 
-
     def use_blocking_regional_access_boundary_lookup(self):
         """Enables blocking regional access boundary lookup to true"""
         self._use_blocking_regional_access_boundary_lookup = True

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -361,9 +361,10 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
         new_manager._data = self._rab_manager._data
         target._rab_manager = new_manager
 
-    def with_regional_access_boundary(self, seed):
+    def _with_regional_access_boundary(self, seed):
         """Returns a copy of these credentials with the the regional_access_boundary
-        set to the provided seed.
+        set to the provided seed. This is intended for internal use only as invalid
+        seeds would produce unexpected results until automatic recovery is supported.
 
         Returns:
             google.auth.credentials.Credentials: A new credentials instance.

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -365,6 +365,10 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
         """Returns a copy of these credentials with the the regional_access_boundary
         set to the provided seed. This is intended for internal use only as invalid
         seeds would produce unexpected results until automatic recovery is supported.
+        Currently this is used by the gcloud CLI and therefore changes to the
+        contract MUST be backwards compatible (e.g. the method signature must be
+        unchanged and a copy of the credenials with the RAB set must be returned).
+
 
         Returns:
             google.auth.credentials.Credentials: A new credentials instance.

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -380,7 +380,7 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
     def _with_blocking_regional_access_boundary_lookup(self):
         """Returns a copy of these credentials with the blocking lookup mode enabled.
         This is intended for internal use only as blocking lookup requires additional
-        care and consideration. Currently this is unsed by the gcloud CLI and
+        care and consideration. Currently this is used by the gcloud CLI and
         therefore changes to the contract MUST be backwards compatible (e.g. the
         method signature must be unchanged and a copy of the credentials with the
         blocking lookup flag set to true must be returned).

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -377,8 +377,13 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
         creds._rab_manager.set_initial_regional_access_boundary(seed)
         return creds
 
-    def with_blocking_regional_access_boundary_lookup(self):
+    def _with_blocking_regional_access_boundary_lookup(self):
         """Returns a copy of these credentials with the blocking lookup mode enabled.
+        This is intended for internal use only as blocking lookup requires additional
+        care and consideration. Currently this is unsed by the gcloud CLI and
+        therefore changes to the contract MUST be backwards compatible (e.g. the
+        method signature must be unchanged and a copy of the credentials with the
+        blocking lookup flag set to true must be returned).
 
         Returns:
             google.auth.credentials.Credentials: A new credentials instance.

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -374,7 +374,10 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
             google.auth.credentials.Credentials: A new credentials instance.
         """
         creds = self._make_copy()
-        creds._rab_manager.set_initial_regional_access_boundary(seed)
+        creds._rab_manager.set_initial_regional_access_boundary(
+            encoded_locations=seed.get("encodedLocations", None),
+            expiry=seed.get("expiry", None),
+        )
         return creds
 
     def _with_blocking_regional_access_boundary_lookup(self):
@@ -389,7 +392,7 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
             google.auth.credentials.Credentials: A new credentials instance.
         """
         creds = self._make_copy()
-        creds._rab_manager.use_blocking_regional_access_boundary_lookup()
+        creds._rab_manager.enable_blocking_lookup()
         return creds
 
     def _maybe_start_regional_access_boundary_refresh(self, request, url):
@@ -473,14 +476,14 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
     def _lookup_regional_access_boundary(
         self,
         request: "google.auth.transport.Request",  # noqa: F821
-        blocking: bool = False,
+        fail_fast: bool = False,
     ) -> "Optional[Dict[str, str]]":
         """Calls the Regional Access Boundary lookup API to retrieve the Regional Access Boundary information.
 
         Args:
             request (google.auth.transport.Request): The object used to make
                 HTTP requests.
-            blocking (bool): Whether the lookup should be blocking.
+            fail_fast (bool): Whether the lookup should fail fast (short timeout, no retries).
 
         Returns:
             Optional[Dict[str, str]]: The Regional Access Boundary information returned by the lookup API, or None if the lookup failed.
@@ -496,7 +499,7 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
         self._apply(headers)
         self._rab_manager.apply_headers(headers)
         return _client._lookup_regional_access_boundary(
-            request, url, headers=headers, blocking=blocking
+            request, url, headers=headers, fail_fast=fail_fast
         )
 
     @abc.abstractmethod

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -361,6 +361,27 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
         new_manager._data = self._rab_manager._data
         target._rab_manager = new_manager
 
+    def with_regional_access_boundary(self, seed):
+        """Returns a copy of these credentials with the the regional_access_boundary
+        set to the provided seed.
+
+        Returns:
+            google.auth.credentials.Credentials: A new credentials instance.
+        """
+        creds = self._make_copy()
+        creds._rab_manager.set_initial_regional_access_boundary(seed)
+        return creds
+
+    def with_blocking_regional_access_boundary_lookup(self):
+        """Returns a copy of these credentials with the blocking lookup mode enabled.
+
+        Returns:
+            google.auth.credentials.Credentials: A new credentials instance.
+        """
+        creds = self._make_copy()
+        creds._rab_manager.use_blocking_regional_access_boundary_lookup()
+        return creds
+
     def _maybe_start_regional_access_boundary_refresh(self, request, url):
         """
         Starts a background thread to refresh the Regional Access Boundary if needed.
@@ -421,10 +442,15 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
         """Refreshes the access token and triggers the Regional Access Boundary
         lookup if necessary.
         """
-        super(CredentialsWithRegionalAccessBoundary, self).before_request(
-            request, method, url, headers
-        )
+        if self._use_non_blocking_refresh:
+            self._non_blocking_refresh(request)
+        else:
+            self._blocking_refresh(request)
+
         self._maybe_start_regional_access_boundary_refresh(request, url)
+
+        metrics.add_metric_header(headers, self._metric_header_for_usage())
+        self.apply(headers)
 
     def refresh(self, request):
         """Refreshes the access token.
@@ -435,13 +461,16 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
         self._perform_refresh_token(request)
 
     def _lookup_regional_access_boundary(
-        self, request: "google.auth.transport.Request"  # noqa: F821
+        self,
+        request: "google.auth.transport.Request",  # noqa: F821
+        blocking: bool = False,
     ) -> "Optional[Dict[str, str]]":
         """Calls the Regional Access Boundary lookup API to retrieve the Regional Access Boundary information.
 
         Args:
             request (google.auth.transport.Request): The object used to make
                 HTTP requests.
+            blocking (bool): Whether the lookup should be blocking.
 
         Returns:
             Optional[Dict[str, str]]: The Regional Access Boundary information returned by the lookup API, or None if the lookup failed.
@@ -456,7 +485,9 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
         headers: Dict[str, str] = {}
         self._apply(headers)
         self._rab_manager.apply_headers(headers)
-        return _client._lookup_regional_access_boundary(request, url, headers=headers)
+        return _client._lookup_regional_access_boundary(
+            request, url, headers=headers, blocking=blocking
+        )
 
     @abc.abstractmethod
     def _build_regional_access_boundary_lookup_url(

--- a/packages/google-auth/google/oauth2/_client.py
+++ b/packages/google-auth/google/oauth2/_client.py
@@ -43,6 +43,8 @@ _URLENCODED_CONTENT_TYPE = "application/x-www-form-urlencoded"
 _JSON_CONTENT_TYPE = "application/json"
 _JWT_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 _REFRESH_GRANT_TYPE = "refresh_token"
+_BLOCKING_REGIONAL_ACCESS_BOUNDARY_LOOKUP_TIMEOUT = 3
+
 
 
 def _handle_error_response(response_data, retryable_error):
@@ -517,7 +519,7 @@ def refresh_grant(
     return _handle_refresh_grant_response(response_data, refresh_token)
 
 
-def _lookup_regional_access_boundary(request, url, headers=None):
+def _lookup_regional_access_boundary(request, url, headers=None, blocking=False):
     """Implements the global lookup of a credential Regional Access Boundary.
     For the lookup, we send a request to the global lookup endpoint and then
     parse the response. Service account credentials, workload identity
@@ -527,6 +529,7 @@ def _lookup_regional_access_boundary(request, url, headers=None):
             HTTP requests.
         url (str): The Regional Access Boundary lookup url.
         headers (Optional[Mapping[str, str]]): The headers for the request.
+        blocking (bool): Whether the lookup should be blocking.
     Returns:
         Optional[Mapping[str,list|str]]: A dictionary containing
             "locations" as a list of allowed locations as strings and
@@ -541,7 +544,7 @@ def _lookup_regional_access_boundary(request, url, headers=None):
     """
 
     response_data = _lookup_regional_access_boundary_request(
-        request, url, headers=headers
+        request, url, headers=headers, blocking=blocking
     )
     if response_data is None:
         # Error was already logged by _lookup_regional_access_boundary_request
@@ -557,7 +560,7 @@ def _lookup_regional_access_boundary(request, url, headers=None):
 
 
 def _lookup_regional_access_boundary_request(
-    request, url, can_retry=True, headers=None
+    request, url, can_retry=True, headers=None, blocking=False
 ):
     """Makes a request to the Regional Access Boundary lookup endpoint.
 
@@ -567,6 +570,7 @@ def _lookup_regional_access_boundary_request(
         url (str): The Regional Access Boundary lookup url.
         can_retry (bool): Enable or disable request retry behavior. Defaults to true.
         headers (Optional[Mapping[str, str]]): The headers for the request.
+        blocking (bool): Whether the lookup should be blocking.
 
     Returns:
         Optional[Mapping[str, str]]: The JSON-decoded response data on success, or None on failure.
@@ -576,7 +580,7 @@ def _lookup_regional_access_boundary_request(
         response_data,
         retryable_error,
     ) = _lookup_regional_access_boundary_request_no_throw(
-        request, url, can_retry, headers
+        request, url, can_retry, headers, blocking
     )
     if not response_status_ok:
         _LOGGER.warning(
@@ -589,7 +593,7 @@ def _lookup_regional_access_boundary_request(
 
 
 def _lookup_regional_access_boundary_request_no_throw(
-    request, url, can_retry=True, headers=None
+    request, url, can_retry=True, headers=None, blocking=False
 ):
     """Makes a request to the Regional Access Boundary lookup endpoint. This
         function doesn't throw on response errors.
@@ -600,6 +604,7 @@ def _lookup_regional_access_boundary_request_no_throw(
         url (str): The Regional Access Boundary lookup url.
         can_retry (bool): Enable or disable request retry behavior. Defaults to true.
         headers (Optional[Mapping[str, str]]): The headers for the request.
+        blocking (bool): Whether the lookup should be blocking.
 
     Returns:
         Tuple(bool, Mapping[str, str], Optional[bool]): A boolean indicating
@@ -611,9 +616,14 @@ def _lookup_regional_access_boundary_request_no_throw(
     response_data = {}
     retryable_error = False
 
-    retries = _exponential_backoff.ExponentialBackoff(total_attempts=6)
+    timeout = (
+        _BLOCKING_REGIONAL_ACCESS_BOUNDARY_LOOKUP_TIMEOUT if blocking else None
+    )
+    total_attempts = 1 if blocking else 6
+    retries = _exponential_backoff.ExponentialBackoff(total_attempts=total_attempts)
+
     for _ in retries:
-        response = request(method="GET", url=url, headers=headers)
+        response = request(method="GET", url=url, headers=headers, timeout=timeout)
         response_body = (
             response.data.decode("utf-8")
             if hasattr(response.data, "decode")

--- a/packages/google-auth/google/oauth2/_client.py
+++ b/packages/google-auth/google/oauth2/_client.py
@@ -46,7 +46,6 @@ _REFRESH_GRANT_TYPE = "refresh_token"
 _BLOCKING_REGIONAL_ACCESS_BOUNDARY_LOOKUP_TIMEOUT = 3
 
 
-
 def _handle_error_response(response_data, retryable_error):
     """Translates an error response into an exception.
 
@@ -616,9 +615,7 @@ def _lookup_regional_access_boundary_request_no_throw(
     response_data = {}
     retryable_error = False
 
-    timeout = (
-        _BLOCKING_REGIONAL_ACCESS_BOUNDARY_LOOKUP_TIMEOUT if blocking else None
-    )
+    timeout = _BLOCKING_REGIONAL_ACCESS_BOUNDARY_LOOKUP_TIMEOUT if blocking else None
     total_attempts = 1 if blocking else 6
     retries = _exponential_backoff.ExponentialBackoff(total_attempts=total_attempts)
 

--- a/packages/google-auth/google/oauth2/_client.py
+++ b/packages/google-auth/google/oauth2/_client.py
@@ -518,7 +518,7 @@ def refresh_grant(
     return _handle_refresh_grant_response(response_data, refresh_token)
 
 
-def _lookup_regional_access_boundary(request, url, headers=None, blocking=False):
+def _lookup_regional_access_boundary(request, url, headers=None, fail_fast=False):
     """Implements the global lookup of a credential Regional Access Boundary.
     For the lookup, we send a request to the global lookup endpoint and then
     parse the response. Service account credentials, workload identity
@@ -528,7 +528,7 @@ def _lookup_regional_access_boundary(request, url, headers=None, blocking=False)
             HTTP requests.
         url (str): The Regional Access Boundary lookup url.
         headers (Optional[Mapping[str, str]]): The headers for the request.
-        blocking (bool): Whether the lookup should be blocking.
+        fail_fast (bool): Whether the lookup should fail fast (uses a short timeout and no retries).
     Returns:
         Optional[Mapping[str,list|str]]: A dictionary containing
             "locations" as a list of allowed locations as strings and
@@ -543,7 +543,7 @@ def _lookup_regional_access_boundary(request, url, headers=None, blocking=False)
     """
 
     response_data = _lookup_regional_access_boundary_request(
-        request, url, headers=headers, blocking=blocking
+        request, url, headers=headers, fail_fast=fail_fast
     )
     if response_data is None:
         # Error was already logged by _lookup_regional_access_boundary_request
@@ -559,7 +559,7 @@ def _lookup_regional_access_boundary(request, url, headers=None, blocking=False)
 
 
 def _lookup_regional_access_boundary_request(
-    request, url, can_retry=True, headers=None, blocking=False
+    request, url, can_retry=True, headers=None, fail_fast=False
 ):
     """Makes a request to the Regional Access Boundary lookup endpoint.
 
@@ -569,7 +569,7 @@ def _lookup_regional_access_boundary_request(
         url (str): The Regional Access Boundary lookup url.
         can_retry (bool): Enable or disable request retry behavior. Defaults to true.
         headers (Optional[Mapping[str, str]]): The headers for the request.
-        blocking (bool): Whether the lookup should be blocking.
+        fail_fast (bool): Whether the lookup should fail fast (uses a short timeout and no retries).
 
     Returns:
         Optional[Mapping[str, str]]: The JSON-decoded response data on success, or None on failure.
@@ -579,7 +579,7 @@ def _lookup_regional_access_boundary_request(
         response_data,
         retryable_error,
     ) = _lookup_regional_access_boundary_request_no_throw(
-        request, url, can_retry, headers, blocking
+        request, url, can_retry=can_retry, headers=headers, fail_fast=fail_fast
     )
     if not response_status_ok:
         _LOGGER.warning(
@@ -592,7 +592,7 @@ def _lookup_regional_access_boundary_request(
 
 
 def _lookup_regional_access_boundary_request_no_throw(
-    request, url, can_retry=True, headers=None, blocking=False
+    request, url, can_retry=True, headers=None, fail_fast=False
 ):
     """Makes a request to the Regional Access Boundary lookup endpoint. This
         function doesn't throw on response errors.
@@ -603,7 +603,7 @@ def _lookup_regional_access_boundary_request_no_throw(
         url (str): The Regional Access Boundary lookup url.
         can_retry (bool): Enable or disable request retry behavior. Defaults to true.
         headers (Optional[Mapping[str, str]]): The headers for the request.
-        blocking (bool): Whether the lookup should be blocking.
+        fail_fast (bool): Whether the lookup should fail fast (uses a short timeout and no retries).
 
     Returns:
         Tuple(bool, Mapping[str, str], Optional[bool]): A boolean indicating
@@ -615,8 +615,8 @@ def _lookup_regional_access_boundary_request_no_throw(
     response_data = {}
     retryable_error = False
 
-    timeout = _BLOCKING_REGIONAL_ACCESS_BOUNDARY_LOOKUP_TIMEOUT if blocking else None
-    total_attempts = 1 if blocking else 6
+    timeout = _BLOCKING_REGIONAL_ACCESS_BOUNDARY_LOOKUP_TIMEOUT if fail_fast else None
+    total_attempts = 1 if fail_fast else 6
     retries = _exponential_backoff.ExponentialBackoff(total_attempts=total_attempts)
 
     for _ in retries:

--- a/packages/google-auth/google/oauth2/credentials.py
+++ b/packages/google-auth/google/oauth2/credentials.py
@@ -373,6 +373,10 @@ class Credentials(
         """
         return None
 
+    def _is_regional_access_boundary_lookup_required(self):
+        """OAuth 2.0 credentials do not support independent lookup."""
+        return False
+
     def _perform_refresh_token(self, request):
         if self._universe_domain != credentials.DEFAULT_UNIVERSE_DOMAIN:
             raise exceptions.RefreshError(

--- a/packages/google-auth/google/oauth2/credentials.py
+++ b/packages/google-auth/google/oauth2/credentials.py
@@ -207,7 +207,7 @@ class Credentials(
         self._refresh_worker = None
         self._use_non_blocking_refresh = d.get("_use_non_blocking_refresh", False)
         self._account = d.get("_account", "")
-        self._rab_manager = (
+        self._rab_manager = d.get("_rab_manager") or (
             _regional_access_boundary_utils._RegionalAccessBoundaryManager()
         )
         self._use_blocking_regional_access_boundary_lookup = False

--- a/packages/google-auth/google/oauth2/credentials.py
+++ b/packages/google-auth/google/oauth2/credentials.py
@@ -210,7 +210,6 @@ class Credentials(
         self._rab_manager = d.get("_rab_manager") or (
             _regional_access_boundary_utils._RegionalAccessBoundaryManager()
         )
-        self._use_blocking_regional_access_boundary_lookup = False
 
     @property
     def refresh_token(self):
@@ -363,6 +362,15 @@ class Credentials(
         return metrics.CRED_TYPE_USER
 
     def _build_regional_access_boundary_lookup_url(self, request=None):
+        """Builds the URL for Regional Access Boundary lookup.
+
+        OAuth 2.0 credentials do not support independent Regional Access Boundary
+        lookup. However, they may support a seeded Regional Access Boundary
+        provided externally (e.g., from gcloud).
+
+        Returns:
+            None: This credential type does not support RAB lookup.
+        """
         return None
 
     def _perform_refresh_token(self, request):

--- a/packages/google-auth/google/oauth2/credentials.py
+++ b/packages/google-auth/google/oauth2/credentials.py
@@ -39,6 +39,7 @@ import warnings
 
 from google.auth import _cloud_sdk
 from google.auth import _helpers
+from google.auth import _regional_access_boundary_utils
 from google.auth import credentials
 from google.auth import exceptions
 from google.auth import metrics
@@ -54,7 +55,11 @@ _GOOGLE_OAUTH2_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 _GOOGLE_OAUTH2_TOKEN_INFO_ENDPOINT = "https://oauth2.googleapis.com/tokeninfo"
 
 
-class Credentials(credentials.ReadOnlyScoped, credentials.CredentialsWithQuotaProject):
+class Credentials(
+    credentials.CredentialsWithRegionalAccessBoundary,
+    credentials.ReadOnlyScoped,
+    credentials.CredentialsWithQuotaProject,
+):
     """Credentials using OAuth 2.0 access and refresh tokens.
 
     The credentials are considered immutable except the tokens and the token
@@ -202,6 +207,10 @@ class Credentials(credentials.ReadOnlyScoped, credentials.CredentialsWithQuotaPr
         self._refresh_worker = None
         self._use_non_blocking_refresh = d.get("_use_non_blocking_refresh", False)
         self._account = d.get("_account", "")
+        self._rab_manager = (
+            _regional_access_boundary_utils._RegionalAccessBoundaryManager()
+        )
+        self._use_blocking_regional_access_boundary_lookup = False
 
     @property
     def refresh_token(self):
@@ -353,8 +362,10 @@ class Credentials(credentials.ReadOnlyScoped, credentials.CredentialsWithQuotaPr
     def _metric_header_for_usage(self):
         return metrics.CRED_TYPE_USER
 
-    @_helpers.copy_docstring(credentials.Credentials)
-    def refresh(self, request):
+    def _build_regional_access_boundary_lookup_url(self, request=None):
+        return None
+
+    def _perform_refresh_token(self, request):
         if self._universe_domain != credentials.DEFAULT_UNIVERSE_DOMAIN:
             raise exceptions.RefreshError(
                 "User credential refresh is only supported in the default "

--- a/packages/google-auth/system_tests/system_tests_sync/test_external_accounts.py
+++ b/packages/google-auth/system_tests/system_tests_sync/test_external_accounts.py
@@ -216,8 +216,13 @@ def test_configurable_token_lifespan(oidc_credentials, http_request):
 
         credentials.refresh(http_request)
 
-        utcmax = _helpers.utcnow() + datetime.timedelta(seconds=TOKEN_LIFETIME_SECONDS)
-        utcmin = utcmax - datetime.timedelta(seconds=BUFFER_SECONDS)
+        now = _helpers.utcnow()
+        utcmax = now + datetime.timedelta(
+            seconds=TOKEN_LIFETIME_SECONDS + BUFFER_SECONDS
+        )
+        utcmin = now + datetime.timedelta(
+            seconds=TOKEN_LIFETIME_SECONDS - BUFFER_SECONDS
+        )
         assert utcmin < credentials._impersonated_credentials.expiry <= utcmax
 
         return True

--- a/packages/google-auth/system_tests/system_tests_sync/test_external_accounts.py
+++ b/packages/google-auth/system_tests/system_tests_sync/test_external_accounts.py
@@ -216,8 +216,10 @@ def test_configurable_token_lifespan(oidc_credentials, http_request):
 
         credentials.refresh(http_request)
 
-        utcmax = _helpers.utcnow() + datetime.timedelta(seconds=TOKEN_LIFETIME_SECONDS)
-        utcmin = utcmax - datetime.timedelta(seconds=BUFFER_SECONDS)
+        now = _helpers.utcnow()
+        # Allow for some clock skew between the test runner and the IAM server.
+        utcmax = now + datetime.timedelta(seconds=TOKEN_LIFETIME_SECONDS + 10)
+        utcmin = now + datetime.timedelta(seconds=TOKEN_LIFETIME_SECONDS - BUFFER_SECONDS)
         assert utcmin < credentials._impersonated_credentials.expiry <= utcmax
 
         return True

--- a/packages/google-auth/system_tests/system_tests_sync/test_external_accounts.py
+++ b/packages/google-auth/system_tests/system_tests_sync/test_external_accounts.py
@@ -216,10 +216,8 @@ def test_configurable_token_lifespan(oidc_credentials, http_request):
 
         credentials.refresh(http_request)
 
-        now = _helpers.utcnow()
-        # Allow for some clock skew between the test runner and the IAM server.
-        utcmax = now + datetime.timedelta(seconds=TOKEN_LIFETIME_SECONDS + 10)
-        utcmin = now + datetime.timedelta(seconds=TOKEN_LIFETIME_SECONDS - BUFFER_SECONDS)
+        utcmax = _helpers.utcnow() + datetime.timedelta(seconds=TOKEN_LIFETIME_SECONDS)
+        utcmin = utcmax - datetime.timedelta(seconds=BUFFER_SECONDS)
         assert utcmin < credentials._impersonated_credentials.expiry <= utcmax
 
         return True

--- a/packages/google-auth/tests/compute_engine/test_credentials.py
+++ b/packages/google-auth/tests/compute_engine/test_credentials.py
@@ -454,7 +454,7 @@ class TestCredentials(object):
     def test_with_blocking_regional_access_boundary_lookup(self):
         creds = self.credentials
         assert not creds._rab_manager._use_blocking_regional_access_boundary_lookup
-        
+
         new_creds = creds.with_blocking_regional_access_boundary_lookup()
         assert new_creds._rab_manager._use_blocking_regional_access_boundary_lookup
         assert new_creds is not creds

--- a/packages/google-auth/tests/compute_engine/test_credentials.py
+++ b/packages/google-auth/tests/compute_engine/test_credentials.py
@@ -451,6 +451,14 @@ class TestCredentials(object):
         kwargs = mock_metadata_get.call_args[1]
         assert "bindCertificateFingerprint" not in kwargs.get("params", {})
 
+    def test_with_blocking_regional_access_boundary_lookup(self):
+        creds = self.credentials
+        assert not creds._rab_manager._use_blocking_regional_access_boundary_lookup
+        
+        new_creds = creds.with_blocking_regional_access_boundary_lookup()
+        assert new_creds._rab_manager._use_blocking_regional_access_boundary_lookup
+        assert new_creds is not creds
+
 
 class TestIDTokenCredentials(object):
     credentials = None

--- a/packages/google-auth/tests/compute_engine/test_credentials.py
+++ b/packages/google-auth/tests/compute_engine/test_credentials.py
@@ -455,7 +455,7 @@ class TestCredentials(object):
         creds = self.credentials
         assert not creds._rab_manager._use_blocking_regional_access_boundary_lookup
 
-        new_creds = creds.with_blocking_regional_access_boundary_lookup()
+        new_creds = creds._with_blocking_regional_access_boundary_lookup()
         assert new_creds._rab_manager._use_blocking_regional_access_boundary_lookup
         assert new_creds is not creds
 

--- a/packages/google-auth/tests/oauth2/test__client.py
+++ b/packages/google-auth/tests/oauth2/test__client.py
@@ -811,6 +811,7 @@ def test_lookup_regional_access_boundary_blocking():
         method="GET", url=url, headers=headers, timeout=3
     )
 
+
 def test_lookup_regional_access_boundary_blocking_error():
     mock_response = mock.create_autospec(transport.Response, instance=True)
     mock_response.status = http_client.INTERNAL_SERVER_ERROR

--- a/packages/google-auth/tests/oauth2/test__client.py
+++ b/packages/google-auth/tests/oauth2/test__client.py
@@ -654,8 +654,9 @@ def test_lookup_regional_access_boundary():
     assert response["encodedLocations"] == "0x80080000000000"
     assert response["locations"] == ["us-central1", "us-east1"]
 
-    mock_request.assert_called_once_with(method="GET", url=url, headers=headers)
-
+    mock_request.assert_called_once_with(
+        method="GET", url=url, headers=headers, timeout=None
+    )
 
 def test_lookup_regional_access_boundary_error():
     mock_response = mock.create_autospec(transport.Response, instance=True)
@@ -672,8 +673,7 @@ def test_lookup_regional_access_boundary_error():
     )
     assert result is None
 
-    mock_request.assert_called_with(method="GET", url=url, headers=headers)
-
+    mock_request.assert_called_with(method="GET", url=url, headers=headers, timeout=None)
 
 @pytest.mark.parametrize(
     "status_code",
@@ -697,8 +697,9 @@ def test_lookup_regional_access_boundary_non_retryable_error(status_code):
     )
     assert result is None
     # Non-retryable errors should only be called once.
-    mock_request.assert_called_once_with(method="GET", url=url, headers=headers)
-
+    mock_request.assert_called_once_with(
+        method="GET", url=url, headers=headers, timeout=None
+    )
 
 def test_lookup_regional_access_boundary_internal_failure_and_retry_failure_error():
     retryable_error = mock.create_autospec(transport.Response, instance=True)
@@ -777,5 +778,5 @@ def test_lookup_regional_access_boundary_with_headers():
     )
 
     mock_request.assert_called_once_with(
-        method="GET", url="http://example.com", headers=headers
+        method="GET", url="http://example.com", headers=headers, timeout=None
     )

--- a/packages/google-auth/tests/oauth2/test__client.py
+++ b/packages/google-auth/tests/oauth2/test__client.py
@@ -810,3 +810,23 @@ def test_lookup_regional_access_boundary_blocking():
     mock_request.assert_called_once_with(
         method="GET", url=url, headers=headers, timeout=3
     )
+
+def test_lookup_regional_access_boundary_blocking_error():
+    mock_response = mock.create_autospec(transport.Response, instance=True)
+    mock_response.status = http_client.INTERNAL_SERVER_ERROR
+    mock_response.data = "this is an error message"
+
+    mock_request = mock.create_autospec(transport.Request)
+    mock_request.return_value = mock_response
+
+    url = "http://example.com"
+    headers = {"Authorization": "Bearer access_token"}
+    # Even if the error is retryable, blocking=True should prevent retries.
+    result = _client._lookup_regional_access_boundary(
+        mock_request, url, headers=headers, blocking=True
+    )
+    assert result is None
+
+    mock_request.assert_called_once_with(
+        method="GET", url=url, headers=headers, timeout=3
+    )

--- a/packages/google-auth/tests/oauth2/test__client.py
+++ b/packages/google-auth/tests/oauth2/test__client.py
@@ -785,3 +785,28 @@ def test_lookup_regional_access_boundary_with_headers():
     mock_request.assert_called_once_with(
         method="GET", url="http://example.com", headers=headers, timeout=None
     )
+
+
+def test_lookup_regional_access_boundary_blocking():
+    response_data = {
+        "locations": ["us-central1"],
+        "encodedLocations": "0xABC",
+    }
+
+    mock_response = mock.create_autospec(transport.Response, instance=True)
+    mock_response.status = http_client.OK
+    mock_response.data = json.dumps(response_data).encode("utf-8")
+
+    mock_request = mock.create_autospec(transport.Request)
+    mock_request.return_value = mock_response
+
+    url = "http://example.com"
+    headers = {"Authorization": "Bearer access_token"}
+    response = _client._lookup_regional_access_boundary(
+        mock_request, url, headers=headers, blocking=True
+    )
+
+    assert response["encodedLocations"] == "0xABC"
+    mock_request.assert_called_once_with(
+        method="GET", url=url, headers=headers, timeout=3
+    )

--- a/packages/google-auth/tests/oauth2/test__client.py
+++ b/packages/google-auth/tests/oauth2/test__client.py
@@ -658,6 +658,7 @@ def test_lookup_regional_access_boundary():
         method="GET", url=url, headers=headers, timeout=None
     )
 
+
 def test_lookup_regional_access_boundary_error():
     mock_response = mock.create_autospec(transport.Response, instance=True)
     mock_response.status = http_client.INTERNAL_SERVER_ERROR
@@ -673,7 +674,10 @@ def test_lookup_regional_access_boundary_error():
     )
     assert result is None
 
-    mock_request.assert_called_with(method="GET", url=url, headers=headers, timeout=None)
+    mock_request.assert_called_with(
+        method="GET", url=url, headers=headers, timeout=None
+    )
+
 
 @pytest.mark.parametrize(
     "status_code",
@@ -700,6 +704,7 @@ def test_lookup_regional_access_boundary_non_retryable_error(status_code):
     mock_request.assert_called_once_with(
         method="GET", url=url, headers=headers, timeout=None
     )
+
 
 def test_lookup_regional_access_boundary_internal_failure_and_retry_failure_error():
     retryable_error = mock.create_autospec(transport.Response, instance=True)

--- a/packages/google-auth/tests/oauth2/test__client.py
+++ b/packages/google-auth/tests/oauth2/test__client.py
@@ -803,7 +803,7 @@ def test_lookup_regional_access_boundary_blocking():
     url = "http://example.com"
     headers = {"Authorization": "Bearer access_token"}
     response = _client._lookup_regional_access_boundary(
-        mock_request, url, headers=headers, blocking=True
+        mock_request, url, headers=headers, fail_fast=True
     )
 
     assert response["encodedLocations"] == "0xABC"
@@ -822,9 +822,9 @@ def test_lookup_regional_access_boundary_blocking_error():
 
     url = "http://example.com"
     headers = {"Authorization": "Bearer access_token"}
-    # Even if the error is retryable, blocking=True should prevent retries.
+    # Even if the error is retryable, fail_fast=True should prevent retries.
     result = _client._lookup_regional_access_boundary(
-        mock_request, url, headers=headers, blocking=True
+        mock_request, url, headers=headers, fail_fast=True
     )
     assert result is None
 

--- a/packages/google-auth/tests/oauth2/test_credentials.py
+++ b/packages/google-auth/tests/oauth2/test_credentials.py
@@ -100,7 +100,7 @@ class TestCredentials(object):
         creds = self.make_credentials()
         assert not creds._rab_manager._use_blocking_regional_access_boundary_lookup
 
-        new_creds = creds.with_blocking_regional_access_boundary_lookup()
+        new_creds = creds._with_blocking_regional_access_boundary_lookup()
         assert new_creds._rab_manager._use_blocking_regional_access_boundary_lookup
         assert new_creds is not creds
 

--- a/packages/google-auth/tests/oauth2/test_credentials.py
+++ b/packages/google-auth/tests/oauth2/test_credentials.py
@@ -99,7 +99,7 @@ class TestCredentials(object):
     def test_with_blocking_regional_access_boundary_lookup(self):
         creds = self.make_credentials()
         assert not creds._rab_manager._use_blocking_regional_access_boundary_lookup
-        
+
         new_creds = creds.with_blocking_regional_access_boundary_lookup()
         assert new_creds._rab_manager._use_blocking_regional_access_boundary_lookup
         assert new_creds is not creds

--- a/packages/google-auth/tests/oauth2/test_credentials.py
+++ b/packages/google-auth/tests/oauth2/test_credentials.py
@@ -96,6 +96,14 @@ class TestCredentials(object):
         assert credentials.rapt_token == self.RAPT_TOKEN
         assert credentials.refresh_handler is None
 
+    def test_with_blocking_regional_access_boundary_lookup(self):
+        creds = self.make_credentials()
+        assert not creds._rab_manager._use_blocking_regional_access_boundary_lookup
+        
+        new_creds = creds.with_blocking_regional_access_boundary_lookup()
+        assert new_creds._rab_manager._use_blocking_regional_access_boundary_lookup
+        assert new_creds is not creds
+
     def test_get_cred_info(self):
         credentials = self.make_credentials()
         credentials._account = "fake-account"

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -241,7 +241,6 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         assert new_creds._rab_manager._data.expiry == seed["expiry"]
         assert new_creds._rab_manager._data.cooldown_expiry is None
 
-
     def test_copy_regional_access_boundary_state(self):
         source_creds = CredentialsImpl()
         snapshot = _regional_access_boundary_utils._RegionalAccessBoundaryData(
@@ -366,8 +365,6 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         assert rab_manager._data.encoded_locations is None
         assert rab_manager._data.expiry is None
         assert rab_manager._data.cooldown_expiry is not None
-
-
 
     def test_credentials_with_regional_access_boundary_initialization(self):
         creds = CredentialsImpl()

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -411,6 +411,7 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         request = mock.Mock()
         result = creds._lookup_regional_access_boundary(request)
         assert result is None
+        request.assert_not_called()
 
     def test_credentials_with_regional_access_boundary_initialization(self):
         creds = CredentialsImpl()

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -236,7 +236,7 @@ class TestCredentialsWithRegionalAccessBoundary(object):
             "encodedLocations": "0xABC",
             "expiry": _helpers.utcnow() + datetime.timedelta(hours=1),
         }
-        new_creds = creds.with_regional_access_boundary(seed)
+        new_creds = creds._with_regional_access_boundary(seed)
         assert new_creds._rab_manager._data.encoded_locations == "0xABC"
         assert new_creds._rab_manager._data.expiry == seed["expiry"]
         assert new_creds._rab_manager._data.cooldown_expiry is None
@@ -326,6 +326,41 @@ class TestCredentialsWithRegionalAccessBoundary(object):
                 request, "http://example.com"
             )
         mock_start_blocking_refresh.assert_called_once_with(creds, request)
+
+    def test_start_blocking_refresh_success(self):
+        creds = CredentialsImpl()
+        request = mock.Mock()
+        
+        with mock.patch.object(
+            creds, "_lookup_regional_access_boundary", return_value={"encodedLocations": "0xABC"}
+        ) as mock_lookup:
+            creds._rab_manager.start_blocking_refresh(creds, request)
+            
+            mock_lookup.assert_called_once_with(request, True)
+            assert creds._rab_manager._data.encoded_locations == "0xABC"
+
+    def test_start_blocking_refresh_failure(self):
+        creds = CredentialsImpl()
+        request = mock.Mock()
+        
+        with mock.patch.object(
+            creds, "_lookup_regional_access_boundary", side_effect=Exception("error")
+        ) as mock_lookup:
+            creds._rab_manager.start_blocking_refresh(creds, request)
+            
+            mock_lookup.assert_called_once_with(request, True)
+            assert creds._rab_manager._data.encoded_locations is None
+            assert creds._rab_manager._data.cooldown_expiry is not None
+
+    @mock.patch("copy.deepcopy")
+    def test_start_refresh_deepcopy_failure(self, mock_deepcopy):
+        mock_deepcopy.side_effect = Exception("deepcopy error")
+        creds = CredentialsImpl()
+        request = mock.Mock()
+        
+        creds._rab_manager.refresh_manager.start_refresh(creds, request, creds._rab_manager)
+        
+        assert creds._rab_manager.refresh_manager._worker is None
 
     @mock.patch.object(CredentialsImpl, "_lookup_regional_access_boundary")
     def test_lookup_regional_access_boundary_success(self, mock_lookup_rab):

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -223,6 +223,25 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         creds._rab_manager.apply_headers(headers)
         assert headers == {}
 
+    def test_with_blocking_regional_access_boundary_lookup(self):
+        creds = CredentialsImpl()
+        assert not creds._rab_manager._use_blocking_regional_access_boundary_lookup
+
+        new_creds = creds.with_blocking_regional_access_boundary_lookup()
+        assert new_creds._rab_manager._use_blocking_regional_access_boundary_lookup
+
+    def test_with_regional_access_boundary(self):
+        creds = CredentialsImpl()
+        seed = {
+            "encodedLocations": "0xABC",
+            "expiry": _helpers.utcnow() + datetime.timedelta(hours=1),
+        }
+        new_creds = creds.with_regional_access_boundary(seed)
+        assert new_creds._rab_manager._data.encoded_locations == "0xABC"
+        assert new_creds._rab_manager._data.expiry == seed["expiry"]
+        assert new_creds._rab_manager._data.cooldown_expiry is None
+
+
     def test_copy_regional_access_boundary_state(self):
         source_creds = CredentialsImpl()
         snapshot = _regional_access_boundary_utils._RegionalAccessBoundaryData(
@@ -293,59 +312,62 @@ class TestCredentialsWithRegionalAccessBoundary(object):
             )
         mock_start_refresh.assert_called_once_with(creds, request, creds._rab_manager)
 
-    @mock.patch("google.oauth2._client._lookup_regional_access_boundary")
-    @mock.patch.object(CredentialsImpl, "_build_regional_access_boundary_lookup_url")
-    def test_lookup_regional_access_boundary_success(
-        self, mock_build_url, mock_lookup_rab
-    ):
+    @mock.patch(
+        "google.auth._regional_access_boundary_utils._RegionalAccessBoundaryManager.start_blocking_refresh"
+    )
+    def test_maybe_start_refresh_blocking(self, mock_start_blocking_refresh):
         creds = CredentialsImpl()
-        creds.token = "token"
+        creds._rab_manager._use_blocking_regional_access_boundary_lookup = True
         request = mock.Mock()
-        mock_build_url.return_value = "http://rab.example.com"
-        mock_lookup_rab.return_value = {"encodedLocations": "success"}
+        with mock.patch.dict(
+            os.environ,
+            {environment_vars.GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED: "true"},
+        ):
+            creds._maybe_start_regional_access_boundary_refresh(
+                request, "http://example.com"
+            )
+        mock_start_blocking_refresh.assert_called_once_with(creds, request)
 
-        result = creds._lookup_regional_access_boundary(request)
+    @mock.patch.object(CredentialsImpl, "_lookup_regional_access_boundary")
+    def test_lookup_regional_access_boundary_success(self, mock_lookup_rab):
+        creds = CredentialsImpl()
+        request = mock.Mock()
+        rab_manager = _regional_access_boundary_utils._RegionalAccessBoundaryManager()
 
-        mock_build_url.assert_called_once()
-        mock_lookup_rab.assert_called_once_with(
-            request, "http://rab.example.com", headers={"authorization": "Bearer token"}
+        mock_lookup_rab.return_value = {
+            "locations": ["us-east1"],
+            "encodedLocations": "0xABC123",
+        }
+
+        worker = _regional_access_boundary_utils._RegionalAccessBoundaryRefreshThread(
+            creds, request, rab_manager
         )
-        assert result == {"encodedLocations": "success"}
+        worker.run()
 
-    @mock.patch("google.oauth2._client._lookup_regional_access_boundary")
-    @mock.patch.object(CredentialsImpl, "_build_regional_access_boundary_lookup_url")
-    def test_lookup_regional_access_boundary_failure(
-        self, mock_build_url, mock_lookup_rab
-    ):
+        mock_lookup_rab.assert_called_once_with(request)
+        assert rab_manager._data.encoded_locations == "0xABC123"
+        assert rab_manager._data.expiry is not None
+        assert rab_manager._data.cooldown_expiry is None
+
+    @mock.patch.object(CredentialsImpl, "_lookup_regional_access_boundary")
+    def test_lookup_regional_access_boundary_failure(self, mock_lookup_rab):
         creds = CredentialsImpl()
-        creds.token = "token"
         request = mock.Mock()
-        mock_build_url.return_value = "http://rab.example.com"
+        rab_manager = _regional_access_boundary_utils._RegionalAccessBoundaryManager()
+
         mock_lookup_rab.return_value = None
 
-        result = creds._lookup_regional_access_boundary(request)
-
-        mock_build_url.assert_called_once()
-        mock_lookup_rab.assert_called_once_with(
-            request, "http://rab.example.com", headers={"authorization": "Bearer token"}
+        worker = _regional_access_boundary_utils._RegionalAccessBoundaryRefreshThread(
+            creds, request, rab_manager
         )
-        assert result is None
+        worker.run()
 
-    @mock.patch("google.oauth2._client._lookup_regional_access_boundary")
-    @mock.patch.object(CredentialsImpl, "_build_regional_access_boundary_lookup_url")
-    def test_lookup_regional_access_boundary_null_url(
-        self, mock_build_url, mock_lookup_rab
-    ):
-        creds = CredentialsImpl()
-        creds.token = "token"
-        request = mock.Mock()
-        mock_build_url.return_value = None
+        mock_lookup_rab.assert_called_once_with(request)
+        assert rab_manager._data.encoded_locations is None
+        assert rab_manager._data.expiry is None
+        assert rab_manager._data.cooldown_expiry is not None
 
-        result = creds._lookup_regional_access_boundary(request)
 
-        mock_build_url.assert_called_once()
-        mock_lookup_rab.assert_not_called()
-        assert result is None
 
     def test_credentials_with_regional_access_boundary_initialization(self):
         creds = CredentialsImpl()

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -22,6 +22,7 @@ from google.auth import _helpers
 from google.auth import _regional_access_boundary_utils
 from google.auth import credentials
 from google.auth import environment_vars
+from google.oauth2 import credentials as oauth2_credentials
 
 
 class CredentialsImpl(credentials.CredentialsWithRegionalAccessBoundary):
@@ -227,7 +228,7 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         creds = CredentialsImpl()
         assert not creds._rab_manager._use_blocking_regional_access_boundary_lookup
 
-        new_creds = creds.with_blocking_regional_access_boundary_lookup()
+        new_creds = creds._with_blocking_regional_access_boundary_lookup()
         assert new_creds._rab_manager._use_blocking_regional_access_boundary_lookup
 
     def test_with_regional_access_boundary(self):
@@ -404,6 +405,12 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         assert rab_manager._data.encoded_locations is None
         assert rab_manager._data.expiry is None
         assert rab_manager._data.cooldown_expiry is not None
+
+    def test_lookup_regional_access_boundary_null_url(self):
+        creds = oauth2_credentials.Credentials(token="token")
+        request = mock.Mock()
+        result = creds._lookup_regional_access_boundary(request)
+        assert result is None
 
     def test_credentials_with_regional_access_boundary_initialization(self):
         creds = CredentialsImpl()

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -339,7 +339,7 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         ) as mock_lookup:
             creds._rab_manager.start_blocking_refresh(creds, request)
 
-            mock_lookup.assert_called_once_with(request, True)
+            mock_lookup.assert_called_once_with(request, fail_fast=True)
             assert creds._rab_manager._data.encoded_locations == "0xABC"
 
     def test_start_blocking_refresh_failure(self):
@@ -351,7 +351,7 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         ) as mock_lookup:
             creds._rab_manager.start_blocking_refresh(creds, request)
 
-            mock_lookup.assert_called_once_with(request, True)
+            mock_lookup.assert_called_once_with(request, fail_fast=True)
             assert creds._rab_manager._data.encoded_locations is None
             assert creds._rab_manager._data.cooldown_expiry is not None
 

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -330,24 +330,26 @@ class TestCredentialsWithRegionalAccessBoundary(object):
     def test_start_blocking_refresh_success(self):
         creds = CredentialsImpl()
         request = mock.Mock()
-        
+
         with mock.patch.object(
-            creds, "_lookup_regional_access_boundary", return_value={"encodedLocations": "0xABC"}
+            creds,
+            "_lookup_regional_access_boundary",
+            return_value={"encodedLocations": "0xABC"},
         ) as mock_lookup:
             creds._rab_manager.start_blocking_refresh(creds, request)
-            
+
             mock_lookup.assert_called_once_with(request, True)
             assert creds._rab_manager._data.encoded_locations == "0xABC"
 
     def test_start_blocking_refresh_failure(self):
         creds = CredentialsImpl()
         request = mock.Mock()
-        
+
         with mock.patch.object(
             creds, "_lookup_regional_access_boundary", side_effect=Exception("error")
         ) as mock_lookup:
             creds._rab_manager.start_blocking_refresh(creds, request)
-            
+
             mock_lookup.assert_called_once_with(request, True)
             assert creds._rab_manager._data.encoded_locations is None
             assert creds._rab_manager._data.cooldown_expiry is not None
@@ -357,9 +359,11 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         mock_deepcopy.side_effect = Exception("deepcopy error")
         creds = CredentialsImpl()
         request = mock.Mock()
-        
-        creds._rab_manager.refresh_manager.start_refresh(creds, request, creds._rab_manager)
-        
+
+        creds._rab_manager.refresh_manager.start_refresh(
+            creds, request, creds._rab_manager
+        )
+
         assert creds._rab_manager.refresh_manager._worker is None
 
     @mock.patch.object(CredentialsImpl, "_lookup_regional_access_boundary")

--- a/packages/google-auth/tests/test_credentials.py
+++ b/packages/google-auth/tests/test_credentials.py
@@ -390,12 +390,16 @@ def test_credentials_with_trust_boundary_bridge():
     with pytest.warns(DeprecationWarning):
         assert creds._build_regional_access_boundary_lookup_url() == "http://legacy.url"
 
+
 def test_before_request_triggers_rab_refresh():
     with mock.patch(
-        "google.auth._regional_access_boundary_utils.is_regional_access_boundary_enabled",
+        "google.auth._regional_access_boundary_utils."
+        "is_regional_access_boundary_enabled",
         return_value=True,
     ):
-        with mock.patch("google.oauth2._client._lookup_regional_access_boundary") as lookup:
+        with mock.patch(
+            "google.oauth2._client._lookup_regional_access_boundary"
+        ) as lookup:
             lookup.return_value = {"encodedLocations": "0xA30"}
 
             creds = CredentialsImpl()

--- a/packages/google-auth/tests/test_credentials.py
+++ b/packages/google-auth/tests/test_credentials.py
@@ -38,7 +38,7 @@ class CredentialsImpl(credentials.CredentialsWithRegionalAccessBoundary):
     def with_quota_project(self, quota_project_id):
         raise NotImplementedError()
 
-    def _build_regional_access_boundary_lookup_url(self):
+    def _build_regional_access_boundary_lookup_url(self, request=None):
         # Using self.token here to make the URL dynamic for testing purposes
         return "http://mock.url/lookup_for_{}".format(self.token)
 
@@ -107,7 +107,7 @@ def test_before_request():
     headers = {}
 
     # First call should call refresh, setting the token.
-    credentials.before_request(request, "http://example.com", "GET", headers)
+    credentials.before_request(request, "GET", "http://example.com", headers)
     assert credentials.valid
     assert credentials.token == "refreshed-token"
     assert headers["authorization"] == "Bearer refreshed-token"
@@ -117,7 +117,7 @@ def test_before_request():
     headers = {}
 
     # Second call shouldn't call refresh.
-    credentials.before_request(request, "http://example.com", "GET", headers)
+    credentials.before_request(request, "GET", "http://example.com", headers)
     assert credentials.valid
     assert credentials.token == "refreshed-token"
     assert headers["authorization"] == "Bearer refreshed-token"
@@ -137,7 +137,7 @@ def test_before_request_with_regional_access_boundary():
     headers = {}
 
     # First call should call refresh, setting the token.
-    creds.before_request(request, "http://example.com", "GET", headers)
+    creds.before_request(request, "GET", "http://example.com", headers)
     assert creds.valid
     assert creds.token == "refreshed-token"
     assert headers["authorization"] == "Bearer refreshed-token"
@@ -147,7 +147,7 @@ def test_before_request_with_regional_access_boundary():
     headers = {}
 
     # Second call shouldn't call refresh.
-    creds.before_request(request, "http://example.com", "GET", headers)
+    creds.before_request(request, "GET", "http://example.com", headers)
     assert creds.valid
     assert creds.token == "refreshed-token"
     assert headers["authorization"] == "Bearer refreshed-token"
@@ -159,7 +159,7 @@ def test_before_request_metrics():
     request = "token"
     headers = {}
 
-    credentials.before_request(request, "http://example.com", "GET", headers)
+    credentials.before_request(request, "GET", "http://example.com", headers)
     assert headers["x-goog-api-client"] == "foo"
 
 
@@ -282,7 +282,7 @@ def test_nonblocking_refresh_fresh_credentials():
     assert c.token_state == credentials.TokenState.FRESH
 
     c.with_non_blocking_refresh()
-    c.before_request(request, "http://example.com", "GET", {})
+    c.before_request(request, "GET", "http://example.com", {})
 
 
 def test_nonblocking_refresh_invalid_credentials():
@@ -294,7 +294,7 @@ def test_nonblocking_refresh_invalid_credentials():
 
     assert c.token_state == credentials.TokenState.INVALID
 
-    c.before_request(request, "http://example.com", "GET", headers)
+    c.before_request(request, "GET", "http://example.com", headers)
     assert c.token_state == credentials.TokenState.FRESH
     assert c.valid
     assert c.token == "refreshed-token"
@@ -310,7 +310,7 @@ def test_nonblocking_refresh_stale_credentials():
     headers = {}
 
     # Invalid credentials MUST require a blocking refresh.
-    c.before_request(request, "http://example.com", "GET", headers)
+    c.before_request(request, "GET", "http://example.com", headers)
     assert c.token_state == credentials.TokenState.FRESH
     assert not c._refresh_worker._worker
 
@@ -322,7 +322,7 @@ def test_nonblocking_refresh_stale_credentials():
 
     # STALE credentials SHOULD spawn a non-blocking worker
     assert c.token_state == credentials.TokenState.STALE
-    c.before_request(request, "http://example.com", "GET", headers)
+    c.before_request(request, "GET", "http://example.com", headers)
     assert c._refresh_worker._worker is not None
 
     assert c.token_state == credentials.TokenState.FRESH
@@ -340,7 +340,7 @@ def test_nonblocking_refresh_failed_credentials():
     headers = {}
 
     # Invalid credentials MUST require a blocking refresh.
-    c.before_request(request, "http://example.com", "GET", headers)
+    c.before_request(request, "GET", "http://example.com", headers)
     assert c.token_state == credentials.TokenState.FRESH
     assert not c._refresh_worker._worker
 
@@ -354,7 +354,7 @@ def test_nonblocking_refresh_failed_credentials():
     assert c.token_state == credentials.TokenState.STALE
     c._refresh_worker._worker = mock.MagicMock()
     c._refresh_worker._worker._error_info = "Some Error"
-    c.before_request(request, "http://example.com", "GET", headers)
+    c.before_request(request, "GET", "http://example.com", headers)
     assert c._refresh_worker._worker is not None
 
     assert c.token_state == credentials.TokenState.FRESH
@@ -373,7 +373,7 @@ def test_token_state_no_expiry():
     c.expiry = None
     assert c.token_state == credentials.TokenState.FRESH
 
-    c.before_request(request, "http://example.com", "GET", {})
+    c.before_request(request, "GET", "http://example.com", {})
 
 
 def test_credentials_with_trust_boundary_bridge():
@@ -389,3 +389,34 @@ def test_credentials_with_trust_boundary_bridge():
     # Verify that calling the new method delegates to the old method
     with pytest.warns(DeprecationWarning):
         assert creds._build_regional_access_boundary_lookup_url() == "http://legacy.url"
+
+def test_before_request_triggers_rab_refresh():
+    with mock.patch(
+        "google.auth._regional_access_boundary_utils.is_regional_access_boundary_enabled",
+        return_value=True,
+    ):
+        with mock.patch("google.oauth2._client._lookup_regional_access_boundary") as lookup:
+            lookup.return_value = {"encodedLocations": "0xA30"}
+
+            creds = CredentialsImpl()
+            creds = creds._with_blocking_regional_access_boundary_lookup()
+
+            request = mock.Mock()
+            headers = {}
+
+            # Initial state: no token
+            assert creds.token is None
+
+            # before_request should trigger token refresh and THEN RAB refresh.
+            # We verify this by checking that the RAB lookup was called with
+            # the URL containing the refreshed token.
+            creds.before_request(request, "GET", "http://example.com", headers)
+
+            assert creds.token == "refreshed-token"
+            assert headers["authorization"] == "Bearer refreshed-token"
+            assert headers["x-allowed-locations"] == "0xA30"
+
+            # Verify lookup was called with the refreshed token's URL
+            lookup.assert_called_once()
+            args, kwargs = lookup.call_args
+            assert args[1] == "http://mock.url/lookup_for_refreshed-token"


### PR DESCRIPTION
In order for the gcloud CLI to support Regional Access Boundary, the Python auth SDK needs to support blocking lookups as well as allowing an initial seed RAB to be provided (gcloud will set this seed if the CLI has a locally cached valid RAB available).

Additional details can be found at [go/rab-python-gcloud-one-pager](https://docs.google.com/document/d/1PvwqXp-jznleIpA8UzXU9of6sMvHPZA8HN_TSSsWFcc/edit?resourcekey=0-yQowO9bsBsHdv_60zQsKnA&tab=t.0)