### PR TITLE
fix: propagate quota_project_id and api_endpoint in AsyncGrpcClient

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/asyncio/async_grpc_client.py
+++ b/packages/google-cloud-storage/google/cloud/storage/asyncio/async_grpc_client.py
@@ -23,6 +23,8 @@ from google.cloud._storage_v2.services.storage.transports.base import (
 )
 from google.cloud.storage import __version__
 
+_DEFAULT_HOST = "storage.googleapis.com"
+
 
 class AsyncGrpcClient:
     """An asynchronous client for interacting with Google Cloud Storage using the gRPC API.
@@ -109,7 +111,15 @@ class AsyncGrpcClient:
 
         primary_user_agent = client_info.to_user_agent()
 
+        host = _DEFAULT_HOST
+        quota_project_id = None
+        if client_options:
+            host = getattr(client_options, "api_endpoint", None) or _DEFAULT_HOST
+            quota_project_id = getattr(client_options, "quota_project_id", None)
+
         channel = transport_cls.create_channel(
+            host=host,
+            quota_project_id=quota_project_id,
             attempt_direct_path=attempt_direct_path,
             credentials=credentials,
             options=(("grpc.primary_user_agent", primary_user_agent),),

--- a/packages/google-cloud-storage/tests/unit/asyncio/test_async_grpc_client.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/test_async_grpc_client.py
@@ -54,6 +54,7 @@ class TestAsyncGrpcClient:
 
         mock_transport_cls.create_channel.assert_called_once_with(
             host="storage.googleapis.com",
+            quota_project_id=None,
             attempt_direct_path=True,
             credentials=mock_creds,
             options=expected_options,
@@ -84,26 +85,28 @@ class TestAsyncGrpcClient:
 
         mock_transport_cls.create_channel.assert_called_once_with(
             host="storage.googleapis.com",
+            quota_project_id=None,
             attempt_direct_path=True,
             credentials=mock_creds,
             options=expected_options,
         )
 
     @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
-    def test_constructor_with_quota_project_and_endpoint(self, mock_async_storage_client):
+    def test_constructor_with_quota_project_and_endpoint(
+        self, mock_async_storage_client
+    ):
         mock_transport_cls = mock.MagicMock()
         mock_async_storage_client.get_transport_class.return_value = mock_transport_cls
         mock_creds = _make_credentials()
-        
+
         from google.api_core import client_options
+
         mock_client_options = client_options.ClientOptions(
-            api_endpoint="custom-endpoint.com",
-            quota_project_id="my-quota-project"
+            api_endpoint="custom-endpoint.com", quota_project_id="my-quota-project"
         )
 
         async_grpc_client.AsyncGrpcClient(
-            credentials=mock_creds,
-            client_options=mock_client_options
+            credentials=mock_creds, client_options=mock_client_options
         )
 
         kwargs = mock_async_storage_client.call_args.kwargs
@@ -138,6 +141,7 @@ class TestAsyncGrpcClient:
 
         mock_transport_cls.create_channel.assert_called_once_with(
             host="storage.googleapis.com",
+            quota_project_id=None,
             attempt_direct_path=False,
             credentials=mock_creds,
             options=expected_options,
@@ -181,6 +185,7 @@ class TestAsyncGrpcClient:
 
         mock_transport_cls.create_channel.assert_called_once_with(
             host="storage.googleapis.com",
+            quota_project_id=None,
             attempt_direct_path=mock_attempt_direct_path,
             credentials=mock_creds,
             options=expected_options,

--- a/packages/google-cloud-storage/tests/unit/asyncio/test_async_grpc_client.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/test_async_grpc_client.py
@@ -53,6 +53,7 @@ class TestAsyncGrpcClient:
         expected_options = (("grpc.primary_user_agent", primary_user_agent),)
 
         mock_transport_cls.create_channel.assert_called_once_with(
+            host="storage.googleapis.com",
             attempt_direct_path=True,
             credentials=mock_creds,
             options=expected_options,
@@ -82,6 +83,37 @@ class TestAsyncGrpcClient:
         expected_options = (("grpc.primary_user_agent", primary_user_agent),)
 
         mock_transport_cls.create_channel.assert_called_once_with(
+            host="storage.googleapis.com",
+            attempt_direct_path=True,
+            credentials=mock_creds,
+            options=expected_options,
+        )
+
+    @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
+    def test_constructor_with_quota_project_and_endpoint(self, mock_async_storage_client):
+        mock_transport_cls = mock.MagicMock()
+        mock_async_storage_client.get_transport_class.return_value = mock_transport_cls
+        mock_creds = _make_credentials()
+        
+        from google.api_core import client_options
+        mock_client_options = client_options.ClientOptions(
+            api_endpoint="custom-endpoint.com",
+            quota_project_id="my-quota-project"
+        )
+
+        async_grpc_client.AsyncGrpcClient(
+            credentials=mock_creds,
+            client_options=mock_client_options
+        )
+
+        kwargs = mock_async_storage_client.call_args.kwargs
+        client_info = kwargs["client_info"]
+        primary_user_agent = client_info.to_user_agent()
+        expected_options = (("grpc.primary_user_agent", primary_user_agent),)
+
+        mock_transport_cls.create_channel.assert_called_once_with(
+            host="custom-endpoint.com",
+            quota_project_id="my-quota-project",
             attempt_direct_path=True,
             credentials=mock_creds,
             options=expected_options,
@@ -105,6 +137,7 @@ class TestAsyncGrpcClient:
         expected_options = (("grpc.primary_user_agent", primary_user_agent),)
 
         mock_transport_cls.create_channel.assert_called_once_with(
+            host="storage.googleapis.com",
             attempt_direct_path=False,
             credentials=mock_creds,
             options=expected_options,
@@ -147,6 +180,7 @@ class TestAsyncGrpcClient:
         expected_options = (("grpc.primary_user_agent", primary_user_agent),)
 
         mock_transport_cls.create_channel.assert_called_once_with(
+            host="storage.googleapis.com",
             attempt_direct_path=mock_attempt_direct_path,
             credentials=mock_creds,
             options=expected_options,


### PR DESCRIPTION
This PR fixes bug 503990490 where AsyncGrpcClient fails to propagate quota_project_id and api_endpoint from ClientOptions to the gRPC channel.