### PR TITLE
chore: specify explicit options for all API paths in librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -113,6 +113,11 @@ libraries:
       - path: google/ads/admanager/v1
     description_override: Manage your Ad Manager inventory, run reports and more.
     python:
+      opt_args_by_api:
+        google/ads/admanager/v1:
+          - python-gapic-namespace=google.ads
+          - python-gapic-name=admanager
+          - warehouse-package-name=google-ads-admanager
       default_version: v1
   - name: google-ads-datamanager
     version: 0.8.0
@@ -122,6 +127,11 @@ libraries:
       A unified ingestion API for data partners, agencies and advertisers to
       connect first-party data across Google advertising products.
     python:
+      opt_args_by_api:
+        google/ads/datamanager/v1:
+          - python-gapic-namespace=google.ads
+          - python-gapic-name=datamanager
+          - warehouse-package-name=google-ads-datamanager
       name_pretty_override: Data Manager API
       client_documentation_override: https://cloud.google.com/python/docs/reference/google-ads-datamanager/latest
       default_version: v1
@@ -150,6 +160,27 @@ libraries:
       - path: google/ai/generativelanguage/v1alpha
     description_override: The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.
     python:
+      opt_args_by_api:
+        google/ai/generativelanguage/v1:
+          - python-gapic-namespace=google.ai
+          - python-gapic-name=generativelanguage
+          - warehouse-package-name=google-ai-generativelanguage
+        google/ai/generativelanguage/v1alpha:
+          - python-gapic-namespace=google.ai
+          - python-gapic-name=generativelanguage
+          - warehouse-package-name=google-ai-generativelanguage
+        google/ai/generativelanguage/v1beta:
+          - python-gapic-namespace=google.ai
+          - python-gapic-name=generativelanguage
+          - warehouse-package-name=google-ai-generativelanguage
+        google/ai/generativelanguage/v1beta2:
+          - python-gapic-namespace=google.ai
+          - python-gapic-name=generativelanguage
+          - warehouse-package-name=google-ai-generativelanguage
+        google/ai/generativelanguage/v1beta3:
+          - python-gapic-namespace=google.ai
+          - python-gapic-name=generativelanguage
+          - warehouse-package-name=google-ai-generativelanguage
       name_pretty_override: Generative Language API
       metadata_name_override: generativelanguage
       default_version: v1beta
@@ -163,6 +194,13 @@ libraries:
       opt_args_by_api:
         google/analytics/admin/v1alpha:
           - autogen-snippets=False
+          - python-gapic-namespace=google.analytics
+          - python-gapic-name=admin
+          - warehouse-package-name=google-analytics-admin
+        google/analytics/admin/v1beta:
+          - python-gapic-namespace=google.analytics
+          - python-gapic-name=admin
+          - warehouse-package-name=google-analytics-admin
       name_pretty_override: Analytics Admin
       metadata_name_override: analyticsadmin
       default_version: v1alpha
@@ -173,6 +211,15 @@ libraries:
       - path: google/analytics/data/v1alpha
     description_override: provides programmatic methods to access report data in Google Analytics App+Web properties.
     python:
+      opt_args_by_api:
+        google/analytics/data/v1alpha:
+          - python-gapic-namespace=google.analytics
+          - python-gapic-name=data
+          - warehouse-package-name=google-analytics-data
+        google/analytics/data/v1beta:
+          - python-gapic-namespace=google.analytics
+          - python-gapic-name=data
+          - warehouse-package-name=google-analytics-data
       name_pretty_override: Analytics Data
       metadata_name_override: analyticsdata
       default_version: v1beta
@@ -190,6 +237,11 @@ libraries:
     keep:
       - tests/unit/gapic/card_v1/test_card.py
     python:
+      opt_args_by_api:
+        google/apps/card/v1:
+          - python-gapic-namespace=google.apps
+          - python-gapic-name=card
+          - warehouse-package-name=google-apps-card
       name_pretty_override: Google Apps Card Protos
       api_shortname_override: card
       api_id_override: card.googleapis.com
@@ -205,6 +257,7 @@ libraries:
           - proto-plus-deps=google.apps.card.v1
           - python-gapic-namespace=google.apps
           - warehouse-package-name=google-apps-chat
+          - python-gapic-name=chat
       name_pretty_override: Chat API
       product_documentation_override: https://developers.google.com/chat/
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -220,9 +273,11 @@ libraries:
         google/apps/events/subscriptions/v1:
           - python-gapic-namespace=google.apps
           - python-gapic-name=events_subscriptions
+          - warehouse-package-name=google-apps-events-subscriptions
         google/apps/events/subscriptions/v1beta:
           - python-gapic-namespace=google.apps
           - python-gapic-name=events_subscriptions
+          - warehouse-package-name=google-apps-events-subscriptions
       name_pretty_override: Google Workspace Events API
       api_shortname_override: subscriptions
       api_id_override: subscriptions.googleapis.com
@@ -235,6 +290,15 @@ libraries:
       - path: google/apps/meet/v2beta
     description_override: Create and manage meetings in Google Meet.
     python:
+      opt_args_by_api:
+        google/apps/meet/v2:
+          - python-gapic-namespace=google.apps
+          - python-gapic-name=meet
+          - warehouse-package-name=google-apps-meet
+        google/apps/meet/v2beta:
+          - python-gapic-namespace=google.apps
+          - python-gapic-name=meet
+          - warehouse-package-name=google-apps-meet
       name_pretty_override: Google Meet API
       default_version: v2
   - name: google-apps-script-type
@@ -257,18 +321,40 @@ libraries:
       - tests/unit/gapic/type/test_type.py
     python:
       opt_args_by_api:
+        google/apps/script/type:
+          - python-gapic-namespace=google.apps.script
+          - python-gapic-name=type
+          - warehouse-package-name=google-apps-script-type
         google/apps/script/type/calendar:
           - proto-plus-deps=google.apps.script.type
+          - python-gapic-namespace=google.apps.script.type
+          - python-gapic-name=calendar
+          - warehouse-package-name=google-apps-script-type
         google/apps/script/type/docs:
           - proto-plus-deps=google.apps.script.type
+          - python-gapic-namespace=google.apps.script.type
+          - python-gapic-name=docs
+          - warehouse-package-name=google-apps-script-type
         google/apps/script/type/drive:
           - proto-plus-deps=google.apps.script.type
+          - python-gapic-namespace=google.apps.script.type
+          - python-gapic-name=drive
+          - warehouse-package-name=google-apps-script-type
         google/apps/script/type/gmail:
           - proto-plus-deps=google.apps.script.type
+          - python-gapic-namespace=google.apps.script.type
+          - python-gapic-name=gmail
+          - warehouse-package-name=google-apps-script-type
         google/apps/script/type/sheets:
           - proto-plus-deps=google.apps.script.type
+          - python-gapic-namespace=google.apps.script.type
+          - python-gapic-name=sheets
+          - warehouse-package-name=google-apps-script-type
         google/apps/script/type/slides:
           - proto-plus-deps=google.apps.script.type
+          - python-gapic-namespace=google.apps.script.type
+          - python-gapic-name=slides
+          - warehouse-package-name=google-apps-script-type
       name_pretty_override: Google Apps Script Type Protos
       api_shortname_override: type
       api_id_override: type.googleapis.com
@@ -281,6 +367,11 @@ libraries:
       - path: google/area120/tables/v1alpha1
     description_override: provides programmatic methods to the Area 120 Tables API.
     python:
+      opt_args_by_api:
+        google/area120/tables/v1alpha1:
+          - python-gapic-namespace=google.area120
+          - python-gapic-name=tables
+          - warehouse-package-name=google-area120-tables
       name_pretty_override: Area 120 Tables
       metadata_name_override: area120tables
       default_version: v1alpha1
@@ -313,6 +404,8 @@ libraries:
       opt_args_by_api:
         google/cloud/accessapproval/v1:
           - warehouse-package-name=google-cloud-access-approval
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=accessapproval
       product_documentation_override: https://cloud.google.com/access-approval
       metadata_name_override: accessapproval
       default_version: v1
@@ -336,6 +429,11 @@ libraries:
       - path: google/cloud/advisorynotifications/v1
     description_override: Advisory Notifications provides well-targeted, timely, and compliant communications about critical security and privacy events in the Google Cloud console and allows you to securely investigate the event, take action, and get support.
     python:
+      opt_args_by_api:
+        google/cloud/advisorynotifications/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=advisorynotifications
+          - warehouse-package-name=google-cloud-advisorynotifications
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: advisorynotifications
       default_version: v1
@@ -346,6 +444,19 @@ libraries:
       - path: google/cloud/alloydb/v1beta
       - path: google/cloud/alloydb/v1alpha
     python:
+      opt_args_by_api:
+        google/cloud/alloydb/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=alloydb
+          - warehouse-package-name=google-cloud-alloydb
+        google/cloud/alloydb/v1alpha:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=alloydb
+          - warehouse-package-name=google-cloud-alloydb
+        google/cloud/alloydb/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=alloydb
+          - warehouse-package-name=google-cloud-alloydb
       product_documentation_override: https://cloud.google.com/alloydb/
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: alloydb
@@ -360,6 +471,19 @@ libraries:
     keep:
       - tests/unit/gapic/connectors_v1/test_connectors.py
     python:
+      opt_args_by_api:
+        google/cloud/alloydb/connectors/v1:
+          - python-gapic-namespace=google.cloud.alloydb
+          - python-gapic-name=connectors
+          - warehouse-package-name=google-cloud-alloydb-connectors
+        google/cloud/alloydb/connectors/v1alpha:
+          - python-gapic-namespace=google.cloud.alloydb
+          - python-gapic-name=connectors
+          - warehouse-package-name=google-cloud-alloydb-connectors
+        google/cloud/alloydb/connectors/v1beta:
+          - python-gapic-namespace=google.cloud.alloydb
+          - python-gapic-name=connectors
+          - warehouse-package-name=google-cloud-alloydb-connectors
       api_shortname_override: connectors
       metadata_name_override: connectors
       default_version: v1
@@ -372,6 +496,8 @@ libraries:
       opt_args_by_api:
         google/cloud/apigateway/v1:
           - warehouse-package-name=google-cloud-api-gateway
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=apigateway
       metadata_name_override: apigateway
       default_version: v1
   - name: google-cloud-api-keys
@@ -395,6 +521,8 @@ libraries:
       opt_args_by_api:
         google/cloud/apigeeconnect/v1:
           - warehouse-package-name=google-cloud-apigee-connect
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=apigeeconnect
       product_documentation_override: https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect
       metadata_name_override: apigeeconnect
       default_version: v1
@@ -419,6 +547,11 @@ libraries:
       - path: google/cloud/apihub/v1
     description_override: API hub lets you consolidate and organize information about all of the APIs of interest to your organization. API hub lets you capture critical information about APIs that allows developers to discover and evaluate them easily and leverage the work of other teams wherever possible. API platform teams can use API hub to have visibility into and manage their portfolio of APIs.
     python:
+      opt_args_by_api:
+        google/cloud/apihub/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=apihub
+          - warehouse-package-name=google-cloud-apihub
       name_pretty_override: API Hub API
       product_documentation_override: https://cloud.google.com/apigee/docs/apihub/what-is-api-hub
       default_version: v1
@@ -427,6 +560,11 @@ libraries:
     apis:
       - path: google/cloud/apiregistry/v1beta
     python:
+      opt_args_by_api:
+        google/cloud/apiregistry/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=apiregistry
+          - warehouse-package-name=google-cloud-apiregistry
       name_pretty_override: Cloud API Registry API
       product_documentation_override: https://docs.cloud.google.com/api-registry/docs/overview
       default_version: v1beta
@@ -468,6 +606,11 @@ libraries:
       - path: google/cloud/apphub/v1
     description_override: 'null '
     python:
+      opt_args_by_api:
+        google/cloud/apphub/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=apphub
+          - warehouse-package-name=google-cloud-apphub
       name_pretty_override: App Hub API
       product_documentation_override: https://cloud.google.com/app-hub/docs/overview
       default_version: v1
@@ -480,6 +623,11 @@ libraries:
       monitor, analyze, and improve the performance and cost-efficiency of their
       cloud applications.
     python:
+      opt_args_by_api:
+        google/cloud/appoptimize/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=appoptimize
+          - warehouse-package-name=google-cloud-appoptimize
       name_pretty_override: App Optimize API
       default_version: v1beta
   - name: google-cloud-artifact-registry
@@ -512,6 +660,21 @@ libraries:
       opt_args_by_api:
         google/cloud/asset/v1:
           - proto-plus-deps=google.cloud.osconfig.v1
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=asset
+          - warehouse-package-name=google-cloud-asset
+        google/cloud/asset/v1p1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=asset
+          - warehouse-package-name=google-cloud-asset
+        google/cloud/asset/v1p2beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=asset
+          - warehouse-package-name=google-cloud-asset
+        google/cloud/asset/v1p5beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=asset
+          - warehouse-package-name=google-cloud-asset
       name_pretty_override: Cloud Asset Inventory
       product_documentation_override: https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
       metadata_name_override: cloudasset
@@ -526,8 +689,12 @@ libraries:
       opt_args_by_api:
         google/cloud/assuredworkloads/v1:
           - warehouse-package-name=google-cloud-assured-workloads
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=assuredworkloads
         google/cloud/assuredworkloads/v1beta1:
           - warehouse-package-name=google-cloud-assured-workloads
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=assuredworkloads
       name_pretty_override: Assured Workloads for Government
       metadata_name_override: assuredworkloads
       default_version: v1
@@ -550,6 +717,11 @@ libraries:
     apis:
       - path: google/cloud/auditmanager/v1
     python:
+      opt_args_by_api:
+        google/cloud/auditmanager/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=auditmanager
+          - warehouse-package-name=google-cloud-auditmanager
       name_pretty_override: Audit Manager API
       default_version: v1
   - name: google-cloud-automl
@@ -565,6 +737,15 @@ libraries:
       - google/cloud/automl_v1beta1/services/tables/tables_client.py
     python:
       library_type: GAPIC_COMBO
+      opt_args_by_api:
+        google/cloud/automl/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=automl
+          - warehouse-package-name=google-cloud-automl
+        google/cloud/automl/v1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=automl
+          - warehouse-package-name=google-cloud-automl
       product_documentation_override: https://cloud.google.com/automl/docs/
       metadata_name_override: automl
       default_version: v1
@@ -574,6 +755,11 @@ libraries:
       - path: google/cloud/backupdr/v1
     description_override: Backup and DR Service ensures that your data is managed, protected, and accessible using both hybrid and cloud-based backup/recovery appliances that are managed using the Backup and DR management console.
     python:
+      opt_args_by_api:
+        google/cloud/backupdr/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=backupdr
+          - warehouse-package-name=google-cloud-backupdr
       name_pretty_override: Backup and DR Service API
       product_documentation_override: https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr
       metadata_name_override: backupdr
@@ -597,6 +783,15 @@ libraries:
       - path: google/cloud/batch/v1
       - path: google/cloud/batch/v1alpha
     python:
+      opt_args_by_api:
+        google/cloud/batch/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=batch
+          - warehouse-package-name=google-cloud-batch
+        google/cloud/batch/v1alpha:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=batch
+          - warehouse-package-name=google-cloud-batch
       name_pretty_override: Cloud Batch
       metadata_name_override: batch
       default_version: v1
@@ -676,6 +871,11 @@ libraries:
       - path: google/cloud/biglake/v1
     description_override: The BigLake API provides access to BigLake Metastore, a serverless, fully managed, and highly available metastore for open-source data that can be used for querying Apache Iceberg tables in BigQuery.
     python:
+      opt_args_by_api:
+        google/cloud/biglake/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=biglake
+          - warehouse-package-name=google-cloud-biglake
       name_pretty_override: BigLake API
       product_documentation_override: https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -722,6 +922,7 @@ libraries:
         google/cloud/bigquery/analyticshub/v1:
           - python-gapic-name=bigquery_analyticshub
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-bigquery-analyticshub
       name_pretty_override: BigQuery Analytics Hub
       metadata_name_override: analyticshub
       default_version: v1
@@ -736,9 +937,11 @@ libraries:
         google/cloud/bigquery/biglake/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_biglake
