### PR TITLE
fix(storage): remove partial file on any download_to_filename error

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/blob.py
+++ b/packages/google-cloud-storage/google/cloud/storage/blob.py
@@ -1271,18 +1271,23 @@ class Blob(_PropertyMixin):
         For *args and **kwargs, refer to the documentation for download_to_filename() for more information.
         """
 
-        try:
-            with open(filename, "wb") as file_obj:
+        with open(filename, "wb") as file_obj:
+            try:
                 self._prep_and_do_download(
                     file_obj,
                     *args,
                     **kwargs,
                 )
-
-        except (DataCorruption, NotFound):
-            # Delete the corrupt or empty downloaded file.
-            os.remove(filename)
-            raise
+            except Exception:
+                # Remove the (empty or partial) file before re-raising so
+                # callers never see a corrupt destination file.  This extends
+                # the existing DataCorruption/NotFound cleanup to cover network
+                # errors, timeouts, and any other unexpected failures.
+                try:
+                    os.remove(filename)
+                except OSError:
+                    pass  # file may not exist if open() itself failed
+                raise
 
         updated = self.updated
         if updated is not None:
@@ -1311,6 +1316,13 @@ class Blob(_PropertyMixin):
 
         If :attr:`user_project` is set on the bucket, bills the API request
         to that project.
+
+        .. note::
+            If the download fails for any reason (network error, timeout,
+            :exc:`~google.cloud.exceptions.NotFound`, etc.), any partially
+            written destination file is removed before re-raising the
+            exception, so the filesystem is never left with an empty or
+            incomplete file.
 
         See a [code sample](https://cloud.google.com/storage/docs/samples/storage-download-encrypted-file#storage_download_encrypted_file-python)
         to download a file with a [`customer-supplied encryption key`](https://cloud.google.com/storage/docs/encryption#customer-supplied).

--- a/packages/google-cloud-storage/tests/unit/test_blob.py
+++ b/packages/google-cloud-storage/tests/unit/test_blob.py
@@ -1962,6 +1962,91 @@ class Test_Blob(unittest.TestCase):
             stream = blob._prep_and_do_download.mock_calls[0].args[0]
             self.assertEqual(stream.name, filename)
 
+    def test_download_to_filename_cleans_up_on_connection_error(self):
+        import requests.exceptions
+
+        blob_name = "blob-name"
+        client = self._make_client()
+        bucket = _Bucket(client)
+        blob = self._make_one(blob_name, bucket=bucket)
+
+        with mock.patch.object(blob, "_prep_and_do_download"):
+            blob._prep_and_do_download.side_effect = requests.exceptions.ConnectionError(
+                "Network is unreachable"
+            )
+
+            filehandle, filename = tempfile.mkstemp()
+            os.close(filehandle)
+            self.assertTrue(os.path.exists(filename))
+
+            with self.assertRaises(requests.exceptions.ConnectionError):
+                blob.download_to_filename(filename)
+
+            self.assertFalse(os.path.exists(filename))
+
+    def test_download_to_filename_cleans_up_on_timeout(self):
+        import requests.exceptions
+
+        blob_name = "blob-name"
+        client = self._make_client()
+        bucket = _Bucket(client)
+        blob = self._make_one(blob_name, bucket=bucket)
+
+        with mock.patch.object(blob, "_prep_and_do_download"):
+            blob._prep_and_do_download.side_effect = requests.exceptions.Timeout(
+                "Timeout of 120.0s exceeded"
+            )
+
+            filehandle, filename = tempfile.mkstemp()
+            os.close(filehandle)
+            self.assertTrue(os.path.exists(filename))
+
+            with self.assertRaises(requests.exceptions.Timeout):
+                blob.download_to_filename(filename)
+
+            self.assertFalse(os.path.exists(filename))
+
+    def test_download_to_filename_cleans_up_on_generic_exception(self):
+        blob_name = "blob-name"
+        client = self._make_client()
+        bucket = _Bucket(client)
+        blob = self._make_one(blob_name, bucket=bucket)
+
+        with mock.patch.object(blob, "_prep_and_do_download"):
+            blob._prep_and_do_download.side_effect = RuntimeError("unexpected failure")
+
+            filehandle, filename = tempfile.mkstemp()
+            os.close(filehandle)
+            self.assertTrue(os.path.exists(filename))
+
+            with self.assertRaises(RuntimeError):
+                blob.download_to_filename(filename)
+
+            self.assertFalse(os.path.exists(filename))
+
+    def test_download_to_filename_keeps_file_on_success(self):
+        blob_name = "blob-name"
+        client = self._make_client()
+        bucket = _Bucket(client)
+        blob = self._make_one(blob_name, bucket=bucket)
+
+        def _write_data(file_obj, **kwargs):
+            file_obj.write(b"hello world")
+
+        with mock.patch.object(
+            blob, "_prep_and_do_download", side_effect=_write_data
+        ):
+            filehandle, filename = tempfile.mkstemp()
+            os.close(filehandle)
+            try:
+                blob.download_to_filename(filename)
+                self.assertTrue(os.path.exists(filename))
+                with open(filename, "rb") as f:
+                    self.assertEqual(f.read(), b"hello world")
+            finally:
+                if os.path.exists(filename):
+                    os.remove(filename)
+
     def _download_as_bytes_helper(
         self, raw_download, timeout=None, single_shot_download=False, **extra_kwargs
     ):


### PR DESCRIPTION
## Problem

`Blob.download_to_filename()` opens the destination file for writing **before** the network request begins. If the download fails (network error, timeout, `ConnectionError`, etc.) the method raises an exception but leaves an empty or partially-written file on disk.

The existing code only cleaned up on `DataCorruption` and `NotFound`, but every other failure mode — including common `requests.exceptions.ConnectionError` / `Timeout` seen with GCS timeouts — still left a corrupt artifact.

**Observed in the wild:**

```
2026-04-18 07:02:07,368 | ERROR | Failed to download decomp file:
  Timeout of 120.0s exceeded, last exception:
  HTTPSConnectionPool(host='storage.googleapis.com', port=443):
  Max retries exceeded ...
  (Caused by NewConnectionError(...): [Errno 101] Network is unreachable)
```

After the above error the destination file exists on disk with 0 bytes, causing subsequent pipeline runs to treat the file as already downloaded and skip the retry.

## Fix

In `_handle_filename_and_download()`, replace `except (DataCorruption, NotFound)` with `except Exception` so the file is removed before re-raising, regardless of the failure type. The inner `try/except OSError` is a safety guard for the edge case where the file was never successfully created.

```python
# Before
try:
    with open(filename, "wb") as file_obj:
        self._prep_and_do_download(file_obj, ...)
except (DataCorruption, NotFound):
    os.remove(filename)
    raise

# After
with open(filename, "wb") as file_obj:
    try:
        self._prep_and_do_download(file_obj, ...)
    except Exception:
        try:
            os.remove(filename)
        except OSError:
            pass
        raise
```

## Tests

Four new unit tests added to `tests/unit/test_blob.py`:

| Test | Validates |
|---|---|
| `test_download_to_filename_cleans_up_on_connection_error` | `ConnectionError` → file removed |
| `test_download_to_filename_cleans_up_on_timeout` | `Timeout` → file removed |
| `test_download_to_filename_cleans_up_on_generic_exception` | Any `RuntimeError` → file removed |
| `test_download_to_filename_keeps_file_on_success` | Success path unaffected |

Existing tests (`test_download_to_filename_corrupted`, `test_download_to_filename_notfound`) pass unchanged.

## Notes

- No behaviour change on success path.
- Backward-compatible: callers that previously checked `os.path.exists()` after a `DataCorruption`/`NotFound` error would already receive `False`; this extends that guarantee to all failure modes.
- Docstring updated to document the cleanup guarantee.
