### PR TITLE
chore: upgrade librarian to v0.10.2-0.20260423145805-fa79d1c1732d

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: python
-version: v0.10.1
+version: v0.10.2-0.20260423145805-fa79d1c1732d
 repo: googleapis/google-cloud-python
 sources:
   googleapis:


### PR DESCRIPTION
This will allow us to onboard google-cloud-datacatalog-lineage-configmanagement