+          - warehouse-package-name=google-cloud-bigquery-biglake
         google/cloud/bigquery/biglake/v1alpha1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_biglake
+          - warehouse-package-name=google-cloud-bigquery-biglake
       name_pretty_override: BigLake API
       product_documentation_override: https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
       metadata_name_override: biglake
@@ -753,6 +956,7 @@ libraries:
         google/cloud/bigquery/connection/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_connection
+          - warehouse-package-name=google-cloud-bigquery-connection
       product_documentation_override: https://cloud.google.com/bigquery/docs/reference/bigqueryconnection
       metadata_name_override: bigqueryconnection
       default_version: v1
@@ -785,18 +989,22 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_datapolicies
           - transport=grpc+rest
+          - warehouse-package-name=google-cloud-bigquery-datapolicies
         google/cloud/bigquery/datapolicies/v1beta1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_datapolicies
           - transport=grpc
+          - warehouse-package-name=google-cloud-bigquery-datapolicies
         google/cloud/bigquery/datapolicies/v2:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_datapolicies
           - transport=grpc+rest
+          - warehouse-package-name=google-cloud-bigquery-datapolicies
         google/cloud/bigquery/datapolicies/v2beta1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_datapolicies
           - transport=grpc+rest
+          - warehouse-package-name=google-cloud-bigquery-datapolicies
       product_documentation_override: https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest
       metadata_name_override: bigquerydatapolicy
       default_version: v1
@@ -810,6 +1018,7 @@ libraries:
         google/cloud/bigquery/datatransfer/v1:
           - python-gapic-name=bigquery_datatransfer
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-bigquery-datatransfer
       metadata_name_override: bigquerydatatransfer
       default_version: v1
   - name: google-cloud-bigquery-logging
@@ -841,9 +1050,11 @@ libraries:
         google/cloud/bigquery/migration/v2:
           - python-gapic-name=bigquery_migration
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-bigquery-migration
         google/cloud/bigquery/migration/v2alpha:
           - python-gapic-name=bigquery_migration
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-bigquery-migration
       name_pretty_override: Google BigQuery Migration
       product_documentation_override: https://cloud.google.com/bigquery/docs/reference/migration/
       metadata_name_override: bigquerymigration
@@ -858,6 +1069,7 @@ libraries:
         google/cloud/bigquery/reservation/v1:
           - python-gapic-name=bigquery_reservation
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-bigquery-reservation
       product_documentation_override: https://cloud.google.com/bigquery/docs/reference/reservations
       metadata_name_override: bigqueryreservation
       default_version: v1
@@ -877,15 +1089,19 @@ libraries:
         google/cloud/bigquery/storage/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_storage
+          - warehouse-package-name=google-cloud-bigquery-storage
         google/cloud/bigquery/storage/v1alpha:
           - python-gapic-name=bigquery_storage
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-bigquery-storage
         google/cloud/bigquery/storage/v1beta:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_storage
+          - warehouse-package-name=google-cloud-bigquery-storage
         google/cloud/bigquery/storage/v1beta2:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_storage
+          - warehouse-package-name=google-cloud-bigquery-storage
       name_pretty_override: Google BigQuery Storage
       product_documentation_override: https://cloud.google.com/bigquery/docs/reference/storage/
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559654
@@ -907,9 +1123,12 @@ libraries:
         google/bigtable/admin/v2:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigtable_admin
+          - warehouse-package-name=google-cloud-bigtable
         google/bigtable/v2:
           - python-gapic-namespace=google.cloud
           - autogen-snippets=False
+          - python-gapic-name=bigtable
+          - warehouse-package-name=google-cloud-bigtable
       name_pretty_override: Google Cloud Bigtable
       product_documentation_override: https://cloud.google.com/bigtable
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559777
@@ -921,6 +1140,11 @@ libraries:
       - path: google/cloud/billing/v1
     description_override: allows developers to manage their billing accounts or browse the catalog of SKUs and pricing.
     python:
+      opt_args_by_api:
+        google/cloud/billing/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=billing
+          - warehouse-package-name=google-cloud-billing
       metadata_name_override: cloudbilling
       default_version: v1
   - name: google-cloud-billing-budgets
@@ -933,8 +1157,14 @@ libraries:
       opt_args_by_api:
         google/cloud/billing/budgets/v1:
           - transport=grpc+rest
+          - python-gapic-namespace=google.cloud.billing
+          - python-gapic-name=budgets
+          - warehouse-package-name=google-cloud-billing-budgets
         google/cloud/billing/budgets/v1beta1:
           - transport=grpc
+          - python-gapic-namespace=google.cloud.billing
+          - python-gapic-name=budgets
+          - warehouse-package-name=google-cloud-billing-budgets
       product_documentation_override: https://cloud.google.com/billing/docs/how-to/budget-api-overview
       metadata_name_override: billingbudgets
       default_version: v1
@@ -948,8 +1178,12 @@ libraries:
       opt_args_by_api:
         google/cloud/binaryauthorization/v1:
           - warehouse-package-name=google-cloud-binary-authorization
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=binaryauthorization
         google/cloud/binaryauthorization/v1beta1:
           - warehouse-package-name=google-cloud-binary-authorization
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=binaryauthorization
       metadata_name_override: binaryauthorization
       default_version: v1
   - name: google-cloud-build
@@ -963,9 +1197,11 @@ libraries:
         google/devtools/cloudbuild/v1:
           - python-gapic-namespace=google.cloud.devtools
           - warehouse-package-name=google-cloud-build
+          - python-gapic-name=cloudbuild
         google/devtools/cloudbuild/v2:
           - warehouse-package-name=google-cloud-build
           - python-gapic-namespace=google.cloud.devtools
+          - python-gapic-name=cloudbuild
       product_documentation_override: https://cloud.google.com/cloud-build/docs/
       metadata_name_override: cloudbuild
       default_version: v1
@@ -975,6 +1211,11 @@ libraries:
       - path: google/cloud/capacityplanner/v1beta
     description_override: Provides programmatic access to Capacity Planner features.
     python:
+      opt_args_by_api:
+        google/cloud/capacityplanner/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=capacityplanner
+          - warehouse-package-name=google-cloud-capacityplanner
       name_pretty_override: Capacity Planner API
       default_version: v1beta
   - name: google-cloud-certificate-manager
@@ -997,6 +1238,15 @@ libraries:
       - path: google/cloud/ces/v1
       - path: google/cloud/ces/v1beta
     python:
+      opt_args_by_api:
+        google/cloud/ces/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=ces
+          - warehouse-package-name=google-cloud-ces
+        google/cloud/ces/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=ces
+          - warehouse-package-name=google-cloud-ces
       name_pretty_override: Gemini Enterprise for Customer Experience API
       default_version: v1
   - name: google-cloud-channel
@@ -1005,6 +1255,11 @@ libraries:
       - path: google/cloud/channel/v1
     description_override: With Channel Services, Google Cloud partners and resellers have a single unified resale platform, with a unified resale catalog, customer management, order management, billing management, policy and authorization management, and cost management.
     python:
+      opt_args_by_api:
+        google/cloud/channel/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=channel
+          - warehouse-package-name=google-cloud-channel
       name_pretty_override: Channel Services
       metadata_name_override: cloudchannel
       default_version: v1
@@ -1014,6 +1269,11 @@ libraries:
       - path: google/cloud/chronicle/v1
     description_override: The Google Cloud Security Operations API, popularly known as the Chronicle API, serves endpoints that enable security analysts to analyze and mitigate a security threat throughout its lifecycle
     python:
+      opt_args_by_api:
+        google/cloud/chronicle/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=chronicle
+          - warehouse-package-name=google-cloud-chronicle
       name_pretty_override: Chronicle API
       product_documentation_override: https://cloud.google.com/chronicle/docs/secops/secops-overview
       default_version: v1
@@ -1024,6 +1284,15 @@ libraries:
       - path: google/cloud/cloudcontrolspartner/v1beta
     description_override: Provides insights about your customers and their Assured Workloads based on your Sovereign Controls by Partners offering.
     python:
+      opt_args_by_api:
+        google/cloud/cloudcontrolspartner/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=cloudcontrolspartner
+          - warehouse-package-name=google-cloud-cloudcontrolspartner
+        google/cloud/cloudcontrolspartner/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=cloudcontrolspartner
+          - warehouse-package-name=google-cloud-cloudcontrolspartner
       name_pretty_override: Cloud Controls Partner API
       product_documentation_override: https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -1034,6 +1303,11 @@ libraries:
       - path: google/cloud/cloudsecuritycompliance/v1
     description_override: 'null '
     python:
+      opt_args_by_api:
+        google/cloud/cloudsecuritycompliance/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=cloudsecuritycompliance
+          - warehouse-package-name=google-cloud-cloudsecuritycompliance
       name_pretty_override: Cloud Security Compliance API
       product_documentation_override: https://cloud.google.com/security-command-center/docs/compliance-manager-overview
       default_version: v1
@@ -1048,9 +1322,11 @@ libraries:
         google/cloud/commerce/consumer/procurement/v1:
           - python-gapic-name=commerce_consumer_procurement
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-commerce-consumer-procurement
         google/cloud/commerce/consumer/procurement/v1alpha1:
           - python-gapic-name=commerce_consumer_procurement
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-commerce-consumer-procurement
       name_pretty_override: Cloud Commerce Consumer Procurement API
       product_documentation_override: https://cloud.google.com/marketplace/docs/
       api_shortname_override: procurement
@@ -1065,6 +1341,11 @@ libraries:
       - tests/unit/gapic/common/test_common.py
     python:
       library_type: CORE
+      opt_args_by_api:
+        google/cloud/common:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=common
+          - warehouse-package-name=google-cloud-common
       name_pretty_override: Google Cloud Common
       product_documentation_override: https://cloud.google.com
       metadata_name_override: common
@@ -1078,6 +1359,9 @@ libraries:
       opt_args_by_api:
         google/cloud/compute/v1:
           - transport=rest
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=compute
+          - warehouse-package-name=google-cloud-compute
       name_pretty_override: Compute Engine
       metadata_name_override: compute
       default_version: v1
@@ -1091,6 +1375,8 @@ libraries:
         google/cloud/compute/v1beta:
           - transport=rest
           - warehouse-package-name=google-cloud-compute-v1beta
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=compute
       name_pretty_override: Compute Engine
       product_documentation_override: https://cloud.google.com/compute/
       issue_tracker_override: https://issuetracker.google.com/issues/new?component=187134&template=0
@@ -1101,6 +1387,11 @@ libraries:
       - path: google/cloud/confidentialcomputing/v1
     description_override: Protect data in-use with Confidential VMs, Confidential GKE, Confidential Dataproc, and Confidential Space.
     python:
+      opt_args_by_api:
+        google/cloud/confidentialcomputing/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=confidentialcomputing
+          - warehouse-package-name=google-cloud-confidentialcomputing
       name_pretty_override: Confidential Computing API
       issue_tracker_override: https://issuetracker.google.com/issues/new?component=1166820
       metadata_name_override: confidentialcomputing
@@ -1111,6 +1402,11 @@ libraries:
       - path: google/cloud/config/v1
     description_override: Infrastructure Manager API
     python:
+      opt_args_by_api:
+        google/cloud/config/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=config
+          - warehouse-package-name=google-cloud-config
       name_pretty_override: Infrastructure Manager API
       product_documentation_override: https://cloud.google.com/infrastructure-manager/docs/overview
       api_shortname_override: config
@@ -1124,6 +1420,19 @@ libraries:
       - path: google/cloud/configdelivery/v1alpha
     description_override: ConfigDelivery service manages the deployment of kubernetes configuration to a fleet of kubernetes clusters.
     python:
+      opt_args_by_api:
+        google/cloud/configdelivery/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=configdelivery
+          - warehouse-package-name=google-cloud-configdelivery
+        google/cloud/configdelivery/v1alpha:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=configdelivery
+          - warehouse-package-name=google-cloud-configdelivery
+        google/cloud/configdelivery/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=configdelivery
+          - warehouse-package-name=google-cloud-configdelivery
       name_pretty_override: Config Delivery API
       product_documentation_override: https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/reference/rest
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -1153,10 +1462,12 @@ libraries:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-container
           - transport=grpc+rest
+          - python-gapic-name=container
         google/container/v1beta1:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-container
           - transport=grpc
+          - python-gapic-name=container
       metadata_name_override: container
       default_version: v1
   - name: google-cloud-containeranalysis
@@ -1169,6 +1480,7 @@ libraries:
         google/devtools/containeranalysis/v1:
           - python-gapic-namespace=google.cloud.devtools
           - warehouse-package-name=google-cloud-containeranalysis
+          - python-gapic-name=containeranalysis
       product_documentation_override: https://cloud.google.com/container-registry/docs/container-analysis
       metadata_name_override: containeranalysis
       default_version: v1
@@ -1180,6 +1492,9 @@ libraries:
       opt_args_by_api:
         google/cloud/contentwarehouse/v1:
           - proto-plus-deps=google.cloud.documentai.v1
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=contentwarehouse
+          - warehouse-package-name=google-cloud-contentwarehouse
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: contentwarehouse
       default_version: v1
@@ -1211,6 +1526,8 @@ libraries:
       opt_args_by_api:
         google/cloud/dataqna/v1alpha:
           - warehouse-package-name=google-cloud-data-qna
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=dataqna
       product_documentation_override: https://cloud.google.com/bigquery/docs/dataqna
       metadata_name_override: dataqna
       default_version: v1alpha
@@ -1227,6 +1544,11 @@ libraries:
       focused on reliability, compliance, security, cost, and administration to
       quickly identify and address relevant issues within their database fleets.
     python:
+      opt_args_by_api:
+        google/cloud/databasecenter/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=databasecenter
+          - warehouse-package-name=google-cloud-databasecenter
       name_pretty_override: Database Center API
       product_documentation_override: https://cloud.google.com/database-center/docs/overview
       default_version: v1beta
@@ -1237,6 +1559,15 @@ libraries:
       - path: google/cloud/datacatalog/v1beta1
     description_override: is a fully managed and highly scalable data discovery and metadata management service.
     python:
+      opt_args_by_api:
+        google/cloud/datacatalog/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=datacatalog
+          - warehouse-package-name=google-cloud-datacatalog
+        google/cloud/datacatalog/v1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=datacatalog
+          - warehouse-package-name=google-cloud-datacatalog
       product_documentation_override: https://cloud.google.com/data-catalog
       metadata_name_override: datacatalog
       default_version: v1
@@ -1250,6 +1581,7 @@ libraries:
         google/cloud/datacatalog/lineage/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=datacatalog_lineage
+          - warehouse-package-name=google-cloud-datacatalog-lineage
       name_pretty_override: Data Lineage API
       product_documentation_override: https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage
       api_shortname_override: lineage
@@ -1288,6 +1620,15 @@ libraries:
       - path: google/cloud/dataform/v1
       - path: google/cloud/dataform/v1beta1
     python:
+      opt_args_by_api:
+        google/cloud/dataform/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=dataform
+          - warehouse-package-name=google-cloud-dataform
+        google/cloud/dataform/v1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=dataform
+          - warehouse-package-name=google-cloud-dataform
       name_pretty_override: Cloud Dataform
       product_documentation_override: https://cloud.google.com
       metadata_name_override: dataform
@@ -1298,6 +1639,11 @@ libraries:
       - path: google/cloud/datalabeling/v1beta1
     description_override: is a service that lets you work with human labelers to generate highly accurate labels for a collection of data that you can use to train your machine learning models.
     python:
+      opt_args_by_api:
+        google/cloud/datalabeling/v1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=datalabeling
+          - warehouse-package-name=google-cloud-datalabeling
       name_pretty_override: Google Cloud Data Labeling
       product_documentation_override: https://cloud.google.com/data-labeling/docs/
       metadata_name_override: datalabeling
@@ -1308,6 +1654,11 @@ libraries:
       - path: google/cloud/dataplex/v1
     description_override: provides intelligent data fabric that enables organizations to centrally manage, monitor, and govern their data across data lakes, data warehouses, and data marts with consistent controls, providing access to trusted data and powering analytics at scale.
     python:
+      opt_args_by_api:
+        google/cloud/dataplex/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=dataplex
+          - warehouse-package-name=google-cloud-dataplex
       product_documentation_override: https://cloud.google.com/dataplex
       metadata_name_override: dataplex
       default_version: v1
