### PR TITLE
fix(sqlalchemy-bigquery): Support Creation of JSON columns

### DIFF
--- a/packages/sqlalchemy-bigquery/sqlalchemy_bigquery/base.py
+++ b/packages/sqlalchemy-bigquery/sqlalchemy_bigquery/base.py
@@ -622,6 +622,9 @@ class BigQueryTypeCompiler(GenericTypeCompiler):
 
     visit_VARBINARY = visit_BLOB = visit_BINARY
 
+    def visit_JSON(self, type_, **kw):
+        return "JSON"
+
     def visit_NUMERIC(self, type_, **kw):
         if (type_.precision is not None) and isinstance(
             kw.get("type_expression"), Column

--- a/packages/sqlalchemy-bigquery/tests/unit/test_table_options.py
+++ b/packages/sqlalchemy-bigquery/tests/unit/test_table_options.py
@@ -62,6 +62,18 @@ def test_table_default_rounding_mode_dialect_option(faux_conn):
     )
 
 
+def test_table_with_json_columns(faux_conn):
+    setup_table(
+        faux_conn,
+        "some_table",
+        sqlalchemy.Column("some_stuff", sqlalchemy.JSON),
+    )
+
+    assert " ".join(faux_conn.test_data["execute"][-1][0].strip().split()) == (
+        "CREATE TABLE `some_table` ( `some_stuff` JSON )"
+    )
+
+
 def test_table_clustering_fields_dialect_option_no_such_column(faux_conn):
     with pytest.raises(sqlalchemy.exc.NoSuchColumnError):
         setup_table(


### PR DESCRIPTION
Fixes #15761 