### PR TITLE
tests(spanner): update `prerelease_deps` nox session to match system tests

### DIFF
--- a/packages/google-cloud-spanner/noxfile.py
+++ b/packages/google-cloud-spanner/noxfile.py
@@ -713,7 +713,9 @@ def prerelease_deps(session, protobuf_implementation, database_dialect):
             ]
             if not session.posargs:
                 sync_args.append(system_test_folder_path)
-                sync_args.append(f"--ignore={os.path.join(system_test_folder_path, '_async')}")
+                sync_args.append(
+                    f"--ignore={os.path.join(system_test_folder_path, '_async')}"
+                )
             else:
                 sync_args.extend(session.posargs)
 

--- a/packages/google-cloud-spanner/noxfile.py
+++ b/packages/google-cloud-spanner/noxfile.py
@@ -712,8 +712,8 @@ def prerelease_deps(session, protobuf_implementation, database_dialect):
                 f"--junitxml=system_{session.python}_sync_sponge_log.xml",
             ]
             if not session.posargs:
-                sync_args.append(os.path.join("tests", "system"))
-                sync_args.append("--ignore=tests/system/_async")
+                sync_args.append(system_test_folder_path)
+                sync_args.append(f"--ignore={os.path.join(system_test_folder_path, '_async')}")
             else:
                 sync_args.extend(session.posargs)
 

--- a/packages/google-cloud-spanner/noxfile.py
+++ b/packages/google-cloud-spanner/noxfile.py
@@ -735,7 +735,7 @@ def prerelease_deps(session, protobuf_implementation, database_dialect):
                 f"--junitxml=system_{session.python}_async_sponge_log.xml",
             ]
             if not session.posargs:
-                async_args.append(os.path.join("tests", "system", "_async"))
+                async_args.append(os.path.join(system_test_folder_path, "_async"))
             else:
                 # If posargs are provided, only run if they match async tests
                 # or just skip if they were already run in sync.

--- a/packages/google-cloud-spanner/noxfile.py
+++ b/packages/google-cloud-spanner/noxfile.py
@@ -655,6 +655,12 @@ def prerelease_deps(session, protobuf_implementation, database_dialect):
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
 
+    system_test_exists = os.path.exists(system_test_path)
+    system_test_folder_exists = os.path.exists(system_test_folder_path)
+    # Sanity check: only run tests if found.
+    if not system_test_exists and not system_test_folder_exists:
+        session.skip("System tests were not found")
+
     if os.environ.get("SPANNER_EMULATOR_HOST"):
         # Run tests against the emulator
         run_system = True
@@ -675,24 +681,75 @@ def prerelease_deps(session, protobuf_implementation, database_dialect):
         run_system = False
 
     if run_system:
-        # Run the tests (deduplicated logic)
-        test_path = (
-            system_test_path
-            if os.path.exists(system_test_path)
-            else system_test_folder_path
-        )
-        session.run(
-            "py.test",
-            "--verbose",
-            f"--junitxml=system_{session.python}_sponge_log.xml",
-            test_path,
-            *session.posargs,
-            env={
-                "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
-                "SPANNER_DATABASE_DIALECT": database_dialect,
-                "SKIP_BACKUP_TESTS": "true",
-            },
-        )
+        # Run py.test against the system tests.
+        if system_test_exists:
+            args = [
+                "py.test",
+                "--quiet",
+                "-o",
+                "asyncio_mode=auto",
+                f"--junitxml=system_{session.python}_sponge_log.xml",
+            ]
+            if not session.posargs:
+                args.append(system_test_path)
+            args.extend(session.posargs)
+
+            session.run(
+                *args,
+                env={
+                    "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
+                    "SPANNER_DATABASE_DIALECT": database_dialect,
+                    "SKIP_BACKUP_TESTS": "true",
+                },
+            )
+        elif system_test_folder_exists:
+            # Run sync tests
+            sync_args = [
+                "py.test",
+                "--quiet",
+                "-o",
+                "asyncio_mode=auto",
+                f"--junitxml=system_{session.python}_sync_sponge_log.xml",
+            ]
+            if not session.posargs:
+                sync_args.append(os.path.join("tests", "system"))
+                sync_args.append("--ignore=tests/system/_async")
+            else:
+                sync_args.extend(session.posargs)
+
+            session.run(
+                *sync_args,
+                env={
+                    "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
+                    "SPANNER_DATABASE_DIALECT": database_dialect,
+                    "SKIP_BACKUP_TESTS": "true",
+                },
+            )
+
+            # Run async tests
+            async_args = [
+                "py.test",
+                "--quiet",
+                "-o",
+                "asyncio_mode=auto",
+                f"--junitxml=system_{session.python}_async_sponge_log.xml",
+            ]
+            if not session.posargs:
+                async_args.append(os.path.join("tests", "system", "_async"))
+            else:
+                # If posargs are provided, only run if they match async tests
+                # or just skip if they were already run in sync.
+                # For simplicity, we only run async folder if no posargs.
+                return
+
+            session.run(
+                *async_args,
+                env={
+                    "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
+                    "SPANNER_DATABASE_DIALECT": database_dialect,
+                    "SKIP_BACKUP_TESTS": "true",
+                },
+            )
 
 
 @nox.session(python=ALL_PYTHON)