@@ -1317,6 +1668,11 @@ libraries:
       - path: google/cloud/dataproc/v1
     description_override: is a faster, easier, more cost-effective way to run Apache Spark and Apache Hadoop.
     python:
+      opt_args_by_api:
+        google/cloud/dataproc/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=dataproc
+          - warehouse-package-name=google-cloud-dataproc
       name_pretty_override: Google Cloud Dataproc
       metadata_name_override: dataproc
       default_version: v1
@@ -1331,10 +1687,16 @@ libraries:
       opt_args_by_api:
         google/cloud/metastore/v1:
           - warehouse-package-name=google-cloud-dataproc-metastore
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=metastore
         google/cloud/metastore/v1alpha:
           - warehouse-package-name=google-cloud-dataproc-metastore
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=metastore
         google/cloud/metastore/v1beta:
           - warehouse-package-name=google-cloud-dataproc-metastore
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=metastore
       metadata_name_override: metastore
       default_version: v1
   - name: google-cloud-datastore
@@ -1357,6 +1719,8 @@ libraries:
           - warehouse-package-name=google-cloud-datastore
         google/datastore/v1:
           - python-gapic-namespace=google.cloud
+          - python-gapic-name=datastore
+          - warehouse-package-name=google-cloud-datastore
       name_pretty_override: Google Cloud Datastore API
       product_documentation_override: https://cloud.google.com/datastore
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559768
@@ -1369,6 +1733,15 @@ libraries:
       - path: google/cloud/datastream/v1alpha1
     description_override: is a serverless and easy-to-use change data capture (CDC) and replication service. It allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.
     python:
+      opt_args_by_api:
+        google/cloud/datastream/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=datastream
+          - warehouse-package-name=google-cloud-datastream
+        google/cloud/datastream/v1alpha1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=datastream
+          - warehouse-package-name=google-cloud-datastream
       metadata_name_override: datastream
       default_version: v1
   - name: google-cloud-deploy
@@ -1377,6 +1750,11 @@ libraries:
       - path: google/cloud/deploy/v1
     description_override: is a service that automates delivery of your applications to a series of target environments in a defined sequence
     python:
+      opt_args_by_api:
+        google/cloud/deploy/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=deploy
+          - warehouse-package-name=google-cloud-deploy
       name_pretty_override: Google Cloud Deploy
       metadata_name_override: clouddeploy
       default_version: v1
@@ -1386,6 +1764,11 @@ libraries:
       - path: google/cloud/developerconnect/v1
     description_override: Developer Connect streamlines integration with third-party source code management platforms by simplifying authentication, authorization, and networking configuration.
     python:
+      opt_args_by_api:
+        google/cloud/developerconnect/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=developerconnect
+          - warehouse-package-name=google-cloud-developerconnect
       name_pretty_override: Developer Connect API
       product_documentation_override: https://cloud.google.com/developer-connect/docs/overview
       default_version: v1
@@ -1395,6 +1778,11 @@ libraries:
       - path: google/cloud/devicestreaming/v1
     description_override: The Cloud API for device streaming usage.
     python:
+      opt_args_by_api:
+        google/cloud/devicestreaming/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=devicestreaming
+          - warehouse-package-name=google-cloud-devicestreaming
       name_pretty_override: Device Streaming API
       default_version: v1
   - name: google-cloud-dialogflow
@@ -1405,6 +1793,15 @@ libraries:
     description_override: is an end-to-end, build-once deploy-everywhere development suite for creating conversational interfaces for websites, mobile applications, popular messaging platforms, and IoT devices. You can use it to build interfaces (such as chatbots and conversational IVR) that enable natural and rich interactions between your users and your business. Dialogflow Enterprise Edition users have access to Google Cloud Support and a service level agreement (SLA) for production deployments.
     skip_generate: true
     python:
+      opt_args_by_api:
+        google/cloud/dialogflow/v2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=dialogflow
+          - warehouse-package-name=google-cloud-dialogflow
+        google/cloud/dialogflow/v2beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=dialogflow
+          - warehouse-package-name=google-cloud-dialogflow
       product_documentation_override: https://www.dialogflow.com/
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5300385
       metadata_name_override: dialogflow
@@ -1434,6 +1831,19 @@ libraries:
       - path: google/cloud/discoveryengine/v1beta
       - path: google/cloud/discoveryengine/v1alpha
     python:
+      opt_args_by_api:
+        google/cloud/discoveryengine/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=discoveryengine
+          - warehouse-package-name=google-cloud-discoveryengine
+        google/cloud/discoveryengine/v1alpha:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=discoveryengine
+          - warehouse-package-name=google-cloud-discoveryengine
+        google/cloud/discoveryengine/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=discoveryengine
+          - warehouse-package-name=google-cloud-discoveryengine
       name_pretty_override: Discovery Engine API
       product_documentation_override: https://cloud.google.com/discovery-engine/
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -1448,6 +1858,8 @@ libraries:
       opt_args_by_api:
         google/privacy/dlp/v2:
           - python-gapic-namespace=google.cloud
+          - python-gapic-name=dlp
+          - warehouse-package-name=google-cloud-dlp
       name_pretty_override: Cloud Data Loss Prevention
       product_documentation_override: https://cloud.google.com/dlp/docs/
       metadata_name_override: dlp
@@ -1461,6 +1873,8 @@ libraries:
       opt_args_by_api:
         google/cloud/clouddms/v1:
           - warehouse-package-name=google-cloud-dms
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=clouddms
       name_pretty_override: Cloud Database Migration Service
       metadata_name_override: datamigration
       default_version: v1
@@ -1484,8 +1898,14 @@ libraries:
       opt_args_by_api:
         google/cloud/documentai/v1:
           - autogen-snippets
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=documentai
+          - warehouse-package-name=google-cloud-documentai
         google/cloud/documentai/v1beta3:
           - autogen-snippets
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=documentai
+          - warehouse-package-name=google-cloud-documentai
       name_pretty_override: Document AI
       metadata_name_override: documentai
       default_version: v1
@@ -1504,6 +1924,15 @@ libraries:
       - path: google/cloud/domains/v1beta1
     description_override: allows you to register and manage domains by using Cloud Domains.
     python:
+      opt_args_by_api:
+        google/cloud/domains/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=domains
+          - warehouse-package-name=google-cloud-domains
+        google/cloud/domains/v1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=domains
+          - warehouse-package-name=google-cloud-domains
       metadata_name_override: domains
       default_version: v1
   - name: google-cloud-edgecontainer
@@ -1512,6 +1941,11 @@ libraries:
       - path: google/cloud/edgecontainer/v1
     description_override: Google Distributed Cloud Edge allows you to run Kubernetes clusters on dedicated hardware provided and maintained by Google that is separate from the Google Cloud data center.
     python:
+      opt_args_by_api:
+        google/cloud/edgecontainer/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=edgecontainer
+          - warehouse-package-name=google-cloud-edgecontainer
       metadata_name_override: edgecontainer
       default_version: v1
   - name: google-cloud-edgenetwork
@@ -1520,6 +1954,11 @@ libraries:
       - path: google/cloud/edgenetwork/v1
     description_override: Network management API for Distributed Cloud Edge
     python:
+      opt_args_by_api:
+        google/cloud/edgenetwork/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=edgenetwork
+          - warehouse-package-name=google-cloud-edgenetwork
       name_pretty_override: Distributed Cloud Edge Network API
       product_documentation_override: https://cloud.google.com/distributed-cloud/edge/latest/docs/overview
       default_version: v1
@@ -1528,6 +1967,11 @@ libraries:
     apis:
       - path: google/cloud/enterpriseknowledgegraph/v1
     python:
+      opt_args_by_api:
+        google/cloud/enterpriseknowledgegraph/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=enterpriseknowledgegraph
+          - warehouse-package-name=google-cloud-enterpriseknowledgegraph
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: enterpriseknowledgegraph
       default_version: v1
@@ -1566,6 +2010,11 @@ libraries:
       - path: google/cloud/eventarc/v1
     description_override: lets you asynchronously deliver events from Google services, SaaS, and your own apps using loosely coupled services that react to state changes. Eventarc requires no infrastructure management, you can optimize productivity and costs while building a modern, event-driven solution.
     python:
+      opt_args_by_api:
+        google/cloud/eventarc/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=eventarc
+          - warehouse-package-name=google-cloud-eventarc
       metadata_name_override: eventarc
       default_version: v1
   - name: google-cloud-eventarc-publishing
@@ -1590,6 +2039,9 @@ libraries:
       opt_args_by_api:
         google/cloud/filestore/v1:
           - proto-plus-deps=google.cloud.common
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=filestore
+          - warehouse-package-name=google-cloud-filestore
       name_pretty_override: Filestore
       metadata_name_override: file
       default_version: v1
@@ -1599,6 +2051,11 @@ libraries:
       - path: google/cloud/financialservices/v1
     description_override: Google Cloud's Anti Money Laundering AI (AML AI) product is an API that scores AML risk. Use it to identify more risk, more defensibly, with fewer false positives and reduced time per review.
     python:
+      opt_args_by_api:
+        google/cloud/financialservices/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=financialservices
+          - warehouse-package-name=google-cloud-financialservices
       name_pretty_override: Anti Money Laundering AI API
       product_documentation_override: https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -1630,13 +2087,17 @@ libraries:
           - python-gapic-name=firestore_admin
           - python-gapic-namespace=google.cloud
           - transport=grpc+rest
+          - warehouse-package-name=google-cloud-firestore
         google/firestore/bundle:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=firestore_bundle
           - transport=grpc
+          - warehouse-package-name=google-cloud-firestore
         google/firestore/v1:
           - python-gapic-namespace=google.cloud
           - transport=grpc+rest
+          - python-gapic-name=firestore
+          - warehouse-package-name=google-cloud-firestore
       name_pretty_override: Cloud Firestore API
       product_documentation_override: https://cloud.google.com/firestore
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5337669
@@ -1649,6 +2110,15 @@ libraries:
       - path: google/cloud/functions/v1
     description_override: is a scalable pay as you go Functions-as-a-Service (FaaS) to run your code with zero server management.
     python:
+      opt_args_by_api:
+        google/cloud/functions/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=functions
+          - warehouse-package-name=google-cloud-functions
+        google/cloud/functions/v2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=functions
+          - warehouse-package-name=google-cloud-functions
       metadata_name_override: cloudfunctions
       default_version: v1
   - name: google-cloud-gdchardwaremanagement
@@ -1657,6 +2127,11 @@ libraries:
       - path: google/cloud/gdchardwaremanagement/v1alpha
     description_override: Google Distributed Cloud connected allows you to run Kubernetes clusters on dedicated hardware provided and maintained by Google that is separate from the Google Cloud data center.
     python:
+      opt_args_by_api:
+        google/cloud/gdchardwaremanagement/v1alpha:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=gdchardwaremanagement
+          - warehouse-package-name=google-cloud-gdchardwaremanagement
       name_pretty_override: GDC Hardware Management API
       default_version: v1alpha
   - name: google-cloud-geminidataanalytics
@@ -1666,6 +2141,15 @@ libraries:
       - path: google/cloud/geminidataanalytics/v1alpha
     description_override: Developers can use the Conversational Analytics API, accessed through geminidataanalytics.googleapis.com, to build an artificial intelligence (AI)-powered chat interface, or data agent, that answers questions about structured data in BigQuery, Looker, and Looker Studio using natural language.
     python:
+      opt_args_by_api:
+        google/cloud/geminidataanalytics/v1alpha:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=geminidataanalytics
+          - warehouse-package-name=google-cloud-geminidataanalytics
+        google/cloud/geminidataanalytics/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=geminidataanalytics
+          - warehouse-package-name=google-cloud-geminidataanalytics
       product_documentation_override: https://cloud.google.com/gemini/docs/conversational-analytics-api/overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1alpha
@@ -1693,8 +2177,12 @@ libraries:
       opt_args_by_api:
         google/cloud/gkeconnect/gateway/v1:
           - warehouse-package-name=google-cloud-gke-connect-gateway
+          - python-gapic-namespace=google.cloud.gkeconnect
+          - python-gapic-name=gateway
         google/cloud/gkeconnect/gateway/v1beta1:
           - warehouse-package-name=google-cloud-gke-connect-gateway
+          - python-gapic-namespace=google.cloud.gkeconnect
+          - python-gapic-name=gateway
       name_pretty_override: GKE Connect Gateway
       product_documentation_override: https://cloud.google.com/anthos/multicluster-management/gateway
       metadata_name_override: connectgateway
@@ -1717,8 +2205,12 @@ libraries:
       opt_args_by_api:
         google/cloud/gkehub/v1:
           - warehouse-package-name=google-cloud-gke-hub
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=gkehub
         google/cloud/gkehub/v1beta1:
           - warehouse-package-name=google-cloud-gke-hub
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=gkehub
       product_documentation_override: https://cloud.google.com/anthos/gke/docs/
       metadata_name_override: gkehub
       default_version: v1
@@ -1743,6 +2235,11 @@ libraries:
       - path: google/cloud/gkerecommender/v1
     description_override: GKE Recommender API
     python:
+      opt_args_by_api:
+        google/cloud/gkerecommender/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=gkerecommender
+          - warehouse-package-name=google-cloud-gkerecommender
       name_pretty_override: GKE Recommender API
       product_documentation_override: https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart
       default_version: v1
@@ -1755,6 +2252,9 @@ libraries:
       opt_args_by_api:
         google/cloud/gsuiteaddons/v1:
           - proto-plus-deps=google.apps.script.type.calendar+google.apps.script.type.docs+google.apps.script.type.drive+google.apps.script.type.gmail+google.apps.script.type.sheets+google.apps.script.type.slides+google.apps.script.type
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=gsuiteaddons
+          - warehouse-package-name=google-cloud-gsuiteaddons
       name_pretty_override: Google Workspace Add-ons API
       metadata_name_override: gsuiteaddons
       default_version: v1
@@ -1765,6 +2265,15 @@ libraries:
       - path: google/cloud/hypercomputecluster/v1beta
     description_override: The Cluster Director API allows you to deploy, manage, and monitor clusters that run AI, ML, or HPC workloads.
     python:
+      opt_args_by_api:
+        google/cloud/hypercomputecluster/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=hypercomputecluster
+          - warehouse-package-name=google-cloud-hypercomputecluster
+        google/cloud/hypercomputecluster/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=hypercomputecluster
+          - warehouse-package-name=google-cloud-hypercomputecluster
       name_pretty_override: Cluster Director API
       product_documentation_override: https://cloud.google.com/blog/products/compute/managed-slurm-and-other-cluster-director-enhancements
       default_version: v1
@@ -1840,6 +2349,11 @@ libraries:
       - path: google/cloud/iamconnectorcredentials/v1alpha
     description_override: iamconnectorcredentials.googleapis.com API.
     python:
+      opt_args_by_api:
+        google/cloud/iamconnectorcredentials/v1alpha:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=iamconnectorcredentials
+          - warehouse-package-name=google-cloud-iamconnectorcredentials
       name_pretty_override: iamconnectorcredentials.googleapis.com API
       product_documentation_override: https://cloud.google.com/iamconnectorcredentials/docs/overview
       default_version: v1alpha
@@ -1849,6 +2363,11 @@ libraries:
       - path: google/cloud/iap/v1
     description_override: Identity-Aware Proxy includes a number of features that can be used to protect access to Google Cloud hosted resources and applications hosted on Google Cloud.
     python:
+      opt_args_by_api:
+        google/cloud/iap/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=iap
+          - warehouse-package-name=google-cloud-iap
       name_pretty_override: Identity-Aware Proxy
       metadata_name_override: iap
       default_version: v1
@@ -1858,6 +2377,11 @@ libraries:
       - path: google/cloud/ids/v1
     description_override: Cloud IDS is an intrusion detection service that provides threat detection for intrusions, malware, spyware, and command-and-control attacks on your network. Cloud IDS works by creating a Google-managed peered network with mirrored VMs. Traffic in the peered network is mirrored, and then inspected by Palo Alto Networks threat protection technologies to provide advanced threat detection.
     python:
+      opt_args_by_api:
+        google/cloud/ids/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=ids
+          - warehouse-package-name=google-cloud-ids
       metadata_name_override: ids
       default_version: v1
   - name: google-cloud-kms
