### PR TITLE
fix: replace deprecated `utcfromtimestamp` in google-auth-oauthlib

### DIFF
--- a/packages/gcp-sphinx-docfx-yaml/tests/testdata/auth/google_auth_oauthlib/helpers.py
+++ b/packages/gcp-sphinx-docfx-yaml/tests/testdata/auth/google_auth_oauthlib/helpers.py
@@ -147,5 +147,7 @@ def credentials_from_session(session, client_config=None):
             scopes=session.scope,
             granted_scopes=session.token.get("scope"),
         )
-    credentials.expiry = datetime.datetime.utcfromtimestamp(session.token["expires_at"])
+    credentials.expiry = datetime.datetime.fromtimestamp(
+        session.token["expires_at"], datetime.timezone.utc
+    ).replace(tzinfo=None)
     return credentials

--- a/packages/google-auth-oauthlib/google_auth_oauthlib/helpers.py
+++ b/packages/google-auth-oauthlib/google_auth_oauthlib/helpers.py
@@ -147,5 +147,7 @@ def credentials_from_session(session, client_config=None):
             scopes=session.scope,
             granted_scopes=session.token.get("scope"),
         )
-    credentials.expiry = datetime.datetime.utcfromtimestamp(session.token["expires_at"])
+    credentials.expiry = datetime.datetime.fromtimestamp(
+        session.token["expires_at"], datetime.timezone.utc
+    ).replace(tzinfo=None)
     return credentials


### PR DESCRIPTION
This PR replaces the usage of the deprecated `datetime.datetime.utcfromtimestamp` in the `google-auth-oauthlib` package and testdata.

Using `datetime.datetime.fromtimestamp(session.token["expires_at"], datetime.timezone.utc).replace(tzinfo=None)` avoids the deprecation warning in Python 3.12 while preserving backwards compatibility by returning a naive datetime object.

Fixes #15433

---
*PR created automatically by Jules for task [232508796818525143](https://jules.google.com/task/232508796818525143) started by @chalmerlowe*