### PR TITLE
perf(storage): use google_crc32c.value() for simpler crc32c calculation

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/asyncio/retry/writes_resumption_strategy.py
+++ b/packages/google-cloud-storage/google/cloud/storage/asyncio/retry/writes_resumption_strategy.py
@@ -84,8 +84,7 @@ class _WriteResumptionStrategy(_BaseResumptionStrategy):
                 break
 
             checksummed_data = storage_type.ChecksummedData(content=chunk)
-            checksum = google_crc32c.Checksum(chunk)
-            checksummed_data.crc32c = int.from_bytes(checksum.digest(), "big")
+            checksummed_data.crc32c = google_crc32c.value(chunk)
 
             request = storage_type.BidiWriteObjectRequest(
                 write_offset=write_state.bytes_sent,

--- a/packages/google-cloud-storage/tests/unit/asyncio/retry/test_reads_resumption_strategy.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/retry/test_reads_resumption_strategy.py
@@ -17,7 +17,7 @@ import io
 import unittest
 
 from google.api_core import exceptions
-from google_crc32c import Checksum
+import google_crc32c
 
 from google.cloud import _storage_v2 as storage_v2
 from google.cloud._storage_v2.types.storage import BidiReadObjectRedirectedError
@@ -77,8 +77,7 @@ class TestReadResumptionStrategy(unittest.TestCase):
         checksummed_data = None
         if content is not None:
             if crc is None:
-                c = Checksum(content)
-                crc = int.from_bytes(c.digest(), "big")
+                crc = google_crc32c.value(content)
             checksummed_data = storage_v2.ChecksummedData(content=content, crc32c=crc)
 
         read_range = None

--- a/packages/google-cloud-storage/tests/unit/asyncio/retry/test_writes_resumption_strategy.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/retry/test_writes_resumption_strategy.py
@@ -125,8 +125,7 @@ class TestWriteResumptionStrategy:
 
         requests = strategy.generate_requests(state)
 
-        expected_crc = google_crc32c.Checksum(chunk_data).digest()
-        expected_int = int.from_bytes(expected_crc, "big")
+        expected_int = google_crc32c.value(chunk_data)
         assert requests[0].checksummed_data.crc32c == expected_int
 
     def test_generate_requests_flush_logic_exact_interval(self, strategy):

--- a/packages/google-cloud-storage/tests/unit/asyncio/test_async_multi_range_downloader.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/test_async_multi_range_downloader.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from google.api_core import exceptions
-from google_crc32c import Checksum
+import google_crc32c
 
 from google.cloud import _storage_v2
 from google.cloud.storage.asyncio import async_read_object_stream
@@ -106,11 +106,8 @@ class TestAsyncMultiRangeDownloader:
         self, mock_cls_async_read_object_stream, mock_random_int
     ):
         data = b"these_are_18_chars"
-        crc32c = Checksum(data).digest()
-        crc32c_int = int.from_bytes(crc32c, "big")
-        crc32c_checksum_for_data_slice = int.from_bytes(
-            Checksum(data[10:16]).digest(), "big"
-        )
+        crc32c_int = google_crc32c.value(data)
+        crc32c_checksum_for_data_slice = google_crc32c.value(data[10:16])
 
         mock_mrd, _ = await self._make_mock_mrd(mock_cls_async_read_object_stream)
         mock_random_int.side_effect = [456, 91011]
@@ -187,8 +184,7 @@ class TestAsyncMultiRangeDownloader:
     ):
         # Arrange
         data = b"these_are_18_chars"
-        crc32c = Checksum(data).digest()
-        crc32c_int = int.from_bytes(crc32c, "big")
+        crc32c_int = google_crc32c.value(data)
 
         mock_mrd, _ = await self._make_mock_mrd(mock_cls_async_read_object_stream)
         mock_random_int.side_effect = [456]


### PR DESCRIPTION
## Summary
- Simplified CRC32C calculation by using `google_crc32c.value()`.
- Improved code readability and reduced complexity in checksum logic.
