### PR TITLE
fix(auth): Disable MDS mTLS feature by default.

### DIFF
--- a/packages/google-auth/google/auth/compute_engine/_mtls.py
+++ b/packages/google-auth/google/auth/compute_engine/_mtls.py
@@ -87,9 +87,7 @@ class MdsMtlsMode(enum.Enum):
 
 def _parse_mds_mode():
     """Parses the GCE_METADATA_MTLS_MODE environment variable."""
-    mode_str = os.environ.get(
-        environment_vars.GCE_METADATA_MTLS_MODE, "default"
-    ).lower()
+    mode_str = os.environ.get(environment_vars.GCE_METADATA_MTLS_MODE, "none").lower()
     try:
         return MdsMtlsMode(mode_str)
     except ValueError:

--- a/packages/google-auth/tests/compute_engine/test__metadata.py
+++ b/packages/google-auth/tests/compute_engine/test__metadata.py
@@ -639,11 +639,17 @@ def test_get_universe_domain_other_error():
 
 
 @mock.patch(
+    "google.auth._agent_identity_utils.get_and_parse_agent_identity_certificate",
+    return_value=None,
+)
+@mock.patch(
     "google.auth.metrics.token_request_access_token_mds",
     return_value=ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
 )
 @mock.patch("google.auth._helpers.utcnow", return_value=datetime.datetime.min)
-def test_get_service_account_token(utcnow, mock_metrics_header_value):
+def test_get_service_account_token(
+    utcnow, mock_metrics_header_value, mock_get_agent_cert
+):
     ttl = 500
     request = make_request(
         json.dumps({"access_token": "token", "expires_in": ttl}),
@@ -666,11 +672,17 @@ def test_get_service_account_token(utcnow, mock_metrics_header_value):
 
 
 @mock.patch(
+    "google.auth._agent_identity_utils.get_and_parse_agent_identity_certificate",
+    return_value=None,
+)
+@mock.patch(
     "google.auth.metrics.token_request_access_token_mds",
     return_value=ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
 )
 @mock.patch("google.auth._helpers.utcnow", return_value=datetime.datetime.min)
-def test_get_service_account_token_with_scopes_list(utcnow, mock_metrics_header_value):
+def test_get_service_account_token_with_scopes_list(
+    utcnow, mock_metrics_header_value, mock_get_agent_cert
+):
     ttl = 500
     request = make_request(
         json.dumps({"access_token": "token", "expires_in": ttl}),
@@ -696,12 +708,16 @@ def test_get_service_account_token_with_scopes_list(utcnow, mock_metrics_header_
 
 
 @mock.patch(
+    "google.auth._agent_identity_utils.get_and_parse_agent_identity_certificate",
+    return_value=None,
+)
+@mock.patch(
     "google.auth.metrics.token_request_access_token_mds",
     return_value=ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
 )
 @mock.patch("google.auth._helpers.utcnow", return_value=datetime.datetime.min)
 def test_get_service_account_token_with_scopes_string(
-    utcnow, mock_metrics_header_value
+    utcnow, mock_metrics_header_value, mock_get_agent_cert
 ):
     ttl = 500
     request = make_request(

--- a/packages/google-auth/tests/compute_engine/test__mtls.py
+++ b/packages/google-auth/tests/compute_engine/test__mtls.py
@@ -55,7 +55,7 @@ def test__MdsMtlsConfig_non_windows_defaults():
 
 def test__parse_mds_mode_default(monkeypatch):
     monkeypatch.delenv(environment_vars.GCE_METADATA_MTLS_MODE, raising=False)
-    assert _mtls._parse_mds_mode() == _mtls.MdsMtlsMode.DEFAULT
+    assert _mtls._parse_mds_mode() == _mtls.MdsMtlsMode.NONE
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
mTLS connection to MDS is failing after a python update. There is a bug in the failover logic that is affecting some users.

This PR:
- disables the feature until the failover logic and mTLS connection are fixed.
- fixes metadata unit tests which were failing due to some get_and_parse_agent_identity_certificate requirement

Fixes #16090