@@ -1866,6 +2390,11 @@ libraries:
       - path: google/cloud/kms/v1
     description_override: a cloud-hosted key management service that lets you manage cryptographic keys for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256, RSA 2048, RSA 3072, RSA 4096, EC P256, and EC P384 cryptographic keys. Cloud KMS is integrated with Cloud IAM and Cloud Audit Logging so that you can manage permissions on individual keys and monitor how these are used. Use Cloud KMS to protect secrets and other sensitive data that you need to store in Google Cloud Platform.
     python:
+      opt_args_by_api:
+        google/cloud/kms/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=kms
+          - warehouse-package-name=google-cloud-kms
       name_pretty_override: Google Cloud Key Management Service
       metadata_name_override: cloudkms
       default_version: v1
@@ -1880,6 +2409,7 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=kms_inventory
           - proto-plus-deps=google.cloud.kms.v1
+          - warehouse-package-name=google-cloud-kms-inventory
       name_pretty_override: KMS Inventory API
       product_documentation_override: https://cloud.google.com/kms/docs/
       api_shortname_override: inventory
@@ -1894,6 +2424,19 @@ libraries:
       - path: google/cloud/language/v1beta2
     description_override: provides natural language understanding technologies to developers, including sentiment analysis, entity analysis, entity sentiment analysis, content classification, and syntax analysis. This API is part of the larger Cloud Machine Learning API family.
     python:
+      opt_args_by_api:
+        google/cloud/language/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=language
+          - warehouse-package-name=google-cloud-language
+        google/cloud/language/v1beta2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=language
+          - warehouse-package-name=google-cloud-language
+        google/cloud/language/v2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=language
+          - warehouse-package-name=google-cloud-language
       name_pretty_override: Natural Language
       product_documentation_override: https://cloud.google.com/natural-language/docs/
       metadata_name_override: language
@@ -1904,6 +2447,11 @@ libraries:
       - path: google/cloud/licensemanager/v1
     description_override: 'License Manager is a tool to manage and track third-party licenses on Google Cloud. '
     python:
+      opt_args_by_api:
+        google/cloud/licensemanager/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=licensemanager
+          - warehouse-package-name=google-cloud-licensemanager
       name_pretty_override: License Manager API
       product_documentation_override: https://cloud.google.com/compute/docs/instances/windows/ms-licensing
       default_version: v1
@@ -1916,6 +2464,8 @@ libraries:
       opt_args_by_api:
         google/cloud/lifesciences/v2beta:
           - warehouse-package-name=google-cloud-life-sciences
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=lifesciences
       metadata_name_override: lifesciences
       default_version: v2beta
   - name: google-cloud-locationfinder
@@ -1924,6 +2474,11 @@ libraries:
       - path: google/cloud/locationfinder/v1
     description_override: Cloud Location Finder lets you identify and filter cloud locations in regions and zones across Google Cloud, Google Distributed Cloud, Microsoft Azure, Amazon Web Services, and Oracle Cloud Infrastructure based on proximity, geographic location, and carbon footprint.
     python:
+      opt_args_by_api:
+        google/cloud/locationfinder/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=locationfinder
+          - warehouse-package-name=google-cloud-locationfinder
       name_pretty_override: Cloud Location Finder API
       product_documentation_override: https://issuetracker.google.com/issues/new?component=1569265&template=1988535
       api_id_override: locationfinder.googleapis.com
@@ -1939,6 +2494,7 @@ libraries:
         google/logging/v2:
           - python-gapic-name=logging
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-logging
       name_pretty_override: Cloud Logging API
       product_documentation_override: https://cloud.google.com/logging/docs
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559764
@@ -1950,6 +2506,11 @@ libraries:
       - path: google/cloud/lustre/v1
     description_override: 'null '
     python:
+      opt_args_by_api:
+        google/cloud/lustre/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=lustre
+          - warehouse-package-name=google-cloud-lustre
       name_pretty_override: Google Cloud Managed Lustre API
       default_version: v1
   - name: google-cloud-maintenance-api
@@ -1963,9 +2524,11 @@ libraries:
         google/cloud/maintenance/api/v1:
           - python-gapic-name=maintenance_api
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-maintenance-api
         google/cloud/maintenance/api/v1beta:
           - python-gapic-name=maintenance_api
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-maintenance-api
       name_pretty_override: Maintenance API
       product_documentation_override: https://cloud.google.com/unified-maintenance/docs/overview
       api_shortname_override: api
@@ -1980,6 +2543,8 @@ libraries:
       opt_args_by_api:
         google/cloud/managedidentities/v1:
           - warehouse-package-name=google-cloud-managed-identities
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=managedidentities
       metadata_name_override: managedidentities
       default_version: v1
   - name: google-cloud-managedkafka
@@ -1988,6 +2553,11 @@ libraries:
       - path: google/cloud/managedkafka/v1
     description_override: Managed Service for Apache Kafka API is a managed cloud service that lets you ingest Kafka streams directly into Google Cloud.
     python:
+      opt_args_by_api:
+        google/cloud/managedkafka/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=managedkafka
+          - warehouse-package-name=google-cloud-managedkafka
       product_documentation_override: https://cloud.google.com/managed-kafka
       default_version: v1
   - name: google-cloud-managedkafka-schemaregistry
@@ -2000,6 +2570,7 @@ libraries:
         google/cloud/managedkafka/schemaregistry/v1:
           - python-gapic-name=managedkafka_schemaregistry
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-managedkafka-schemaregistry
       name_pretty_override: Managed Service for Apache Kafka API
       api_shortname_override: schemaregistry
       api_id_override: schemaregistry.googleapis.com
@@ -2013,6 +2584,8 @@ libraries:
       opt_args_by_api:
         google/cloud/mediatranslation/v1beta1:
           - warehouse-package-name=google-cloud-media-translation
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=mediatranslation
       metadata_name_override: mediatranslation
       default_version: v1beta1
   - name: google-cloud-memcache
@@ -2022,6 +2595,15 @@ libraries:
       - path: google/cloud/memcache/v1beta2
     description_override: is a fully-managed in-memory data store service for Memcache.
     python:
+      opt_args_by_api:
+        google/cloud/memcache/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=memcache
+          - warehouse-package-name=google-cloud-memcache
+        google/cloud/memcache/v1beta2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=memcache
+          - warehouse-package-name=google-cloud-memcache
       product_documentation_override: https://cloud.google.com/memorystore/docs/memcached/
       metadata_name_override: memcache
       default_version: v1
@@ -2032,6 +2614,15 @@ libraries:
       - path: google/cloud/memorystore/v1beta
     description_override: Memorystore for Valkey is a fully managed Valkey Cluster service for Google Cloud. Applications running on Google Cloud can achieve extreme performance by leveraging the highly scalable, available, secure Valkey service without the burden of managing complex Valkey deployments.
     python:
+      opt_args_by_api:
+        google/cloud/memorystore/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=memorystore
+          - warehouse-package-name=google-cloud-memorystore
+        google/cloud/memorystore/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=memorystore
+          - warehouse-package-name=google-cloud-memorystore
       product_documentation_override: https://cloud.google.com/memorystore/docs/valkey
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
@@ -2041,6 +2632,11 @@ libraries:
       - path: google/cloud/migrationcenter/v1
     description_override: A unified platform that helps you accelerate your end-to-end cloud journey from your current on-premises or cloud environments to Google Cloud.
     python:
+      opt_args_by_api:
+        google/cloud/migrationcenter/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=migrationcenter
+          - warehouse-package-name=google-cloud-migrationcenter
       name_pretty_override: Migration Center API
       product_documentation_override: https://cloud.google.com/migration-center/docs/migration-center-overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -2053,6 +2649,15 @@ libraries:
       - path: google/cloud/modelarmor/v1beta
     description_override: Model Armor helps you protect against risks like prompt injection, harmful content, and data leakage in generative AI applications by letting you define policies that filter user prompts and model responses.
     python:
+      opt_args_by_api:
+        google/cloud/modelarmor/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=modelarmor
+          - warehouse-package-name=google-cloud-modelarmor
+        google/cloud/modelarmor/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=modelarmor
+          - warehouse-package-name=google-cloud-modelarmor
       name_pretty_override: Model Armor API
       product_documentation_override: https://cloud.google.com/security-command-center/docs/model-armor-overview
       api_shortname_override: securitycenter
@@ -2068,6 +2673,8 @@ libraries:
       opt_args_by_api:
         google/monitoring/v3:
           - python-gapic-namespace=google.cloud
+          - python-gapic-name=monitoring
+          - warehouse-package-name=google-cloud-monitoring
       name_pretty_override: Stackdriver Monitoring
       metadata_name_override: monitoring
       default_version: v3
@@ -2117,6 +2724,11 @@ libraries:
       - path: google/cloud/netapp/v1
     description_override: NetApp API
     python:
+      opt_args_by_api:
+        google/cloud/netapp/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=netapp
+          - warehouse-package-name=google-cloud-netapp
       name_pretty_override: NetApp API
       product_documentation_override: https://cloud.google.com/netapp/volumes/docs/discover/overview
       metadata_name_override: netapp
@@ -2132,10 +2744,16 @@ libraries:
       opt_args_by_api:
         google/cloud/networkconnectivity/v1:
           - warehouse-package-name=google-cloud-network-connectivity
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=networkconnectivity
         google/cloud/networkconnectivity/v1alpha1:
           - warehouse-package-name=google-cloud-network-connectivity
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=networkconnectivity
         google/cloud/networkconnectivity/v1beta:
           - warehouse-package-name=google-cloud-network-connectivity
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=networkconnectivity
       name_pretty_override: Network Connectivity Center
       metadata_name_override: networkconnectivity
       default_version: v1
@@ -2199,10 +2817,19 @@ libraries:
       opt_args_by_api:
         google/cloud/notebooks/v1:
           - transport=grpc
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=notebooks
+          - warehouse-package-name=google-cloud-notebooks
         google/cloud/notebooks/v1beta1:
           - transport=grpc+rest
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=notebooks
+          - warehouse-package-name=google-cloud-notebooks
         google/cloud/notebooks/v2:
           - transport=grpc+rest
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=notebooks
+          - warehouse-package-name=google-cloud-notebooks
       name_pretty_override: AI Platform Notebooks
       product_documentation_override: https://cloud.google.com/ai-platform/notebooks/
       metadata_name_override: notebooks
@@ -2213,6 +2840,11 @@ libraries:
       - path: google/cloud/optimization/v1
     description_override: is a managed routing service that takes your list of orders, vehicles, constraints, and objectives and returns the most efficient plan for your entire fleet in near real-time.
     python:
+      opt_args_by_api:
+        google/cloud/optimization/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=optimization
+          - warehouse-package-name=google-cloud-optimization
       metadata_name_override: optimization
       default_version: v1
   - name: google-cloud-oracledatabase
@@ -2221,6 +2853,11 @@ libraries:
       - path: google/cloud/oracledatabase/v1
     description_override: The Oracle Database@Google Cloud API provides a set of APIs to manage Oracle database services, such as Exadata and Autonomous Databases.
     python:
+      opt_args_by_api:
+        google/cloud/oracledatabase/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=oracledatabase
+          - warehouse-package-name=google-cloud-oracledatabase
       name_pretty_override: Oracle Database@Google Cloud API
       default_version: v1
   - name: google-cloud-orchestration-airflow
@@ -2232,6 +2869,12 @@ libraries:
     python:
       opt_args_by_api:
         google/cloud/orchestration/airflow/service/v1:
+          - warehouse-package-name=google-cloud-orchestration-airflow
+          - python-gapic-namespace=google.cloud.orchestration.airflow
+          - python-gapic-name=service
+        google/cloud/orchestration/airflow/service/v1beta1:
+          - python-gapic-namespace=google.cloud.orchestration.airflow
+          - python-gapic-name=service
           - warehouse-package-name=google-cloud-orchestration-airflow
       metadata_name_override: composer
       default_version: v1
@@ -2245,6 +2888,8 @@ libraries:
       opt_args_by_api:
         google/cloud/orgpolicy/v2:
           - warehouse-package-name=google-cloud-org-policy
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=orgpolicy
       proto_only_apis:
         - google/cloud/orgpolicy/v1
       product_documentation_override: https://cloud.google.com/resource-manager/docs/organization-policy/overview
@@ -2260,8 +2905,12 @@ libraries:
       opt_args_by_api:
         google/cloud/osconfig/v1:
           - warehouse-package-name=google-cloud-os-config
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=osconfig
         google/cloud/osconfig/v1alpha:
           - warehouse-package-name=google-cloud-os-config
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=osconfig
       product_documentation_override: https://cloud.google.com/compute/docs/manage-os
       metadata_name_override: osconfig
       default_version: v1
@@ -2276,6 +2925,8 @@ libraries:
         google/cloud/oslogin/v1:
           - warehouse-package-name=google-cloud-os-login
           - proto-plus-deps=google.cloud.oslogin.common
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=oslogin
       name_pretty_override: Google Cloud OS Login
       product_documentation_override: https://cloud.google.com/compute/docs/oslogin/
       metadata_name_override: oslogin
@@ -2287,6 +2938,15 @@ libraries:
       - path: google/cloud/parallelstore/v1beta
     description_override: Parallelstore is based on Intel DAOS and delivers up to 6.3x greater read throughput performance compared to competitive Lustre scratch offerings.
     python:
+      opt_args_by_api:
+        google/cloud/parallelstore/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=parallelstore
+          - warehouse-package-name=google-cloud-parallelstore
+        google/cloud/parallelstore/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=parallelstore
+          - warehouse-package-name=google-cloud-parallelstore
       name_pretty_override: Parallelstore API
       product_documentation_override: https://cloud.google.com/parallelstore
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -2297,6 +2957,11 @@ libraries:
       - path: google/cloud/parametermanager/v1
     description_override: '(Public Preview) Parameter Manager is a single source of truth to store, access and manage the lifecycle of your workload parameters. Parameter Manager aims to make management of sensitive application parameters effortless for customers without diminishing focus on security. '
     python:
+      opt_args_by_api:
+        google/cloud/parametermanager/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=parametermanager
+          - warehouse-package-name=google-cloud-parametermanager
       name_pretty_override: Parameter Manager API
       product_documentation_override: https://cloud.google.com/secret-manager/parameter-manager/docs/overview
       issue_tracker_override: https://issuetracker.google.com/issues/new?component=1442085&template=2002674
@@ -2310,6 +2975,8 @@ libraries:
       opt_args_by_api:
         google/cloud/phishingprotection/v1beta1:
           - warehouse-package-name=google-cloud-phishing-protection
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=phishingprotection
       product_documentation_override: https://cloud.google.com/phishing-protection/docs/
       metadata_name_override: phishingprotection
       default_version: v1beta1
@@ -2322,6 +2989,8 @@ libraries:
       opt_args_by_api:
         google/cloud/policytroubleshooter/v1:
           - warehouse-package-name=google-cloud-policy-troubleshooter
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=policytroubleshooter
       name_pretty_override: IAM Policy Troubleshooter API
       product_documentation_override: https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/
       metadata_name_override: policytroubleshooter
@@ -2335,6 +3004,9 @@ libraries:
       opt_args_by_api:
         google/cloud/policysimulator/v1:
           - proto-plus-deps=google.cloud.orgpolicy.v2
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=policysimulator
+          - warehouse-package-name=google-cloud-policysimulator
       name_pretty_override: Policy Simulator API
       product_documentation_override: https://cloud.google.com/policy-intelligence/docs/iam-simulator-overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -2349,6 +3021,7 @@ libraries:
         google/cloud/policytroubleshooter/iam/v3:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=policytroubleshooter_iam
+          - warehouse-package-name=google-cloud-policytroubleshooter-iam
       name_pretty_override: Policy Troubleshooter API
       product_documentation_override: https://cloud.google.com/policy-intelligence/docs/troubleshoot-access
       api_shortname_override: iam
@@ -2364,8 +3037,12 @@ libraries:
       opt_args_by_api:
         google/cloud/security/privateca/v1:
           - warehouse-package-name=google-cloud-private-ca
+          - python-gapic-namespace=google.cloud.security
+          - python-gapic-name=privateca
         google/cloud/security/privateca/v1beta1:
           - warehouse-package-name=google-cloud-private-ca
