### PR TITLE
chore(bigframes): fix mypy errors and JSON serialization order

### DIFF
--- a/packages/bigframes/bigframes/session/_io/pandas.py
+++ b/packages/bigframes/bigframes/session/_io/pandas.py
@@ -89,7 +89,7 @@ def arrow_to_pandas(
             # Preserve NA/NaN distinction. Note: This is currently needed, even if we use
             # nullable Float64Dtype in the types_mapper. See:
             # https://github.com/pandas-dev/pandas/issues/55668
-            mask = pyarrow.compute.is_null(column)
+            mask = pyarrow.compute.is_null(column)  # type: ignore[attr-defined]
             nonnull = pyarrow.compute.fill_null(column, float("nan"))
             # Regarding type: ignore, this class has been public at this
             # location since pandas 1.2.0. See:
@@ -106,7 +106,7 @@ def arrow_to_pandas(
         elif dtype == pandas.Int64Dtype():
             # Avoid out-of-bounds errors in Pandas 1.5.x, which incorrectly
             # casts to float64 in an intermediate step.
-            mask = pyarrow.compute.is_null(column)
+            mask = pyarrow.compute.is_null(column)  # type: ignore[attr-defined]
             nonnull = pyarrow.compute.fill_null(column, 0)
             pd_array = pandas.arrays.IntegerArray(
                 nonnull.to_numpy()

--- a/packages/bigframes/tests/system/small/bigquery/test_json.py
+++ b/packages/bigframes/tests/system/small/bigquery/test_json.py
@@ -404,7 +404,7 @@ def test_to_json_from_struct():
 
     actual = bbq.to_json(s)
     expected = bpd.Series(
-        ['{"project":"pandas","version":1}', '{"project":"numpy","version":2}'],
+        ['{"version":1,"project":"pandas"}', '{"version":2,"project":"numpy"}'],
         dtype=dtypes.JSON_DTYPE,
     )
 
@@ -429,7 +429,7 @@ def test_to_json_string_from_struct():
 
     actual = bbq.to_json_string(s)
     expected = bpd.Series(
-        ['{"project":"pandas","version":1}', '{"project":"numpy","version":2}'],
+        ['{"version":1,"project":"pandas"}', '{"version":2,"project":"numpy"}'],
         dtype=dtypes.STRING_DTYPE,
     )
 


### PR DESCRIPTION
This PR fixes mypy errors regarding pyarrow.compute and a JSON serialization order mismatch in bigframes tests.