### PR TITLE
chore(librarian): remove incomplete entry in config.yaml

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -16,7 +16,6 @@ libraries:
     id: bigframes
     release_blocked: true
   - generate_blocked: true
-  - generate_blocked: true
     id: google-cloud-dialogflow
   - generate_blocked: true
     id: google-crc32c


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-python/pull/16549 removed `release_blocked` for `google-cloud-firestore`. The `generated_blocked` was not removed however since `id: google-cloud-firestore` was removed in the PR, the `generated_blocked` remained in the config.yaml as an incorrect entry.

There is already an entry for `google-cloud-firestore` with `generate_blocked` here:

https://github.com/googleapis/google-cloud-python/blob/f03d376efb45aa6eb44d0396b600b0683055e83b/.librarian/config.yaml#L267-L268