+          - python-gapic-namespace=google.cloud.security
+          - python-gapic-name=privateca
       name_pretty_override: Private Certificate Authority
       metadata_name_override: privateca
       default_version: v1
@@ -2379,6 +3056,8 @@ libraries:
         google/cloud/privatecatalog/v1beta1:
           - warehouse-package-name=google-cloud-private-catalog
           - autogen-snippets
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=privatecatalog
       name_pretty_override: Private Catalog
       metadata_name_override: cloudprivatecatalog
       default_version: v1beta1
@@ -2388,6 +3067,11 @@ libraries:
       - path: google/cloud/privilegedaccessmanager/v1
     description_override: Privileged Access Manager (PAM) helps you on your journey towards least privilege and helps mitigate risks tied to privileged access misuse or abuse. PAM allows you to shift from always-on standing privileges towards on-demand access with just-in-time, time-bound, and approval-based access elevations. PAM allows IAM administrators to create entitlements that can grant just-in-time, temporary access to any resource scope. Requesters can explore eligible entitlements and request the access needed for their task. Approvers are notified when approvals await their decision. Streamlined workflows facilitated by using PAM can support various use cases, including emergency access for incident responders, time-boxed access for developers for critical deployment or maintenance, temporary access for operators for data ingestion and audits, JIT access to service accounts for automated tasks, and more.
     python:
+      opt_args_by_api:
+        google/cloud/privilegedaccessmanager/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=privilegedaccessmanager
+          - warehouse-package-name=google-cloud-privilegedaccessmanager
       name_pretty_override: Privileged Access Manager API
       product_documentation_override: https://cloud.google.com/iam/docs/pam-overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -2402,6 +3086,8 @@ libraries:
       opt_args_by_api:
         google/pubsub/v1:
           - warehouse-package-name=google-cloud-pubsub
+          - python-gapic-namespace=google
+          - python-gapic-name=pubsub
       name_pretty_override: Google Cloud Pub/Sub
       product_documentation_override: https://cloud.google.com/pubsub/docs/
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559741
@@ -2418,9 +3104,11 @@ libraries:
         google/api/cloudquotas/v1:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-quotas
+          - python-gapic-name=cloudquotas
         google/api/cloudquotas/v1beta:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-quotas
+          - python-gapic-name=cloudquotas
       name_pretty_override: Cloud Quotas API
       product_documentation_override: https://cloud.google.com/docs/quota/api-overview
       metadata_name_override: google-cloud-cloudquotas
@@ -2431,6 +3119,11 @@ libraries:
       - path: google/cloud/rapidmigrationassessment/v1
     description_override: The Rapid Migration Assessment service is our first-party migration assessment and planning tool.
     python:
+      opt_args_by_api:
+        google/cloud/rapidmigrationassessment/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=rapidmigrationassessment
+          - warehouse-package-name=google-cloud-rapidmigrationassessment
       name_pretty_override: Rapid Migration Assessment API
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: rapidmigrationassessment
@@ -2444,6 +3137,8 @@ libraries:
       opt_args_by_api:
         google/cloud/recaptchaenterprise/v1:
           - warehouse-package-name=google-cloud-recaptcha-enterprise
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=recaptchaenterprise
       metadata_name_override: recaptchaenterprise
       default_version: v1
   - name: google-cloud-recommendations-ai
@@ -2455,6 +3150,8 @@ libraries:
       opt_args_by_api:
         google/cloud/recommendationengine/v1beta1:
           - warehouse-package-name=google-cloud-recommendations-ai
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=recommendationengine
       metadata_name_override: recommendationengine
       default_version: v1beta1
   - name: google-cloud-recommender
@@ -2464,6 +3161,15 @@ libraries:
       - path: google/cloud/recommender/v1beta1
     description_override: delivers highly personalized product recommendations at scale.
     python:
+      opt_args_by_api:
+        google/cloud/recommender/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=recommender
+          - warehouse-package-name=google-cloud-recommender
+        google/cloud/recommender/v1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=recommender
+          - warehouse-package-name=google-cloud-recommender
       name_pretty_override: Cloud Recommender
       metadata_name_override: recommender
       default_version: v1
@@ -2474,6 +3180,15 @@ libraries:
       - path: google/cloud/redis/v1beta1
     description_override: is a fully managed Redis service for the Google Cloud. Applications running on Google Cloud can achieve extreme performance by leveraging the highly scalable, available, secure Redis service without the burden of managing complex Redis deployments.
     python:
+      opt_args_by_api:
+        google/cloud/redis/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=redis
+          - warehouse-package-name=google-cloud-redis
+        google/cloud/redis/v1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=redis
+          - warehouse-package-name=google-cloud-redis
       name_pretty_override: Cloud Redis
       product_documentation_override: https://cloud.google.com/memorystore/docs/redis/
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5169231
@@ -2490,9 +3205,11 @@ libraries:
         google/cloud/redis/cluster/v1:
           - python-gapic-name=redis_cluster
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-redis-cluster
         google/cloud/redis/cluster/v1beta1:
           - python-gapic-name=redis_cluster
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-redis-cluster
       name_pretty_override: Google Cloud Memorystore for Redis API
       product_documentation_override: https://cloud.google.com/redis/docs
       api_shortname_override: cluster
@@ -2507,6 +3224,8 @@ libraries:
       opt_args_by_api:
         google/cloud/resourcemanager/v3:
           - warehouse-package-name=google-cloud-resource-manager
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=resourcemanager
       name_pretty_override: Resource Manager
       metadata_name_override: cloudresourcemanager
       default_version: v3
@@ -2518,6 +3237,19 @@ libraries:
       - path: google/cloud/retail/v2alpha
     description_override: Cloud Retail service enables customers to build end-to-end personalized recommendation systems without requiring a high level of expertise in machine learning, recommendation system, or Google Cloud.
     python:
+      opt_args_by_api:
+        google/cloud/retail/v2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=retail
+          - warehouse-package-name=google-cloud-retail
+        google/cloud/retail/v2alpha:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=retail
+          - warehouse-package-name=google-cloud-retail
+        google/cloud/retail/v2beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=retail
+          - warehouse-package-name=google-cloud-retail
       name_pretty_override: Retail
       product_documentation_override: https://cloud.google.com/retail/docs/
       metadata_name_override: retail
@@ -2528,6 +3260,11 @@ libraries:
       - path: google/cloud/run/v2
     description_override: is a managed compute platform that enables you to run containers that are invocable via requests or events.
     python:
+      opt_args_by_api:
+        google/cloud/run/v2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=run
+          - warehouse-package-name=google-cloud-run
       name_pretty_override: Cloud Run
       metadata_name_override: run
       default_version: v2
@@ -2551,6 +3288,7 @@ libraries:
         google/cloud/saasplatform/saasservicemgmt/v1beta1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=saasplatform_saasservicemgmt
+          - warehouse-package-name=google-cloud-saasplatform-saasservicemgmt
       name_pretty_override: SaaS Runtime API
       product_documentation_override: https://cloud.google.com/saas-runtime/docs/overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -2562,6 +3300,15 @@ libraries:
       - path: google/cloud/scheduler/v1beta1
     description_override: lets you set up scheduled units of work to be executed at defined times or regular intervals. These work units are commonly known as cron jobs. Typical use cases might include sending out a report email on a daily basis, updating some cached data every 10 minutes, or updating some summary information once an hour.
     python:
+      opt_args_by_api:
+        google/cloud/scheduler/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=scheduler
+          - warehouse-package-name=google-cloud-scheduler
+        google/cloud/scheduler/v1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=scheduler
+          - warehouse-package-name=google-cloud-scheduler
       metadata_name_override: cloudscheduler
       default_version: v1
   - name: google-cloud-secret-manager
@@ -2575,9 +3322,16 @@ libraries:
       opt_args_by_api:
         google/cloud/secretmanager/v1:
           - warehouse-package-name=google-cloud-secret-manager
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=secretmanager
+        google/cloud/secretmanager/v1beta2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=secretmanager
+          - warehouse-package-name=google-cloud-secret-manager
         google/cloud/secrets/v1beta1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=secretmanager
+          - warehouse-package-name=google-cloud-secret-manager
       metadata_name_override: secretmanager
       default_version: v1
   - name: google-cloud-securesourcemanager
@@ -2586,6 +3340,11 @@ libraries:
       - path: google/cloud/securesourcemanager/v1
     description_override: Regionally deployed, single-tenant managed source code repository hosted on Google Cloud.
     python:
+      opt_args_by_api:
+        google/cloud/securesourcemanager/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=securesourcemanager
+          - warehouse-package-name=google-cloud-securesourcemanager
       name_pretty_override: Secure Source Manager API
       product_documentation_override: https://cloud.google.com/secure-source-manager/docs/overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -2599,8 +3358,14 @@ libraries:
     description_override: simplifies the deployment and management of public CAs without managing infrastructure.
     python:
       opt_args_by_api:
+        google/cloud/security/publicca/v1:
+          - python-gapic-namespace=google.cloud.security
+          - python-gapic-name=publicca
+          - warehouse-package-name=google-cloud-security-publicca
         google/cloud/security/publicca/v1beta1:
           - warehouse-package-name=google-cloud-public-ca
+          - python-gapic-namespace=google.cloud.security
+          - python-gapic-name=publicca
       product_documentation_override: https://cloud.google.com/certificate-manager/docs/public-ca
       metadata_name_override: publicca
       default_version: v1
@@ -2613,6 +3378,23 @@ libraries:
       - path: google/cloud/securitycenter/v1beta1
     description_override: makes it easier for you to prevent, detect, and respond to threats. Identify security misconfigurations in virtual machines, networks, applications, and storage buckets from a centralized dashboard. Take action on them before they can potentially result in business damage or loss. Built-in capabilities can quickly surface suspicious activity in your Stackdriver security logs or indicate compromised virtual machines. Respond to threats by following actionable recommendations or exporting logs to your SIEM for further investigation.
     python:
+      opt_args_by_api:
+        google/cloud/securitycenter/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=securitycenter
+          - warehouse-package-name=google-cloud-securitycenter
+        google/cloud/securitycenter/v1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=securitycenter
+          - warehouse-package-name=google-cloud-securitycenter
+        google/cloud/securitycenter/v1p1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=securitycenter
+          - warehouse-package-name=google-cloud-securitycenter
+        google/cloud/securitycenter/v2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=securitycenter
+          - warehouse-package-name=google-cloud-securitycenter
       name_pretty_override: Google Cloud Security Command Center
       product_documentation_override: https://cloud.google.com/security-command-center
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559748
@@ -2623,6 +3405,11 @@ libraries:
     apis:
       - path: google/cloud/securitycentermanagement/v1
     python:
+      opt_args_by_api:
+        google/cloud/securitycentermanagement/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=securitycentermanagement
+          - warehouse-package-name=google-cloud-securitycentermanagement
       name_pretty_override: Security Center Management API
       product_documentation_override: https://cloud.google.com/securitycentermanagement/docs/overview
       api_shortname_override: securitycenter
@@ -2658,8 +3445,12 @@ libraries:
       opt_args_by_api:
         google/cloud/servicedirectory/v1:
           - warehouse-package-name=google-cloud-service-directory
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=servicedirectory
         google/cloud/servicedirectory/v1beta1:
           - warehouse-package-name=google-cloud-service-directory
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=servicedirectory
       metadata_name_override: servicedirectory
       default_version: v1
   - name: google-cloud-service-management
@@ -2695,6 +3486,11 @@ libraries:
       - path: google/cloud/servicehealth/v1
     description_override: Personalized Service Health helps you gain visibility into disruptive events impacting Google Cloud products.
     python:
+      opt_args_by_api:
+        google/cloud/servicehealth/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=servicehealth
+          - warehouse-package-name=google-cloud-servicehealth
       name_pretty_override: Service Health API
       product_documentation_override: https://cloud.google.com/service-health/docs/overview
       default_version: v1
@@ -2704,6 +3500,11 @@ libraries:
       - path: google/cloud/shell/v1
     description_override: is an interactive shell environment for Google Cloud that makes it easy for you to learn and experiment with Google Cloud and manage your projects and resources from your web browser.
     python:
+      opt_args_by_api:
+        google/cloud/shell/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=shell
+          - warehouse-package-name=google-cloud-shell
       metadata_name_override: cloudshell
       default_version: v1
   - name: google-cloud-source-context
@@ -2751,11 +3552,15 @@ libraries:
         google/spanner/admin/database/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=spanner_admin_database
+          - warehouse-package-name=google-cloud-spanner
         google/spanner/admin/instance/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=spanner_admin_instance
+          - warehouse-package-name=google-cloud-spanner
         google/spanner/v1:
           - python-gapic-namespace=google.cloud
+          - python-gapic-name=spanner
+          - warehouse-package-name=google-cloud-spanner
       product_documentation_override: https://cloud.google.com/spanner/docs/
       issue_tracker_override: https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open
       metadata_name_override: spanner
@@ -2769,6 +3574,19 @@ libraries:
     description_override: enables easy integration of Google speech recognition technologies into developer applications. Send audio and receive a text transcription from the Speech-to-Text API service.
     python:
       library_type: GAPIC_COMBO
+      opt_args_by_api:
+        google/cloud/speech/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=speech
+          - warehouse-package-name=google-cloud-speech
+        google/cloud/speech/v1p1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=speech
+          - warehouse-package-name=google-cloud-speech
+        google/cloud/speech/v2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=speech
+          - warehouse-package-name=google-cloud-speech
       name_pretty_override: Cloud Speech
       product_documentation_override: https://cloud.google.com/speech-to-text/docs/
       metadata_name_override: speech
@@ -2824,6 +3642,11 @@ libraries:
       - path: google/cloud/storagebatchoperations/v1
     description_override: 'null '
     python:
+      opt_args_by_api:
+        google/cloud/storagebatchoperations/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=storagebatchoperations
+          - warehouse-package-name=google-cloud-storagebatchoperations
       name_pretty_override: Storage Batch Operations API
       product_documentation_override: https://cloud.google.com/storage/docs/batch-operations/overview
       default_version: v1
@@ -2833,6 +3656,11 @@ libraries:
       - path: google/cloud/storageinsights/v1
     description_override: The Storage Insights inventory report feature helps you manage your object storage at scale.
     python:
+      opt_args_by_api:
+        google/cloud/storageinsights/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=storageinsights
+          - warehouse-package-name=google-cloud-storageinsights
       name_pretty_override: Storage Insights API
       product_documentation_override: https://cloud.google.com/storage/docs/insights/storage-insights
       metadata_name_override: storageinsights
@@ -2844,6 +3672,15 @@ libraries:
       - path: google/cloud/support/v2beta
     description_override: Manages Google Cloud technical support cases for Customer Care support offerings.
     python:
+      opt_args_by_api:
+        google/cloud/support/v2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=support
+          - warehouse-package-name=google-cloud-support
+        google/cloud/support/v2beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=support
+          - warehouse-package-name=google-cloud-support
       name_pretty_override: Google Cloud Support API
       product_documentation_override: https://cloud.google.com/support/docs/reference/support-api
       api_shortname_override: support
@@ -2857,6 +3694,15 @@ libraries:
       - path: google/cloud/talent/v4beta1
     description_override: Cloud Talent Solution provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.
     python:
+      opt_args_by_api:
+        google/cloud/talent/v4:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=talent
+          - warehouse-package-name=google-cloud-talent
+        google/cloud/talent/v4beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=talent
+          - warehouse-package-name=google-cloud-talent
       name_pretty_override: Talent Solution
       metadata_name_override: talent
       default_version: v4
@@ -2868,6 +3714,19 @@ libraries:
       - path: google/cloud/tasks/v2beta2
     description_override: a fully managed service that allows you to manage the execution, dispatch and delivery of a large number of distributed tasks. You can asynchronously perform work outside of a user request. Your tasks can be executed on App Engine or any arbitrary HTTP endpoint.
     python:
+      opt_args_by_api:
+        google/cloud/tasks/v2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=tasks
+          - warehouse-package-name=google-cloud-tasks
+        google/cloud/tasks/v2beta2:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=tasks
+          - warehouse-package-name=google-cloud-tasks
+        google/cloud/tasks/v2beta3:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=tasks
+          - warehouse-package-name=google-cloud-tasks
       product_documentation_override: https://cloud.google.com/tasks/docs/
       metadata_name_override: cloudtasks
       default_version: v2