--- a/packages/google-cloud-spanner/tests/system/test_instance_api.py
+++ b/packages/google-cloud-spanner/tests/system/test_instance_api.py
@@ -36,8 +36,14 @@ def test_list_instances(
 ):
     instances = list(spanner_client.list_instances())
 
+    existing_names = {single_instance.name for single_instance in existing_instances}
+    shared_instance_name = shared_instance.name
+
     for instance in instances:
-        assert instance in existing_instances or instance is shared_instance
+        # We compare by '.name' (the full resource path) rather than the object itself.
+        # Protobuf objects may fail equality (==) if one has extra metadata populated
+        # by the server (like 'edition' or 'backup_schedules') that the other lacks.
+        assert instance.name in existing_names or instance.name == shared_instance_name
 
 
 def test_reload_instance(spanner_client, shared_instance_id, shared_instance):

--- a/packages/google-cloud-spanner/tests/system/test_instance_api.py
+++ b/packages/google-cloud-spanner/tests/system/test_instance_api.py
@@ -34,16 +34,21 @@ def test_list_instances(
     existing_instances,
     shared_instance,
 ):
+    # Retrieve all instances currently visible in the project.
     instances = list(spanner_client.list_instances())
 
-    existing_names = {single_instance.name for single_instance in existing_instances}
-    shared_instance_name = shared_instance.name
+    # We use the instance name (the full resource path) rather than the object itself.
+    # Protobuf objects may fail equality (==) if one has extra metadata populated
+    # by the server (like 'edition' or 'backup_schedules') that the other lacks.
+    instance_names = {instance.name for instance in instances}
 
-    for instance in instances:
-        # We compare by '.name' (the full resource path) rather than the object itself.
-        # Protobuf objects may fail equality (==) if one has extra metadata populated
-        # by the server (like 'edition' or 'backup_schedules') that the other lacks.
-        assert instance.name in existing_names or instance.name == shared_instance_name
+    # In a parallel CI environment, other tests may create instances
+    # (like 'multi-region-...') simultaneously.
+    # Only verify `shared_instance.name` is in the list of instances.
+    assert shared_instance.name in instance_names, (
+        f"Expected instance {shared_instance.name} was not found in the "
+        f"list of project instances: {instance_names}"
+    )
 
 
 def test_reload_instance(spanner_client, shared_instance_id, shared_instance):


### PR DESCRIPTION
This PR fixes 2 failing tests which appear in https://github.com/googleapis/google-cloud-python/pull/16762

In the system test presubmit `Kokoro System Tests`, the assertion is too strict. Protobuf objects may fail equality (==) if one has extra metadata populated by the server that the other lacks. If the server fills in a default field in one response but not another, the assertion fails even if the ID is identical. In addition, we need to cater for the chance that other spanner instances are created while tests are running. For example, in [one test result](https://btx.cloud.google.com/invocations/946e7000-b177-491a-947a-88f2daf52a68/log) we expected instance `projects/precise-truck-742/instances/google-cloud-python-systest` but found `projects/precise-truck-742/instances/multi-region-1776903230037`

```
=================================== FAILURES ===================================
_____________________________ test_list_instances ______________________________
..

    def test_list_instances(
        no_create_instance,
        spanner_client,
        existing_instances,
        shared_instance,
    ):
        instances = list(spanner_client.list_instances())
    
        for instance in instances:
>           assert instance in existing_instances or instance is shared_instance
...
tests/system/test_instance_api.py:40: AssertionError
```

The other failure only appears in the `Kokoro Pre-release Tests`.  Updating the `prerelease_deps` nox session to match the system test session resolves the issue.

```
==================================== ERRORS ====================================
____________________ ERROR at setup of test_table_not_found ____________________

self = 

    def setup(self) -> None:
        runner_fixture_id = f"_{self._loop_scope}_scoped_runner"
        if runner_fixture_id not in self.fixturenames:
            self.fixturenames.append(runner_fixture_id)
>       return super().setup()
               ^^^^^^^^^^^^^^^

.nox/8f8a4a6e/lib/python3.14/site-packages/pytest_asyncio/plugin.py:458: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

fixturedef = 
request = >

    @pytest.hookimpl(wrapper=True)
    def pytest_fixture_setup(fixturedef: FixtureDef, request) -> object | None:
        asyncio_mode = _get_asyncio_mode(request.config)
        if not _is_asyncio_fixture_function(fixturedef.func):
            if asyncio_mode == Mode.STRICT:
                # Ignore async fixtures without explicit asyncio mark in strict mode
                # This applies to pytest_trio fixtures, for example
>               return (yield)
                        ^^^^^
E               pytest.PytestRemovedIn9Warning: '' requested an async fixture 'instance_configs', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
E               See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture

.nox/8f8a4a6e/lib/python3.14/site-packages/pytest_asyncio/plugin.py:728: PytestRemovedIn9Warning

```