### PR TITLE
fix(storage): test_transfer_manager counts unwanted deprecated warnings

### DIFF
--- a/packages/google-cloud-storage/tests/unit/test_fileio.py
+++ b/packages/google-cloud-storage/tests/unit/test_fileio.py
@@ -922,8 +922,8 @@ class TestBlobWriterText(unittest.TestCase, _BlobWriterBase):
 
         # The transmit_next_chunk method must actually consume bytes from the
         # sliding buffer for the flush() feature to work properly.
-        upload.transmit_next_chunk.side_effect = (
-            lambda _: unwrapped_writer._buffer.read(chunk_size)
+        upload.transmit_next_chunk.side_effect = lambda _: (
+            unwrapped_writer._buffer.read(chunk_size)
         )
 
         # Write under chunk_size. This should be buffered and the upload not

--- a/packages/google-cloud-storage/tests/unit/test_transfer_manager.py
+++ b/packages/google-cloud-storage/tests/unit/test_transfer_manager.py
@@ -556,8 +556,17 @@ def test_download_many_to_path_raises_invalid_path_error():
                 skip_if_exists=True,
             )
 
-    assert len(w) == 1
-    assert "will **NOT** be downloaded" in str(w[0].message)
+    invalid_path_warnings = [
+        warning
+        for warning in w
+        if str(warning.message).startswith("The blob ")
+        and "will **NOT** be downloaded" in str(warning.message)
+    ]
+
+    assert len(invalid_path_warnings) == 1, "---".join(
+        [str(warning.message) for warning in w]
+    )
+
     assert len(results) == 1
     assert isinstance(results[0], UserWarning)
 

--- a/packages/google-cloud-storage/tests/unit/test_transfer_manager.py
+++ b/packages/google-cloud-storage/tests/unit/test_transfer_manager.py
@@ -563,8 +563,8 @@ def test_download_many_to_path_raises_invalid_path_error():
         and "will **NOT** be downloaded" in str(warning.message)
     ]
 
-    assert len(invalid_path_warnings) == 1, "---".join(
-        [str(warning.message) for warning in w]
+    assert len(invalid_path_warnings) == 1, (
+        f"Expected 1 invalid path warning, found {len(invalid_path_warnings)}. All warnings: {[str(warning.message) for warning in w]}"
     )
 
     assert len(results) == 1


### PR DESCRIPTION
test_transfer_manager::test_download_many_to_path_raises_invalid_path_error catches all types of warnings (including FutureWarnings and DeprecationWarnings) whereas it is only required to check invalid path warnings.
Fixed the test to only include invalid_path_warnings