@@ -2878,6 +3737,15 @@ libraries:
       - path: google/cloud/telcoautomation/v1alpha1
     description_override: APIs to automate 5G deployment and management of cloud infrastructure and network functions.
     python:
+      opt_args_by_api:
+        google/cloud/telcoautomation/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=telcoautomation
+          - warehouse-package-name=google-cloud-telcoautomation
+        google/cloud/telcoautomation/v1alpha1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=telcoautomation
+          - warehouse-package-name=google-cloud-telcoautomation
       name_pretty_override: Telco Automation API
       default_version: v1
   - name: google-cloud-testutils
@@ -2895,6 +3763,15 @@ libraries:
       - path: google/cloud/texttospeech/v1beta1
     description_override: enables easy integration of Google text recognition technologies into developer applications. Send text and receive synthesized audio output from the Cloud Text-to-Speech API service.
     python:
+      opt_args_by_api:
+        google/cloud/texttospeech/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=texttospeech
+          - warehouse-package-name=google-cloud-texttospeech
+        google/cloud/texttospeech/v1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=texttospeech
+          - warehouse-package-name=google-cloud-texttospeech
       name_pretty_override: Google Cloud Text-to-Speech
       metadata_name_override: texttospeech
       default_version: v1
@@ -2909,10 +3786,19 @@ libraries:
       opt_args_by_api:
         google/cloud/tpu/v1:
           - transport=grpc
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=tpu
+          - warehouse-package-name=google-cloud-tpu
         google/cloud/tpu/v2:
           - transport=grpc+rest
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=tpu
+          - warehouse-package-name=google-cloud-tpu
         google/cloud/tpu/v2alpha1:
           - transport=grpc
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=tpu
+          - warehouse-package-name=google-cloud-tpu
       metadata_name_override: tpu
       default_version: v1
   - name: google-cloud-trace
@@ -2926,9 +3812,11 @@ libraries:
         google/devtools/cloudtrace/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=trace
+          - warehouse-package-name=google-cloud-trace
         google/devtools/cloudtrace/v2:
           - python-gapic-name=trace
           - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-trace
       metadata_name_override: cloudtrace
       default_version: v2
   - name: google-cloud-translate
@@ -2942,8 +3830,12 @@ libraries:
       opt_args_by_api:
         google/cloud/translate/v3:
           - python-gapic-name=translate
+          - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-translate
         google/cloud/translate/v3beta1:
           - python-gapic-name=translate
+          - python-gapic-namespace=google.cloud
+          - warehouse-package-name=google-cloud-translate
       product_documentation_override: https://cloud.google.com/translate/docs/
       metadata_name_override: translate
       default_version: v3
@@ -2963,6 +3855,15 @@ libraries:
       approximate nearest neighbor (ANN) searches to find semantically similar
       items at scale.
     python:
+      opt_args_by_api:
+        google/cloud/vectorsearch/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=vectorsearch
+          - warehouse-package-name=google-cloud-vectorsearch
+        google/cloud/vectorsearch/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=vectorsearch
+          - warehouse-package-name=google-cloud-vectorsearch
       name_pretty_override: Vector Search API
       product_documentation_override: https://docs.cloud.google.com/vertex-ai/docs/vector-search-2/overview
       default_version: v1
@@ -2985,6 +3886,11 @@ libraries:
       - path: google/cloud/video/stitcher/v1
     description_override: The Video Stitcher API helps you generate dynamic content for delivery to client devices. You can call the Video Stitcher API from your servers to dynamically insert ads into video-on-demand and livestreams for your users.
     python:
+      opt_args_by_api:
+        google/cloud/video/stitcher/v1:
+          - python-gapic-namespace=google.cloud.video
+          - python-gapic-name=stitcher
+          - warehouse-package-name=google-cloud-video-stitcher
       metadata_name_override: videostitcher
       default_version: v1
   - name: google-cloud-video-transcoder
@@ -2993,6 +3899,11 @@ libraries:
       - path: google/cloud/video/transcoder/v1
     description_override: allows you to transcode videos into a variety of formats. The Transcoder API benefits broadcasters, production companies, businesses, and individuals looking to transform their video content for use across a variety of user devices.
     python:
+      opt_args_by_api:
+        google/cloud/video/transcoder/v1:
+          - python-gapic-namespace=google.cloud.video
+          - python-gapic-name=transcoder
+          - warehouse-package-name=google-cloud-video-transcoder
       metadata_name_override: transcoder
       default_version: v1
   - name: google-cloud-videointelligence
@@ -3008,14 +3919,29 @@ libraries:
       opt_args_by_api:
         google/cloud/videointelligence/v1:
           - transport=grpc+rest
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=videointelligence
+          - warehouse-package-name=google-cloud-videointelligence
         google/cloud/videointelligence/v1beta2:
           - transport=grpc+rest
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=videointelligence
+          - warehouse-package-name=google-cloud-videointelligence
         google/cloud/videointelligence/v1p1beta1:
           - transport=grpc+rest
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=videointelligence
+          - warehouse-package-name=google-cloud-videointelligence
         google/cloud/videointelligence/v1p2beta1:
           - transport=grpc+rest
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=videointelligence
+          - warehouse-package-name=google-cloud-videointelligence
         google/cloud/videointelligence/v1p3beta1:
           - transport=grpc
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=videointelligence
+          - warehouse-package-name=google-cloud-videointelligence
       name_pretty_override: Video Intelligence
       product_documentation_override: https://cloud.google.com/video-intelligence/docs/
       metadata_name_override: videointelligence
@@ -3031,6 +3957,27 @@ libraries:
     description_override: allows developers to easily integrate vision detection features within applications, including image labeling, face and landmark detection, optical character recognition (OCR), and tagging of explicit content.
     python:
       library_type: GAPIC_COMBO
+      opt_args_by_api:
+        google/cloud/vision/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=vision
+          - warehouse-package-name=google-cloud-vision
+        google/cloud/vision/v1p1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=vision
+          - warehouse-package-name=google-cloud-vision
+        google/cloud/vision/v1p2beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=vision
+          - warehouse-package-name=google-cloud-vision
+        google/cloud/vision/v1p3beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=vision
+          - warehouse-package-name=google-cloud-vision
+        google/cloud/vision/v1p4beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=vision
+          - warehouse-package-name=google-cloud-vision
       product_documentation_override: https://cloud.google.com/vision/docs/
       metadata_name_override: vision
       default_version: v1
@@ -3041,6 +3988,15 @@ libraries:
       - path: google/cloud/visionai/v1alpha1
     description_override: Easily build and deploy Vertex AI Vision applications using a single platform.
     python:
+      opt_args_by_api:
+        google/cloud/visionai/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=visionai
+          - warehouse-package-name=google-cloud-visionai
+        google/cloud/visionai/v1alpha1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=visionai
+          - warehouse-package-name=google-cloud-visionai
       name_pretty_override: Vision AI API
       issue_tracker_override: https://issuetracker.google.com/issues/new?component=187174&pli=1&template=1161261
       default_version: v1
@@ -3053,6 +4009,8 @@ libraries:
       opt_args_by_api:
         google/cloud/vmmigration/v1:
           - warehouse-package-name=google-cloud-vm-migration
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=vmmigration
       name_pretty_override: Cloud VM Migration
       metadata_name_override: vmmigration
       default_version: v1
@@ -3061,6 +4019,11 @@ libraries:
     apis:
       - path: google/cloud/vmwareengine/v1
     python:
+      opt_args_by_api:
+        google/cloud/vmwareengine/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=vmwareengine
+          - warehouse-package-name=google-cloud-vmwareengine
       name_pretty_override: Google Cloud VMware Engine
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: vmwareengine
@@ -3074,6 +4037,8 @@ libraries:
       opt_args_by_api:
         google/cloud/vpcaccess/v1:
           - warehouse-package-name=google-cloud-vpc-access
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=vpcaccess
       name_pretty_override: Virtual Private Cloud
       metadata_name_override: vpcaccess
       default_version: v1
@@ -3084,6 +4049,15 @@ libraries:
       - path: google/cloud/webrisk/v1beta1
     description_override: is a Google Cloud service that lets client applications check URLs against Google's constantly updated lists of unsafe web resources. Unsafe web resources include social engineering sites—such as phishing and deceptive sites—and sites that host malware or unwanted software. With the Web Risk API, you can quickly identify known bad sites, warn users before they click infected links, and prevent users from posting links to known infected pages from your site. The Web Risk API includes data on more than a million unsafe URLs and stays up to date by examining billions of URLs each day.
     python:
+      opt_args_by_api:
+        google/cloud/webrisk/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=webrisk
+          - warehouse-package-name=google-cloud-webrisk
+        google/cloud/webrisk/v1beta1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=webrisk
+          - warehouse-package-name=google-cloud-webrisk
       product_documentation_override: https://cloud.google.com/web-risk/docs/
       metadata_name_override: webrisk
       default_version: v1
@@ -3095,6 +4069,19 @@ libraries:
       - path: google/cloud/websecurityscanner/v1alpha
     description_override: identifies security vulnerabilities in your App Engine, Compute Engine, and Google Kubernetes Engine web applications. It crawls your application, following all links within the scope of your starting URLs, and attempts to exercise as many user inputs and event handlers as possible.
     python:
+      opt_args_by_api:
+        google/cloud/websecurityscanner/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=websecurityscanner
+          - warehouse-package-name=google-cloud-websecurityscanner
+        google/cloud/websecurityscanner/v1alpha:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=websecurityscanner
+          - warehouse-package-name=google-cloud-websecurityscanner
+        google/cloud/websecurityscanner/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=websecurityscanner
+          - warehouse-package-name=google-cloud-websecurityscanner
       name_pretty_override: Cloud Security Scanner
       product_documentation_override: https://cloud.google.com/security-scanner/docs/
       api_shortname_override: securitycenter
@@ -3113,12 +4100,24 @@ libraries:
       opt_args_by_api:
         google/cloud/workflows/executions/v1:
           - transport=grpc
+          - python-gapic-namespace=google.cloud.workflows
+          - python-gapic-name=executions
+          - warehouse-package-name=google-cloud-workflows
         google/cloud/workflows/executions/v1beta:
           - transport=grpc
+          - python-gapic-namespace=google.cloud.workflows
+          - python-gapic-name=executions
+          - warehouse-package-name=google-cloud-workflows
         google/cloud/workflows/v1:
           - transport=grpc+rest
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=workflows
+          - warehouse-package-name=google-cloud-workflows
         google/cloud/workflows/v1beta:
           - transport=grpc+rest
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=workflows
+          - warehouse-package-name=google-cloud-workflows
       name_pretty_override: Cloud Workflows
       metadata_name_override: workflows
       default_version: v1
@@ -3131,6 +4130,11 @@ libraries:
       workloads to automate the deployment and validation of your workloads
       against best practices and recommendations.
     python:
+      opt_args_by_api:
+        google/cloud/workloadmanager/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=workloadmanager
+          - warehouse-package-name=google-cloud-workloadmanager
       name_pretty_override: Workload Manager API
       default_version: v1
   - name: google-cloud-workstations
@@ -3139,6 +4143,15 @@ libraries:
       - path: google/cloud/workstations/v1
       - path: google/cloud/workstations/v1beta
     python:
+      opt_args_by_api:
+        google/cloud/workstations/v1:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=workstations
+          - warehouse-package-name=google-cloud-workstations
+        google/cloud/workstations/v1beta:
+          - python-gapic-namespace=google.cloud
+          - python-gapic-name=workstations
+          - warehouse-package-name=google-cloud-workstations
       product_documentation_override: https://cloud.google.com/workstations/
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: workstations
@@ -3159,6 +4172,11 @@ libraries:
       - tests/unit/gapic/type/test_type.py
     python:
       library_type: OTHER
+      opt_args_by_api:
+        google/geo/type:
+          - python-gapic-namespace=google.geo
+          - python-gapic-name=type
+          - warehouse-package-name=google-geo-type
       name_pretty_override: Geo Type Protos
       product_documentation_override: https://mapsplatform.google.com/maps-products
       api_id_override: type.googleapis.com
@@ -3174,6 +4192,9 @@ libraries:
       opt_args_by_api:
         google/maps/addressvalidation/v1:
           - proto-plus-deps=google.geo.type
+          - python-gapic-namespace=google.maps
+          - python-gapic-name=addressvalidation
+          - warehouse-package-name=google-maps-addressvalidation
       name_pretty_override: Address Validation API
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: addressvalidation
@@ -3184,6 +4205,11 @@ libraries:
       - path: google/maps/areainsights/v1
     description_override: 'Places Insights API. '
     python:
+      opt_args_by_api:
+        google/maps/areainsights/v1:
+          - python-gapic-namespace=google.maps
+          - python-gapic-name=areainsights
+          - warehouse-package-name=google-maps-areainsights
       name_pretty_override: Places Insights API
       api_shortname_override: areainsights
       default_version: v1
@@ -3197,6 +4223,8 @@ libraries:
         google/maps/fleetengine/v1:
           - python-gapic-namespace=google.maps
           - proto-plus-deps=google.geo.type
+          - python-gapic-name=fleetengine
+          - warehouse-package-name=google-maps-fleetengine
       name_pretty_override: Local Rides and Deliveries API
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: fleetengine
@@ -3212,6 +4240,7 @@ libraries:
           - python-gapic-namespace=google.maps
           - python-gapic-name=fleetengine_delivery
           - proto-plus-deps=google.geo.type
+          - warehouse-package-name=google-maps-fleetengine-delivery
       name_pretty_override: Last Mile Fleet Solution Delivery API
       api_shortname_override: fleetengine
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -3229,6 +4258,9 @@ libraries:
       opt_args_by_api:
         google/maps/geocode/v4:
           - proto-plus-deps=google.geo.type
+          - python-gapic-namespace=google.maps
+          - python-gapic-name=geocode
+          - warehouse-package-name=google-maps-geocode
       name_pretty_override: Geocoding API
       api_shortname_override: geocoding-backend
       client_documentation_override: https://cloud.google.com/python/docs/reference/google-maps-geocode/latest
@@ -3239,6 +4271,11 @@ libraries:
       - path: google/maps/mapsplatformdatasets/v1
     description_override: Maps Platform Datasets API
     python:
+      opt_args_by_api:
+        google/maps/mapsplatformdatasets/v1:
+          - python-gapic-namespace=google.maps
+          - python-gapic-name=mapsplatformdatasets
+          - warehouse-package-name=google-maps-mapsplatformdatasets
       name_pretty_override: Maps Platform Datasets API
       product_documentation_override: https://developers.google.com/maps
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -3250,6 +4287,11 @@ libraries:
       - path: google/maps/navconnect/v1
     description_override: Navigation Connect API.
     python:
+      opt_args_by_api:
+        google/maps/navconnect/v1:
+          - python-gapic-namespace=google.maps
+          - python-gapic-name=navconnect
+          - warehouse-package-name=google-maps-navconnect
       name_pretty_override: Navigation Connect API
       client_documentation_override: https://cloud.google.com/python/docs/reference/google-maps-navconnect/latest
       default_version: v1
@@ -3263,6 +4305,9 @@ libraries:
         google/maps/places/v1:
           - autogen-snippets=False
           - proto-plus-deps=google.geo.type
+          - python-gapic-namespace=google.maps
+          - python-gapic-name=places
+          - warehouse-package-name=google-maps-places
       name_pretty_override: Places API
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: places
@@ -3273,6 +4318,11 @@ libraries:
       - path: google/maps/routeoptimization/v1
     description_override: The Route Optimization API assigns tasks and routes to a vehicle fleet, optimizing against the objectives and constraints that you supply for your transportation goals.
     python:
+      opt_args_by_api:
+        google/maps/routeoptimization/v1:
+          - python-gapic-namespace=google.maps
+          - python-gapic-name=routeoptimization
+          - warehouse-package-name=google-maps-routeoptimization
       name_pretty_override: Route Optimization API
       default_version: v1
   - name: google-maps-routing
@@ -3284,6 +4334,9 @@ libraries:
       opt_args_by_api:
         google/maps/routing/v2:
           - proto-plus-deps=google.geo.type
+          - python-gapic-namespace=google.maps
+          - python-gapic-name=routing
+          - warehouse-package-name=google-maps-routing
       name_pretty_override: Google Maps Routing
       api_shortname_override: routing
       api_id_override: routing.googleapis.com
@@ -3296,6 +4349,11 @@ libraries:
       - path: google/maps/solar/v1
     description_override: The Google Maps Platform Solar API is a service focused on helping accelerate solar and energy system installations.
     python:
+      opt_args_by_api:
+        google/maps/solar/v1:
+          - python-gapic-namespace=google.maps
+          - python-gapic-name=solar
+          - warehouse-package-name=google-maps-solar
       name_pretty_override: Solar API
       default_version: v1
   - name: google-resumable-media
@@ -3313,6 +4371,9 @@ libraries:
       opt_args_by_api:
         google/shopping/css/v1:
           - proto-plus-deps=google.shopping.type
+          - python-gapic-namespace=google.shopping
+          - python-gapic-name=css
+          - warehouse-package-name=google-shopping-css
       name_pretty_override: CSS API
       default_version: v1
   - name: google-shopping-merchant-accounts
@@ -3327,10 +4388,12 @@ libraries:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_accounts
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-accounts
         google/shopping/merchant/accounts/v1beta:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_accounts
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-accounts
       name_pretty_override: Merchant API
       api_shortname_override: accounts
       api_id_override: accounts.googleapis.com
@@ -3347,9 +4410,11 @@ libraries:
         google/shopping/merchant/conversions/v1:
           - python-gapic-namespace=google.shopping
           - python-gapic-name=merchant_conversions
+          - warehouse-package-name=google-shopping-merchant-conversions
         google/shopping/merchant/conversions/v1beta:
           - python-gapic-name=merchant_conversions
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-conversions
       name_pretty_override: Merchant API
       api_shortname_override: conversions
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -3366,10 +4431,12 @@ libraries:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_datasources
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-datasources
         google/shopping/merchant/datasources/v1beta:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_datasources
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-datasources
       name_pretty_override: Merchant API
       api_shortname_override: datasources
       api_id_override: datasources.googleapis.com
@@ -3387,10 +4454,12 @@ libraries:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_inventories
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-inventories
         google/shopping/merchant/inventories/v1beta:
           - proto-plus-deps=google.shopping.type
           - python-gapic-namespace=google.shopping
           - python-gapic-name=merchant_inventories
+          - warehouse-package-name=google-shopping-merchant-inventories
       name_pretty_override: Merchant Inventories API
       api_shortname_override: inventories
       api_id_override: inventories.googleapis.com
@@ -3407,10 +4476,12 @@ libraries:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_issueresolution
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-issueresolution
         google/shopping/merchant/issueresolution/v1beta:
           - proto-plus-deps=google.shopping.type
           - python-gapic-namespace=google.shopping
           - python-gapic-name=merchant_issueresolution
+          - warehouse-package-name=google-shopping-merchant-issueresolution
       name_pretty_override: Merchant API
       api_shortname_override: issueresolution
       api_id_override: issueresolution.googleapis.com
@@ -3427,10 +4498,12 @@ libraries:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_lfp
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-lfp
         google/shopping/merchant/lfp/v1beta:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_lfp
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-lfp
       name_pretty_override: Merchant API
       api_shortname_override: lfp
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -3446,10 +4519,12 @@ libraries:
         google/shopping/merchant/notifications/v1:
           - python-gapic-namespace=google.shopping
           - python-gapic-name=merchant_notifications
+          - warehouse-package-name=google-shopping-merchant-notifications
         google/shopping/merchant/notifications/v1beta:
           - proto-plus-deps=google.shopping.type
           - python-gapic-namespace=google.shopping
           - python-gapic-name=merchant_notifications
+          - warehouse-package-name=google-shopping-merchant-notifications
       name_pretty_override: Merchant API
       api_shortname_override: notifications
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -3466,10 +4541,12 @@ libraries:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_ordertracking
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-ordertracking
         google/shopping/merchant/ordertracking/v1beta:
           - proto-plus-deps=google.shopping.type
           - python-gapic-namespace=google.shopping
           - python-gapic-name=merchant_ordertracking
+          - warehouse-package-name=google-shopping-merchant-ordertracking
       name_pretty_override: Merchant API
       api_shortname_override: ordertracking
       api_id_override: ordertracking.googleapis.com
@@ -3486,10 +4563,12 @@ libraries:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_products
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-products
         google/shopping/merchant/products/v1beta:
           - proto-plus-deps=google.shopping.type
           - python-gapic-namespace=google.shopping
           - python-gapic-name=merchant_products
+          - warehouse-package-name=google-shopping-merchant-products
       name_pretty_override: Merchant API
       api_shortname_override: products
       api_id_override: products.googleapis.com
@@ -3505,6 +4584,7 @@ libraries:
         google/shopping/merchant/productstudio/v1alpha:
           - python-gapic-name=merchant_productstudio
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-productstudio
       name_pretty_override: Merchant ProductStudio API
       api_shortname_override: productstudio
       api_id_override: productstudio.googleapis.com
@@ -3522,10 +4602,12 @@ libraries:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_promotions
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-promotions
         google/shopping/merchant/promotions/v1beta:
           - proto-plus-deps=google.shopping.type
           - python-gapic-namespace=google.shopping
           - python-gapic-name=merchant_promotions
+          - warehouse-package-name=google-shopping-merchant-promotions
       name_pretty_override: Merchant API
       api_shortname_override: promotions
       api_id_override: promotions.googleapis.com
@@ -3542,9 +4624,11 @@ libraries:
         google/shopping/merchant/quota/v1:
           - python-gapic-namespace=google.shopping
           - python-gapic-name=merchant_quota
+          - warehouse-package-name=google-shopping-merchant-quota
         google/shopping/merchant/quota/v1beta:
           - python-gapic-namespace=google.shopping
           - python-gapic-name=merchant_quota
+          - warehouse-package-name=google-shopping-merchant-quota
       name_pretty_override: Shopping Merchant Quota
       default_version: v1
   - name: google-shopping-merchant-reports
@@ -3560,14 +4644,17 @@ libraries:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_reports
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-reports
         google/shopping/merchant/reports/v1alpha:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_reports
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-reports
         google/shopping/merchant/reports/v1beta:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_reports
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-reports
       name_pretty_override: Merchant Reports API
       api_shortname_override: reports
       api_id_override: reports.googleapis.com
@@ -3583,6 +4670,7 @@ libraries:
           - proto-plus-deps=google.shopping.type
           - python-gapic-name=merchant_reviews
           - python-gapic-namespace=google.shopping
+          - warehouse-package-name=google-shopping-merchant-reviews
       name_pretty_override: Merchant Reviews API
       api_shortname_override: reviews
       api_id_override: reviews.googleapis.com
@@ -3595,6 +4683,11 @@ libraries:
     keep:
       - tests/unit/gapic/type/test_type.py
     python:
+      opt_args_by_api:
+        google/shopping/type:
+          - python-gapic-namespace=google.shopping
+          - python-gapic-name=type
+          - warehouse-package-name=google-shopping-type
       name_pretty_override: Shopping Type Protos
       product_documentation_override: https://developers.google.com/merchant/api
       api_shortname_override: type
@@ -3637,6 +4730,7 @@ libraries:
         grafeas/v1:
           - python-gapic-namespace=grafeas
           - warehouse-package-name=grafeas
+          - python-gapic-name=grafeas
       name_pretty_override: Grafeas
       default_version: v1
   - name: grpc-google-iam-v1

--- a/packages/google-apps-script-type/google/apps/script/type/calendar/py.typed
+++ b/packages/google-apps-script-type/google/apps/script/type/calendar/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-apps-script-type-calendar package uses inline types.
+# The google-apps-script-type package uses inline types.

--- a/packages/google-apps-script-type/google/apps/script/type/docs/py.typed
+++ b/packages/google-apps-script-type/google/apps/script/type/docs/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-apps-script-type-docs package uses inline types.
+# The google-apps-script-type package uses inline types.

--- a/packages/google-apps-script-type/google/apps/script/type/drive/py.typed
+++ b/packages/google-apps-script-type/google/apps/script/type/drive/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-apps-script-type-drive package uses inline types.
+# The google-apps-script-type package uses inline types.

--- a/packages/google-apps-script-type/google/apps/script/type/gmail/py.typed
+++ b/packages/google-apps-script-type/google/apps/script/type/gmail/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-apps-script-type-gmail package uses inline types.
+# The google-apps-script-type package uses inline types.

--- a/packages/google-apps-script-type/google/apps/script/type/sheets/py.typed
+++ b/packages/google-apps-script-type/google/apps/script/type/sheets/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-apps-script-type-sheets package uses inline types.
+# The google-apps-script-type package uses inline types.

--- a/packages/google-apps-script-type/google/apps/script/type/slides/py.typed
+++ b/packages/google-apps-script-type/google/apps/script/type/slides/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-apps-script-type-slides package uses inline types.
+# The google-apps-script-type package uses inline types.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin/py.typed
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-firestore-admin package uses inline types.
+# The google-cloud-firestore package uses inline types.

--- a/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/py.typed
+++ b/packages/google-cloud-firestore/google/cloud/firestore_admin_v1/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-firestore-admin package uses inline types.
+# The google-cloud-firestore package uses inline types.

--- a/packages/google-cloud-firestore/google/cloud/firestore_bundle/py.typed
+++ b/packages/google-cloud-firestore/google/cloud/firestore_bundle/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-firestore-bundle package uses inline types.
+# The google-cloud-firestore package uses inline types.

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_bulk_delete_documents_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_bulk_delete_documents_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_BulkDeleteDocuments_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_bulk_delete_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_bulk_delete_documents_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_BulkDeleteDocuments_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_clone_database_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_clone_database_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_CloneDatabase_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_clone_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_clone_database_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_CloneDatabase_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_backup_schedule_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_backup_schedule_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_CreateBackupSchedule_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_backup_schedule_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_backup_schedule_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_CreateBackupSchedule_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_database_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_database_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_CreateDatabase_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_database_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_CreateDatabase_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_index_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_index_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_CreateIndex_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_index_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_index_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_CreateIndex_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_user_creds_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_CreateUserCreds_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_create_user_creds_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_CreateUserCreds_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_DeleteBackup_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_schedule_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_schedule_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_DeleteBackupSchedule_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_schedule_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_schedule_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_DeleteBackupSchedule_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_backup_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_DeleteBackup_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_database_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_database_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_DeleteDatabase_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_database_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_DeleteDatabase_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_index_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_index_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_DeleteIndex_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_index_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_index_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_DeleteIndex_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_user_creds_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_DeleteUserCreds_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_delete_user_creds_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_DeleteUserCreds_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_disable_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_disable_user_creds_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_DisableUserCreds_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_disable_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_disable_user_creds_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_DisableUserCreds_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_enable_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_enable_user_creds_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_EnableUserCreds_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_enable_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_enable_user_creds_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_EnableUserCreds_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_export_documents_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_export_documents_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ExportDocuments_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_export_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_export_documents_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ExportDocuments_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_GetBackup_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_schedule_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_schedule_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_GetBackupSchedule_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_schedule_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_schedule_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_GetBackupSchedule_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_backup_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_GetBackup_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_database_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_database_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_GetDatabase_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_database_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_GetDatabase_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_field_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_field_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_GetField_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_field_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_field_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_GetField_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_index_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_index_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_GetIndex_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_index_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_index_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_GetIndex_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_user_creds_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_GetUserCreds_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_get_user_creds_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_GetUserCreds_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_import_documents_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_import_documents_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ImportDocuments_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_import_documents_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_import_documents_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ImportDocuments_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backup_schedules_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backup_schedules_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ListBackupSchedules_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backup_schedules_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backup_schedules_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ListBackupSchedules_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backups_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backups_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ListBackups_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backups_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_backups_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ListBackups_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_databases_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_databases_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ListDatabases_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_databases_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_databases_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ListDatabases_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_fields_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_fields_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ListFields_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_fields_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_fields_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ListFields_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_indexes_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_indexes_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ListIndexes_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_indexes_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_indexes_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ListIndexes_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_user_creds_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_user_creds_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ListUserCreds_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_user_creds_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_list_user_creds_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ListUserCreds_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_reset_user_password_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_reset_user_password_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ResetUserPassword_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_reset_user_password_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_reset_user_password_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_ResetUserPassword_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_restore_database_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_restore_database_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_RestoreDatabase_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_restore_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_restore_database_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_RestoreDatabase_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_backup_schedule_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_backup_schedule_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_UpdateBackupSchedule_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_backup_schedule_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_backup_schedule_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_UpdateBackupSchedule_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_database_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_database_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_UpdateDatabase_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_database_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_database_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_UpdateDatabase_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_field_async.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_field_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_UpdateField_async]

--- a/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_field_sync.py
+++ b/packages/google-cloud-firestore/samples/generated_samples/firestore_v1_generated_firestore_admin_update_field_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-firestore-admin
+#   python3 -m pip install google-cloud-firestore
 
 
 # [START firestore_v1_generated_FirestoreAdmin_UpdateField_sync]

--- a/packages/google-cloud-firestore/samples/generated_samples/snippet_metadata_google.firestore.admin.v1.json
+++ b/packages/google-cloud-firestore/samples/generated_samples/snippet_metadata_google.firestore.admin.v1.json
@@ -7,7 +7,7 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-cloud-firestore-admin",
+    "name": "google-cloud-firestore",
     "version": "2.27.0"
   },
   "snippets": [

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/py.typed
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-orchestration-airflow-service package uses inline types.
+# The google-cloud-orchestration-airflow package uses inline types.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_check_upgrade_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_check_upgrade_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_CheckUpgrade_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_check_upgrade_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_check_upgrade_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_CheckUpgrade_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_environment_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_environment_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_CreateEnvironment_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_environment_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_CreateEnvironment_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_config_map_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_CreateUserWorkloadsConfigMap_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_config_map_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_CreateUserWorkloadsConfigMap_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_CreateUserWorkloadsSecret_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_CreateUserWorkloadsSecret_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_database_failover_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_database_failover_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_DatabaseFailover_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_database_failover_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_database_failover_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_DatabaseFailover_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_environment_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_environment_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_DeleteEnvironment_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_environment_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_DeleteEnvironment_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_config_map_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_DeleteUserWorkloadsConfigMap_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_config_map_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_DeleteUserWorkloadsConfigMap_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_DeleteUserWorkloadsSecret_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_DeleteUserWorkloadsSecret_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_execute_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_execute_airflow_command_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_ExecuteAirflowCommand_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_execute_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_execute_airflow_command_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_ExecuteAirflowCommand_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_fetch_database_properties_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_fetch_database_properties_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_FetchDatabaseProperties_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_fetch_database_properties_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_fetch_database_properties_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_FetchDatabaseProperties_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_environment_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_environment_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_GetEnvironment_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_environment_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_GetEnvironment_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_config_map_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_GetUserWorkloadsConfigMap_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_config_map_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_GetUserWorkloadsConfigMap_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_GetUserWorkloadsSecret_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_GetUserWorkloadsSecret_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_environments_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_environments_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_ListEnvironments_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_environments_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_environments_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_ListEnvironments_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_config_maps_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_config_maps_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_ListUserWorkloadsConfigMaps_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_config_maps_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_config_maps_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_ListUserWorkloadsConfigMaps_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_secrets_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_secrets_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_ListUserWorkloadsSecrets_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_secrets_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_secrets_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_ListUserWorkloadsSecrets_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_workloads_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_workloads_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_ListWorkloads_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_workloads_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_workloads_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_ListWorkloads_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_load_snapshot_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_load_snapshot_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_LoadSnapshot_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_load_snapshot_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_load_snapshot_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_LoadSnapshot_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_poll_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_poll_airflow_command_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_PollAirflowCommand_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_poll_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_poll_airflow_command_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_PollAirflowCommand_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_restart_web_server_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_restart_web_server_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_RestartWebServer_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_restart_web_server_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_restart_web_server_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_RestartWebServer_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_save_snapshot_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_save_snapshot_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_SaveSnapshot_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_save_snapshot_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_save_snapshot_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_SaveSnapshot_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_stop_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_stop_airflow_command_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_StopAirflowCommand_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_stop_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_stop_airflow_command_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_StopAirflowCommand_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_environment_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_environment_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_UpdateEnvironment_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_environment_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_UpdateEnvironment_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_config_map_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_UpdateUserWorkloadsConfigMap_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_config_map_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_UpdateUserWorkloadsConfigMap_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_UpdateUserWorkloadsSecret_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_Environments_UpdateUserWorkloadsSecret_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_image_versions_list_image_versions_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_image_versions_list_image_versions_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_ImageVersions_ListImageVersions_async]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_image_versions_list_image_versions_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_image_versions_list_image_versions_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-orchestration-airflow-service
+#   python3 -m pip install google-cloud-orchestration-airflow
 
 
 # [START composer_v1beta1_generated_ImageVersions_ListImageVersions_sync]

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/snippet_metadata_google.cloud.orchestration.airflow.service.v1beta1.json
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/snippet_metadata_google.cloud.orchestration.airflow.service.v1beta1.json
@@ -7,7 +7,7 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-cloud-orchestration-airflow-service",
+    "name": "google-cloud-orchestration-airflow",
     "version": "1.20.0"
   },
   "snippets": [

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/py.typed
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-secretmanager package uses inline types.
+# The google-cloud-secret-manager package uses inline types.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/py.typed
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-secretmanager package uses inline types.
+# The google-cloud-secret-manager package uses inline types.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_access_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_access_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_AccessSecretVersion_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_access_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_access_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_AccessSecretVersion_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_add_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_add_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_AddSecretVersion_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_add_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_add_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_AddSecretVersion_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_create_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_create_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_CreateSecret_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_create_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_create_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_CreateSecret_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_delete_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_delete_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_DeleteSecret_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_delete_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_delete_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_DeleteSecret_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_destroy_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_destroy_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_DestroySecretVersion_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_destroy_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_destroy_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_DestroySecretVersion_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_disable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_disable_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_DisableSecretVersion_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_disable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_disable_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_DisableSecretVersion_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_enable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_enable_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_EnableSecretVersion_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_enable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_enable_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_EnableSecretVersion_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_iam_policy_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_GetIamPolicy_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_iam_policy_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_GetIamPolicy_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_GetSecret_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_GetSecret_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_GetSecretVersion_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_GetSecretVersion_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secret_versions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secret_versions_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_ListSecretVersions_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secret_versions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secret_versions_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_ListSecretVersions_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secrets_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secrets_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_ListSecrets_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secrets_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secrets_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_ListSecrets_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_set_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_set_iam_policy_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_SetIamPolicy_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_set_iam_policy_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_SetIamPolicy_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_test_iam_permissions_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_TestIamPermissions_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_test_iam_permissions_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_TestIamPermissions_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_update_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_update_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_UpdateSecret_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_update_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_update_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta1_generated_SecretManagerService_UpdateSecret_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_access_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_access_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_AccessSecretVersion_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_access_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_access_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_AccessSecretVersion_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_add_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_add_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_AddSecretVersion_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_add_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_add_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_AddSecretVersion_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_create_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_create_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_CreateSecret_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_create_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_create_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_CreateSecret_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_delete_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_delete_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_DeleteSecret_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_delete_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_delete_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_DeleteSecret_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_destroy_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_destroy_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_DestroySecretVersion_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_destroy_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_destroy_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_DestroySecretVersion_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_disable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_disable_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_DisableSecretVersion_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_disable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_disable_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_DisableSecretVersion_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_enable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_enable_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_EnableSecretVersion_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_enable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_enable_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_EnableSecretVersion_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_iam_policy_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_GetIamPolicy_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_iam_policy_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_GetIamPolicy_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_GetSecret_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_GetSecret_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_version_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_GetSecretVersion_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_version_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_GetSecretVersion_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secret_versions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secret_versions_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_ListSecretVersions_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secret_versions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secret_versions_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_ListSecretVersions_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secrets_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secrets_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_ListSecrets_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secrets_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secrets_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_ListSecrets_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_set_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_set_iam_policy_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_SetIamPolicy_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_set_iam_policy_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_SetIamPolicy_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_test_iam_permissions_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_TestIamPermissions_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_test_iam_permissions_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_TestIamPermissions_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_update_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_update_secret_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_UpdateSecret_async]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_update_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_update_secret_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-secretmanager
+#   python3 -m pip install google-cloud-secret-manager
 
 
 # [START secretmanager_v1beta2_generated_SecretManagerService_UpdateSecret_sync]

--- a/packages/google-cloud-secret-manager/samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1beta2.json
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/snippet_metadata_google.cloud.secretmanager.v1beta2.json
@@ -7,7 +7,7 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-cloud-secretmanager",
+    "name": "google-cloud-secret-manager",
     "version": "2.27.0"
   },
   "snippets": [

--- a/packages/google-cloud-secret-manager/samples/generated_samples/snippet_metadata_google.cloud.secrets.v1beta1.json
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/snippet_metadata_google.cloud.secrets.v1beta1.json
@@ -7,7 +7,7 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-cloud-secretmanager",
+    "name": "google-cloud-secret-manager",
     "version": "2.27.0"
   },
   "snippets": [

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database/py.typed
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-spanner-admin-database package uses inline types.
+# The google-cloud-spanner package uses inline types.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/py.typed
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-spanner-admin-database package uses inline types.
+# The google-cloud-spanner package uses inline types.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance/py.typed
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-spanner-admin-instance package uses inline types.
+# The google-cloud-spanner package uses inline types.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/py.typed
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-spanner-admin-instance package uses inline types.
+# The google-cloud-spanner package uses inline types.

--- a/packages/google-cloud-spanner/samples/generated_samples/snippet_metadata_google.spanner.admin.database.v1.json
+++ b/packages/google-cloud-spanner/samples/generated_samples/snippet_metadata_google.spanner.admin.database.v1.json
@@ -7,7 +7,7 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-cloud-spanner-admin-database",
+    "name": "google-cloud-spanner",
     "version": "3.65.0"
   },
   "snippets": [

--- a/packages/google-cloud-spanner/samples/generated_samples/snippet_metadata_google.spanner.admin.instance.v1.json
+++ b/packages/google-cloud-spanner/samples/generated_samples/snippet_metadata_google.spanner.admin.instance.v1.json
@@ -7,7 +7,7 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-cloud-spanner-admin-instance",
+    "name": "google-cloud-spanner",
     "version": "3.65.0"
   },
   "snippets": [

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_add_split_points_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_add_split_points_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_AddSplitPoints_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_add_split_points_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_add_split_points_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_AddSplitPoints_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_copy_backup_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_copy_backup_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_CopyBackup_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_copy_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_copy_backup_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_CopyBackup_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_CreateBackup_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_schedule_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_schedule_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_CreateBackupSchedule_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_schedule_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_schedule_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_CreateBackupSchedule_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_CreateBackup_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_database_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_database_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_CreateDatabase_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_database_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_CreateDatabase_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_DeleteBackup_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_schedule_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_schedule_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_DeleteBackupSchedule_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_schedule_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_schedule_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_DeleteBackupSchedule_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_DeleteBackup_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_drop_database_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_drop_database_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_DropDatabase_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_drop_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_drop_database_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_DropDatabase_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_GetBackup_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_schedule_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_schedule_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_GetBackupSchedule_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_schedule_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_schedule_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_GetBackupSchedule_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_GetBackup_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_GetDatabase_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_ddl_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_ddl_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_GetDatabaseDdl_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_ddl_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_ddl_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_GetDatabaseDdl_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_GetDatabase_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_iam_policy_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_iam_policy_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_GetIamPolicy_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_iam_policy_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_iam_policy_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_GetIamPolicy_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_internal_update_graph_operation_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_internal_update_graph_operation_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_InternalUpdateGraphOperation_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_internal_update_graph_operation_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_internal_update_graph_operation_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_InternalUpdateGraphOperation_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_operations_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_operations_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_ListBackupOperations_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_operations_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_operations_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_ListBackupOperations_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_schedules_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_schedules_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_ListBackupSchedules_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_schedules_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_schedules_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_ListBackupSchedules_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backups_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backups_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_ListBackups_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backups_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backups_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_ListBackups_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_operations_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_operations_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_ListDatabaseOperations_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_operations_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_operations_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_ListDatabaseOperations_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_roles_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_roles_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_ListDatabaseRoles_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_roles_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_roles_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_ListDatabaseRoles_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_databases_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_databases_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_ListDatabases_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_databases_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_databases_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_ListDatabases_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_restore_database_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_restore_database_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_RestoreDatabase_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_restore_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_restore_database_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_RestoreDatabase_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_set_iam_policy_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_set_iam_policy_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_SetIamPolicy_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_set_iam_policy_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_set_iam_policy_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_SetIamPolicy_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_test_iam_permissions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_test_iam_permissions_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_TestIamPermissions_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_test_iam_permissions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_test_iam_permissions_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_TestIamPermissions_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_UpdateBackup_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_schedule_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_schedule_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_UpdateBackupSchedule_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_schedule_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_schedule_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_UpdateBackupSchedule_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_UpdateBackup_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_UpdateDatabase_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_ddl_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_ddl_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_UpdateDatabaseDdl_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_ddl_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_ddl_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_UpdateDatabaseDdl_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-database
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_DatabaseAdmin_UpdateDatabase_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_CreateInstance_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_config_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_config_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_CreateInstanceConfig_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_config_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_config_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_CreateInstanceConfig_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_partition_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_partition_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_CreateInstancePartition_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_partition_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_partition_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_CreateInstancePartition_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_CreateInstance_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_DeleteInstance_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_config_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_config_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_DeleteInstanceConfig_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_config_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_config_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_DeleteInstanceConfig_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_partition_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_partition_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_DeleteInstancePartition_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_partition_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_partition_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_DeleteInstancePartition_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_DeleteInstance_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_iam_policy_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_iam_policy_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_GetIamPolicy_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_iam_policy_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_iam_policy_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_GetIamPolicy_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_GetInstance_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_config_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_config_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_GetInstanceConfig_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_config_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_config_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_GetInstanceConfig_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_partition_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_partition_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_GetInstancePartition_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_partition_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_partition_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_GetInstancePartition_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_GetInstance_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_config_operations_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_config_operations_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_ListInstanceConfigOperations_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_config_operations_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_config_operations_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_ListInstanceConfigOperations_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_configs_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_configs_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_ListInstanceConfigs_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_configs_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_configs_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_ListInstanceConfigs_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partition_operations_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partition_operations_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_ListInstancePartitionOperations_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partition_operations_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partition_operations_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_ListInstancePartitionOperations_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partitions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partitions_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_ListInstancePartitions_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partitions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partitions_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_ListInstancePartitions_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instances_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instances_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_ListInstances_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instances_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instances_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_ListInstances_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_move_instance_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_move_instance_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_MoveInstance_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_move_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_move_instance_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_MoveInstance_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_set_iam_policy_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_set_iam_policy_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_SetIamPolicy_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_set_iam_policy_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_set_iam_policy_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_SetIamPolicy_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_test_iam_permissions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_test_iam_permissions_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_TestIamPermissions_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_test_iam_permissions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_test_iam_permissions_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_TestIamPermissions_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_UpdateInstance_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_config_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_config_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_UpdateInstanceConfig_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_config_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_config_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_UpdateInstanceConfig_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_partition_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_partition_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_UpdateInstancePartition_async]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_partition_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_partition_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_UpdateInstancePartition_sync]

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-spanner-admin-instance
+#   python3 -m pip install google-cloud-spanner
 
 
 # [START spanner_v1_generated_InstanceAdmin_UpdateInstance_sync]

--- a/packages/google-cloud-storage/tests/unit/asyncio/retry/test_reads_resumption_strategy.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/retry/test_reads_resumption_strategy.py
@@ -16,8 +16,8 @@ import asyncio
 import io
 import unittest
 
-from google.api_core import exceptions
 import google_crc32c
+from google.api_core import exceptions
 
 from google.cloud import _storage_v2 as storage_v2
 from google.cloud._storage_v2.types.storage import BidiReadObjectRedirectedError

--- a/packages/google-cloud-storage/tests/unit/asyncio/retry/test_reads_resumption_strategy.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/retry/test_reads_resumption_strategy.py
@@ -16,8 +16,8 @@ import asyncio
 import io
 import unittest
 
-import google_crc32c
 from google.api_core import exceptions
+import google_crc32c
 
 from google.cloud import _storage_v2 as storage_v2
 from google.cloud._storage_v2.types.storage import BidiReadObjectRedirectedError

--- a/packages/google-cloud-storage/tests/unit/asyncio/test_async_multi_range_downloader.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/test_async_multi_range_downloader.py
@@ -17,9 +17,9 @@ from io import BytesIO
 from unittest import mock
 from unittest.mock import AsyncMock
 
+import google_crc32c
 import pytest
 from google.api_core import exceptions
-import google_crc32c
 
 from google.cloud import _storage_v2
 from google.cloud.storage.asyncio import async_read_object_stream

--- a/packages/google-cloud-storage/tests/unit/asyncio/test_async_multi_range_downloader.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/test_async_multi_range_downloader.py
@@ -17,9 +17,9 @@ from io import BytesIO
 from unittest import mock
 from unittest.mock import AsyncMock
 
-import google_crc32c
 import pytest
 from google.api_core import exceptions
+import google_crc32c
 
 from google.cloud import _storage_v2
 from google.cloud.storage.asyncio import async_read_object_stream

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions/py.typed
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-workflows-executions package uses inline types.
+# The google-cloud-workflows package uses inline types.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/py.typed
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-workflows-executions package uses inline types.
+# The google-cloud-workflows package uses inline types.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/py.typed
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/py.typed
@@ -1,2 +1,2 @@
 # Marker file for PEP 561.
-# The google-cloud-workflows-executions package uses inline types.
+# The google-cloud-workflows package uses inline types.

--- a/packages/google-cloud-workflows/samples/generated_samples/snippet_metadata_google.cloud.workflows.executions.v1.json
+++ b/packages/google-cloud-workflows/samples/generated_samples/snippet_metadata_google.cloud.workflows.executions.v1.json
@@ -7,7 +7,7 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-cloud-workflows-executions",
+    "name": "google-cloud-workflows",
     "version": "1.21.0"
   },
   "snippets": [

--- a/packages/google-cloud-workflows/samples/generated_samples/snippet_metadata_google.cloud.workflows.executions.v1beta.json
+++ b/packages/google-cloud-workflows/samples/generated_samples/snippet_metadata_google.cloud.workflows.executions.v1beta.json
@@ -7,7 +7,7 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-cloud-workflows-executions",
+    "name": "google-cloud-workflows",
     "version": "1.21.0"
   },
   "snippets": [

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1_generated_Executions_CancelExecution_async]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1_generated_Executions_CancelExecution_sync]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1_generated_Executions_CreateExecution_async]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1_generated_Executions_CreateExecution_sync]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1_generated_Executions_GetExecution_async]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1_generated_Executions_GetExecution_sync]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1_generated_Executions_ListExecutions_async]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1_generated_Executions_ListExecutions_sync]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1beta_generated_Executions_CancelExecution_async]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1beta_generated_Executions_CancelExecution_sync]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1beta_generated_Executions_CreateExecution_async]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1beta_generated_Executions_CreateExecution_sync]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1beta_generated_Executions_GetExecution_async]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1beta_generated_Executions_GetExecution_sync]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_async.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1beta_generated_Executions_ListExecutions_async]

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_sync.py
@@ -20,7 +20,7 @@
 # It may require modifications to work in your environment.
 
 # To install the latest published package dependency, execute the following:
-#   python3 -m pip install google-cloud-workflows-executions
+#   python3 -m pip install google-cloud-workflows
 
 
 # [START workflowexecutions_v1beta_generated_Executions_ListExecutions_sync]


### PR DESCRIPTION
This means we don't use the generator default for any of:

- python-gapic-name
- python-gapic-namespace
- warehouse-package-name

Only API paths which didn't already have an explicit default were updated.

The changes are all from explicitly specifying `warehouse-package-name`, and are all corrections from where the generator was inferring the package name incorrectly. (And regenerating Datastore, which wasn't automated in #16737.)

This is the first step in https://github.com/googleapis/librarian/issues/5163 - we will then change librarian to use a new approach to inference (deriving the namespace just from the first two components of the API path), and remove all the explicit options which would be inferred the same way. So while this PR adds a lot of lines to the config, many will later be removed again.