### PR TITLE
prototype: removing product_documentation_override with more values in librarian/sdk.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -58,7 +58,6 @@ libraries:
     python:
       library_type: INTEGRATION
       name_pretty_override: A unified Python API in BigQuery
-      product_documentation_override: https://cloud.google.com/bigquery
       api_shortname_override: bigquery
       api_id_override: bigquery.googleapis.com
       client_documentation_override: https://cloud.google.com/python/docs/reference/bigframes/latest
@@ -68,7 +67,6 @@ libraries:
     python:
       library_type: INTEGRATION
       name_pretty_override: Google BigQuery connector for Jupyter and IPython
-      product_documentation_override: https://cloud.google.com/bigquery
       api_id_override: bigquery.googleapis.com
       client_documentation_override: https://googleapis.dev/python/bigquery-magics/latest/
       issue_tracker_override: https://github.com/googleapis/python-bigquery-magics/issues
@@ -78,7 +76,6 @@ libraries:
     python:
       library_type: INTEGRATION
       name_pretty_override: Pandas Data Types for SQL systems (BigQuery, Spanner)
-      product_documentation_override: https://pandas.pydata.org/pandas-docs/stable/ecosystem.html#ecosystem-extensions
       api_id_override: bigquery.googleapis.com
       client_documentation_override: https://googleapis.dev/python/db-dtypes/latest/index.html
   - name: django-google-spanner
@@ -87,7 +84,6 @@ libraries:
     python:
       library_type: INTEGRATION
       name_pretty_override: Cloud Spanner Django
-      product_documentation_override: https://cloud.google.com/spanner/docs/
       api_shortname_override: django-google-spanner
       issue_tracker_override: https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open
   - name: gapic-generator
@@ -103,7 +99,6 @@ libraries:
     python:
       library_type: OTHER
       name_pretty_override: Sphinx DocFX YAML Generator
-      product_documentation_override: https://github.com/googleapis/sphinx-docfx-yaml
       client_documentation_override: https://github.com/googleapis/sphinx-docfx-yaml
       issue_tracker_override: https://github.com/googleapis/sphinx-docfx-yaml/issues
       skip_readme_copy: true
@@ -259,7 +254,6 @@ libraries:
           - warehouse-package-name=google-apps-chat
           - python-gapic-name=chat
       name_pretty_override: Chat API
-      product_documentation_override: https://developers.google.com/chat/
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-apps-events-subscriptions
@@ -406,7 +400,6 @@ libraries:
           - warehouse-package-name=google-cloud-access-approval
           - python-gapic-namespace=google.cloud
           - python-gapic-name=accessapproval
-      product_documentation_override: https://cloud.google.com/access-approval
       metadata_name_override: accessapproval
       default_version: v1
   - name: google-cloud-access-context-manager
@@ -418,7 +411,6 @@ libraries:
       proto_only_apis:
         - google/identity/accesscontextmanager/v1
         - google/identity/accesscontextmanager/type
-      product_documentation_override: https://cloud.google.com/access-context-manager/docs/overview
       client_documentation_override: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-access-context-manager
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: accesscontextmanager
@@ -457,7 +449,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=alloydb
           - warehouse-package-name=google-cloud-alloydb
-      product_documentation_override: https://cloud.google.com/alloydb/
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: alloydb
       default_version: v1
@@ -523,7 +514,6 @@ libraries:
           - warehouse-package-name=google-cloud-apigee-connect
           - python-gapic-namespace=google.cloud
           - python-gapic-name=apigeeconnect
-      product_documentation_override: https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect
       metadata_name_override: apigeeconnect
       default_version: v1
   - name: google-cloud-apigee-registry
@@ -538,7 +528,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=apigee_registry
       name_pretty_override: Apigee Registry API
-      product_documentation_override: https://cloud.google.com/apigee/docs/api-hub/get-started-registry-api
       metadata_name_override: apigeeregistry
       default_version: v1
   - name: google-cloud-apihub
@@ -553,7 +542,6 @@ libraries:
           - python-gapic-name=apihub
           - warehouse-package-name=google-cloud-apihub
       name_pretty_override: API Hub API
-      product_documentation_override: https://cloud.google.com/apigee/docs/apihub/what-is-api-hub
       default_version: v1
   - name: google-cloud-apiregistry
     version: 0.2.0
@@ -566,7 +554,6 @@ libraries:
           - python-gapic-name=apiregistry
           - warehouse-package-name=google-cloud-apiregistry
       name_pretty_override: Cloud API Registry API
-      product_documentation_override: https://docs.cloud.google.com/api-registry/docs/overview
       default_version: v1beta
   - name: google-cloud-appengine-admin
     version: 1.17.0
@@ -579,7 +566,6 @@ libraries:
           - warehouse-package-name=google-cloud-appengine-admin
           - python-gapic-namespace=google.cloud
           - python-gapic-name=appengine_admin
-      product_documentation_override: https://cloud.google.com/appengine/docs/admin-api/
       metadata_name_override: appengine
       default_version: v1
   - name: google-cloud-appengine-logging
@@ -596,7 +582,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=appengine_logging
       name_pretty_override: App Engine Logging Protos
-      product_documentation_override: https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: appenginelogging
       default_version: v1
@@ -612,7 +597,6 @@ libraries:
           - python-gapic-name=apphub
           - warehouse-package-name=google-cloud-apphub
       name_pretty_override: App Hub API
-      product_documentation_override: https://cloud.google.com/app-hub/docs/overview
       default_version: v1
   - name: google-cloud-appoptimize
     version: 0.1.0
@@ -676,7 +660,6 @@ libraries:
           - python-gapic-name=asset
           - warehouse-package-name=google-cloud-asset
       name_pretty_override: Cloud Asset Inventory
-      product_documentation_override: https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
       metadata_name_override: cloudasset
       default_version: v1
   - name: google-cloud-assured-workloads
@@ -707,7 +690,6 @@ libraries:
       proto_only_apis:
         - google/cloud/audit
       name_pretty_override: Audit Log API
-      product_documentation_override: https://cloud.google.com/logging/docs/audit
       api_shortname_override: auditlog
       client_documentation_override: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-audit-log
       metadata_name_override: auditlog
@@ -746,7 +728,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=automl
           - warehouse-package-name=google-cloud-automl
-      product_documentation_override: https://cloud.google.com/automl/docs/
       metadata_name_override: automl
       default_version: v1
   - name: google-cloud-backupdr
@@ -761,7 +742,6 @@ libraries:
           - python-gapic-name=backupdr
           - warehouse-package-name=google-cloud-backupdr
       name_pretty_override: Backup and DR Service API
-      product_documentation_override: https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr
       metadata_name_override: backupdr
       default_version: v1
   - name: google-cloud-bare-metal-solution
@@ -877,7 +857,6 @@ libraries:
           - python-gapic-name=biglake
           - warehouse-package-name=google-cloud-biglake
       name_pretty_override: BigLake API
-      product_documentation_override: https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-cloud-biglake-hive
@@ -895,7 +874,6 @@ libraries:
           - python-gapic-name=biglake_hive
           - warehouse-package-name=google-cloud-biglake-hive
       name_pretty_override: BigLake API
-      product_documentation_override: https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
       default_version: v1beta
   - name: google-cloud-bigquery
     version: 3.41.0
@@ -906,7 +884,6 @@ libraries:
     python:
       library_type: GAPIC_COMBO
       name_pretty_override: Google Cloud BigQuery
-      product_documentation_override: https://cloud.google.com/bigquery
       api_shortname_override: bigquery
       api_id_override: bigquery.googleapis.com
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559654
@@ -943,7 +920,6 @@ libraries:
           - python-gapic-name=bigquery_biglake
           - warehouse-package-name=google-cloud-bigquery-biglake
       name_pretty_override: BigLake API
-      product_documentation_override: https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
       metadata_name_override: biglake
       default_version: v1
   - name: google-cloud-bigquery-connection
@@ -957,7 +933,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_connection
           - warehouse-package-name=google-cloud-bigquery-connection
-      product_documentation_override: https://cloud.google.com/bigquery/docs/reference/bigqueryconnection
       metadata_name_override: bigqueryconnection
       default_version: v1
   - name: google-cloud-bigquery-data-exchange
@@ -972,7 +947,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-bigquery-data-exchange
       name_pretty_override: BigQuery Analytics Hub
-      product_documentation_override: https://cloud.google.com/bigquery/docs/analytics-hub-introduction
       metadata_name_override: analyticshub
       default_version: v1beta1
   - name: google-cloud-bigquery-datapolicies
@@ -1005,7 +979,6 @@ libraries:
           - python-gapic-name=bigquery_datapolicies
           - transport=grpc+rest
           - warehouse-package-name=google-cloud-bigquery-datapolicies
-      product_documentation_override: https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest
       metadata_name_override: bigquerydatapolicy
       default_version: v1
   - name: google-cloud-bigquery-datatransfer
@@ -1035,7 +1008,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_logging
       name_pretty_override: BigQuery Logging Protos
-      product_documentation_override: https://cloud.google.com/bigquery/docs/reference/auditlogs
       api_shortname_override: bigquerylogging
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: bigquerylogging
@@ -1056,7 +1028,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-bigquery-migration
       name_pretty_override: Google BigQuery Migration
-      product_documentation_override: https://cloud.google.com/bigquery/docs/reference/migration/
       metadata_name_override: bigquerymigration
       default_version: v2
   - name: google-cloud-bigquery-reservation
@@ -1070,7 +1041,6 @@ libraries:
           - python-gapic-name=bigquery_reservation
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-bigquery-reservation
-      product_documentation_override: https://cloud.google.com/bigquery/docs/reference/reservations
       metadata_name_override: bigqueryreservation
       default_version: v1
   - name: google-cloud-bigquery-storage
@@ -1103,7 +1073,6 @@ libraries:
           - python-gapic-name=bigquery_storage
           - warehouse-package-name=google-cloud-bigquery-storage
       name_pretty_override: Google BigQuery Storage
-      product_documentation_override: https://cloud.google.com/bigquery/docs/reference/storage/
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559654
       metadata_name_override: bigquerystorage
       default_version: v1
@@ -1130,7 +1099,6 @@ libraries:
           - python-gapic-name=bigtable
           - warehouse-package-name=google-cloud-bigtable
       name_pretty_override: Google Cloud Bigtable
-      product_documentation_override: https://cloud.google.com/bigtable
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559777
       metadata_name_override: bigtable
       default_version: v2
@@ -1165,7 +1133,6 @@ libraries:
           - python-gapic-namespace=google.cloud.billing
           - python-gapic-name=budgets
           - warehouse-package-name=google-cloud-billing-budgets
-      product_documentation_override: https://cloud.google.com/billing/docs/how-to/budget-api-overview
       metadata_name_override: billingbudgets
       default_version: v1
   - name: google-cloud-binary-authorization
@@ -1202,7 +1169,6 @@ libraries:
           - warehouse-package-name=google-cloud-build
           - python-gapic-namespace=google.cloud.devtools
           - python-gapic-name=cloudbuild
-      product_documentation_override: https://cloud.google.com/cloud-build/docs/
       metadata_name_override: cloudbuild
       default_version: v1
   - name: google-cloud-capacityplanner
@@ -1229,7 +1195,6 @@ libraries:
           - python-gapic-name=certificate_manager
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-certificate-manager
-      product_documentation_override: https://cloud.google.com/python/docs/reference/certificatemanager/latest
       metadata_name_override: certificatemanager
       default_version: v1
   - name: google-cloud-ces
@@ -1275,7 +1240,6 @@ libraries:
           - python-gapic-name=chronicle
           - warehouse-package-name=google-cloud-chronicle
       name_pretty_override: Chronicle API
-      product_documentation_override: https://cloud.google.com/chronicle/docs/secops/secops-overview
       default_version: v1
   - name: google-cloud-cloudcontrolspartner
     version: 0.5.0
@@ -1294,7 +1258,6 @@ libraries:
           - python-gapic-name=cloudcontrolspartner
           - warehouse-package-name=google-cloud-cloudcontrolspartner
       name_pretty_override: Cloud Controls Partner API
-      product_documentation_override: https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-cloud-cloudsecuritycompliance
@@ -1309,7 +1272,6 @@ libraries:
           - python-gapic-name=cloudsecuritycompliance
           - warehouse-package-name=google-cloud-cloudsecuritycompliance
       name_pretty_override: Cloud Security Compliance API
-      product_documentation_override: https://cloud.google.com/security-command-center/docs/compliance-manager-overview
       default_version: v1
   - name: google-cloud-commerce-consumer-procurement
     version: 0.5.0
@@ -1328,7 +1290,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-commerce-consumer-procurement
       name_pretty_override: Cloud Commerce Consumer Procurement API
-      product_documentation_override: https://cloud.google.com/marketplace/docs/
       api_shortname_override: procurement
       metadata_name_override: procurement
       default_version: v1
@@ -1347,7 +1308,6 @@ libraries:
           - python-gapic-name=common
           - warehouse-package-name=google-cloud-common
       name_pretty_override: Google Cloud Common
-      product_documentation_override: https://cloud.google.com
       metadata_name_override: common
       default_version: apiVersion
   - name: google-cloud-compute
@@ -1378,7 +1338,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=compute
       name_pretty_override: Compute Engine
-      product_documentation_override: https://cloud.google.com/compute/
       issue_tracker_override: https://issuetracker.google.com/issues/new?component=187134&template=0
       default_version: v1beta
   - name: google-cloud-confidentialcomputing
@@ -1408,7 +1367,6 @@ libraries:
           - python-gapic-name=config
           - warehouse-package-name=google-cloud-config
       name_pretty_override: Infrastructure Manager API
-      product_documentation_override: https://cloud.google.com/infrastructure-manager/docs/overview
       api_shortname_override: config
       metadata_name_override: config
       default_version: v1
@@ -1434,7 +1392,6 @@ libraries:
           - python-gapic-name=configdelivery
           - warehouse-package-name=google-cloud-configdelivery
       name_pretty_override: Config Delivery API
-      product_documentation_override: https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/reference/rest
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1alpha
   - name: google-cloud-contact-center-insights
@@ -1481,7 +1438,6 @@ libraries:
           - python-gapic-namespace=google.cloud.devtools
           - warehouse-package-name=google-cloud-containeranalysis
           - python-gapic-name=containeranalysis
-      product_documentation_override: https://cloud.google.com/container-registry/docs/container-analysis
       metadata_name_override: containeranalysis
       default_version: v1
   - name: google-cloud-contentwarehouse
@@ -1528,7 +1484,6 @@ libraries:
           - warehouse-package-name=google-cloud-data-qna
           - python-gapic-namespace=google.cloud
           - python-gapic-name=dataqna
-      product_documentation_override: https://cloud.google.com/bigquery/docs/dataqna
       metadata_name_override: dataqna
       default_version: v1alpha
   - name: google-cloud-databasecenter
@@ -1550,7 +1505,6 @@ libraries:
           - python-gapic-name=databasecenter
           - warehouse-package-name=google-cloud-databasecenter
       name_pretty_override: Database Center API
-      product_documentation_override: https://cloud.google.com/database-center/docs/overview
       default_version: v1beta
   - name: google-cloud-datacatalog
     version: 3.30.0
@@ -1568,7 +1522,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=datacatalog
           - warehouse-package-name=google-cloud-datacatalog
-      product_documentation_override: https://cloud.google.com/data-catalog
       metadata_name_override: datacatalog
       default_version: v1
   - name: google-cloud-datacatalog-lineage
@@ -1583,7 +1536,6 @@ libraries:
           - python-gapic-name=datacatalog_lineage
           - warehouse-package-name=google-cloud-datacatalog-lineage
       name_pretty_override: Data Lineage API
-      product_documentation_override: https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage
       api_shortname_override: lineage
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: lineage
@@ -1599,7 +1551,6 @@ libraries:
           - python-gapic-name=datacatalog_lineage_configmanagement
           - warehouse-package-name=google-cloud-datacatalog-lineage-configmanagement
       name_pretty_override: Data Lineage API
-      product_documentation_override: https://cloud.google.com/dataplex/docs/about-data-lineage
       default_version: v1
   - name: google-cloud-dataflow-client
     version: 0.13.0
@@ -1630,7 +1581,6 @@ libraries:
           - python-gapic-name=dataform
           - warehouse-package-name=google-cloud-dataform
       name_pretty_override: Cloud Dataform
-      product_documentation_override: https://cloud.google.com
       metadata_name_override: dataform
       default_version: v1beta1
   - name: google-cloud-datalabeling
@@ -1645,7 +1595,6 @@ libraries:
           - python-gapic-name=datalabeling
           - warehouse-package-name=google-cloud-datalabeling
       name_pretty_override: Google Cloud Data Labeling
-      product_documentation_override: https://cloud.google.com/data-labeling/docs/
       metadata_name_override: datalabeling
       default_version: v1beta1
   - name: google-cloud-dataplex
@@ -1659,7 +1608,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=dataplex
           - warehouse-package-name=google-cloud-dataplex
-      product_documentation_override: https://cloud.google.com/dataplex
       metadata_name_override: dataplex
       default_version: v1
   - name: google-cloud-dataproc
@@ -1722,7 +1670,6 @@ libraries:
           - python-gapic-name=datastore
           - warehouse-package-name=google-cloud-datastore
       name_pretty_override: Google Cloud Datastore API
-      product_documentation_override: https://cloud.google.com/datastore
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559768
       metadata_name_override: datastore
       default_version: v1
@@ -1770,7 +1717,6 @@ libraries:
           - python-gapic-name=developerconnect
           - warehouse-package-name=google-cloud-developerconnect
       name_pretty_override: Developer Connect API
-      product_documentation_override: https://cloud.google.com/developer-connect/docs/overview
       default_version: v1
   - name: google-cloud-devicestreaming
     version: 0.4.0
@@ -1802,7 +1748,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=dialogflow
           - warehouse-package-name=google-cloud-dialogflow
-      product_documentation_override: https://www.dialogflow.com/
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5300385
       metadata_name_override: dialogflow
       default_version: v2
@@ -1845,7 +1790,6 @@ libraries:
           - python-gapic-name=discoveryengine
           - warehouse-package-name=google-cloud-discoveryengine
       name_pretty_override: Discovery Engine API
-      product_documentation_override: https://cloud.google.com/discovery-engine/
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: discoveryengine
       default_version: v1beta
@@ -1861,7 +1805,6 @@ libraries:
           - python-gapic-name=dlp
           - warehouse-package-name=google-cloud-dlp
       name_pretty_override: Cloud Data Loss Prevention
-      product_documentation_override: https://cloud.google.com/dlp/docs/
       metadata_name_override: dlp
       default_version: v2
   - name: google-cloud-dms
@@ -1884,7 +1827,6 @@ libraries:
     python:
       library_type: REST
       name_pretty_override: Cloud DNS
-      product_documentation_override: https://cloud.google.com/dns
       api_shortname_override: dns
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559772
       metadata_name_override: dns
@@ -1960,7 +1902,6 @@ libraries:
           - python-gapic-name=edgenetwork
           - warehouse-package-name=google-cloud-edgenetwork
       name_pretty_override: Distributed Cloud Edge Network API
-      product_documentation_override: https://cloud.google.com/distributed-cloud/edge/latest/docs/overview
       default_version: v1
   - name: google-cloud-enterpriseknowledgegraph
     version: 0.6.0
@@ -2001,7 +1942,6 @@ libraries:
           - warehouse-package-name=google-cloud-essential-contacts
           - python-gapic-namespace=google.cloud
           - python-gapic-name=essential_contacts
-      product_documentation_override: https://cloud.google.com/resource-manager/docs/managing-notification-contacts/
       metadata_name_override: essentialcontacts
       default_version: v1
   - name: google-cloud-eventarc
@@ -2057,7 +1997,6 @@ libraries:
           - python-gapic-name=financialservices
           - warehouse-package-name=google-cloud-financialservices
       name_pretty_override: Anti Money Laundering AI API
-      product_documentation_override: https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-cloud-firestore
@@ -2099,7 +2038,6 @@ libraries:
           - python-gapic-name=firestore
           - warehouse-package-name=google-cloud-firestore
       name_pretty_override: Cloud Firestore API
-      product_documentation_override: https://cloud.google.com/firestore
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5337669
       metadata_name_override: firestore
       default_version: v1
@@ -2150,7 +2088,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=geminidataanalytics
           - warehouse-package-name=google-cloud-geminidataanalytics
-      product_documentation_override: https://cloud.google.com/gemini/docs/conversational-analytics-api/overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1alpha
   - name: google-cloud-gke-backup
@@ -2164,7 +2101,6 @@ libraries:
           - python-gapic-name=gke_backup
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-gke-backup
-      product_documentation_override: https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke
       metadata_name_override: gkebackup
       default_version: v1
   - name: google-cloud-gke-connect-gateway
@@ -2184,7 +2120,6 @@ libraries:
           - python-gapic-namespace=google.cloud.gkeconnect
           - python-gapic-name=gateway
       name_pretty_override: GKE Connect Gateway
-      product_documentation_override: https://cloud.google.com/anthos/multicluster-management/gateway
       metadata_name_override: connectgateway
       default_version: v1
   - name: google-cloud-gke-hub
@@ -2211,7 +2146,6 @@ libraries:
           - warehouse-package-name=google-cloud-gke-hub
           - python-gapic-namespace=google.cloud
           - python-gapic-name=gkehub
-      product_documentation_override: https://cloud.google.com/anthos/gke/docs/
       metadata_name_override: gkehub
       default_version: v1
   - name: google-cloud-gke-multicloud
@@ -2226,7 +2160,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-gke-multicloud
       name_pretty_override: Anthos Multicloud
-      product_documentation_override: https://cloud.google.com/anthos/clusters/docs/multi-cloud
       metadata_name_override: gkemulticloud
       default_version: v1
   - name: google-cloud-gkerecommender
@@ -2241,7 +2174,6 @@ libraries:
           - python-gapic-name=gkerecommender
           - warehouse-package-name=google-cloud-gkerecommender
       name_pretty_override: GKE Recommender API
-      product_documentation_override: https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart
       default_version: v1
   - name: google-cloud-gsuiteaddons
     version: 0.5.0
@@ -2275,7 +2207,6 @@ libraries:
           - python-gapic-name=hypercomputecluster
           - warehouse-package-name=google-cloud-hypercomputecluster
       name_pretty_override: Cluster Director API
-      product_documentation_override: https://cloud.google.com/blog/products/compute/managed-slurm-and-other-cluster-director-enhancements
       default_version: v1
   - name: google-cloud-iam
     version: 2.22.0
@@ -2320,7 +2251,6 @@ libraries:
           - warehouse-package-name=google-cloud-iam
           - transport=grpc+rest
       name_pretty_override: Cloud Identity and Access Management
-      product_documentation_override: https://cloud.google.com/iam/docs/
       api_shortname_override: iamcredentials
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559761
       metadata_name_override: iam
@@ -2339,7 +2269,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=iam_logging
       name_pretty_override: IAM Logging Protos
-      product_documentation_override: https://cloud.google.com/iam/docs/audit-logging
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: iamlogging
       default_version: v1
@@ -2355,7 +2284,6 @@ libraries:
           - python-gapic-name=iamconnectorcredentials
           - warehouse-package-name=google-cloud-iamconnectorcredentials
       name_pretty_override: iamconnectorcredentials.googleapis.com API
-      product_documentation_override: https://cloud.google.com/iamconnectorcredentials/docs/overview
       default_version: v1alpha
   - name: google-cloud-iap
     version: 1.21.0
@@ -2411,7 +2339,6 @@ libraries:
           - proto-plus-deps=google.cloud.kms.v1
           - warehouse-package-name=google-cloud-kms-inventory
       name_pretty_override: KMS Inventory API
-      product_documentation_override: https://cloud.google.com/kms/docs/
       api_shortname_override: inventory
       api_id_override: inventory.googleapis.com
       metadata_name_override: inventory
@@ -2438,7 +2365,6 @@ libraries:
           - python-gapic-name=language
           - warehouse-package-name=google-cloud-language
       name_pretty_override: Natural Language
-      product_documentation_override: https://cloud.google.com/natural-language/docs/
       metadata_name_override: language
       default_version: v1
   - name: google-cloud-licensemanager
@@ -2453,7 +2379,6 @@ libraries:
           - python-gapic-name=licensemanager
           - warehouse-package-name=google-cloud-licensemanager
       name_pretty_override: License Manager API
-      product_documentation_override: https://cloud.google.com/compute/docs/instances/windows/ms-licensing
       default_version: v1
   - name: google-cloud-life-sciences
     version: 0.12.0
@@ -2480,7 +2405,6 @@ libraries:
           - python-gapic-name=locationfinder
           - warehouse-package-name=google-cloud-locationfinder
       name_pretty_override: Cloud Location Finder API
-      product_documentation_override: https://issuetracker.google.com/issues/new?component=1569265&template=1988535
       api_id_override: locationfinder.googleapis.com
       default_version: v1
   - name: google-cloud-logging
@@ -2496,7 +2420,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-logging
       name_pretty_override: Cloud Logging API
-      product_documentation_override: https://cloud.google.com/logging/docs
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559764
       metadata_name_override: logging
       default_version: v2
@@ -2530,7 +2453,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-maintenance-api
       name_pretty_override: Maintenance API
-      product_documentation_override: https://cloud.google.com/unified-maintenance/docs/overview
       api_shortname_override: api
       api_id_override: api.googleapis.com
       default_version: v1
@@ -2558,7 +2480,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=managedkafka
           - warehouse-package-name=google-cloud-managedkafka
-      product_documentation_override: https://cloud.google.com/managed-kafka
       default_version: v1
   - name: google-cloud-managedkafka-schemaregistry
     version: 0.4.0
@@ -2604,7 +2525,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=memcache
           - warehouse-package-name=google-cloud-memcache
-      product_documentation_override: https://cloud.google.com/memorystore/docs/memcached/
       metadata_name_override: memcache
       default_version: v1
   - name: google-cloud-memorystore
@@ -2623,7 +2543,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=memorystore
           - warehouse-package-name=google-cloud-memorystore
-      product_documentation_override: https://cloud.google.com/memorystore/docs/valkey
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-cloud-migrationcenter
@@ -2638,7 +2557,6 @@ libraries:
           - python-gapic-name=migrationcenter
           - warehouse-package-name=google-cloud-migrationcenter
       name_pretty_override: Migration Center API
-      product_documentation_override: https://cloud.google.com/migration-center/docs/migration-center-overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: migrationcenter
       default_version: v1
@@ -2659,7 +2577,6 @@ libraries:
           - python-gapic-name=modelarmor
           - warehouse-package-name=google-cloud-modelarmor
       name_pretty_override: Model Armor API
-      product_documentation_override: https://cloud.google.com/security-command-center/docs/model-armor-overview
       api_shortname_override: securitycenter
       api_id_override: securitycenter.googleapis.com
       default_version: v1
@@ -2730,7 +2647,6 @@ libraries:
           - python-gapic-name=netapp
           - warehouse-package-name=google-cloud-netapp
       name_pretty_override: NetApp API
-      product_documentation_override: https://cloud.google.com/netapp/volumes/docs/discover/overview
       metadata_name_override: netapp
       default_version: v1
   - name: google-cloud-network-connectivity
@@ -2790,7 +2706,6 @@ libraries:
           - warehouse-package-name=google-cloud-network-security
           - python-gapic-namespace=google.cloud
           - python-gapic-name=network_security
-      product_documentation_override: https://cloud.google.com/traffic-director/docs/reference/network-security/rest
       metadata_name_override: networksecurity
       default_version: v1
   - name: google-cloud-network-services
@@ -2803,7 +2718,6 @@ libraries:
           - python-gapic-name=network_services
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-network-services
-      product_documentation_override: https://cloud.google.com
       metadata_name_override: networkservices
       default_version: v1
   - name: google-cloud-notebooks
@@ -2831,7 +2745,6 @@ libraries:
           - python-gapic-name=notebooks
           - warehouse-package-name=google-cloud-notebooks
       name_pretty_override: AI Platform Notebooks
-      product_documentation_override: https://cloud.google.com/ai-platform/notebooks/
       metadata_name_override: notebooks
       default_version: v1
   - name: google-cloud-optimization
@@ -2892,7 +2805,6 @@ libraries:
           - python-gapic-name=orgpolicy
       proto_only_apis:
         - google/cloud/orgpolicy/v1
-      product_documentation_override: https://cloud.google.com/resource-manager/docs/organization-policy/overview
       metadata_name_override: orgpolicy
       default_version: v2
   - name: google-cloud-os-config
@@ -2911,7 +2823,6 @@ libraries:
           - warehouse-package-name=google-cloud-os-config
           - python-gapic-namespace=google.cloud
           - python-gapic-name=osconfig
-      product_documentation_override: https://cloud.google.com/compute/docs/manage-os
       metadata_name_override: osconfig
       default_version: v1
   - name: google-cloud-os-login
@@ -2928,7 +2839,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=oslogin
       name_pretty_override: Google Cloud OS Login
-      product_documentation_override: https://cloud.google.com/compute/docs/oslogin/
       metadata_name_override: oslogin
       default_version: v1
   - name: google-cloud-parallelstore
@@ -2948,7 +2858,6 @@ libraries:
           - python-gapic-name=parallelstore
           - warehouse-package-name=google-cloud-parallelstore
       name_pretty_override: Parallelstore API
-      product_documentation_override: https://cloud.google.com/parallelstore
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1beta
   - name: google-cloud-parametermanager
@@ -2963,7 +2872,6 @@ libraries:
           - python-gapic-name=parametermanager
           - warehouse-package-name=google-cloud-parametermanager
       name_pretty_override: Parameter Manager API
-      product_documentation_override: https://cloud.google.com/secret-manager/parameter-manager/docs/overview
       issue_tracker_override: https://issuetracker.google.com/issues/new?component=1442085&template=2002674
       default_version: v1
   - name: google-cloud-phishing-protection
@@ -2977,7 +2885,6 @@ libraries:
           - warehouse-package-name=google-cloud-phishing-protection
           - python-gapic-namespace=google.cloud
           - python-gapic-name=phishingprotection
-      product_documentation_override: https://cloud.google.com/phishing-protection/docs/
       metadata_name_override: phishingprotection
       default_version: v1beta1
   - name: google-cloud-policy-troubleshooter
@@ -2992,7 +2899,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=policytroubleshooter
       name_pretty_override: IAM Policy Troubleshooter API
-      product_documentation_override: https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/
       metadata_name_override: policytroubleshooter
       default_version: v1
   - name: google-cloud-policysimulator
@@ -3008,7 +2914,6 @@ libraries:
           - python-gapic-name=policysimulator
           - warehouse-package-name=google-cloud-policysimulator
       name_pretty_override: Policy Simulator API
-      product_documentation_override: https://cloud.google.com/policy-intelligence/docs/iam-simulator-overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: policysimulator
       default_version: v1
@@ -3023,7 +2928,6 @@ libraries:
           - python-gapic-name=policytroubleshooter_iam
           - warehouse-package-name=google-cloud-policytroubleshooter-iam
       name_pretty_override: Policy Troubleshooter API
-      product_documentation_override: https://cloud.google.com/policy-intelligence/docs/troubleshoot-access
       api_shortname_override: iam
       metadata_name_override: policytroubleshooter-iam
       default_version: v3
@@ -3073,7 +2977,6 @@ libraries:
           - python-gapic-name=privilegedaccessmanager
           - warehouse-package-name=google-cloud-privilegedaccessmanager
       name_pretty_override: Privileged Access Manager API
-      product_documentation_override: https://cloud.google.com/iam/docs/pam-overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-cloud-pubsub
@@ -3089,7 +2992,6 @@ libraries:
           - python-gapic-namespace=google
           - python-gapic-name=pubsub
       name_pretty_override: Google Cloud Pub/Sub
-      product_documentation_override: https://cloud.google.com/pubsub/docs/
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559741
       metadata_name_override: pubsub
       default_version: v1
@@ -3110,7 +3012,6 @@ libraries:
           - warehouse-package-name=google-cloud-quotas
           - python-gapic-name=cloudquotas
       name_pretty_override: Cloud Quotas API
-      product_documentation_override: https://cloud.google.com/docs/quota/api-overview
       metadata_name_override: google-cloud-cloudquotas
       default_version: v1
   - name: google-cloud-rapidmigrationassessment
@@ -3190,7 +3091,6 @@ libraries:
           - python-gapic-name=redis
           - warehouse-package-name=google-cloud-redis
       name_pretty_override: Cloud Redis
-      product_documentation_override: https://cloud.google.com/memorystore/docs/redis/
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5169231
       metadata_name_override: redis
       default_version: v1
@@ -3211,7 +3111,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-redis-cluster
       name_pretty_override: Google Cloud Memorystore for Redis API
-      product_documentation_override: https://cloud.google.com/redis/docs
       api_shortname_override: cluster
       api_id_override: cluster.googleapis.com
       default_version: v1
@@ -3251,7 +3150,6 @@ libraries:
           - python-gapic-name=retail
           - warehouse-package-name=google-cloud-retail
       name_pretty_override: Retail
-      product_documentation_override: https://cloud.google.com/retail/docs/
       metadata_name_override: retail
       default_version: v2
   - name: google-cloud-run
@@ -3273,7 +3171,6 @@ libraries:
     python:
       library_type: GAPIC_MANUAL
       name_pretty_override: Google Cloud Runtime Configurator
-      product_documentation_override: https://cloud.google.com/deployment-manager/runtime-configurator/
       api_shortname_override: runtimeconfig
       api_id_override: runtimeconfig.googleapis.com
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559663
@@ -3290,7 +3187,6 @@ libraries:
           - python-gapic-name=saasplatform_saasservicemgmt
           - warehouse-package-name=google-cloud-saasplatform-saasservicemgmt
       name_pretty_override: SaaS Runtime API
-      product_documentation_override: https://cloud.google.com/saas-runtime/docs/overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1beta1
   - name: google-cloud-scheduler
@@ -3346,7 +3242,6 @@ libraries:
           - python-gapic-name=securesourcemanager
           - warehouse-package-name=google-cloud-securesourcemanager
       name_pretty_override: Secure Source Manager API
-      product_documentation_override: https://cloud.google.com/secure-source-manager/docs/overview
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: securesourcemanager
       default_version: v1
@@ -3366,7 +3261,6 @@ libraries:
           - warehouse-package-name=google-cloud-public-ca
           - python-gapic-namespace=google.cloud.security
           - python-gapic-name=publicca
-      product_documentation_override: https://cloud.google.com/certificate-manager/docs/public-ca
       metadata_name_override: publicca
       default_version: v1
   - name: google-cloud-securitycenter
@@ -3396,7 +3290,6 @@ libraries:
           - python-gapic-name=securitycenter
           - warehouse-package-name=google-cloud-securitycenter
       name_pretty_override: Google Cloud Security Command Center
-      product_documentation_override: https://cloud.google.com/security-command-center
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559748
       metadata_name_override: securitycenter
       default_version: v1
@@ -3411,7 +3304,6 @@ libraries:
           - python-gapic-name=securitycentermanagement
           - warehouse-package-name=google-cloud-securitycentermanagement
       name_pretty_override: Security Center Management API
-      product_documentation_override: https://cloud.google.com/securitycentermanagement/docs/overview
       api_shortname_override: securitycenter
       api_id_override: securitycenter.googleapis.com
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -3432,7 +3324,6 @@ libraries:
           - python-gapic-name=servicecontrol
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-service-control
-      product_documentation_override: https://cloud.google.com/service-infrastructure/docs/overview/
       metadata_name_override: servicecontrol
       default_version: v1
   - name: google-cloud-service-directory
@@ -3464,7 +3355,6 @@ libraries:
           - python-gapic-name=servicemanagement
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-service-management
-      product_documentation_override: https://cloud.google.com/service-infrastructure/docs/overview/
       metadata_name_override: servicemanagement
       default_version: v1
   - name: google-cloud-service-usage
@@ -3492,7 +3382,6 @@ libraries:
           - python-gapic-name=servicehealth
           - warehouse-package-name=google-cloud-servicehealth
       name_pretty_override: Service Health API
-      product_documentation_override: https://cloud.google.com/service-health/docs/overview
       default_version: v1
   - name: google-cloud-shell
     version: 1.15.0
@@ -3521,7 +3410,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=source_context
       name_pretty_override: Source Context
-      product_documentation_override: https://cloud.google.com
       api_shortname_override: source
       api_id_override: source.googleapis.com
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -3561,7 +3449,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=spanner
           - warehouse-package-name=google-cloud-spanner
-      product_documentation_override: https://cloud.google.com/spanner/docs/
       issue_tracker_override: https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open
       metadata_name_override: spanner
       default_version: v1
@@ -3588,7 +3475,6 @@ libraries:
           - python-gapic-name=speech
           - warehouse-package-name=google-cloud-speech
       name_pretty_override: Cloud Speech
-      product_documentation_override: https://cloud.google.com/speech-to-text/docs/
       metadata_name_override: speech
       default_version: v1
   - name: google-cloud-storage
@@ -3604,7 +3490,6 @@ libraries:
           - python-gapic-name=_storage
           - warehouse-package-name=google-cloud-storage
       name_pretty_override: Google Cloud Storage
-      product_documentation_override: https://cloud.google.com/storage
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559782
       metadata_name_override: storage
       default_version: v2
@@ -3620,7 +3505,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-storage-control
       name_pretty_override: Storage Control API
-      product_documentation_override: https://cloud.google.com/storage/docs/reference/rpc/google.storage.control.v2
       default_version: v2
   - name: google-cloud-storage-transfer
     version: 1.20.0
@@ -3648,7 +3532,6 @@ libraries:
           - python-gapic-name=storagebatchoperations
           - warehouse-package-name=google-cloud-storagebatchoperations
       name_pretty_override: Storage Batch Operations API
-      product_documentation_override: https://cloud.google.com/storage/docs/batch-operations/overview
       default_version: v1
   - name: google-cloud-storageinsights
     version: 0.4.0
@@ -3662,7 +3545,6 @@ libraries:
           - python-gapic-name=storageinsights
           - warehouse-package-name=google-cloud-storageinsights
       name_pretty_override: Storage Insights API
-      product_documentation_override: https://cloud.google.com/storage/docs/insights/storage-insights
       metadata_name_override: storageinsights
       default_version: v1
   - name: google-cloud-support
@@ -3682,7 +3564,6 @@ libraries:
           - python-gapic-name=support
           - warehouse-package-name=google-cloud-support
       name_pretty_override: Google Cloud Support API
-      product_documentation_override: https://cloud.google.com/support/docs/reference/support-api
       api_shortname_override: support
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: support
@@ -3727,7 +3608,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=tasks
           - warehouse-package-name=google-cloud-tasks
-      product_documentation_override: https://cloud.google.com/tasks/docs/
       metadata_name_override: cloudtasks
       default_version: v2
   - name: google-cloud-telcoautomation
@@ -3836,7 +3716,6 @@ libraries:
           - python-gapic-name=translate
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-translate
-      product_documentation_override: https://cloud.google.com/translate/docs/
       metadata_name_override: translate
       default_version: v3
   - name: google-cloud-vectorsearch
@@ -3865,7 +3744,6 @@ libraries:
           - python-gapic-name=vectorsearch
           - warehouse-package-name=google-cloud-vectorsearch
       name_pretty_override: Vector Search API
-      product_documentation_override: https://docs.cloud.google.com/vertex-ai/docs/vector-search-2/overview
       default_version: v1
   - name: google-cloud-video-live-stream
     version: 1.16.0
@@ -3943,7 +3821,6 @@ libraries:
           - python-gapic-name=videointelligence
           - warehouse-package-name=google-cloud-videointelligence
       name_pretty_override: Video Intelligence
-      product_documentation_override: https://cloud.google.com/video-intelligence/docs/
       metadata_name_override: videointelligence
       default_version: v1
   - name: google-cloud-vision
@@ -3978,7 +3855,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=vision
           - warehouse-package-name=google-cloud-vision
-      product_documentation_override: https://cloud.google.com/vision/docs/
       metadata_name_override: vision
       default_version: v1
   - name: google-cloud-visionai
@@ -4058,7 +3934,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=webrisk
           - warehouse-package-name=google-cloud-webrisk
-      product_documentation_override: https://cloud.google.com/web-risk/docs/
       metadata_name_override: webrisk
       default_version: v1
   - name: google-cloud-websecurityscanner
@@ -4083,7 +3958,6 @@ libraries:
           - python-gapic-name=websecurityscanner
           - warehouse-package-name=google-cloud-websecurityscanner
       name_pretty_override: Cloud Security Scanner
-      product_documentation_override: https://cloud.google.com/security-scanner/docs/
       api_shortname_override: securitycenter
       api_id_override: securitycenter.googleapis.com
       metadata_name_override: websecurityscanner
@@ -4152,7 +4026,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=workstations
           - warehouse-package-name=google-cloud-workstations
-      product_documentation_override: https://cloud.google.com/workstations/
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: workstations
       default_version: v1
@@ -4178,7 +4051,6 @@ libraries:
           - python-gapic-name=type
           - warehouse-package-name=google-geo-type
       name_pretty_override: Geo Type Protos
-      product_documentation_override: https://mapsplatform.google.com/maps-products
       api_id_override: type.googleapis.com
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: geotype
@@ -4277,7 +4149,6 @@ libraries:
           - python-gapic-name=mapsplatformdatasets
           - warehouse-package-name=google-maps-mapsplatformdatasets
       name_pretty_override: Maps Platform Datasets API
-      product_documentation_override: https://developers.google.com/maps
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: mapsplatformdatasets
       default_version: v1
@@ -4689,7 +4560,6 @@ libraries:
           - python-gapic-name=type
           - warehouse-package-name=google-shopping-type
       name_pretty_override: Shopping Type Protos
-      product_documentation_override: https://developers.google.com/merchant/api
       api_shortname_override: type
       api_id_override: type.googleapis.com
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
@@ -4715,7 +4585,6 @@ libraries:
         - google/logging/type
         - google/rpc/context
       name_pretty_override: Google APIs Common Protos
-      product_documentation_override: https://github.com/googleapis/googleapis/tree/master/google
       client_documentation_override: https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos
       issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: apiVersion
@@ -4741,7 +4610,6 @@ libraries:
       proto_only_apis:
         - google/iam/v1
       name_pretty_override: Cloud Identity and Access Management
-      product_documentation_override: https://cloud.google.com/iam/docs/
       api_shortname_override: iam
       api_id_override: iam.googleapis.com
       client_documentation_override: https://cloud.google.com/python/docs/reference/grpc-iam/latest
@@ -4752,7 +4620,6 @@ libraries:
     python:
       library_type: INTEGRATION
       name_pretty_override: Google BigQuery connector for pandas
-      product_documentation_override: https://cloud.google.com/bigquery
       api_id_override: bigquery.googleapis.com
       client_documentation_override: https://googleapis.dev/python/pandas-gbq/latest/
       issue_tracker_override: https://github.com/googleapis/python-bigquery-pandas/issues
@@ -4776,7 +4643,6 @@ libraries:
     python:
       library_type: INTEGRATION
       name_pretty_override: Spanner dialect for SQLAlchemy
-      product_documentation_override: https://cloud.google.com/spanner/docs
       api_shortname_override: sqlalchemy-spanner
       client_documentation_override: https://github.com/googleapis/python-spanner-sqlalchemy
       issue_tracker_override: https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open

--- a/packages/bigframes/.repo-metadata.json
+++ b/packages/bigframes/.repo-metadata.json
@@ -8,7 +8,6 @@
     "library_type": "INTEGRATION",
     "name": "bigframes",
     "name_pretty": "A unified Python API in BigQuery",
-    "product_documentation": "https://cloud.google.com/bigquery",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/bigquery-magics/.repo-metadata.json
+++ b/packages/bigquery-magics/.repo-metadata.json
@@ -7,7 +7,6 @@
     "library_type": "INTEGRATION",
     "name": "bigquery-magics",
     "name_pretty": "Google BigQuery connector for Jupyter and IPython",
-    "product_documentation": "https://cloud.google.com/bigquery",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/db-dtypes/.repo-metadata.json
+++ b/packages/db-dtypes/.repo-metadata.json
@@ -6,7 +6,6 @@
     "library_type": "INTEGRATION",
     "name": "db-dtypes",
     "name_pretty": "Pandas Data Types for SQL systems (BigQuery, Spanner)",
-    "product_documentation": "https://pandas.pydata.org/pandas-docs/stable/ecosystem.html#ecosystem-extensions",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/gcp-sphinx-docfx-yaml/.repo-metadata.json
+++ b/packages/gcp-sphinx-docfx-yaml/.repo-metadata.json
@@ -6,7 +6,6 @@
     "library_type": "OTHER",
     "name": "gcp-sphinx-docfx-yaml",
     "name_pretty": "Sphinx DocFX YAML Generator",
-    "product_documentation": "https://github.com/googleapis/sphinx-docfx-yaml",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-apps-chat/.repo-metadata.json
+++ b/packages/google-apps-chat/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-apps-chat",
     "name_pretty": "Chat API",
-    "product_documentation": "https://developers.google.com/chat/",
+    "product_documentation": "https://developers.google.com/chat/concepts",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-apps-chat/README.rst
+++ b/packages/google-apps-chat/README.rst
@@ -16,9 +16,9 @@ messages.
    :target: https://pypi.org/project/google-apps-chat/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-apps-chat.svg
    :target: https://pypi.org/project/google-apps-chat/
-.. _Chat API: https://developers.google.com/chat/
+.. _Chat API: https://developers.google.com/chat/concepts
 .. _Client Library Documentation: https://googleapis.dev/python/google-apps-chat/latest
-.. _Product Documentation:  https://developers.google.com/chat/
+.. _Product Documentation:  https://developers.google.com/chat/concepts
 
 Quick Start
 -----------
@@ -32,7 +32,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Chat API.:  https://developers.google.com/chat/
+.. _Enable the Chat API.:  https://developers.google.com/chat/concepts
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -106,7 +106,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Chat API Product documentation:  https://developers.google.com/chat/
+.. _Chat API Product documentation:  https://developers.google.com/chat/concepts
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-apps-chat/docs/README.rst
+++ b/packages/google-apps-chat/docs/README.rst
@@ -16,9 +16,9 @@ messages.
    :target: https://pypi.org/project/google-apps-chat/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-apps-chat.svg
    :target: https://pypi.org/project/google-apps-chat/
-.. _Chat API: https://developers.google.com/chat/
+.. _Chat API: https://developers.google.com/chat/concepts
 .. _Client Library Documentation: https://googleapis.dev/python/google-apps-chat/latest
-.. _Product Documentation:  https://developers.google.com/chat/
+.. _Product Documentation:  https://developers.google.com/chat/concepts
 
 Quick Start
 -----------
@@ -32,7 +32,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Chat API.:  https://developers.google.com/chat/
+.. _Enable the Chat API.:  https://developers.google.com/chat/concepts
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -106,7 +106,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Chat API Product documentation:  https://developers.google.com/chat/
+.. _Chat API Product documentation:  https://developers.google.com/chat/concepts
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-access-approval/.repo-metadata.json
+++ b/packages/google-cloud-access-approval/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "accessapproval",
     "name_pretty": "Access Approval",
-    "product_documentation": "https://cloud.google.com/access-approval",
+    "product_documentation": "https://cloud.google.com/access-approval/docs",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-access-approval/README.rst
+++ b/packages/google-cloud-access-approval/README.rst
@@ -14,9 +14,9 @@ Python Client for Access Approval
    :target: https://pypi.org/project/google-cloud-access-approval/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-access-approval.svg
    :target: https://pypi.org/project/google-cloud-access-approval/
-.. _Access Approval: https://cloud.google.com/access-approval
+.. _Access Approval: https://cloud.google.com/access-approval/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/accessapproval/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/access-approval
+.. _Product Documentation:  https://cloud.google.com/access-approval/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Access Approval.:  https://cloud.google.com/access-approval
+.. _Enable the Access Approval.:  https://cloud.google.com/access-approval/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Access Approval Product documentation:  https://cloud.google.com/access-approval
+.. _Access Approval Product documentation:  https://cloud.google.com/access-approval/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-access-approval/docs/README.rst
+++ b/packages/google-cloud-access-approval/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Access Approval
    :target: https://pypi.org/project/google-cloud-access-approval/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-access-approval.svg
    :target: https://pypi.org/project/google-cloud-access-approval/
-.. _Access Approval: https://cloud.google.com/access-approval
+.. _Access Approval: https://cloud.google.com/access-approval/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/accessapproval/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/access-approval
+.. _Product Documentation:  https://cloud.google.com/access-approval/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Access Approval.:  https://cloud.google.com/access-approval
+.. _Enable the Access Approval.:  https://cloud.google.com/access-approval/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Access Approval Product documentation:  https://cloud.google.com/access-approval
+.. _Access Approval Product documentation:  https://cloud.google.com/access-approval/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-access-context-manager/.repo-metadata.json
+++ b/packages/google-cloud-access-context-manager/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "accesscontextmanager",
     "name_pretty": "Access Context Manager",
-    "product_documentation": "https://cloud.google.com/access-context-manager/docs/overview",
+    "product_documentation": "https://cloud.google.com/access-context-manager/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-access-context-manager/README.rst
+++ b/packages/google-cloud-access-context-manager/README.rst
@@ -15,9 +15,9 @@ services.
    :target: https://pypi.org/project/google-cloud-access-context-manager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-access-context-manager.svg
    :target: https://pypi.org/project/google-cloud-access-context-manager/
-.. _Access Context Manager: https://cloud.google.com/access-context-manager/docs/overview
+.. _Access Context Manager: https://cloud.google.com/access-context-manager/
 .. _Client Library Documentation: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-access-context-manager
-.. _Product Documentation:  https://cloud.google.com/access-context-manager/docs/overview
+.. _Product Documentation:  https://cloud.google.com/access-context-manager/
 
 Quick Start
 -----------
@@ -31,7 +31,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Access Context Manager.:  https://cloud.google.com/access-context-manager/docs/overview
+.. _Enable the Access Context Manager.:  https://cloud.google.com/access-context-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -105,7 +105,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Access Context Manager Product documentation:  https://cloud.google.com/access-context-manager/docs/overview
+.. _Access Context Manager Product documentation:  https://cloud.google.com/access-context-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-access-context-manager/docs/README.rst
+++ b/packages/google-cloud-access-context-manager/docs/README.rst
@@ -15,9 +15,9 @@ services.
    :target: https://pypi.org/project/google-cloud-access-context-manager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-access-context-manager.svg
    :target: https://pypi.org/project/google-cloud-access-context-manager/
-.. _Access Context Manager: https://cloud.google.com/access-context-manager/docs/overview
+.. _Access Context Manager: https://cloud.google.com/access-context-manager/
 .. _Client Library Documentation: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-access-context-manager
-.. _Product Documentation:  https://cloud.google.com/access-context-manager/docs/overview
+.. _Product Documentation:  https://cloud.google.com/access-context-manager/
 
 Quick Start
 -----------
@@ -31,7 +31,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Access Context Manager.:  https://cloud.google.com/access-context-manager/docs/overview
+.. _Enable the Access Context Manager.:  https://cloud.google.com/access-context-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -105,7 +105,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Access Context Manager Product documentation:  https://cloud.google.com/access-context-manager/docs/overview
+.. _Access Context Manager Product documentation:  https://cloud.google.com/access-context-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-alloydb/.repo-metadata.json
+++ b/packages/google-cloud-alloydb/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "alloydb",
     "name_pretty": "AlloyDB",
-    "product_documentation": "https://cloud.google.com/alloydb/",
+    "product_documentation": "https://cloud.google.com/alloydb/docs",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-alloydb/README.rst
+++ b/packages/google-cloud-alloydb/README.rst
@@ -24,9 +24,9 @@ application changes; and modernize legacy proprietary databases.
    :target: https://pypi.org/project/google-cloud-alloydb/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-alloydb.svg
    :target: https://pypi.org/project/google-cloud-alloydb/
-.. _AlloyDB: https://cloud.google.com/alloydb/
+.. _AlloyDB: https://cloud.google.com/alloydb/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/alloydb/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/alloydb/
+.. _Product Documentation:  https://cloud.google.com/alloydb/docs
 
 Quick Start
 -----------
@@ -40,7 +40,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the AlloyDB.:  https://cloud.google.com/alloydb/
+.. _Enable the AlloyDB.:  https://cloud.google.com/alloydb/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -114,7 +114,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _AlloyDB Product documentation:  https://cloud.google.com/alloydb/
+.. _AlloyDB Product documentation:  https://cloud.google.com/alloydb/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-alloydb/docs/README.rst
+++ b/packages/google-cloud-alloydb/docs/README.rst
@@ -24,9 +24,9 @@ application changes; and modernize legacy proprietary databases.
    :target: https://pypi.org/project/google-cloud-alloydb/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-alloydb.svg
    :target: https://pypi.org/project/google-cloud-alloydb/
-.. _AlloyDB: https://cloud.google.com/alloydb/
+.. _AlloyDB: https://cloud.google.com/alloydb/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/alloydb/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/alloydb/
+.. _Product Documentation:  https://cloud.google.com/alloydb/docs
 
 Quick Start
 -----------
@@ -40,7 +40,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the AlloyDB.:  https://cloud.google.com/alloydb/
+.. _Enable the AlloyDB.:  https://cloud.google.com/alloydb/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -114,7 +114,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _AlloyDB Product documentation:  https://cloud.google.com/alloydb/
+.. _AlloyDB Product documentation:  https://cloud.google.com/alloydb/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-apigee-connect/.repo-metadata.json
+++ b/packages/google-cloud-apigee-connect/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "apigeeconnect",
     "name_pretty": "Apigee Connect",
-    "product_documentation": "https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect",
+    "product_documentation": "https://cloud.google.com/apigee/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-apigee-connect/README.rst
+++ b/packages/google-cloud-apigee-connect/README.rst
@@ -14,9 +14,9 @@ Python Client for Apigee Connect
    :target: https://pypi.org/project/google-cloud-apigee-connect/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-apigee-connect.svg
    :target: https://pypi.org/project/google-cloud-apigee-connect/
-.. _Apigee Connect: https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect
+.. _Apigee Connect: https://cloud.google.com/apigee/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/apigeeconnect/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect
+.. _Product Documentation:  https://cloud.google.com/apigee/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Apigee Connect.:  https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect
+.. _Enable the Apigee Connect.:  https://cloud.google.com/apigee/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Apigee Connect Product documentation:  https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect
+.. _Apigee Connect Product documentation:  https://cloud.google.com/apigee/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-apigee-connect/docs/README.rst
+++ b/packages/google-cloud-apigee-connect/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Apigee Connect
    :target: https://pypi.org/project/google-cloud-apigee-connect/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-apigee-connect.svg
    :target: https://pypi.org/project/google-cloud-apigee-connect/
-.. _Apigee Connect: https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect
+.. _Apigee Connect: https://cloud.google.com/apigee/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/apigeeconnect/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect
+.. _Product Documentation:  https://cloud.google.com/apigee/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Apigee Connect.:  https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect
+.. _Enable the Apigee Connect.:  https://cloud.google.com/apigee/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Apigee Connect Product documentation:  https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect
+.. _Apigee Connect Product documentation:  https://cloud.google.com/apigee/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-apigee-registry/.repo-metadata.json
+++ b/packages/google-cloud-apigee-registry/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "apigeeregistry",
     "name_pretty": "Apigee Registry API",
-    "product_documentation": "https://cloud.google.com/apigee/docs/api-hub/get-started-registry-api",
+    "product_documentation": "https://cloud.google.com/apigee/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-apigee-registry/README.rst
+++ b/packages/google-cloud-apigee-registry/README.rst
@@ -14,9 +14,9 @@ Python Client for Apigee Registry API
    :target: https://pypi.org/project/google-cloud-apigee-registry/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-apigee-registry.svg
    :target: https://pypi.org/project/google-cloud-apigee-registry/
-.. _Apigee Registry API: https://cloud.google.com/apigee/docs/api-hub/get-started-registry-api
+.. _Apigee Registry API: https://cloud.google.com/apigee/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/apigeeregistry/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/apigee/docs/api-hub/get-started-registry-api
+.. _Product Documentation:  https://cloud.google.com/apigee/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Apigee Registry API.:  https://cloud.google.com/apigee/docs/api-hub/get-started-registry-api
+.. _Enable the Apigee Registry API.:  https://cloud.google.com/apigee/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Apigee Registry API Product documentation:  https://cloud.google.com/apigee/docs/api-hub/get-started-registry-api
+.. _Apigee Registry API Product documentation:  https://cloud.google.com/apigee/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-apigee-registry/docs/README.rst
+++ b/packages/google-cloud-apigee-registry/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Apigee Registry API
    :target: https://pypi.org/project/google-cloud-apigee-registry/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-apigee-registry.svg
    :target: https://pypi.org/project/google-cloud-apigee-registry/
-.. _Apigee Registry API: https://cloud.google.com/apigee/docs/api-hub/get-started-registry-api
+.. _Apigee Registry API: https://cloud.google.com/apigee/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/apigeeregistry/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/apigee/docs/api-hub/get-started-registry-api
+.. _Product Documentation:  https://cloud.google.com/apigee/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Apigee Registry API.:  https://cloud.google.com/apigee/docs/api-hub/get-started-registry-api
+.. _Enable the Apigee Registry API.:  https://cloud.google.com/apigee/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Apigee Registry API Product documentation:  https://cloud.google.com/apigee/docs/api-hub/get-started-registry-api
+.. _Apigee Registry API Product documentation:  https://cloud.google.com/apigee/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-apihub/.repo-metadata.json
+++ b/packages/google-cloud-apihub/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-apihub",
     "name_pretty": "API Hub API",
-    "product_documentation": "https://cloud.google.com/apigee/docs/apihub/what-is-api-hub",
+    "product_documentation": "https://cloud.google.com/apigee/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-apihub/README.rst
+++ b/packages/google-cloud-apihub/README.rst
@@ -14,9 +14,9 @@ Python Client for API Hub API
    :target: https://pypi.org/project/google-cloud-apihub/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-apihub.svg
    :target: https://pypi.org/project/google-cloud-apihub/
-.. _API Hub API: https://cloud.google.com/apigee/docs/apihub/what-is-api-hub
+.. _API Hub API: https://cloud.google.com/apigee/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-apihub/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/apigee/docs/apihub/what-is-api-hub
+.. _Product Documentation:  https://cloud.google.com/apigee/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the API Hub API.:  https://cloud.google.com/apigee/docs/apihub/what-is-api-hub
+.. _Enable the API Hub API.:  https://cloud.google.com/apigee/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _API Hub API Product documentation:  https://cloud.google.com/apigee/docs/apihub/what-is-api-hub
+.. _API Hub API Product documentation:  https://cloud.google.com/apigee/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-apihub/docs/README.rst
+++ b/packages/google-cloud-apihub/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for API Hub API
    :target: https://pypi.org/project/google-cloud-apihub/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-apihub.svg
    :target: https://pypi.org/project/google-cloud-apihub/
-.. _API Hub API: https://cloud.google.com/apigee/docs/apihub/what-is-api-hub
+.. _API Hub API: https://cloud.google.com/apigee/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-apihub/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/apigee/docs/apihub/what-is-api-hub
+.. _Product Documentation:  https://cloud.google.com/apigee/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the API Hub API.:  https://cloud.google.com/apigee/docs/apihub/what-is-api-hub
+.. _Enable the API Hub API.:  https://cloud.google.com/apigee/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _API Hub API Product documentation:  https://cloud.google.com/apigee/docs/apihub/what-is-api-hub
+.. _API Hub API Product documentation:  https://cloud.google.com/apigee/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-apiregistry/.repo-metadata.json
+++ b/packages/google-cloud-apiregistry/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-apiregistry",
     "name_pretty": "Cloud API Registry API",
-    "product_documentation": "https://docs.cloud.google.com/api-registry/docs/overview",
+    "product_documentation": "https://docs.cloud.google.com/api-registry/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-apiregistry/README.rst
+++ b/packages/google-cloud-apiregistry/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud API Registry API
    :target: https://pypi.org/project/google-cloud-apiregistry/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-apiregistry.svg
    :target: https://pypi.org/project/google-cloud-apiregistry/
-.. _Cloud API Registry API: https://docs.cloud.google.com/api-registry/docs/overview
+.. _Cloud API Registry API: https://docs.cloud.google.com/api-registry/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-apiregistry/latest/summary_overview
-.. _Product Documentation:  https://docs.cloud.google.com/api-registry/docs/overview
+.. _Product Documentation:  https://docs.cloud.google.com/api-registry/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud API Registry API.:  https://docs.cloud.google.com/api-registry/docs/overview
+.. _Enable the Cloud API Registry API.:  https://docs.cloud.google.com/api-registry/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud API Registry API Product documentation:  https://docs.cloud.google.com/api-registry/docs/overview
+.. _Cloud API Registry API Product documentation:  https://docs.cloud.google.com/api-registry/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-apiregistry/docs/README.rst
+++ b/packages/google-cloud-apiregistry/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud API Registry API
    :target: https://pypi.org/project/google-cloud-apiregistry/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-apiregistry.svg
    :target: https://pypi.org/project/google-cloud-apiregistry/
-.. _Cloud API Registry API: https://docs.cloud.google.com/api-registry/docs/overview
+.. _Cloud API Registry API: https://docs.cloud.google.com/api-registry/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-apiregistry/latest/summary_overview
-.. _Product Documentation:  https://docs.cloud.google.com/api-registry/docs/overview
+.. _Product Documentation:  https://docs.cloud.google.com/api-registry/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud API Registry API.:  https://docs.cloud.google.com/api-registry/docs/overview
+.. _Enable the Cloud API Registry API.:  https://docs.cloud.google.com/api-registry/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud API Registry API Product documentation:  https://docs.cloud.google.com/api-registry/docs/overview
+.. _Cloud API Registry API Product documentation:  https://docs.cloud.google.com/api-registry/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-appengine-admin/.repo-metadata.json
+++ b/packages/google-cloud-appengine-admin/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "appengine",
     "name_pretty": "App Engine Admin",
-    "product_documentation": "https://cloud.google.com/appengine/docs/admin-api/",
+    "product_documentation": "https://cloud.google.com/appengine/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-appengine-admin/README.rst
+++ b/packages/google-cloud-appengine-admin/README.rst
@@ -14,9 +14,9 @@ Python Client for App Engine Admin
    :target: https://pypi.org/project/google-cloud-appengine-admin/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-appengine-admin.svg
    :target: https://pypi.org/project/google-cloud-appengine-admin/
-.. _App Engine Admin: https://cloud.google.com/appengine/docs/admin-api/
+.. _App Engine Admin: https://cloud.google.com/appengine/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/appengine/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/appengine/docs/admin-api/
+.. _Product Documentation:  https://cloud.google.com/appengine/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the App Engine Admin.:  https://cloud.google.com/appengine/docs/admin-api/
+.. _Enable the App Engine Admin.:  https://cloud.google.com/appengine/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _App Engine Admin Product documentation:  https://cloud.google.com/appengine/docs/admin-api/
+.. _App Engine Admin Product documentation:  https://cloud.google.com/appengine/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-appengine-admin/docs/README.rst
+++ b/packages/google-cloud-appengine-admin/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for App Engine Admin
    :target: https://pypi.org/project/google-cloud-appengine-admin/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-appengine-admin.svg
    :target: https://pypi.org/project/google-cloud-appengine-admin/
-.. _App Engine Admin: https://cloud.google.com/appengine/docs/admin-api/
+.. _App Engine Admin: https://cloud.google.com/appengine/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/appengine/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/appengine/docs/admin-api/
+.. _Product Documentation:  https://cloud.google.com/appengine/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the App Engine Admin.:  https://cloud.google.com/appengine/docs/admin-api/
+.. _Enable the App Engine Admin.:  https://cloud.google.com/appengine/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _App Engine Admin Product documentation:  https://cloud.google.com/appengine/docs/admin-api/
+.. _App Engine Admin Product documentation:  https://cloud.google.com/appengine/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-appengine-logging/.repo-metadata.json
+++ b/packages/google-cloud-appengine-logging/.repo-metadata.json
@@ -7,7 +7,7 @@
     "library_type": "OTHER",
     "name": "appenginelogging",
     "name_pretty": "App Engine Logging Protos",
-    "product_documentation": "https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1",
+    "product_documentation": "https://cloud.google.com/logging/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-appengine-logging/README.rst
+++ b/packages/google-cloud-appengine-logging/README.rst
@@ -14,9 +14,9 @@ Python Client for App Engine Logging Protos
    :target: https://pypi.org/project/google-cloud-appengine-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-appengine-logging.svg
    :target: https://pypi.org/project/google-cloud-appengine-logging/
-.. _App Engine Logging Protos: https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1
+.. _App Engine Logging Protos: https://cloud.google.com/logging/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/appenginelogging/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1
+.. _Product Documentation:  https://cloud.google.com/logging/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the App Engine Logging Protos.:  https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1
+.. _Enable the App Engine Logging Protos.:  https://cloud.google.com/logging/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _App Engine Logging Protos Product documentation:  https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1
+.. _App Engine Logging Protos Product documentation:  https://cloud.google.com/logging/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-appengine-logging/docs/README.rst
+++ b/packages/google-cloud-appengine-logging/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for App Engine Logging Protos
    :target: https://pypi.org/project/google-cloud-appengine-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-appengine-logging.svg
    :target: https://pypi.org/project/google-cloud-appengine-logging/
-.. _App Engine Logging Protos: https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1
+.. _App Engine Logging Protos: https://cloud.google.com/logging/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/appenginelogging/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1
+.. _Product Documentation:  https://cloud.google.com/logging/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the App Engine Logging Protos.:  https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1
+.. _Enable the App Engine Logging Protos.:  https://cloud.google.com/logging/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _App Engine Logging Protos Product documentation:  https://cloud.google.com/logging/docs/reference/v2/rpc/google.appengine.logging.v1
+.. _App Engine Logging Protos Product documentation:  https://cloud.google.com/logging/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-apphub/.repo-metadata.json
+++ b/packages/google-cloud-apphub/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-apphub",
     "name_pretty": "App Hub API",
-    "product_documentation": "https://cloud.google.com/app-hub/docs/overview",
+    "product_documentation": "https://cloud.google.com/app-hub/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-apphub/README.rst
+++ b/packages/google-cloud-apphub/README.rst
@@ -14,9 +14,9 @@ Python Client for App Hub API
    :target: https://pypi.org/project/google-cloud-apphub/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-apphub.svg
    :target: https://pypi.org/project/google-cloud-apphub/
-.. _App Hub API: https://cloud.google.com/app-hub/docs/overview
+.. _App Hub API: https://cloud.google.com/app-hub/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-apphub/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/app-hub/docs/overview
+.. _Product Documentation:  https://cloud.google.com/app-hub/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the App Hub API.:  https://cloud.google.com/app-hub/docs/overview
+.. _Enable the App Hub API.:  https://cloud.google.com/app-hub/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _App Hub API Product documentation:  https://cloud.google.com/app-hub/docs/overview
+.. _App Hub API Product documentation:  https://cloud.google.com/app-hub/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-apphub/docs/README.rst
+++ b/packages/google-cloud-apphub/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for App Hub API
    :target: https://pypi.org/project/google-cloud-apphub/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-apphub.svg
    :target: https://pypi.org/project/google-cloud-apphub/
-.. _App Hub API: https://cloud.google.com/app-hub/docs/overview
+.. _App Hub API: https://cloud.google.com/app-hub/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-apphub/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/app-hub/docs/overview
+.. _Product Documentation:  https://cloud.google.com/app-hub/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the App Hub API.:  https://cloud.google.com/app-hub/docs/overview
+.. _Enable the App Hub API.:  https://cloud.google.com/app-hub/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _App Hub API Product documentation:  https://cloud.google.com/app-hub/docs/overview
+.. _App Hub API Product documentation:  https://cloud.google.com/app-hub/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-asset/.repo-metadata.json
+++ b/packages/google-cloud-asset/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "cloudasset",
     "name_pretty": "Cloud Asset Inventory",
-    "product_documentation": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
+    "product_documentation": "https://cloud.google.com/resource-manager/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-asset/README.rst
+++ b/packages/google-cloud-asset/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Asset Inventory
    :target: https://pypi.org/project/google-cloud-asset/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-asset.svg
    :target: https://pypi.org/project/google-cloud-asset/
-.. _Cloud Asset Inventory: https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
+.. _Cloud Asset Inventory: https://cloud.google.com/resource-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudasset/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
+.. _Product Documentation:  https://cloud.google.com/resource-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Asset Inventory.:  https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
+.. _Enable the Cloud Asset Inventory.:  https://cloud.google.com/resource-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Asset Inventory Product documentation:  https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
+.. _Cloud Asset Inventory Product documentation:  https://cloud.google.com/resource-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-asset/docs/README.rst
+++ b/packages/google-cloud-asset/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Asset Inventory
    :target: https://pypi.org/project/google-cloud-asset/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-asset.svg
    :target: https://pypi.org/project/google-cloud-asset/
-.. _Cloud Asset Inventory: https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
+.. _Cloud Asset Inventory: https://cloud.google.com/resource-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudasset/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
+.. _Product Documentation:  https://cloud.google.com/resource-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Asset Inventory.:  https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
+.. _Enable the Cloud Asset Inventory.:  https://cloud.google.com/resource-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Asset Inventory Product documentation:  https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
+.. _Cloud Asset Inventory Product documentation:  https://cloud.google.com/resource-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-audit-log/.repo-metadata.json
+++ b/packages/google-cloud-audit-log/.repo-metadata.json
@@ -8,7 +8,7 @@
     "library_type": "OTHER",
     "name": "auditlog",
     "name_pretty": "Audit Log API",
-    "product_documentation": "https://cloud.google.com/logging/docs/audit",
+    "product_documentation": "https://cloud.google.com/logging/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-audit-log/README.rst
+++ b/packages/google-cloud-audit-log/README.rst
@@ -14,9 +14,9 @@ Python Client for Audit Log API
    :target: https://pypi.org/project/google-cloud-audit-log/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-audit-log.svg
    :target: https://pypi.org/project/google-cloud-audit-log/
-.. _Audit Log API: https://cloud.google.com/logging/docs/audit
+.. _Audit Log API: https://cloud.google.com/logging/
 .. _Client Library Documentation: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-audit-log/summary_overview
-.. _Product Documentation:  https://cloud.google.com/logging/docs/audit
+.. _Product Documentation:  https://cloud.google.com/logging/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Audit Log API.:  https://cloud.google.com/logging/docs/audit
+.. _Enable the Audit Log API.:  https://cloud.google.com/logging/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Audit Log API Product documentation:  https://cloud.google.com/logging/docs/audit
+.. _Audit Log API Product documentation:  https://cloud.google.com/logging/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-audit-log/docs/README.rst
+++ b/packages/google-cloud-audit-log/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Audit Log API
    :target: https://pypi.org/project/google-cloud-audit-log/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-audit-log.svg
    :target: https://pypi.org/project/google-cloud-audit-log/
-.. _Audit Log API: https://cloud.google.com/logging/docs/audit
+.. _Audit Log API: https://cloud.google.com/logging/
 .. _Client Library Documentation: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-audit-log/summary_overview
-.. _Product Documentation:  https://cloud.google.com/logging/docs/audit
+.. _Product Documentation:  https://cloud.google.com/logging/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Audit Log API.:  https://cloud.google.com/logging/docs/audit
+.. _Enable the Audit Log API.:  https://cloud.google.com/logging/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Audit Log API Product documentation:  https://cloud.google.com/logging/docs/audit
+.. _Audit Log API Product documentation:  https://cloud.google.com/logging/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-automl/.repo-metadata.json
+++ b/packages/google-cloud-automl/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_COMBO",
     "name": "automl",
     "name_pretty": "Cloud AutoML",
-    "product_documentation": "https://cloud.google.com/automl/docs/",
+    "product_documentation": "https://cloud.google.com/automl/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-automl/README.rst
+++ b/packages/google-cloud-automl/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud AutoML
    :target: https://pypi.org/project/google-cloud-automl/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-automl.svg
    :target: https://pypi.org/project/google-cloud-automl/
-.. _Cloud AutoML: https://cloud.google.com/automl/docs/
+.. _Cloud AutoML: https://cloud.google.com/automl/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/automl/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/automl/docs/
+.. _Product Documentation:  https://cloud.google.com/automl/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud AutoML.:  https://cloud.google.com/automl/docs/
+.. _Enable the Cloud AutoML.:  https://cloud.google.com/automl/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud AutoML Product documentation:  https://cloud.google.com/automl/docs/
+.. _Cloud AutoML Product documentation:  https://cloud.google.com/automl/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-automl/docs/README.rst
+++ b/packages/google-cloud-automl/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud AutoML
    :target: https://pypi.org/project/google-cloud-automl/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-automl.svg
    :target: https://pypi.org/project/google-cloud-automl/
-.. _Cloud AutoML: https://cloud.google.com/automl/docs/
+.. _Cloud AutoML: https://cloud.google.com/automl/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/automl/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/automl/docs/
+.. _Product Documentation:  https://cloud.google.com/automl/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud AutoML.:  https://cloud.google.com/automl/docs/
+.. _Enable the Cloud AutoML.:  https://cloud.google.com/automl/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud AutoML Product documentation:  https://cloud.google.com/automl/docs/
+.. _Cloud AutoML Product documentation:  https://cloud.google.com/automl/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-backupdr/.repo-metadata.json
+++ b/packages/google-cloud-backupdr/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "backupdr",
     "name_pretty": "Backup and DR Service API",
-    "product_documentation": "https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr",
+    "product_documentation": "https://cloud.google.com/backup-disaster-recovery/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-backupdr/README.rst
+++ b/packages/google-cloud-backupdr/README.rst
@@ -14,9 +14,9 @@ Python Client for Backup and DR Service API
    :target: https://pypi.org/project/google-cloud-backupdr/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-backupdr.svg
    :target: https://pypi.org/project/google-cloud-backupdr/
-.. _Backup and DR Service API: https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr
+.. _Backup and DR Service API: https://cloud.google.com/backup-disaster-recovery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/backupdr/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr
+.. _Product Documentation:  https://cloud.google.com/backup-disaster-recovery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Backup and DR Service API.:  https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr
+.. _Enable the Backup and DR Service API.:  https://cloud.google.com/backup-disaster-recovery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Backup and DR Service API Product documentation:  https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr
+.. _Backup and DR Service API Product documentation:  https://cloud.google.com/backup-disaster-recovery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-backupdr/docs/README.rst
+++ b/packages/google-cloud-backupdr/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Backup and DR Service API
    :target: https://pypi.org/project/google-cloud-backupdr/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-backupdr.svg
    :target: https://pypi.org/project/google-cloud-backupdr/
-.. _Backup and DR Service API: https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr
+.. _Backup and DR Service API: https://cloud.google.com/backup-disaster-recovery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/backupdr/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr
+.. _Product Documentation:  https://cloud.google.com/backup-disaster-recovery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Backup and DR Service API.:  https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr
+.. _Enable the Backup and DR Service API.:  https://cloud.google.com/backup-disaster-recovery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Backup and DR Service API Product documentation:  https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr
+.. _Backup and DR Service API Product documentation:  https://cloud.google.com/backup-disaster-recovery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-biglake-hive/.repo-metadata.json
+++ b/packages/google-cloud-biglake-hive/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-biglake-hive",
     "name_pretty": "BigLake API",
-    "product_documentation": "https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore",
+    "product_documentation": "https://cloud.google.com/bigquery/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-biglake-hive/README.rst
+++ b/packages/google-cloud-biglake-hive/README.rst
@@ -16,9 +16,9 @@ used for querying Apache Iceberg tables in BigQuery.
    :target: https://pypi.org/project/google-cloud-biglake-hive/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-biglake-hive.svg
    :target: https://pypi.org/project/google-cloud-biglake-hive/
-.. _BigLake API: https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _BigLake API: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-biglake-hive/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -32,7 +32,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigLake API.:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _Enable the BigLake API.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -106,7 +106,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigLake API Product documentation:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _BigLake API Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-biglake-hive/docs/README.rst
+++ b/packages/google-cloud-biglake-hive/docs/README.rst
@@ -16,9 +16,9 @@ used for querying Apache Iceberg tables in BigQuery.
    :target: https://pypi.org/project/google-cloud-biglake-hive/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-biglake-hive.svg
    :target: https://pypi.org/project/google-cloud-biglake-hive/
-.. _BigLake API: https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _BigLake API: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-biglake-hive/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -32,7 +32,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigLake API.:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _Enable the BigLake API.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -106,7 +106,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigLake API Product documentation:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _BigLake API Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-biglake/.repo-metadata.json
+++ b/packages/google-cloud-biglake/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-biglake",
     "name_pretty": "BigLake API",
-    "product_documentation": "https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore",
+    "product_documentation": "https://cloud.google.com/bigquery/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-biglake/README.rst
+++ b/packages/google-cloud-biglake/README.rst
@@ -14,9 +14,9 @@ Python Client for BigLake API
    :target: https://pypi.org/project/google-cloud-biglake/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-biglake.svg
    :target: https://pypi.org/project/google-cloud-biglake/
-.. _BigLake API: https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _BigLake API: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-biglake/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigLake API.:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _Enable the BigLake API.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigLake API Product documentation:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _BigLake API Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-biglake/docs/README.rst
+++ b/packages/google-cloud-biglake/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for BigLake API
    :target: https://pypi.org/project/google-cloud-biglake/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-biglake.svg
    :target: https://pypi.org/project/google-cloud-biglake/
-.. _BigLake API: https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _BigLake API: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-biglake/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigLake API.:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _Enable the BigLake API.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigLake API Product documentation:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _BigLake API Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-biglake/.repo-metadata.json
+++ b/packages/google-cloud-bigquery-biglake/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "biglake",
     "name_pretty": "BigLake API",
-    "product_documentation": "https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore",
+    "product_documentation": "https://cloud.google.com/bigquery/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-bigquery-biglake/README.rst
+++ b/packages/google-cloud-bigquery-biglake/README.rst
@@ -14,9 +14,9 @@ Python Client for BigLake API
    :target: https://pypi.org/project/google-cloud-bigquery-biglake/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-biglake.svg
    :target: https://pypi.org/project/google-cloud-bigquery-biglake/
-.. _BigLake API: https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _BigLake API: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/biglake/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigLake API.:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _Enable the BigLake API.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigLake API Product documentation:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _BigLake API Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-biglake/docs/README.rst
+++ b/packages/google-cloud-bigquery-biglake/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for BigLake API
    :target: https://pypi.org/project/google-cloud-bigquery-biglake/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-biglake.svg
    :target: https://pypi.org/project/google-cloud-bigquery-biglake/
-.. _BigLake API: https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _BigLake API: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/biglake/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigLake API.:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _Enable the BigLake API.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigLake API Product documentation:  https://cloud.google.com/bigquery/docs/iceberg-tables#create-using-biglake-metastore
+.. _BigLake API Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-connection/.repo-metadata.json
+++ b/packages/google-cloud-bigquery-connection/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "bigqueryconnection",
     "name_pretty": "BigQuery Connection",
-    "product_documentation": "https://cloud.google.com/bigquery/docs/reference/bigqueryconnection",
+    "product_documentation": "https://cloud.google.com/bigquery/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-bigquery-connection/README.rst
+++ b/packages/google-cloud-bigquery-connection/README.rst
@@ -14,9 +14,9 @@ Python Client for BigQuery Connection
    :target: https://pypi.org/project/google-cloud-bigquery-connection/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-connection.svg
    :target: https://pypi.org/project/google-cloud-bigquery-connection/
-.. _BigQuery Connection: https://cloud.google.com/bigquery/docs/reference/bigqueryconnection
+.. _BigQuery Connection: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigqueryconnection/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/bigqueryconnection
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigQuery Connection.:  https://cloud.google.com/bigquery/docs/reference/bigqueryconnection
+.. _Enable the BigQuery Connection.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigQuery Connection Product documentation:  https://cloud.google.com/bigquery/docs/reference/bigqueryconnection
+.. _BigQuery Connection Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-connection/docs/README.rst
+++ b/packages/google-cloud-bigquery-connection/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for BigQuery Connection
    :target: https://pypi.org/project/google-cloud-bigquery-connection/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-connection.svg
    :target: https://pypi.org/project/google-cloud-bigquery-connection/
-.. _BigQuery Connection: https://cloud.google.com/bigquery/docs/reference/bigqueryconnection
+.. _BigQuery Connection: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigqueryconnection/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/bigqueryconnection
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigQuery Connection.:  https://cloud.google.com/bigquery/docs/reference/bigqueryconnection
+.. _Enable the BigQuery Connection.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigQuery Connection Product documentation:  https://cloud.google.com/bigquery/docs/reference/bigqueryconnection
+.. _BigQuery Connection Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-data-exchange/.repo-metadata.json
+++ b/packages/google-cloud-bigquery-data-exchange/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "analyticshub",
     "name_pretty": "BigQuery Analytics Hub",
-    "product_documentation": "https://cloud.google.com/bigquery/docs/analytics-hub-introduction",
+    "product_documentation": "https://cloud.google.com/bigquery/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-bigquery-data-exchange/README.rst
+++ b/packages/google-cloud-bigquery-data-exchange/README.rst
@@ -14,9 +14,9 @@ Python Client for BigQuery Analytics Hub
    :target: https://pypi.org/project/google-cloud-bigquery-data-exchange/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-data-exchange.svg
    :target: https://pypi.org/project/google-cloud-bigquery-data-exchange/
-.. _BigQuery Analytics Hub: https://cloud.google.com/bigquery/docs/analytics-hub-introduction
+.. _BigQuery Analytics Hub: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/analyticshub/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/analytics-hub-introduction
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigQuery Analytics Hub.:  https://cloud.google.com/bigquery/docs/analytics-hub-introduction
+.. _Enable the BigQuery Analytics Hub.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigQuery Analytics Hub Product documentation:  https://cloud.google.com/bigquery/docs/analytics-hub-introduction
+.. _BigQuery Analytics Hub Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-data-exchange/docs/README.rst
+++ b/packages/google-cloud-bigquery-data-exchange/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for BigQuery Analytics Hub
    :target: https://pypi.org/project/google-cloud-bigquery-data-exchange/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-data-exchange.svg
    :target: https://pypi.org/project/google-cloud-bigquery-data-exchange/
-.. _BigQuery Analytics Hub: https://cloud.google.com/bigquery/docs/analytics-hub-introduction
+.. _BigQuery Analytics Hub: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/analyticshub/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/analytics-hub-introduction
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigQuery Analytics Hub.:  https://cloud.google.com/bigquery/docs/analytics-hub-introduction
+.. _Enable the BigQuery Analytics Hub.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigQuery Analytics Hub Product documentation:  https://cloud.google.com/bigquery/docs/analytics-hub-introduction
+.. _BigQuery Analytics Hub Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-datapolicies/.repo-metadata.json
+++ b/packages/google-cloud-bigquery-datapolicies/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "bigquerydatapolicy",
     "name_pretty": "BigQuery Data Policy",
-    "product_documentation": "https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest",
+    "product_documentation": "https://cloud.google.com/bigquery/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-bigquery-datapolicies/README.rst
+++ b/packages/google-cloud-bigquery-datapolicies/README.rst
@@ -14,9 +14,9 @@ Python Client for BigQuery Data Policy
    :target: https://pypi.org/project/google-cloud-bigquery-datapolicies/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-datapolicies.svg
    :target: https://pypi.org/project/google-cloud-bigquery-datapolicies/
-.. _BigQuery Data Policy: https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest
+.. _BigQuery Data Policy: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerydatapolicy/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigQuery Data Policy.:  https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest
+.. _Enable the BigQuery Data Policy.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigQuery Data Policy Product documentation:  https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest
+.. _BigQuery Data Policy Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-datapolicies/docs/README.rst
+++ b/packages/google-cloud-bigquery-datapolicies/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for BigQuery Data Policy
    :target: https://pypi.org/project/google-cloud-bigquery-datapolicies/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-datapolicies.svg
    :target: https://pypi.org/project/google-cloud-bigquery-datapolicies/
-.. _BigQuery Data Policy: https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest
+.. _BigQuery Data Policy: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerydatapolicy/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigQuery Data Policy.:  https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest
+.. _Enable the BigQuery Data Policy.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigQuery Data Policy Product documentation:  https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest
+.. _BigQuery Data Policy Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-logging/.repo-metadata.json
+++ b/packages/google-cloud-bigquery-logging/.repo-metadata.json
@@ -8,7 +8,7 @@
     "library_type": "OTHER",
     "name": "bigquerylogging",
     "name_pretty": "BigQuery Logging Protos",
-    "product_documentation": "https://cloud.google.com/bigquery/docs/reference/auditlogs",
+    "product_documentation": "https://cloud.google.com/bigquery/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-bigquery-logging/README.rst
+++ b/packages/google-cloud-bigquery-logging/README.rst
@@ -14,9 +14,9 @@ Python Client for BigQuery Logging Protos
    :target: https://pypi.org/project/google-cloud-bigquery-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-logging.svg
    :target: https://pypi.org/project/google-cloud-bigquery-logging/
-.. _BigQuery Logging Protos: https://cloud.google.com/bigquery/docs/reference/auditlogs
+.. _BigQuery Logging Protos: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerylogging/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/auditlogs
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigQuery Logging Protos.:  https://cloud.google.com/bigquery/docs/reference/auditlogs
+.. _Enable the BigQuery Logging Protos.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigQuery Logging Protos Product documentation:  https://cloud.google.com/bigquery/docs/reference/auditlogs
+.. _BigQuery Logging Protos Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-logging/docs/README.rst
+++ b/packages/google-cloud-bigquery-logging/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for BigQuery Logging Protos
    :target: https://pypi.org/project/google-cloud-bigquery-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-logging.svg
    :target: https://pypi.org/project/google-cloud-bigquery-logging/
-.. _BigQuery Logging Protos: https://cloud.google.com/bigquery/docs/reference/auditlogs
+.. _BigQuery Logging Protos: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerylogging/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/auditlogs
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigQuery Logging Protos.:  https://cloud.google.com/bigquery/docs/reference/auditlogs
+.. _Enable the BigQuery Logging Protos.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigQuery Logging Protos Product documentation:  https://cloud.google.com/bigquery/docs/reference/auditlogs
+.. _BigQuery Logging Protos Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-migration/.repo-metadata.json
+++ b/packages/google-cloud-bigquery-migration/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "bigquerymigration",
     "name_pretty": "Google BigQuery Migration",
-    "product_documentation": "https://cloud.google.com/bigquery/docs/reference/migration/",
+    "product_documentation": "https://cloud.google.com/bigquery/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-bigquery-migration/README.rst
+++ b/packages/google-cloud-bigquery-migration/README.rst
@@ -15,9 +15,9 @@ agent management.
    :target: https://pypi.org/project/google-cloud-bigquery-migration/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-migration.svg
    :target: https://pypi.org/project/google-cloud-bigquery-migration/
-.. _Google BigQuery Migration: https://cloud.google.com/bigquery/docs/reference/migration/
+.. _Google BigQuery Migration: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerymigration/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/migration/
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -31,7 +31,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google BigQuery Migration.:  https://cloud.google.com/bigquery/docs/reference/migration/
+.. _Enable the Google BigQuery Migration.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -105,7 +105,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google BigQuery Migration Product documentation:  https://cloud.google.com/bigquery/docs/reference/migration/
+.. _Google BigQuery Migration Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-migration/docs/README.rst
+++ b/packages/google-cloud-bigquery-migration/docs/README.rst
@@ -15,9 +15,9 @@ agent management.
    :target: https://pypi.org/project/google-cloud-bigquery-migration/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-migration.svg
    :target: https://pypi.org/project/google-cloud-bigquery-migration/
-.. _Google BigQuery Migration: https://cloud.google.com/bigquery/docs/reference/migration/
+.. _Google BigQuery Migration: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerymigration/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/migration/
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -31,7 +31,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google BigQuery Migration.:  https://cloud.google.com/bigquery/docs/reference/migration/
+.. _Enable the Google BigQuery Migration.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -105,7 +105,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google BigQuery Migration Product documentation:  https://cloud.google.com/bigquery/docs/reference/migration/
+.. _Google BigQuery Migration Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-reservation/.repo-metadata.json
+++ b/packages/google-cloud-bigquery-reservation/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "bigqueryreservation",
     "name_pretty": "BigQuery Reservation",
-    "product_documentation": "https://cloud.google.com/bigquery/docs/reference/reservations",
+    "product_documentation": "https://cloud.google.com/bigquery/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-bigquery-reservation/README.rst
+++ b/packages/google-cloud-bigquery-reservation/README.rst
@@ -14,9 +14,9 @@ Python Client for BigQuery Reservation
    :target: https://pypi.org/project/google-cloud-bigquery-reservation/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-reservation.svg
    :target: https://pypi.org/project/google-cloud-bigquery-reservation/
-.. _BigQuery Reservation: https://cloud.google.com/bigquery/docs/reference/reservations
+.. _BigQuery Reservation: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigqueryreservation/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/reservations
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigQuery Reservation.:  https://cloud.google.com/bigquery/docs/reference/reservations
+.. _Enable the BigQuery Reservation.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigQuery Reservation Product documentation:  https://cloud.google.com/bigquery/docs/reference/reservations
+.. _BigQuery Reservation Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-reservation/docs/README.rst
+++ b/packages/google-cloud-bigquery-reservation/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for BigQuery Reservation
    :target: https://pypi.org/project/google-cloud-bigquery-reservation/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-reservation.svg
    :target: https://pypi.org/project/google-cloud-bigquery-reservation/
-.. _BigQuery Reservation: https://cloud.google.com/bigquery/docs/reference/reservations
+.. _BigQuery Reservation: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigqueryreservation/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/reservations
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the BigQuery Reservation.:  https://cloud.google.com/bigquery/docs/reference/reservations
+.. _Enable the BigQuery Reservation.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigQuery Reservation Product documentation:  https://cloud.google.com/bigquery/docs/reference/reservations
+.. _BigQuery Reservation Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-storage/.repo-metadata.json
+++ b/packages/google-cloud-bigquery-storage/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_COMBO",
     "name": "bigquerystorage",
     "name_pretty": "Google BigQuery Storage",
-    "product_documentation": "https://cloud.google.com/bigquery/docs/reference/storage/",
+    "product_documentation": "https://cloud.google.com/bigquery/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-bigquery-storage/README.rst
+++ b/packages/google-cloud-bigquery-storage/README.rst
@@ -14,9 +14,9 @@ Python Client for Google BigQuery Storage
    :target: https://pypi.org/project/google-cloud-bigquery-storage/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-storage.svg
    :target: https://pypi.org/project/google-cloud-bigquery-storage/
-.. _Google BigQuery Storage: https://cloud.google.com/bigquery/docs/reference/storage/
+.. _Google BigQuery Storage: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerystorage/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/storage/
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google BigQuery Storage.:  https://cloud.google.com/bigquery/docs/reference/storage/
+.. _Enable the Google BigQuery Storage.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google BigQuery Storage Product documentation:  https://cloud.google.com/bigquery/docs/reference/storage/
+.. _Google BigQuery Storage Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-storage/docs/README.rst
+++ b/packages/google-cloud-bigquery-storage/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Google BigQuery Storage
    :target: https://pypi.org/project/google-cloud-bigquery-storage/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-storage.svg
    :target: https://pypi.org/project/google-cloud-bigquery-storage/
-.. _Google BigQuery Storage: https://cloud.google.com/bigquery/docs/reference/storage/
+.. _Google BigQuery Storage: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerystorage/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/storage/
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google BigQuery Storage.:  https://cloud.google.com/bigquery/docs/reference/storage/
+.. _Enable the Google BigQuery Storage.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google BigQuery Storage Product documentation:  https://cloud.google.com/bigquery/docs/reference/storage/
+.. _Google BigQuery Storage Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery/.repo-metadata.json
+++ b/packages/google-cloud-bigquery/.repo-metadata.json
@@ -9,7 +9,6 @@
     "library_type": "GAPIC_COMBO",
     "name": "bigquery",
     "name_pretty": "Google Cloud BigQuery",
-    "product_documentation": "https://cloud.google.com/bigquery",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-billing-budgets/.repo-metadata.json
+++ b/packages/google-cloud-billing-budgets/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "billingbudgets",
     "name_pretty": "Cloud Billing Budget",
-    "product_documentation": "https://cloud.google.com/billing/docs/how-to/budget-api-overview",
+    "product_documentation": "https://cloud.google.com/billing/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-billing-budgets/README.rst
+++ b/packages/google-cloud-billing-budgets/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Billing Budget
    :target: https://pypi.org/project/google-cloud-billing-budgets/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-billing-budgets.svg
    :target: https://pypi.org/project/google-cloud-billing-budgets/
-.. _Cloud Billing Budget: https://cloud.google.com/billing/docs/how-to/budget-api-overview
+.. _Cloud Billing Budget: https://cloud.google.com/billing/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/billingbudgets/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/billing/docs/how-to/budget-api-overview
+.. _Product Documentation:  https://cloud.google.com/billing/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Billing Budget.:  https://cloud.google.com/billing/docs/how-to/budget-api-overview
+.. _Enable the Cloud Billing Budget.:  https://cloud.google.com/billing/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Billing Budget Product documentation:  https://cloud.google.com/billing/docs/how-to/budget-api-overview
+.. _Cloud Billing Budget Product documentation:  https://cloud.google.com/billing/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-billing-budgets/docs/README.rst
+++ b/packages/google-cloud-billing-budgets/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Billing Budget
    :target: https://pypi.org/project/google-cloud-billing-budgets/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-billing-budgets.svg
    :target: https://pypi.org/project/google-cloud-billing-budgets/
-.. _Cloud Billing Budget: https://cloud.google.com/billing/docs/how-to/budget-api-overview
+.. _Cloud Billing Budget: https://cloud.google.com/billing/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/billingbudgets/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/billing/docs/how-to/budget-api-overview
+.. _Product Documentation:  https://cloud.google.com/billing/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Billing Budget.:  https://cloud.google.com/billing/docs/how-to/budget-api-overview
+.. _Enable the Cloud Billing Budget.:  https://cloud.google.com/billing/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Billing Budget Product documentation:  https://cloud.google.com/billing/docs/how-to/budget-api-overview
+.. _Cloud Billing Budget Product documentation:  https://cloud.google.com/billing/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-build/.repo-metadata.json
+++ b/packages/google-cloud-build/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "cloudbuild",
     "name_pretty": "Cloud Build",
-    "product_documentation": "https://cloud.google.com/cloud-build/docs/",
+    "product_documentation": "https://cloud.google.com/cloud-build/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-build/README.rst
+++ b/packages/google-cloud-build/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Build
    :target: https://pypi.org/project/google-cloud-build/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-build.svg
    :target: https://pypi.org/project/google-cloud-build/
-.. _Cloud Build: https://cloud.google.com/cloud-build/docs/
+.. _Cloud Build: https://cloud.google.com/cloud-build/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudbuild/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/cloud-build/docs/
+.. _Product Documentation:  https://cloud.google.com/cloud-build/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Build.:  https://cloud.google.com/cloud-build/docs/
+.. _Enable the Cloud Build.:  https://cloud.google.com/cloud-build/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Build Product documentation:  https://cloud.google.com/cloud-build/docs/
+.. _Cloud Build Product documentation:  https://cloud.google.com/cloud-build/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-build/docs/README.rst
+++ b/packages/google-cloud-build/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Build
    :target: https://pypi.org/project/google-cloud-build/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-build.svg
    :target: https://pypi.org/project/google-cloud-build/
-.. _Cloud Build: https://cloud.google.com/cloud-build/docs/
+.. _Cloud Build: https://cloud.google.com/cloud-build/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudbuild/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/cloud-build/docs/
+.. _Product Documentation:  https://cloud.google.com/cloud-build/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Build.:  https://cloud.google.com/cloud-build/docs/
+.. _Enable the Cloud Build.:  https://cloud.google.com/cloud-build/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Build Product documentation:  https://cloud.google.com/cloud-build/docs/
+.. _Cloud Build Product documentation:  https://cloud.google.com/cloud-build/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-certificate-manager/.repo-metadata.json
+++ b/packages/google-cloud-certificate-manager/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "certificatemanager",
     "name_pretty": "Certificate Manager",
-    "product_documentation": "https://cloud.google.com/python/docs/reference/certificatemanager/latest",
+    "product_documentation": "https://cloud.google.com/python/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-certificate-manager/README.rst
+++ b/packages/google-cloud-certificate-manager/README.rst
@@ -14,9 +14,9 @@ Python Client for Certificate Manager
    :target: https://pypi.org/project/google-cloud-certificate-manager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-certificate-manager.svg
    :target: https://pypi.org/project/google-cloud-certificate-manager/
-.. _Certificate Manager: https://cloud.google.com/python/docs/reference/certificatemanager/latest
+.. _Certificate Manager: https://cloud.google.com/python/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/certificatemanager/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/python/docs/reference/certificatemanager/latest
+.. _Product Documentation:  https://cloud.google.com/python/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Certificate Manager.:  https://cloud.google.com/python/docs/reference/certificatemanager/latest
+.. _Enable the Certificate Manager.:  https://cloud.google.com/python/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Certificate Manager Product documentation:  https://cloud.google.com/python/docs/reference/certificatemanager/latest
+.. _Certificate Manager Product documentation:  https://cloud.google.com/python/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-certificate-manager/docs/README.rst
+++ b/packages/google-cloud-certificate-manager/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Certificate Manager
    :target: https://pypi.org/project/google-cloud-certificate-manager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-certificate-manager.svg
    :target: https://pypi.org/project/google-cloud-certificate-manager/
-.. _Certificate Manager: https://cloud.google.com/python/docs/reference/certificatemanager/latest
+.. _Certificate Manager: https://cloud.google.com/python/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/certificatemanager/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/python/docs/reference/certificatemanager/latest
+.. _Product Documentation:  https://cloud.google.com/python/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Certificate Manager.:  https://cloud.google.com/python/docs/reference/certificatemanager/latest
+.. _Enable the Certificate Manager.:  https://cloud.google.com/python/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Certificate Manager Product documentation:  https://cloud.google.com/python/docs/reference/certificatemanager/latest
+.. _Certificate Manager Product documentation:  https://cloud.google.com/python/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-chronicle/.repo-metadata.json
+++ b/packages/google-cloud-chronicle/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-chronicle",
     "name_pretty": "Chronicle API",
-    "product_documentation": "https://cloud.google.com/chronicle/docs/secops/secops-overview",
+    "product_documentation": "https://cloud.google.com/chronicle/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-chronicle/README.rst
+++ b/packages/google-cloud-chronicle/README.rst
@@ -14,9 +14,9 @@ Python Client for Chronicle API
    :target: https://pypi.org/project/google-cloud-chronicle/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-chronicle.svg
    :target: https://pypi.org/project/google-cloud-chronicle/
-.. _Chronicle API: https://cloud.google.com/chronicle/docs/secops/secops-overview
+.. _Chronicle API: https://cloud.google.com/chronicle/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-chronicle/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/chronicle/docs/secops/secops-overview
+.. _Product Documentation:  https://cloud.google.com/chronicle/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Chronicle API.:  https://cloud.google.com/chronicle/docs/secops/secops-overview
+.. _Enable the Chronicle API.:  https://cloud.google.com/chronicle/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Chronicle API Product documentation:  https://cloud.google.com/chronicle/docs/secops/secops-overview
+.. _Chronicle API Product documentation:  https://cloud.google.com/chronicle/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-chronicle/docs/README.rst
+++ b/packages/google-cloud-chronicle/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Chronicle API
    :target: https://pypi.org/project/google-cloud-chronicle/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-chronicle.svg
    :target: https://pypi.org/project/google-cloud-chronicle/
-.. _Chronicle API: https://cloud.google.com/chronicle/docs/secops/secops-overview
+.. _Chronicle API: https://cloud.google.com/chronicle/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-chronicle/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/chronicle/docs/secops/secops-overview
+.. _Product Documentation:  https://cloud.google.com/chronicle/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Chronicle API.:  https://cloud.google.com/chronicle/docs/secops/secops-overview
+.. _Enable the Chronicle API.:  https://cloud.google.com/chronicle/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Chronicle API Product documentation:  https://cloud.google.com/chronicle/docs/secops/secops-overview
+.. _Chronicle API Product documentation:  https://cloud.google.com/chronicle/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-cloudcontrolspartner/.repo-metadata.json
+++ b/packages/google-cloud-cloudcontrolspartner/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-cloudcontrolspartner",
     "name_pretty": "Cloud Controls Partner API",
-    "product_documentation": "https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest",
+    "product_documentation": "https://cloud.google.com/sovereign-controls-by-partners/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-cloudcontrolspartner/README.rst
+++ b/packages/google-cloud-cloudcontrolspartner/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Controls Partner API
    :target: https://pypi.org/project/google-cloud-cloudcontrolspartner/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-cloudcontrolspartner.svg
    :target: https://pypi.org/project/google-cloud-cloudcontrolspartner/
-.. _Cloud Controls Partner API: https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest
+.. _Cloud Controls Partner API: https://cloud.google.com/sovereign-controls-by-partners/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-cloudcontrolspartner/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest
+.. _Product Documentation:  https://cloud.google.com/sovereign-controls-by-partners/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Controls Partner API.:  https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest
+.. _Enable the Cloud Controls Partner API.:  https://cloud.google.com/sovereign-controls-by-partners/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Controls Partner API Product documentation:  https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest
+.. _Cloud Controls Partner API Product documentation:  https://cloud.google.com/sovereign-controls-by-partners/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-cloudcontrolspartner/docs/README.rst
+++ b/packages/google-cloud-cloudcontrolspartner/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Controls Partner API
    :target: https://pypi.org/project/google-cloud-cloudcontrolspartner/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-cloudcontrolspartner.svg
    :target: https://pypi.org/project/google-cloud-cloudcontrolspartner/
-.. _Cloud Controls Partner API: https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest
+.. _Cloud Controls Partner API: https://cloud.google.com/sovereign-controls-by-partners/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-cloudcontrolspartner/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest
+.. _Product Documentation:  https://cloud.google.com/sovereign-controls-by-partners/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Controls Partner API.:  https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest
+.. _Enable the Cloud Controls Partner API.:  https://cloud.google.com/sovereign-controls-by-partners/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Controls Partner API Product documentation:  https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest
+.. _Cloud Controls Partner API Product documentation:  https://cloud.google.com/sovereign-controls-by-partners/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-cloudsecuritycompliance/.repo-metadata.json
+++ b/packages/google-cloud-cloudsecuritycompliance/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-cloudsecuritycompliance",
     "name_pretty": "Cloud Security Compliance API",
-    "product_documentation": "https://cloud.google.com/security-command-center/docs/compliance-manager-overview",
+    "product_documentation": "https://cloud.google.com/security-command-center/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-cloudsecuritycompliance/README.rst
+++ b/packages/google-cloud-cloudsecuritycompliance/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Security Compliance API
    :target: https://pypi.org/project/google-cloud-cloudsecuritycompliance/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-cloudsecuritycompliance.svg
    :target: https://pypi.org/project/google-cloud-cloudsecuritycompliance/
-.. _Cloud Security Compliance API: https://cloud.google.com/security-command-center/docs/compliance-manager-overview
+.. _Cloud Security Compliance API: https://cloud.google.com/security-command-center/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-cloudsecuritycompliance/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/security-command-center/docs/compliance-manager-overview
+.. _Product Documentation:  https://cloud.google.com/security-command-center/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Security Compliance API.:  https://cloud.google.com/security-command-center/docs/compliance-manager-overview
+.. _Enable the Cloud Security Compliance API.:  https://cloud.google.com/security-command-center/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Security Compliance API Product documentation:  https://cloud.google.com/security-command-center/docs/compliance-manager-overview
+.. _Cloud Security Compliance API Product documentation:  https://cloud.google.com/security-command-center/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-cloudsecuritycompliance/docs/README.rst
+++ b/packages/google-cloud-cloudsecuritycompliance/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Security Compliance API
    :target: https://pypi.org/project/google-cloud-cloudsecuritycompliance/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-cloudsecuritycompliance.svg
    :target: https://pypi.org/project/google-cloud-cloudsecuritycompliance/
-.. _Cloud Security Compliance API: https://cloud.google.com/security-command-center/docs/compliance-manager-overview
+.. _Cloud Security Compliance API: https://cloud.google.com/security-command-center/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-cloudsecuritycompliance/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/security-command-center/docs/compliance-manager-overview
+.. _Product Documentation:  https://cloud.google.com/security-command-center/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Security Compliance API.:  https://cloud.google.com/security-command-center/docs/compliance-manager-overview
+.. _Enable the Cloud Security Compliance API.:  https://cloud.google.com/security-command-center/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Security Compliance API Product documentation:  https://cloud.google.com/security-command-center/docs/compliance-manager-overview
+.. _Cloud Security Compliance API Product documentation:  https://cloud.google.com/security-command-center/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-commerce-consumer-procurement/.repo-metadata.json
+++ b/packages/google-cloud-commerce-consumer-procurement/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "procurement",
     "name_pretty": "Cloud Commerce Consumer Procurement API",
-    "product_documentation": "https://cloud.google.com/marketplace/docs/",
+    "product_documentation": "https://cloud.google.com/marketplace/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-commerce-consumer-procurement/README.rst
+++ b/packages/google-cloud-commerce-consumer-procurement/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Commerce Consumer Procurement API
    :target: https://pypi.org/project/google-cloud-commerce-consumer-procurement/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-commerce-consumer-procurement.svg
    :target: https://pypi.org/project/google-cloud-commerce-consumer-procurement/
-.. _Cloud Commerce Consumer Procurement API: https://cloud.google.com/marketplace/docs/
+.. _Cloud Commerce Consumer Procurement API: https://cloud.google.com/marketplace/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/procurement/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/marketplace/docs/
+.. _Product Documentation:  https://cloud.google.com/marketplace/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Commerce Consumer Procurement API.:  https://cloud.google.com/marketplace/docs/
+.. _Enable the Cloud Commerce Consumer Procurement API.:  https://cloud.google.com/marketplace/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Commerce Consumer Procurement API Product documentation:  https://cloud.google.com/marketplace/docs/
+.. _Cloud Commerce Consumer Procurement API Product documentation:  https://cloud.google.com/marketplace/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-commerce-consumer-procurement/docs/README.rst
+++ b/packages/google-cloud-commerce-consumer-procurement/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Commerce Consumer Procurement API
    :target: https://pypi.org/project/google-cloud-commerce-consumer-procurement/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-commerce-consumer-procurement.svg
    :target: https://pypi.org/project/google-cloud-commerce-consumer-procurement/
-.. _Cloud Commerce Consumer Procurement API: https://cloud.google.com/marketplace/docs/
+.. _Cloud Commerce Consumer Procurement API: https://cloud.google.com/marketplace/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/procurement/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/marketplace/docs/
+.. _Product Documentation:  https://cloud.google.com/marketplace/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Commerce Consumer Procurement API.:  https://cloud.google.com/marketplace/docs/
+.. _Enable the Cloud Commerce Consumer Procurement API.:  https://cloud.google.com/marketplace/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Commerce Consumer Procurement API Product documentation:  https://cloud.google.com/marketplace/docs/
+.. _Cloud Commerce Consumer Procurement API Product documentation:  https://cloud.google.com/marketplace/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-config/.repo-metadata.json
+++ b/packages/google-cloud-config/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "config",
     "name_pretty": "Infrastructure Manager API",
-    "product_documentation": "https://cloud.google.com/infrastructure-manager/docs/overview",
+    "product_documentation": "https://cloud.google.com/infrastructure-manager/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-config/README.rst
+++ b/packages/google-cloud-config/README.rst
@@ -14,9 +14,9 @@ Python Client for Infrastructure Manager API
    :target: https://pypi.org/project/google-cloud-config/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-config.svg
    :target: https://pypi.org/project/google-cloud-config/
-.. _Infrastructure Manager API: https://cloud.google.com/infrastructure-manager/docs/overview
+.. _Infrastructure Manager API: https://cloud.google.com/infrastructure-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/config/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/infrastructure-manager/docs/overview
+.. _Product Documentation:  https://cloud.google.com/infrastructure-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Infrastructure Manager API.:  https://cloud.google.com/infrastructure-manager/docs/overview
+.. _Enable the Infrastructure Manager API.:  https://cloud.google.com/infrastructure-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Infrastructure Manager API Product documentation:  https://cloud.google.com/infrastructure-manager/docs/overview
+.. _Infrastructure Manager API Product documentation:  https://cloud.google.com/infrastructure-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-config/docs/README.rst
+++ b/packages/google-cloud-config/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Infrastructure Manager API
    :target: https://pypi.org/project/google-cloud-config/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-config.svg
    :target: https://pypi.org/project/google-cloud-config/
-.. _Infrastructure Manager API: https://cloud.google.com/infrastructure-manager/docs/overview
+.. _Infrastructure Manager API: https://cloud.google.com/infrastructure-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/config/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/infrastructure-manager/docs/overview
+.. _Product Documentation:  https://cloud.google.com/infrastructure-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Infrastructure Manager API.:  https://cloud.google.com/infrastructure-manager/docs/overview
+.. _Enable the Infrastructure Manager API.:  https://cloud.google.com/infrastructure-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Infrastructure Manager API Product documentation:  https://cloud.google.com/infrastructure-manager/docs/overview
+.. _Infrastructure Manager API Product documentation:  https://cloud.google.com/infrastructure-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-configdelivery/.repo-metadata.json
+++ b/packages/google-cloud-configdelivery/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-configdelivery",
     "name_pretty": "Config Delivery API",
-    "product_documentation": "https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/reference/rest",
+    "product_documentation": "https://cloud.google.com/kubernetes-engine/enterprise/config-sync/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-configdelivery/README.rst
+++ b/packages/google-cloud-configdelivery/README.rst
@@ -14,9 +14,9 @@ Python Client for Config Delivery API
    :target: https://pypi.org/project/google-cloud-configdelivery/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-configdelivery.svg
    :target: https://pypi.org/project/google-cloud-configdelivery/
-.. _Config Delivery API: https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/reference/rest
+.. _Config Delivery API: https://cloud.google.com/kubernetes-engine/enterprise/config-sync/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-configdelivery/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/reference/rest
+.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/enterprise/config-sync/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Config Delivery API.:  https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/reference/rest
+.. _Enable the Config Delivery API.:  https://cloud.google.com/kubernetes-engine/enterprise/config-sync/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Config Delivery API Product documentation:  https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/reference/rest
+.. _Config Delivery API Product documentation:  https://cloud.google.com/kubernetes-engine/enterprise/config-sync/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-configdelivery/docs/README.rst
+++ b/packages/google-cloud-configdelivery/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Config Delivery API
    :target: https://pypi.org/project/google-cloud-configdelivery/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-configdelivery.svg
    :target: https://pypi.org/project/google-cloud-configdelivery/
-.. _Config Delivery API: https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/reference/rest
+.. _Config Delivery API: https://cloud.google.com/kubernetes-engine/enterprise/config-sync/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-configdelivery/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/reference/rest
+.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/enterprise/config-sync/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Config Delivery API.:  https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/reference/rest
+.. _Enable the Config Delivery API.:  https://cloud.google.com/kubernetes-engine/enterprise/config-sync/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Config Delivery API Product documentation:  https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/reference/rest
+.. _Config Delivery API Product documentation:  https://cloud.google.com/kubernetes-engine/enterprise/config-sync/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-containeranalysis/.repo-metadata.json
+++ b/packages/google-cloud-containeranalysis/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "containeranalysis",
     "name_pretty": "Container Analysis",
-    "product_documentation": "https://cloud.google.com/container-registry/docs/container-analysis",
+    "product_documentation": "https://cloud.google.com/container-registry/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-containeranalysis/README.rst
+++ b/packages/google-cloud-containeranalysis/README.rst
@@ -14,9 +14,9 @@ Python Client for Container Analysis
    :target: https://pypi.org/project/google-cloud-containeranalysis/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-containeranalysis.svg
    :target: https://pypi.org/project/google-cloud-containeranalysis/
-.. _Container Analysis: https://cloud.google.com/container-registry/docs/container-analysis
+.. _Container Analysis: https://cloud.google.com/container-registry/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/containeranalysis/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/container-registry/docs/container-analysis
+.. _Product Documentation:  https://cloud.google.com/container-registry/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Container Analysis.:  https://cloud.google.com/container-registry/docs/container-analysis
+.. _Enable the Container Analysis.:  https://cloud.google.com/container-registry/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Container Analysis Product documentation:  https://cloud.google.com/container-registry/docs/container-analysis
+.. _Container Analysis Product documentation:  https://cloud.google.com/container-registry/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-containeranalysis/docs/README.rst
+++ b/packages/google-cloud-containeranalysis/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Container Analysis
    :target: https://pypi.org/project/google-cloud-containeranalysis/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-containeranalysis.svg
    :target: https://pypi.org/project/google-cloud-containeranalysis/
-.. _Container Analysis: https://cloud.google.com/container-registry/docs/container-analysis
+.. _Container Analysis: https://cloud.google.com/container-registry/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/containeranalysis/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/container-registry/docs/container-analysis
+.. _Product Documentation:  https://cloud.google.com/container-registry/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Container Analysis.:  https://cloud.google.com/container-registry/docs/container-analysis
+.. _Enable the Container Analysis.:  https://cloud.google.com/container-registry/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Container Analysis Product documentation:  https://cloud.google.com/container-registry/docs/container-analysis
+.. _Container Analysis Product documentation:  https://cloud.google.com/container-registry/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-data-qna/.repo-metadata.json
+++ b/packages/google-cloud-data-qna/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "dataqna",
     "name_pretty": "Data QnA",
-    "product_documentation": "https://cloud.google.com/bigquery/docs/dataqna",
+    "product_documentation": "https://cloud.google.com/bigquery/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-data-qna/README.rst
+++ b/packages/google-cloud-data-qna/README.rst
@@ -14,9 +14,9 @@ Python Client for Data QnA
    :target: https://pypi.org/project/google-cloud-data-qna/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-data-qna.svg
    :target: https://pypi.org/project/google-cloud-data-qna/
-.. _Data QnA: https://cloud.google.com/bigquery/docs/dataqna
+.. _Data QnA: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dataqna/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/dataqna
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Data QnA.:  https://cloud.google.com/bigquery/docs/dataqna
+.. _Enable the Data QnA.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Data QnA Product documentation:  https://cloud.google.com/bigquery/docs/dataqna
+.. _Data QnA Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-data-qna/docs/README.rst
+++ b/packages/google-cloud-data-qna/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Data QnA
    :target: https://pypi.org/project/google-cloud-data-qna/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-data-qna.svg
    :target: https://pypi.org/project/google-cloud-data-qna/
-.. _Data QnA: https://cloud.google.com/bigquery/docs/dataqna
+.. _Data QnA: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dataqna/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/bigquery/docs/dataqna
+.. _Product Documentation:  https://cloud.google.com/bigquery/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Data QnA.:  https://cloud.google.com/bigquery/docs/dataqna
+.. _Enable the Data QnA.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Data QnA Product documentation:  https://cloud.google.com/bigquery/docs/dataqna
+.. _Data QnA Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-databasecenter/.repo-metadata.json
+++ b/packages/google-cloud-databasecenter/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-databasecenter",
     "name_pretty": "Database Center API",
-    "product_documentation": "https://cloud.google.com/database-center/docs/overview",
+    "product_documentation": "https://cloud.google.com/database-center/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-databasecenter/README.rst
+++ b/packages/google-cloud-databasecenter/README.rst
@@ -20,9 +20,9 @@ quickly identify and address relevant issues within their database fleets.
    :target: https://pypi.org/project/google-cloud-databasecenter/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-databasecenter.svg
    :target: https://pypi.org/project/google-cloud-databasecenter/
-.. _Database Center API: https://cloud.google.com/database-center/docs/overview
+.. _Database Center API: https://cloud.google.com/database-center/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-databasecenter/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/database-center/docs/overview
+.. _Product Documentation:  https://cloud.google.com/database-center/
 
 Quick Start
 -----------
@@ -36,7 +36,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Database Center API.:  https://cloud.google.com/database-center/docs/overview
+.. _Enable the Database Center API.:  https://cloud.google.com/database-center/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -110,7 +110,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Database Center API Product documentation:  https://cloud.google.com/database-center/docs/overview
+.. _Database Center API Product documentation:  https://cloud.google.com/database-center/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-databasecenter/docs/README.rst
+++ b/packages/google-cloud-databasecenter/docs/README.rst
@@ -20,9 +20,9 @@ quickly identify and address relevant issues within their database fleets.
    :target: https://pypi.org/project/google-cloud-databasecenter/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-databasecenter.svg
    :target: https://pypi.org/project/google-cloud-databasecenter/
-.. _Database Center API: https://cloud.google.com/database-center/docs/overview
+.. _Database Center API: https://cloud.google.com/database-center/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-databasecenter/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/database-center/docs/overview
+.. _Product Documentation:  https://cloud.google.com/database-center/
 
 Quick Start
 -----------
@@ -36,7 +36,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Database Center API.:  https://cloud.google.com/database-center/docs/overview
+.. _Enable the Database Center API.:  https://cloud.google.com/database-center/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -110,7 +110,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Database Center API Product documentation:  https://cloud.google.com/database-center/docs/overview
+.. _Database Center API Product documentation:  https://cloud.google.com/database-center/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/.repo-metadata.json
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-datacatalog-lineage-configmanagement",
     "name_pretty": "Data Lineage API",
-    "product_documentation": "https://cloud.google.com/dataplex/docs/about-data-lineage",
+    "product_documentation": "https://cloud.google.com/dataplex/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/README.rst
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/README.rst
@@ -14,9 +14,9 @@ Python Client for Data Lineage API
    :target: https://pypi.org/project/google-cloud-datacatalog-lineage-configmanagement/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datacatalog-lineage-configmanagement.svg
    :target: https://pypi.org/project/google-cloud-datacatalog-lineage-configmanagement/
-.. _Data Lineage API: https://cloud.google.com/dataplex/docs/about-data-lineage
+.. _Data Lineage API: https://cloud.google.com/dataplex/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-datacatalog-lineage-configmanagement/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/dataplex/docs/about-data-lineage
+.. _Product Documentation:  https://cloud.google.com/dataplex/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Data Lineage API.:  https://cloud.google.com/dataplex/docs/about-data-lineage
+.. _Enable the Data Lineage API.:  https://cloud.google.com/dataplex/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Data Lineage API Product documentation:  https://cloud.google.com/dataplex/docs/about-data-lineage
+.. _Data Lineage API Product documentation:  https://cloud.google.com/dataplex/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/docs/README.rst
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Data Lineage API
    :target: https://pypi.org/project/google-cloud-datacatalog-lineage-configmanagement/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datacatalog-lineage-configmanagement.svg
    :target: https://pypi.org/project/google-cloud-datacatalog-lineage-configmanagement/
-.. _Data Lineage API: https://cloud.google.com/dataplex/docs/about-data-lineage
+.. _Data Lineage API: https://cloud.google.com/dataplex/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-datacatalog-lineage-configmanagement/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/dataplex/docs/about-data-lineage
+.. _Product Documentation:  https://cloud.google.com/dataplex/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Data Lineage API.:  https://cloud.google.com/dataplex/docs/about-data-lineage
+.. _Enable the Data Lineage API.:  https://cloud.google.com/dataplex/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Data Lineage API Product documentation:  https://cloud.google.com/dataplex/docs/about-data-lineage
+.. _Data Lineage API Product documentation:  https://cloud.google.com/dataplex/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-datacatalog-lineage/.repo-metadata.json
+++ b/packages/google-cloud-datacatalog-lineage/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "lineage",
     "name_pretty": "Data Lineage API",
-    "product_documentation": "https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage",
+    "product_documentation": "https://cloud.google.com/data-catalog/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-datacatalog-lineage/README.rst
+++ b/packages/google-cloud-datacatalog-lineage/README.rst
@@ -14,9 +14,9 @@ Python Client for Data Lineage API
    :target: https://pypi.org/project/google-cloud-datacatalog-lineage/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datacatalog-lineage.svg
    :target: https://pypi.org/project/google-cloud-datacatalog-lineage/
-.. _Data Lineage API: https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage
+.. _Data Lineage API: https://cloud.google.com/data-catalog/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/lineage/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage
+.. _Product Documentation:  https://cloud.google.com/data-catalog/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Data Lineage API.:  https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage
+.. _Enable the Data Lineage API.:  https://cloud.google.com/data-catalog/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Data Lineage API Product documentation:  https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage
+.. _Data Lineage API Product documentation:  https://cloud.google.com/data-catalog/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-datacatalog-lineage/docs/README.rst
+++ b/packages/google-cloud-datacatalog-lineage/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Data Lineage API
    :target: https://pypi.org/project/google-cloud-datacatalog-lineage/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datacatalog-lineage.svg
    :target: https://pypi.org/project/google-cloud-datacatalog-lineage/
-.. _Data Lineage API: https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage
+.. _Data Lineage API: https://cloud.google.com/data-catalog/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/lineage/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage
+.. _Product Documentation:  https://cloud.google.com/data-catalog/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Data Lineage API.:  https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage
+.. _Enable the Data Lineage API.:  https://cloud.google.com/data-catalog/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Data Lineage API Product documentation:  https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage
+.. _Data Lineage API Product documentation:  https://cloud.google.com/data-catalog/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-datacatalog/.repo-metadata.json
+++ b/packages/google-cloud-datacatalog/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "datacatalog",
     "name_pretty": "Google Cloud Data Catalog",
-    "product_documentation": "https://cloud.google.com/data-catalog",
+    "product_documentation": "https://cloud.google.com/data-catalog/docs",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-datacatalog/README.rst
+++ b/packages/google-cloud-datacatalog/README.rst
@@ -14,9 +14,9 @@ Python Client for Google Cloud Data Catalog
    :target: https://pypi.org/project/google-cloud-datacatalog/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datacatalog.svg
    :target: https://pypi.org/project/google-cloud-datacatalog/
-.. _Google Cloud Data Catalog: https://cloud.google.com/data-catalog
+.. _Google Cloud Data Catalog: https://cloud.google.com/data-catalog/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/datacatalog/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/data-catalog
+.. _Product Documentation:  https://cloud.google.com/data-catalog/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Data Catalog.:  https://cloud.google.com/data-catalog
+.. _Enable the Google Cloud Data Catalog.:  https://cloud.google.com/data-catalog/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Data Catalog Product documentation:  https://cloud.google.com/data-catalog
+.. _Google Cloud Data Catalog Product documentation:  https://cloud.google.com/data-catalog/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-datacatalog/docs/README.rst
+++ b/packages/google-cloud-datacatalog/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Google Cloud Data Catalog
    :target: https://pypi.org/project/google-cloud-datacatalog/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datacatalog.svg
    :target: https://pypi.org/project/google-cloud-datacatalog/
-.. _Google Cloud Data Catalog: https://cloud.google.com/data-catalog
+.. _Google Cloud Data Catalog: https://cloud.google.com/data-catalog/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/datacatalog/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/data-catalog
+.. _Product Documentation:  https://cloud.google.com/data-catalog/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Data Catalog.:  https://cloud.google.com/data-catalog
+.. _Enable the Google Cloud Data Catalog.:  https://cloud.google.com/data-catalog/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Data Catalog Product documentation:  https://cloud.google.com/data-catalog
+.. _Google Cloud Data Catalog Product documentation:  https://cloud.google.com/data-catalog/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-dataform/.repo-metadata.json
+++ b/packages/google-cloud-dataform/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "dataform",
     "name_pretty": "Cloud Dataform",
-    "product_documentation": "https://cloud.google.com",
+    "product_documentation": "https://cloud.google.com/dataform/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-dataform/README.rst
+++ b/packages/google-cloud-dataform/README.rst
@@ -15,9 +15,9 @@ BigQuery.
    :target: https://pypi.org/project/google-cloud-dataform/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dataform.svg
    :target: https://pypi.org/project/google-cloud-dataform/
-.. _Cloud Dataform: https://cloud.google.com
+.. _Cloud Dataform: https://cloud.google.com/dataform/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dataform/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com
+.. _Product Documentation:  https://cloud.google.com/dataform/
 
 Quick Start
 -----------
@@ -31,7 +31,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Dataform.:  https://cloud.google.com
+.. _Enable the Cloud Dataform.:  https://cloud.google.com/dataform/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -105,7 +105,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Dataform Product documentation:  https://cloud.google.com
+.. _Cloud Dataform Product documentation:  https://cloud.google.com/dataform/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-dataform/docs/README.rst
+++ b/packages/google-cloud-dataform/docs/README.rst
@@ -15,9 +15,9 @@ BigQuery.
    :target: https://pypi.org/project/google-cloud-dataform/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dataform.svg
    :target: https://pypi.org/project/google-cloud-dataform/
-.. _Cloud Dataform: https://cloud.google.com
+.. _Cloud Dataform: https://cloud.google.com/dataform/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dataform/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com
+.. _Product Documentation:  https://cloud.google.com/dataform/
 
 Quick Start
 -----------
@@ -31,7 +31,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Dataform.:  https://cloud.google.com
+.. _Enable the Cloud Dataform.:  https://cloud.google.com/dataform/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -105,7 +105,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Dataform Product documentation:  https://cloud.google.com
+.. _Cloud Dataform Product documentation:  https://cloud.google.com/dataform/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-datalabeling/.repo-metadata.json
+++ b/packages/google-cloud-datalabeling/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "datalabeling",
     "name_pretty": "Google Cloud Data Labeling",
-    "product_documentation": "https://cloud.google.com/data-labeling/docs/",
+    "product_documentation": "https://cloud.google.com/data-labeling/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-datalabeling/README.rst
+++ b/packages/google-cloud-datalabeling/README.rst
@@ -14,9 +14,9 @@ Python Client for Google Cloud Data Labeling
    :target: https://pypi.org/project/google-cloud-datalabeling/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datalabeling.svg
    :target: https://pypi.org/project/google-cloud-datalabeling/
-.. _Google Cloud Data Labeling: https://cloud.google.com/data-labeling/docs/
+.. _Google Cloud Data Labeling: https://cloud.google.com/data-labeling/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/datalabeling/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/data-labeling/docs/
+.. _Product Documentation:  https://cloud.google.com/data-labeling/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Data Labeling.:  https://cloud.google.com/data-labeling/docs/
+.. _Enable the Google Cloud Data Labeling.:  https://cloud.google.com/data-labeling/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Data Labeling Product documentation:  https://cloud.google.com/data-labeling/docs/
+.. _Google Cloud Data Labeling Product documentation:  https://cloud.google.com/data-labeling/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-datalabeling/docs/README.rst
+++ b/packages/google-cloud-datalabeling/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Google Cloud Data Labeling
    :target: https://pypi.org/project/google-cloud-datalabeling/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datalabeling.svg
    :target: https://pypi.org/project/google-cloud-datalabeling/
-.. _Google Cloud Data Labeling: https://cloud.google.com/data-labeling/docs/
+.. _Google Cloud Data Labeling: https://cloud.google.com/data-labeling/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/datalabeling/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/data-labeling/docs/
+.. _Product Documentation:  https://cloud.google.com/data-labeling/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Data Labeling.:  https://cloud.google.com/data-labeling/docs/
+.. _Enable the Google Cloud Data Labeling.:  https://cloud.google.com/data-labeling/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Data Labeling Product documentation:  https://cloud.google.com/data-labeling/docs/
+.. _Google Cloud Data Labeling Product documentation:  https://cloud.google.com/data-labeling/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-dataplex/.repo-metadata.json
+++ b/packages/google-cloud-dataplex/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "dataplex",
     "name_pretty": "Cloud Dataplex",
-    "product_documentation": "https://cloud.google.com/dataplex",
+    "product_documentation": "https://cloud.google.com/dataplex/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-dataplex/README.rst
+++ b/packages/google-cloud-dataplex/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Dataplex
    :target: https://pypi.org/project/google-cloud-dataplex/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dataplex.svg
    :target: https://pypi.org/project/google-cloud-dataplex/
-.. _Cloud Dataplex: https://cloud.google.com/dataplex
+.. _Cloud Dataplex: https://cloud.google.com/dataplex/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dataplex/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/dataplex
+.. _Product Documentation:  https://cloud.google.com/dataplex/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Dataplex.:  https://cloud.google.com/dataplex
+.. _Enable the Cloud Dataplex.:  https://cloud.google.com/dataplex/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Dataplex Product documentation:  https://cloud.google.com/dataplex
+.. _Cloud Dataplex Product documentation:  https://cloud.google.com/dataplex/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-dataplex/docs/README.rst
+++ b/packages/google-cloud-dataplex/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Dataplex
    :target: https://pypi.org/project/google-cloud-dataplex/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dataplex.svg
    :target: https://pypi.org/project/google-cloud-dataplex/
-.. _Cloud Dataplex: https://cloud.google.com/dataplex
+.. _Cloud Dataplex: https://cloud.google.com/dataplex/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dataplex/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/dataplex
+.. _Product Documentation:  https://cloud.google.com/dataplex/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Dataplex.:  https://cloud.google.com/dataplex
+.. _Enable the Cloud Dataplex.:  https://cloud.google.com/dataplex/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Dataplex Product documentation:  https://cloud.google.com/dataplex
+.. _Cloud Dataplex Product documentation:  https://cloud.google.com/dataplex/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-developerconnect/.repo-metadata.json
+++ b/packages/google-cloud-developerconnect/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-developerconnect",
     "name_pretty": "Developer Connect API",
-    "product_documentation": "https://cloud.google.com/developer-connect/docs/overview",
+    "product_documentation": "https://cloud.google.com/developer-connect/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-developerconnect/README.rst
+++ b/packages/google-cloud-developerconnect/README.rst
@@ -14,9 +14,9 @@ Python Client for Developer Connect API
    :target: https://pypi.org/project/google-cloud-developerconnect/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-developerconnect.svg
    :target: https://pypi.org/project/google-cloud-developerconnect/
-.. _Developer Connect API: https://cloud.google.com/developer-connect/docs/overview
+.. _Developer Connect API: https://cloud.google.com/developer-connect/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-developerconnect/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/developer-connect/docs/overview
+.. _Product Documentation:  https://cloud.google.com/developer-connect/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Developer Connect API.:  https://cloud.google.com/developer-connect/docs/overview
+.. _Enable the Developer Connect API.:  https://cloud.google.com/developer-connect/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Developer Connect API Product documentation:  https://cloud.google.com/developer-connect/docs/overview
+.. _Developer Connect API Product documentation:  https://cloud.google.com/developer-connect/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-developerconnect/docs/README.rst
+++ b/packages/google-cloud-developerconnect/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Developer Connect API
    :target: https://pypi.org/project/google-cloud-developerconnect/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-developerconnect.svg
    :target: https://pypi.org/project/google-cloud-developerconnect/
-.. _Developer Connect API: https://cloud.google.com/developer-connect/docs/overview
+.. _Developer Connect API: https://cloud.google.com/developer-connect/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-developerconnect/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/developer-connect/docs/overview
+.. _Product Documentation:  https://cloud.google.com/developer-connect/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Developer Connect API.:  https://cloud.google.com/developer-connect/docs/overview
+.. _Enable the Developer Connect API.:  https://cloud.google.com/developer-connect/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Developer Connect API Product documentation:  https://cloud.google.com/developer-connect/docs/overview
+.. _Developer Connect API Product documentation:  https://cloud.google.com/developer-connect/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-discoveryengine/.repo-metadata.json
+++ b/packages/google-cloud-discoveryengine/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "discoveryengine",
     "name_pretty": "Discovery Engine API",
-    "product_documentation": "https://cloud.google.com/discovery-engine/",
+    "product_documentation": "https://cloud.google.com/generative-ai-app-builder/docs",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-discoveryengine/README.rst
+++ b/packages/google-cloud-discoveryengine/README.rst
@@ -14,9 +14,9 @@ Python Client for Discovery Engine API
    :target: https://pypi.org/project/google-cloud-discoveryengine/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-discoveryengine.svg
    :target: https://pypi.org/project/google-cloud-discoveryengine/
-.. _Discovery Engine API: https://cloud.google.com/discovery-engine/
+.. _Discovery Engine API: https://cloud.google.com/generative-ai-app-builder/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/discoveryengine/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/discovery-engine/
+.. _Product Documentation:  https://cloud.google.com/generative-ai-app-builder/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Discovery Engine API.:  https://cloud.google.com/discovery-engine/
+.. _Enable the Discovery Engine API.:  https://cloud.google.com/generative-ai-app-builder/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Discovery Engine API Product documentation:  https://cloud.google.com/discovery-engine/
+.. _Discovery Engine API Product documentation:  https://cloud.google.com/generative-ai-app-builder/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-discoveryengine/docs/README.rst
+++ b/packages/google-cloud-discoveryengine/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Discovery Engine API
    :target: https://pypi.org/project/google-cloud-discoveryengine/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-discoveryengine.svg
    :target: https://pypi.org/project/google-cloud-discoveryengine/
-.. _Discovery Engine API: https://cloud.google.com/discovery-engine/
+.. _Discovery Engine API: https://cloud.google.com/generative-ai-app-builder/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/discoveryengine/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/discovery-engine/
+.. _Product Documentation:  https://cloud.google.com/generative-ai-app-builder/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Discovery Engine API.:  https://cloud.google.com/discovery-engine/
+.. _Enable the Discovery Engine API.:  https://cloud.google.com/generative-ai-app-builder/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Discovery Engine API Product documentation:  https://cloud.google.com/discovery-engine/
+.. _Discovery Engine API Product documentation:  https://cloud.google.com/generative-ai-app-builder/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-dlp/.repo-metadata.json
+++ b/packages/google-cloud-dlp/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "dlp",
     "name_pretty": "Cloud Data Loss Prevention",
-    "product_documentation": "https://cloud.google.com/dlp/docs/",
+    "product_documentation": "https://cloud.google.com/dlp/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-dlp/README.rst
+++ b/packages/google-cloud-dlp/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Data Loss Prevention
    :target: https://pypi.org/project/google-cloud-dlp/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dlp.svg
    :target: https://pypi.org/project/google-cloud-dlp/
-.. _Cloud Data Loss Prevention: https://cloud.google.com/dlp/docs/
+.. _Cloud Data Loss Prevention: https://cloud.google.com/dlp/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dlp/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/dlp/docs/
+.. _Product Documentation:  https://cloud.google.com/dlp/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Data Loss Prevention.:  https://cloud.google.com/dlp/docs/
+.. _Enable the Cloud Data Loss Prevention.:  https://cloud.google.com/dlp/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Data Loss Prevention Product documentation:  https://cloud.google.com/dlp/docs/
+.. _Cloud Data Loss Prevention Product documentation:  https://cloud.google.com/dlp/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-dlp/docs/README.rst
+++ b/packages/google-cloud-dlp/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Data Loss Prevention
    :target: https://pypi.org/project/google-cloud-dlp/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dlp.svg
    :target: https://pypi.org/project/google-cloud-dlp/
-.. _Cloud Data Loss Prevention: https://cloud.google.com/dlp/docs/
+.. _Cloud Data Loss Prevention: https://cloud.google.com/dlp/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dlp/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/dlp/docs/
+.. _Product Documentation:  https://cloud.google.com/dlp/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Data Loss Prevention.:  https://cloud.google.com/dlp/docs/
+.. _Enable the Cloud Data Loss Prevention.:  https://cloud.google.com/dlp/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Data Loss Prevention Product documentation:  https://cloud.google.com/dlp/docs/
+.. _Cloud Data Loss Prevention Product documentation:  https://cloud.google.com/dlp/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-dns/.repo-metadata.json
+++ b/packages/google-cloud-dns/.repo-metadata.json
@@ -7,7 +7,6 @@
     "library_type": "REST",
     "name": "dns",
     "name_pretty": "Cloud DNS",
-    "product_documentation": "https://cloud.google.com/dns",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-edgenetwork/.repo-metadata.json
+++ b/packages/google-cloud-edgenetwork/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-edgenetwork",
     "name_pretty": "Distributed Cloud Edge Network API",
-    "product_documentation": "https://cloud.google.com/distributed-cloud/edge/latest/docs/overview",
+    "product_documentation": "https://cloud.google.com/distributed-cloud/edge/latest/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-edgenetwork/README.rst
+++ b/packages/google-cloud-edgenetwork/README.rst
@@ -14,9 +14,9 @@ Python Client for Distributed Cloud Edge Network API
    :target: https://pypi.org/project/google-cloud-edgenetwork/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-edgenetwork.svg
    :target: https://pypi.org/project/google-cloud-edgenetwork/
-.. _Distributed Cloud Edge Network API: https://cloud.google.com/distributed-cloud/edge/latest/docs/overview
+.. _Distributed Cloud Edge Network API: https://cloud.google.com/distributed-cloud/edge/latest/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-edgenetwork/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/distributed-cloud/edge/latest/docs/overview
+.. _Product Documentation:  https://cloud.google.com/distributed-cloud/edge/latest/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Distributed Cloud Edge Network API.:  https://cloud.google.com/distributed-cloud/edge/latest/docs/overview
+.. _Enable the Distributed Cloud Edge Network API.:  https://cloud.google.com/distributed-cloud/edge/latest/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Distributed Cloud Edge Network API Product documentation:  https://cloud.google.com/distributed-cloud/edge/latest/docs/overview
+.. _Distributed Cloud Edge Network API Product documentation:  https://cloud.google.com/distributed-cloud/edge/latest/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-edgenetwork/docs/README.rst
+++ b/packages/google-cloud-edgenetwork/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Distributed Cloud Edge Network API
    :target: https://pypi.org/project/google-cloud-edgenetwork/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-edgenetwork.svg
    :target: https://pypi.org/project/google-cloud-edgenetwork/
-.. _Distributed Cloud Edge Network API: https://cloud.google.com/distributed-cloud/edge/latest/docs/overview
+.. _Distributed Cloud Edge Network API: https://cloud.google.com/distributed-cloud/edge/latest/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-edgenetwork/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/distributed-cloud/edge/latest/docs/overview
+.. _Product Documentation:  https://cloud.google.com/distributed-cloud/edge/latest/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Distributed Cloud Edge Network API.:  https://cloud.google.com/distributed-cloud/edge/latest/docs/overview
+.. _Enable the Distributed Cloud Edge Network API.:  https://cloud.google.com/distributed-cloud/edge/latest/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Distributed Cloud Edge Network API Product documentation:  https://cloud.google.com/distributed-cloud/edge/latest/docs/overview
+.. _Distributed Cloud Edge Network API Product documentation:  https://cloud.google.com/distributed-cloud/edge/latest/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-essential-contacts/.repo-metadata.json
+++ b/packages/google-cloud-essential-contacts/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "essentialcontacts",
     "name_pretty": "Essential Contacts",
-    "product_documentation": "https://cloud.google.com/resource-manager/docs/managing-notification-contacts/",
+    "product_documentation": "https://cloud.google.com/resource-manager/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-essential-contacts/README.rst
+++ b/packages/google-cloud-essential-contacts/README.rst
@@ -14,9 +14,9 @@ Python Client for Essential Contacts
    :target: https://pypi.org/project/google-cloud-essential-contacts/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-essential-contacts.svg
    :target: https://pypi.org/project/google-cloud-essential-contacts/
-.. _Essential Contacts: https://cloud.google.com/resource-manager/docs/managing-notification-contacts/
+.. _Essential Contacts: https://cloud.google.com/resource-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/essentialcontacts/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/resource-manager/docs/managing-notification-contacts/
+.. _Product Documentation:  https://cloud.google.com/resource-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Essential Contacts.:  https://cloud.google.com/resource-manager/docs/managing-notification-contacts/
+.. _Enable the Essential Contacts.:  https://cloud.google.com/resource-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Essential Contacts Product documentation:  https://cloud.google.com/resource-manager/docs/managing-notification-contacts/
+.. _Essential Contacts Product documentation:  https://cloud.google.com/resource-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-essential-contacts/docs/README.rst
+++ b/packages/google-cloud-essential-contacts/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Essential Contacts
    :target: https://pypi.org/project/google-cloud-essential-contacts/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-essential-contacts.svg
    :target: https://pypi.org/project/google-cloud-essential-contacts/
-.. _Essential Contacts: https://cloud.google.com/resource-manager/docs/managing-notification-contacts/
+.. _Essential Contacts: https://cloud.google.com/resource-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/essentialcontacts/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/resource-manager/docs/managing-notification-contacts/
+.. _Product Documentation:  https://cloud.google.com/resource-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Essential Contacts.:  https://cloud.google.com/resource-manager/docs/managing-notification-contacts/
+.. _Enable the Essential Contacts.:  https://cloud.google.com/resource-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Essential Contacts Product documentation:  https://cloud.google.com/resource-manager/docs/managing-notification-contacts/
+.. _Essential Contacts Product documentation:  https://cloud.google.com/resource-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-financialservices/.repo-metadata.json
+++ b/packages/google-cloud-financialservices/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-financialservices",
     "name_pretty": "Anti Money Laundering AI API",
-    "product_documentation": "https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview",
+    "product_documentation": "https://cloud.google.com/financial-services/anti-money-laundering/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-financialservices/README.rst
+++ b/packages/google-cloud-financialservices/README.rst
@@ -14,9 +14,9 @@ Python Client for Anti Money Laundering AI API
    :target: https://pypi.org/project/google-cloud-financialservices/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-financialservices.svg
    :target: https://pypi.org/project/google-cloud-financialservices/
-.. _Anti Money Laundering AI API: https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview
+.. _Anti Money Laundering AI API: https://cloud.google.com/financial-services/anti-money-laundering/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-financialservices/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview
+.. _Product Documentation:  https://cloud.google.com/financial-services/anti-money-laundering/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Anti Money Laundering AI API.:  https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview
+.. _Enable the Anti Money Laundering AI API.:  https://cloud.google.com/financial-services/anti-money-laundering/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Anti Money Laundering AI API Product documentation:  https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview
+.. _Anti Money Laundering AI API Product documentation:  https://cloud.google.com/financial-services/anti-money-laundering/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-financialservices/docs/README.rst
+++ b/packages/google-cloud-financialservices/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Anti Money Laundering AI API
    :target: https://pypi.org/project/google-cloud-financialservices/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-financialservices.svg
    :target: https://pypi.org/project/google-cloud-financialservices/
-.. _Anti Money Laundering AI API: https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview
+.. _Anti Money Laundering AI API: https://cloud.google.com/financial-services/anti-money-laundering/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-financialservices/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview
+.. _Product Documentation:  https://cloud.google.com/financial-services/anti-money-laundering/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Anti Money Laundering AI API.:  https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview
+.. _Enable the Anti Money Laundering AI API.:  https://cloud.google.com/financial-services/anti-money-laundering/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Anti Money Laundering AI API Product documentation:  https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview
+.. _Anti Money Laundering AI API Product documentation:  https://cloud.google.com/financial-services/anti-money-laundering/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-geminidataanalytics/.repo-metadata.json
+++ b/packages/google-cloud-geminidataanalytics/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-geminidataanalytics",
     "name_pretty": "Data Analytics API with Gemini",
-    "product_documentation": "https://cloud.google.com/gemini/docs/conversational-analytics-api/overview",
+    "product_documentation": "https://cloud.google.com/gemini/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-geminidataanalytics/README.rst
+++ b/packages/google-cloud-geminidataanalytics/README.rst
@@ -14,9 +14,9 @@ Python Client for Data Analytics API with Gemini
    :target: https://pypi.org/project/google-cloud-geminidataanalytics/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-geminidataanalytics.svg
    :target: https://pypi.org/project/google-cloud-geminidataanalytics/
-.. _Data Analytics API with Gemini: https://cloud.google.com/gemini/docs/conversational-analytics-api/overview
+.. _Data Analytics API with Gemini: https://cloud.google.com/gemini/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-geminidataanalytics/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/gemini/docs/conversational-analytics-api/overview
+.. _Product Documentation:  https://cloud.google.com/gemini/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Data Analytics API with Gemini.:  https://cloud.google.com/gemini/docs/conversational-analytics-api/overview
+.. _Enable the Data Analytics API with Gemini.:  https://cloud.google.com/gemini/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Data Analytics API with Gemini Product documentation:  https://cloud.google.com/gemini/docs/conversational-analytics-api/overview
+.. _Data Analytics API with Gemini Product documentation:  https://cloud.google.com/gemini/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-geminidataanalytics/docs/README.rst
+++ b/packages/google-cloud-geminidataanalytics/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Data Analytics API with Gemini
    :target: https://pypi.org/project/google-cloud-geminidataanalytics/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-geminidataanalytics.svg
    :target: https://pypi.org/project/google-cloud-geminidataanalytics/
-.. _Data Analytics API with Gemini: https://cloud.google.com/gemini/docs/conversational-analytics-api/overview
+.. _Data Analytics API with Gemini: https://cloud.google.com/gemini/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-geminidataanalytics/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/gemini/docs/conversational-analytics-api/overview
+.. _Product Documentation:  https://cloud.google.com/gemini/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Data Analytics API with Gemini.:  https://cloud.google.com/gemini/docs/conversational-analytics-api/overview
+.. _Enable the Data Analytics API with Gemini.:  https://cloud.google.com/gemini/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Data Analytics API with Gemini Product documentation:  https://cloud.google.com/gemini/docs/conversational-analytics-api/overview
+.. _Data Analytics API with Gemini Product documentation:  https://cloud.google.com/gemini/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-gke-backup/.repo-metadata.json
+++ b/packages/google-cloud-gke-backup/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "gkebackup",
     "name_pretty": "Backup for GKE",
-    "product_documentation": "https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke",
+    "product_documentation": "https://cloud.google.com/kubernetes-engine/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-gke-backup/README.rst
+++ b/packages/google-cloud-gke-backup/README.rst
@@ -14,9 +14,9 @@ Python Client for Backup for GKE
    :target: https://pypi.org/project/google-cloud-gke-backup/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gke-backup.svg
    :target: https://pypi.org/project/google-cloud-gke-backup/
-.. _Backup for GKE: https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke
+.. _Backup for GKE: https://cloud.google.com/kubernetes-engine/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/gkebackup/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke
+.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Backup for GKE.:  https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke
+.. _Enable the Backup for GKE.:  https://cloud.google.com/kubernetes-engine/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Backup for GKE Product documentation:  https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke
+.. _Backup for GKE Product documentation:  https://cloud.google.com/kubernetes-engine/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-gke-backup/docs/README.rst
+++ b/packages/google-cloud-gke-backup/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Backup for GKE
    :target: https://pypi.org/project/google-cloud-gke-backup/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gke-backup.svg
    :target: https://pypi.org/project/google-cloud-gke-backup/
-.. _Backup for GKE: https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke
+.. _Backup for GKE: https://cloud.google.com/kubernetes-engine/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/gkebackup/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke
+.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Backup for GKE.:  https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke
+.. _Enable the Backup for GKE.:  https://cloud.google.com/kubernetes-engine/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Backup for GKE Product documentation:  https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke
+.. _Backup for GKE Product documentation:  https://cloud.google.com/kubernetes-engine/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-gke-connect-gateway/.repo-metadata.json
+++ b/packages/google-cloud-gke-connect-gateway/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "connectgateway",
     "name_pretty": "GKE Connect Gateway",
-    "product_documentation": "https://cloud.google.com/anthos/multicluster-management/gateway",
+    "product_documentation": "https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-gke-connect-gateway/README.rst
+++ b/packages/google-cloud-gke-connect-gateway/README.rst
@@ -14,9 +14,9 @@ Python Client for GKE Connect Gateway
    :target: https://pypi.org/project/google-cloud-gke-connect-gateway/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gke-connect-gateway.svg
    :target: https://pypi.org/project/google-cloud-gke-connect-gateway/
-.. _GKE Connect Gateway: https://cloud.google.com/anthos/multicluster-management/gateway
+.. _GKE Connect Gateway: https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/connectgateway/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/anthos/multicluster-management/gateway
+.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the GKE Connect Gateway.:  https://cloud.google.com/anthos/multicluster-management/gateway
+.. _Enable the GKE Connect Gateway.:  https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _GKE Connect Gateway Product documentation:  https://cloud.google.com/anthos/multicluster-management/gateway
+.. _GKE Connect Gateway Product documentation:  https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-gke-connect-gateway/docs/README.rst
+++ b/packages/google-cloud-gke-connect-gateway/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for GKE Connect Gateway
    :target: https://pypi.org/project/google-cloud-gke-connect-gateway/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gke-connect-gateway.svg
    :target: https://pypi.org/project/google-cloud-gke-connect-gateway/
-.. _GKE Connect Gateway: https://cloud.google.com/anthos/multicluster-management/gateway
+.. _GKE Connect Gateway: https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/connectgateway/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/anthos/multicluster-management/gateway
+.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the GKE Connect Gateway.:  https://cloud.google.com/anthos/multicluster-management/gateway
+.. _Enable the GKE Connect Gateway.:  https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _GKE Connect Gateway Product documentation:  https://cloud.google.com/anthos/multicluster-management/gateway
+.. _GKE Connect Gateway Product documentation:  https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-gke-hub/.repo-metadata.json
+++ b/packages/google-cloud-gke-hub/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "gkehub",
     "name_pretty": "GKE Hub",
-    "product_documentation": "https://cloud.google.com/anthos/gke/docs/",
+    "product_documentation": "https://cloud.google.com/anthos/gke/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-gke-hub/README.rst
+++ b/packages/google-cloud-gke-hub/README.rst
@@ -14,9 +14,9 @@ Python Client for GKE Hub
    :target: https://pypi.org/project/google-cloud-gke-hub/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gke-hub.svg
    :target: https://pypi.org/project/google-cloud-gke-hub/
-.. _GKE Hub: https://cloud.google.com/anthos/gke/docs/
+.. _GKE Hub: https://cloud.google.com/anthos/gke/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/gkehub/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/anthos/gke/docs/
+.. _Product Documentation:  https://cloud.google.com/anthos/gke/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the GKE Hub.:  https://cloud.google.com/anthos/gke/docs/
+.. _Enable the GKE Hub.:  https://cloud.google.com/anthos/gke/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _GKE Hub Product documentation:  https://cloud.google.com/anthos/gke/docs/
+.. _GKE Hub Product documentation:  https://cloud.google.com/anthos/gke/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-gke-hub/docs/README.rst
+++ b/packages/google-cloud-gke-hub/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for GKE Hub
    :target: https://pypi.org/project/google-cloud-gke-hub/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gke-hub.svg
    :target: https://pypi.org/project/google-cloud-gke-hub/
-.. _GKE Hub: https://cloud.google.com/anthos/gke/docs/
+.. _GKE Hub: https://cloud.google.com/anthos/gke/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/gkehub/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/anthos/gke/docs/
+.. _Product Documentation:  https://cloud.google.com/anthos/gke/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the GKE Hub.:  https://cloud.google.com/anthos/gke/docs/
+.. _Enable the GKE Hub.:  https://cloud.google.com/anthos/gke/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _GKE Hub Product documentation:  https://cloud.google.com/anthos/gke/docs/
+.. _GKE Hub Product documentation:  https://cloud.google.com/anthos/gke/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-gke-multicloud/.repo-metadata.json
+++ b/packages/google-cloud-gke-multicloud/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "gkemulticloud",
     "name_pretty": "Anthos Multicloud",
-    "product_documentation": "https://cloud.google.com/anthos/clusters/docs/multi-cloud",
+    "product_documentation": "https://cloud.google.com/kubernetes-engine/multi-cloud/docs",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-gke-multicloud/README.rst
+++ b/packages/google-cloud-gke-multicloud/README.rst
@@ -14,9 +14,9 @@ Python Client for Anthos Multicloud
    :target: https://pypi.org/project/google-cloud-gke-multicloud/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gke-multicloud.svg
    :target: https://pypi.org/project/google-cloud-gke-multicloud/
-.. _Anthos Multicloud: https://cloud.google.com/anthos/clusters/docs/multi-cloud
+.. _Anthos Multicloud: https://cloud.google.com/kubernetes-engine/multi-cloud/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/gkemulticloud/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/anthos/clusters/docs/multi-cloud
+.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/multi-cloud/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Anthos Multicloud.:  https://cloud.google.com/anthos/clusters/docs/multi-cloud
+.. _Enable the Anthos Multicloud.:  https://cloud.google.com/kubernetes-engine/multi-cloud/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Anthos Multicloud Product documentation:  https://cloud.google.com/anthos/clusters/docs/multi-cloud
+.. _Anthos Multicloud Product documentation:  https://cloud.google.com/kubernetes-engine/multi-cloud/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-gke-multicloud/docs/README.rst
+++ b/packages/google-cloud-gke-multicloud/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Anthos Multicloud
    :target: https://pypi.org/project/google-cloud-gke-multicloud/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gke-multicloud.svg
    :target: https://pypi.org/project/google-cloud-gke-multicloud/
-.. _Anthos Multicloud: https://cloud.google.com/anthos/clusters/docs/multi-cloud
+.. _Anthos Multicloud: https://cloud.google.com/kubernetes-engine/multi-cloud/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/gkemulticloud/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/anthos/clusters/docs/multi-cloud
+.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/multi-cloud/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Anthos Multicloud.:  https://cloud.google.com/anthos/clusters/docs/multi-cloud
+.. _Enable the Anthos Multicloud.:  https://cloud.google.com/kubernetes-engine/multi-cloud/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Anthos Multicloud Product documentation:  https://cloud.google.com/anthos/clusters/docs/multi-cloud
+.. _Anthos Multicloud Product documentation:  https://cloud.google.com/kubernetes-engine/multi-cloud/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-gkerecommender/.repo-metadata.json
+++ b/packages/google-cloud-gkerecommender/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-gkerecommender",
     "name_pretty": "GKE Recommender API",
-    "product_documentation": "https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart",
+    "product_documentation": "https://cloud.google.com/kubernetes-engine/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-gkerecommender/README.rst
+++ b/packages/google-cloud-gkerecommender/README.rst
@@ -14,9 +14,9 @@ Python Client for GKE Recommender API
    :target: https://pypi.org/project/google-cloud-gkerecommender/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gkerecommender.svg
    :target: https://pypi.org/project/google-cloud-gkerecommender/
-.. _GKE Recommender API: https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart
+.. _GKE Recommender API: https://cloud.google.com/kubernetes-engine/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-gkerecommender/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart
+.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the GKE Recommender API.:  https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart
+.. _Enable the GKE Recommender API.:  https://cloud.google.com/kubernetes-engine/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _GKE Recommender API Product documentation:  https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart
+.. _GKE Recommender API Product documentation:  https://cloud.google.com/kubernetes-engine/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-gkerecommender/docs/README.rst
+++ b/packages/google-cloud-gkerecommender/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for GKE Recommender API
    :target: https://pypi.org/project/google-cloud-gkerecommender/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gkerecommender.svg
    :target: https://pypi.org/project/google-cloud-gkerecommender/
-.. _GKE Recommender API: https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart
+.. _GKE Recommender API: https://cloud.google.com/kubernetes-engine/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-gkerecommender/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart
+.. _Product Documentation:  https://cloud.google.com/kubernetes-engine/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the GKE Recommender API.:  https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart
+.. _Enable the GKE Recommender API.:  https://cloud.google.com/kubernetes-engine/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _GKE Recommender API Product documentation:  https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart
+.. _GKE Recommender API Product documentation:  https://cloud.google.com/kubernetes-engine/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-hypercomputecluster/.repo-metadata.json
+++ b/packages/google-cloud-hypercomputecluster/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-hypercomputecluster",
     "name_pretty": "Cluster Director API",
-    "product_documentation": "https://cloud.google.com/blog/products/compute/managed-slurm-and-other-cluster-director-enhancements",
+    "product_documentation": "https://cloud.google.com/cluster-director/docs",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-hypercomputecluster/README.rst
+++ b/packages/google-cloud-hypercomputecluster/README.rst
@@ -14,9 +14,9 @@ Python Client for Cluster Director API
    :target: https://pypi.org/project/google-cloud-hypercomputecluster/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-hypercomputecluster.svg
    :target: https://pypi.org/project/google-cloud-hypercomputecluster/
-.. _Cluster Director API: https://cloud.google.com/blog/products/compute/managed-slurm-and-other-cluster-director-enhancements
+.. _Cluster Director API: https://cloud.google.com/cluster-director/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-hypercomputecluster/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/blog/products/compute/managed-slurm-and-other-cluster-director-enhancements
+.. _Product Documentation:  https://cloud.google.com/cluster-director/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cluster Director API.:  https://cloud.google.com/blog/products/compute/managed-slurm-and-other-cluster-director-enhancements
+.. _Enable the Cluster Director API.:  https://cloud.google.com/cluster-director/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cluster Director API Product documentation:  https://cloud.google.com/blog/products/compute/managed-slurm-and-other-cluster-director-enhancements
+.. _Cluster Director API Product documentation:  https://cloud.google.com/cluster-director/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-hypercomputecluster/docs/README.rst
+++ b/packages/google-cloud-hypercomputecluster/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cluster Director API
    :target: https://pypi.org/project/google-cloud-hypercomputecluster/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-hypercomputecluster.svg
    :target: https://pypi.org/project/google-cloud-hypercomputecluster/
-.. _Cluster Director API: https://cloud.google.com/blog/products/compute/managed-slurm-and-other-cluster-director-enhancements
+.. _Cluster Director API: https://cloud.google.com/cluster-director/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-hypercomputecluster/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/blog/products/compute/managed-slurm-and-other-cluster-director-enhancements
+.. _Product Documentation:  https://cloud.google.com/cluster-director/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cluster Director API.:  https://cloud.google.com/blog/products/compute/managed-slurm-and-other-cluster-director-enhancements
+.. _Enable the Cluster Director API.:  https://cloud.google.com/cluster-director/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cluster Director API Product documentation:  https://cloud.google.com/blog/products/compute/managed-slurm-and-other-cluster-director-enhancements
+.. _Cluster Director API Product documentation:  https://cloud.google.com/cluster-director/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-iam-logging/.repo-metadata.json
+++ b/packages/google-cloud-iam-logging/.repo-metadata.json
@@ -7,7 +7,7 @@
     "library_type": "OTHER",
     "name": "iamlogging",
     "name_pretty": "IAM Logging Protos",
-    "product_documentation": "https://cloud.google.com/iam/docs/audit-logging",
+    "product_documentation": "https://cloud.google.com/iam/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-iam-logging/README.rst
+++ b/packages/google-cloud-iam-logging/README.rst
@@ -14,9 +14,9 @@ Python Client for IAM Logging Protos
    :target: https://pypi.org/project/google-cloud-iam-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-iam-logging.svg
    :target: https://pypi.org/project/google-cloud-iam-logging/
-.. _IAM Logging Protos: https://cloud.google.com/iam/docs/audit-logging
+.. _IAM Logging Protos: https://cloud.google.com/iam/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/iamlogging/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/iam/docs/audit-logging
+.. _Product Documentation:  https://cloud.google.com/iam/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the IAM Logging Protos.:  https://cloud.google.com/iam/docs/audit-logging
+.. _Enable the IAM Logging Protos.:  https://cloud.google.com/iam/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _IAM Logging Protos Product documentation:  https://cloud.google.com/iam/docs/audit-logging
+.. _IAM Logging Protos Product documentation:  https://cloud.google.com/iam/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-iam-logging/docs/README.rst
+++ b/packages/google-cloud-iam-logging/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for IAM Logging Protos
    :target: https://pypi.org/project/google-cloud-iam-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-iam-logging.svg
    :target: https://pypi.org/project/google-cloud-iam-logging/
-.. _IAM Logging Protos: https://cloud.google.com/iam/docs/audit-logging
+.. _IAM Logging Protos: https://cloud.google.com/iam/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/iamlogging/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/iam/docs/audit-logging
+.. _Product Documentation:  https://cloud.google.com/iam/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the IAM Logging Protos.:  https://cloud.google.com/iam/docs/audit-logging
+.. _Enable the IAM Logging Protos.:  https://cloud.google.com/iam/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _IAM Logging Protos Product documentation:  https://cloud.google.com/iam/docs/audit-logging
+.. _IAM Logging Protos Product documentation:  https://cloud.google.com/iam/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-iam/.repo-metadata.json
+++ b/packages/google-cloud-iam/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "iam",
     "name_pretty": "Cloud Identity and Access Management",
-    "product_documentation": "https://cloud.google.com/iam/docs/",
+    "product_documentation": "https://cloud.google.com/iam/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-iam/README.rst
+++ b/packages/google-cloud-iam/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Identity and Access Management
    :target: https://pypi.org/project/google-cloud-iam/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-iam.svg
    :target: https://pypi.org/project/google-cloud-iam/
-.. _Cloud Identity and Access Management: https://cloud.google.com/iam/docs/
+.. _Cloud Identity and Access Management: https://cloud.google.com/iam/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/iam/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/iam/docs/
+.. _Product Documentation:  https://cloud.google.com/iam/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Identity and Access Management.:  https://cloud.google.com/iam/docs/
+.. _Enable the Cloud Identity and Access Management.:  https://cloud.google.com/iam/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Identity and Access Management Product documentation:  https://cloud.google.com/iam/docs/
+.. _Cloud Identity and Access Management Product documentation:  https://cloud.google.com/iam/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-iam/docs/README.rst
+++ b/packages/google-cloud-iam/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Identity and Access Management
    :target: https://pypi.org/project/google-cloud-iam/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-iam.svg
    :target: https://pypi.org/project/google-cloud-iam/
-.. _Cloud Identity and Access Management: https://cloud.google.com/iam/docs/
+.. _Cloud Identity and Access Management: https://cloud.google.com/iam/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/iam/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/iam/docs/
+.. _Product Documentation:  https://cloud.google.com/iam/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Identity and Access Management.:  https://cloud.google.com/iam/docs/
+.. _Enable the Cloud Identity and Access Management.:  https://cloud.google.com/iam/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Identity and Access Management Product documentation:  https://cloud.google.com/iam/docs/
+.. _Cloud Identity and Access Management Product documentation:  https://cloud.google.com/iam/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-iamconnectorcredentials/.repo-metadata.json
+++ b/packages/google-cloud-iamconnectorcredentials/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-iamconnectorcredentials",
     "name_pretty": "iamconnectorcredentials.googleapis.com API",
-    "product_documentation": "https://cloud.google.com/iamconnectorcredentials/docs/overview",
+    "product_documentation": "https://cloud.google.com/iamconnectorcredentials/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-iamconnectorcredentials/README.rst
+++ b/packages/google-cloud-iamconnectorcredentials/README.rst
@@ -14,9 +14,9 @@ Python Client for iamconnectorcredentials.googleapis.com API
    :target: https://pypi.org/project/google-cloud-iamconnectorcredentials/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-iamconnectorcredentials.svg
    :target: https://pypi.org/project/google-cloud-iamconnectorcredentials/
-.. _iamconnectorcredentials.googleapis.com API: https://cloud.google.com/iamconnectorcredentials/docs/overview
+.. _iamconnectorcredentials.googleapis.com API: https://cloud.google.com/iamconnectorcredentials/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-iamconnectorcredentials/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/iamconnectorcredentials/docs/overview
+.. _Product Documentation:  https://cloud.google.com/iamconnectorcredentials/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the iamconnectorcredentials.googleapis.com API.:  https://cloud.google.com/iamconnectorcredentials/docs/overview
+.. _Enable the iamconnectorcredentials.googleapis.com API.:  https://cloud.google.com/iamconnectorcredentials/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _iamconnectorcredentials.googleapis.com API Product documentation:  https://cloud.google.com/iamconnectorcredentials/docs/overview
+.. _iamconnectorcredentials.googleapis.com API Product documentation:  https://cloud.google.com/iamconnectorcredentials/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-iamconnectorcredentials/docs/README.rst
+++ b/packages/google-cloud-iamconnectorcredentials/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for iamconnectorcredentials.googleapis.com API
    :target: https://pypi.org/project/google-cloud-iamconnectorcredentials/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-iamconnectorcredentials.svg
    :target: https://pypi.org/project/google-cloud-iamconnectorcredentials/
-.. _iamconnectorcredentials.googleapis.com API: https://cloud.google.com/iamconnectorcredentials/docs/overview
+.. _iamconnectorcredentials.googleapis.com API: https://cloud.google.com/iamconnectorcredentials/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-iamconnectorcredentials/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/iamconnectorcredentials/docs/overview
+.. _Product Documentation:  https://cloud.google.com/iamconnectorcredentials/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the iamconnectorcredentials.googleapis.com API.:  https://cloud.google.com/iamconnectorcredentials/docs/overview
+.. _Enable the iamconnectorcredentials.googleapis.com API.:  https://cloud.google.com/iamconnectorcredentials/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _iamconnectorcredentials.googleapis.com API Product documentation:  https://cloud.google.com/iamconnectorcredentials/docs/overview
+.. _iamconnectorcredentials.googleapis.com API Product documentation:  https://cloud.google.com/iamconnectorcredentials/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-kms-inventory/.repo-metadata.json
+++ b/packages/google-cloud-kms-inventory/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "inventory",
     "name_pretty": "KMS Inventory API",
-    "product_documentation": "https://cloud.google.com/kms/docs/",
+    "product_documentation": "https://cloud.google.com/kms/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-kms-inventory/README.rst
+++ b/packages/google-cloud-kms-inventory/README.rst
@@ -14,9 +14,9 @@ Python Client for KMS Inventory API
    :target: https://pypi.org/project/google-cloud-kms-inventory/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-kms-inventory.svg
    :target: https://pypi.org/project/google-cloud-kms-inventory/
-.. _KMS Inventory API: https://cloud.google.com/kms/docs/
+.. _KMS Inventory API: https://cloud.google.com/kms/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/inventory/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/kms/docs/
+.. _Product Documentation:  https://cloud.google.com/kms/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the KMS Inventory API.:  https://cloud.google.com/kms/docs/
+.. _Enable the KMS Inventory API.:  https://cloud.google.com/kms/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _KMS Inventory API Product documentation:  https://cloud.google.com/kms/docs/
+.. _KMS Inventory API Product documentation:  https://cloud.google.com/kms/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-kms-inventory/docs/README.rst
+++ b/packages/google-cloud-kms-inventory/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for KMS Inventory API
    :target: https://pypi.org/project/google-cloud-kms-inventory/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-kms-inventory.svg
    :target: https://pypi.org/project/google-cloud-kms-inventory/
-.. _KMS Inventory API: https://cloud.google.com/kms/docs/
+.. _KMS Inventory API: https://cloud.google.com/kms/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/inventory/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/kms/docs/
+.. _Product Documentation:  https://cloud.google.com/kms/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the KMS Inventory API.:  https://cloud.google.com/kms/docs/
+.. _Enable the KMS Inventory API.:  https://cloud.google.com/kms/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _KMS Inventory API Product documentation:  https://cloud.google.com/kms/docs/
+.. _KMS Inventory API Product documentation:  https://cloud.google.com/kms/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-language/.repo-metadata.json
+++ b/packages/google-cloud-language/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "language",
     "name_pretty": "Natural Language",
-    "product_documentation": "https://cloud.google.com/natural-language/docs/",
+    "product_documentation": "https://cloud.google.com/natural-language/docs",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-language/README.rst
+++ b/packages/google-cloud-language/README.rst
@@ -14,9 +14,9 @@ Python Client for Natural Language
    :target: https://pypi.org/project/google-cloud-language/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-language.svg
    :target: https://pypi.org/project/google-cloud-language/
-.. _Natural Language: https://cloud.google.com/natural-language/docs/
+.. _Natural Language: https://cloud.google.com/natural-language/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/language/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/natural-language/docs/
+.. _Product Documentation:  https://cloud.google.com/natural-language/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Natural Language.:  https://cloud.google.com/natural-language/docs/
+.. _Enable the Natural Language.:  https://cloud.google.com/natural-language/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Natural Language Product documentation:  https://cloud.google.com/natural-language/docs/
+.. _Natural Language Product documentation:  https://cloud.google.com/natural-language/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-language/docs/README.rst
+++ b/packages/google-cloud-language/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Natural Language
    :target: https://pypi.org/project/google-cloud-language/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-language.svg
    :target: https://pypi.org/project/google-cloud-language/
-.. _Natural Language: https://cloud.google.com/natural-language/docs/
+.. _Natural Language: https://cloud.google.com/natural-language/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/language/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/natural-language/docs/
+.. _Product Documentation:  https://cloud.google.com/natural-language/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Natural Language.:  https://cloud.google.com/natural-language/docs/
+.. _Enable the Natural Language.:  https://cloud.google.com/natural-language/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Natural Language Product documentation:  https://cloud.google.com/natural-language/docs/
+.. _Natural Language Product documentation:  https://cloud.google.com/natural-language/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-licensemanager/.repo-metadata.json
+++ b/packages/google-cloud-licensemanager/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-licensemanager",
     "name_pretty": "License Manager API",
-    "product_documentation": "https://cloud.google.com/compute/docs/instances/windows/ms-licensing",
+    "product_documentation": "https://cloud.google.com/compute/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-licensemanager/README.rst
+++ b/packages/google-cloud-licensemanager/README.rst
@@ -14,9 +14,9 @@ Python Client for License Manager API
    :target: https://pypi.org/project/google-cloud-licensemanager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-licensemanager.svg
    :target: https://pypi.org/project/google-cloud-licensemanager/
-.. _License Manager API: https://cloud.google.com/compute/docs/instances/windows/ms-licensing
+.. _License Manager API: https://cloud.google.com/compute/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-licensemanager/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/compute/docs/instances/windows/ms-licensing
+.. _Product Documentation:  https://cloud.google.com/compute/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the License Manager API.:  https://cloud.google.com/compute/docs/instances/windows/ms-licensing
+.. _Enable the License Manager API.:  https://cloud.google.com/compute/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _License Manager API Product documentation:  https://cloud.google.com/compute/docs/instances/windows/ms-licensing
+.. _License Manager API Product documentation:  https://cloud.google.com/compute/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-licensemanager/docs/README.rst
+++ b/packages/google-cloud-licensemanager/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for License Manager API
    :target: https://pypi.org/project/google-cloud-licensemanager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-licensemanager.svg
    :target: https://pypi.org/project/google-cloud-licensemanager/
-.. _License Manager API: https://cloud.google.com/compute/docs/instances/windows/ms-licensing
+.. _License Manager API: https://cloud.google.com/compute/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-licensemanager/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/compute/docs/instances/windows/ms-licensing
+.. _Product Documentation:  https://cloud.google.com/compute/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the License Manager API.:  https://cloud.google.com/compute/docs/instances/windows/ms-licensing
+.. _Enable the License Manager API.:  https://cloud.google.com/compute/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _License Manager API Product documentation:  https://cloud.google.com/compute/docs/instances/windows/ms-licensing
+.. _License Manager API Product documentation:  https://cloud.google.com/compute/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-locationfinder/.repo-metadata.json
+++ b/packages/google-cloud-locationfinder/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-locationfinder",
     "name_pretty": "Cloud Location Finder API",
-    "product_documentation": "https://issuetracker.google.com/issues/new?component=1569265\u0026template=1988535",
+    "product_documentation": "https://cloud.google.com/location-finder/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-locationfinder/README.rst
+++ b/packages/google-cloud-locationfinder/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Location Finder API
    :target: https://pypi.org/project/google-cloud-locationfinder/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-locationfinder.svg
    :target: https://pypi.org/project/google-cloud-locationfinder/
-.. _Cloud Location Finder API: https://issuetracker.google.com/issues/new?component=1569265&template=1988535
+.. _Cloud Location Finder API: https://cloud.google.com/location-finder/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-locationfinder/latest/summary_overview
-.. _Product Documentation:  https://issuetracker.google.com/issues/new?component=1569265&template=1988535
+.. _Product Documentation:  https://cloud.google.com/location-finder/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Location Finder API.:  https://issuetracker.google.com/issues/new?component=1569265&template=1988535
+.. _Enable the Cloud Location Finder API.:  https://cloud.google.com/location-finder/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Location Finder API Product documentation:  https://issuetracker.google.com/issues/new?component=1569265&template=1988535
+.. _Cloud Location Finder API Product documentation:  https://cloud.google.com/location-finder/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-locationfinder/docs/README.rst
+++ b/packages/google-cloud-locationfinder/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Location Finder API
    :target: https://pypi.org/project/google-cloud-locationfinder/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-locationfinder.svg
    :target: https://pypi.org/project/google-cloud-locationfinder/
-.. _Cloud Location Finder API: https://issuetracker.google.com/issues/new?component=1569265&template=1988535
+.. _Cloud Location Finder API: https://cloud.google.com/location-finder/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-locationfinder/latest/summary_overview
-.. _Product Documentation:  https://issuetracker.google.com/issues/new?component=1569265&template=1988535
+.. _Product Documentation:  https://cloud.google.com/location-finder/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Location Finder API.:  https://issuetracker.google.com/issues/new?component=1569265&template=1988535
+.. _Enable the Cloud Location Finder API.:  https://cloud.google.com/location-finder/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Location Finder API Product documentation:  https://issuetracker.google.com/issues/new?component=1569265&template=1988535
+.. _Cloud Location Finder API Product documentation:  https://cloud.google.com/location-finder/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-logging/.repo-metadata.json
+++ b/packages/google-cloud-logging/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_COMBO",
     "name": "logging",
     "name_pretty": "Cloud Logging API",
-    "product_documentation": "https://cloud.google.com/logging/docs",
+    "product_documentation": "https://cloud.google.com/logging/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-logging/README.rst
+++ b/packages/google-cloud-logging/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Logging API
    :target: https://pypi.org/project/google-cloud-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-logging.svg
    :target: https://pypi.org/project/google-cloud-logging/
-.. _Cloud Logging API: https://cloud.google.com/logging/docs
+.. _Cloud Logging API: https://cloud.google.com/logging/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/logging/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/logging/docs
+.. _Product Documentation:  https://cloud.google.com/logging/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Logging API.:  https://cloud.google.com/logging/docs
+.. _Enable the Cloud Logging API.:  https://cloud.google.com/logging/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 For an interactive walkthrough on how to use this library in a python application, click the Guide Me button below:
@@ -111,7 +111,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Logging API Product documentation:  https://cloud.google.com/logging/docs
+.. _Cloud Logging API Product documentation:  https://cloud.google.com/logging/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-logging/docs/README.rst
+++ b/packages/google-cloud-logging/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Logging API
    :target: https://pypi.org/project/google-cloud-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-logging.svg
    :target: https://pypi.org/project/google-cloud-logging/
-.. _Cloud Logging API: https://cloud.google.com/logging/docs
+.. _Cloud Logging API: https://cloud.google.com/logging/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/logging/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/logging/docs
+.. _Product Documentation:  https://cloud.google.com/logging/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Logging API.:  https://cloud.google.com/logging/docs
+.. _Enable the Cloud Logging API.:  https://cloud.google.com/logging/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 For an interactive walkthrough on how to use this library in a python application, click the Guide Me button below:
@@ -111,7 +111,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Logging API Product documentation:  https://cloud.google.com/logging/docs
+.. _Cloud Logging API Product documentation:  https://cloud.google.com/logging/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-maintenance-api/.repo-metadata.json
+++ b/packages/google-cloud-maintenance-api/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-maintenance-api",
     "name_pretty": "Maintenance API",
-    "product_documentation": "https://cloud.google.com/unified-maintenance/docs/overview",
+    "product_documentation": "https://cloud.google.com/unified-maintenance/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-maintenance-api/README.rst
+++ b/packages/google-cloud-maintenance-api/README.rst
@@ -14,9 +14,9 @@ Python Client for Maintenance API
    :target: https://pypi.org/project/google-cloud-maintenance-api/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-maintenance-api.svg
    :target: https://pypi.org/project/google-cloud-maintenance-api/
-.. _Maintenance API: https://cloud.google.com/unified-maintenance/docs/overview
+.. _Maintenance API: https://cloud.google.com/unified-maintenance/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-maintenance-api/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/unified-maintenance/docs/overview
+.. _Product Documentation:  https://cloud.google.com/unified-maintenance/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Maintenance API.:  https://cloud.google.com/unified-maintenance/docs/overview
+.. _Enable the Maintenance API.:  https://cloud.google.com/unified-maintenance/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Maintenance API Product documentation:  https://cloud.google.com/unified-maintenance/docs/overview
+.. _Maintenance API Product documentation:  https://cloud.google.com/unified-maintenance/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-maintenance-api/docs/README.rst
+++ b/packages/google-cloud-maintenance-api/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Maintenance API
    :target: https://pypi.org/project/google-cloud-maintenance-api/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-maintenance-api.svg
    :target: https://pypi.org/project/google-cloud-maintenance-api/
-.. _Maintenance API: https://cloud.google.com/unified-maintenance/docs/overview
+.. _Maintenance API: https://cloud.google.com/unified-maintenance/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-maintenance-api/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/unified-maintenance/docs/overview
+.. _Product Documentation:  https://cloud.google.com/unified-maintenance/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Maintenance API.:  https://cloud.google.com/unified-maintenance/docs/overview
+.. _Enable the Maintenance API.:  https://cloud.google.com/unified-maintenance/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Maintenance API Product documentation:  https://cloud.google.com/unified-maintenance/docs/overview
+.. _Maintenance API Product documentation:  https://cloud.google.com/unified-maintenance/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-managedkafka/.repo-metadata.json
+++ b/packages/google-cloud-managedkafka/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-managedkafka",
     "name_pretty": "Managed Service for Apache Kafka",
-    "product_documentation": "https://cloud.google.com/managed-kafka",
+    "product_documentation": "https://cloud.google.com/managed-service-for-apache-kafka/docs",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-managedkafka/README.rst
+++ b/packages/google-cloud-managedkafka/README.rst
@@ -14,9 +14,9 @@ Python Client for Managed Service for Apache Kafka
    :target: https://pypi.org/project/google-cloud-managedkafka/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-managedkafka.svg
    :target: https://pypi.org/project/google-cloud-managedkafka/
-.. _Managed Service for Apache Kafka: https://cloud.google.com/managed-kafka
+.. _Managed Service for Apache Kafka: https://cloud.google.com/managed-service-for-apache-kafka/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-managedkafka/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/managed-kafka
+.. _Product Documentation:  https://cloud.google.com/managed-service-for-apache-kafka/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Managed Service for Apache Kafka.:  https://cloud.google.com/managed-kafka
+.. _Enable the Managed Service for Apache Kafka.:  https://cloud.google.com/managed-service-for-apache-kafka/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Managed Service for Apache Kafka Product documentation:  https://cloud.google.com/managed-kafka
+.. _Managed Service for Apache Kafka Product documentation:  https://cloud.google.com/managed-service-for-apache-kafka/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-managedkafka/docs/README.rst
+++ b/packages/google-cloud-managedkafka/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Managed Service for Apache Kafka
    :target: https://pypi.org/project/google-cloud-managedkafka/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-managedkafka.svg
    :target: https://pypi.org/project/google-cloud-managedkafka/
-.. _Managed Service for Apache Kafka: https://cloud.google.com/managed-kafka
+.. _Managed Service for Apache Kafka: https://cloud.google.com/managed-service-for-apache-kafka/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-managedkafka/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/managed-kafka
+.. _Product Documentation:  https://cloud.google.com/managed-service-for-apache-kafka/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Managed Service for Apache Kafka.:  https://cloud.google.com/managed-kafka
+.. _Enable the Managed Service for Apache Kafka.:  https://cloud.google.com/managed-service-for-apache-kafka/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Managed Service for Apache Kafka Product documentation:  https://cloud.google.com/managed-kafka
+.. _Managed Service for Apache Kafka Product documentation:  https://cloud.google.com/managed-service-for-apache-kafka/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-memcache/.repo-metadata.json
+++ b/packages/google-cloud-memcache/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "memcache",
     "name_pretty": "Cloud Memorystore for Memcached",
-    "product_documentation": "https://cloud.google.com/memorystore/docs/memcached/",
+    "product_documentation": "https://cloud.google.com/memorystore/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-memcache/README.rst
+++ b/packages/google-cloud-memcache/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Memorystore for Memcached
    :target: https://pypi.org/project/google-cloud-memcache/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-memcache.svg
    :target: https://pypi.org/project/google-cloud-memcache/
-.. _Cloud Memorystore for Memcached: https://cloud.google.com/memorystore/docs/memcached/
+.. _Cloud Memorystore for Memcached: https://cloud.google.com/memorystore/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/memcache/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/memorystore/docs/memcached/
+.. _Product Documentation:  https://cloud.google.com/memorystore/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Memorystore for Memcached.:  https://cloud.google.com/memorystore/docs/memcached/
+.. _Enable the Cloud Memorystore for Memcached.:  https://cloud.google.com/memorystore/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Memorystore for Memcached Product documentation:  https://cloud.google.com/memorystore/docs/memcached/
+.. _Cloud Memorystore for Memcached Product documentation:  https://cloud.google.com/memorystore/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-memcache/docs/README.rst
+++ b/packages/google-cloud-memcache/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Memorystore for Memcached
    :target: https://pypi.org/project/google-cloud-memcache/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-memcache.svg
    :target: https://pypi.org/project/google-cloud-memcache/
-.. _Cloud Memorystore for Memcached: https://cloud.google.com/memorystore/docs/memcached/
+.. _Cloud Memorystore for Memcached: https://cloud.google.com/memorystore/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/memcache/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/memorystore/docs/memcached/
+.. _Product Documentation:  https://cloud.google.com/memorystore/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Memorystore for Memcached.:  https://cloud.google.com/memorystore/docs/memcached/
+.. _Enable the Cloud Memorystore for Memcached.:  https://cloud.google.com/memorystore/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Memorystore for Memcached Product documentation:  https://cloud.google.com/memorystore/docs/memcached/
+.. _Cloud Memorystore for Memcached Product documentation:  https://cloud.google.com/memorystore/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-memorystore/.repo-metadata.json
+++ b/packages/google-cloud-memorystore/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-memorystore",
     "name_pretty": "Memorystore",
-    "product_documentation": "https://cloud.google.com/memorystore/docs/valkey",
+    "product_documentation": "https://cloud.google.com/memorystore/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-memorystore/README.rst
+++ b/packages/google-cloud-memorystore/README.rst
@@ -14,9 +14,9 @@ Python Client for Memorystore
    :target: https://pypi.org/project/google-cloud-memorystore/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-memorystore.svg
    :target: https://pypi.org/project/google-cloud-memorystore/
-.. _Memorystore: https://cloud.google.com/memorystore/docs/valkey
+.. _Memorystore: https://cloud.google.com/memorystore/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-memorystore/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/memorystore/docs/valkey
+.. _Product Documentation:  https://cloud.google.com/memorystore/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Memorystore.:  https://cloud.google.com/memorystore/docs/valkey
+.. _Enable the Memorystore.:  https://cloud.google.com/memorystore/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Memorystore Product documentation:  https://cloud.google.com/memorystore/docs/valkey
+.. _Memorystore Product documentation:  https://cloud.google.com/memorystore/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-memorystore/docs/README.rst
+++ b/packages/google-cloud-memorystore/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Memorystore
    :target: https://pypi.org/project/google-cloud-memorystore/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-memorystore.svg
    :target: https://pypi.org/project/google-cloud-memorystore/
-.. _Memorystore: https://cloud.google.com/memorystore/docs/valkey
+.. _Memorystore: https://cloud.google.com/memorystore/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-memorystore/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/memorystore/docs/valkey
+.. _Product Documentation:  https://cloud.google.com/memorystore/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Memorystore.:  https://cloud.google.com/memorystore/docs/valkey
+.. _Enable the Memorystore.:  https://cloud.google.com/memorystore/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Memorystore Product documentation:  https://cloud.google.com/memorystore/docs/valkey
+.. _Memorystore Product documentation:  https://cloud.google.com/memorystore/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-migrationcenter/.repo-metadata.json
+++ b/packages/google-cloud-migrationcenter/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "migrationcenter",
     "name_pretty": "Migration Center API",
-    "product_documentation": "https://cloud.google.com/migration-center/docs/migration-center-overview",
+    "product_documentation": "https://cloud.google.com/migration-center/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-migrationcenter/README.rst
+++ b/packages/google-cloud-migrationcenter/README.rst
@@ -14,9 +14,9 @@ Python Client for Migration Center API
    :target: https://pypi.org/project/google-cloud-migrationcenter/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-migrationcenter.svg
    :target: https://pypi.org/project/google-cloud-migrationcenter/
-.. _Migration Center API: https://cloud.google.com/migration-center/docs/migration-center-overview
+.. _Migration Center API: https://cloud.google.com/migration-center/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/migrationcenter/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/migration-center/docs/migration-center-overview
+.. _Product Documentation:  https://cloud.google.com/migration-center/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Migration Center API.:  https://cloud.google.com/migration-center/docs/migration-center-overview
+.. _Enable the Migration Center API.:  https://cloud.google.com/migration-center/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Migration Center API Product documentation:  https://cloud.google.com/migration-center/docs/migration-center-overview
+.. _Migration Center API Product documentation:  https://cloud.google.com/migration-center/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-migrationcenter/docs/README.rst
+++ b/packages/google-cloud-migrationcenter/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Migration Center API
    :target: https://pypi.org/project/google-cloud-migrationcenter/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-migrationcenter.svg
    :target: https://pypi.org/project/google-cloud-migrationcenter/
-.. _Migration Center API: https://cloud.google.com/migration-center/docs/migration-center-overview
+.. _Migration Center API: https://cloud.google.com/migration-center/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/migrationcenter/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/migration-center/docs/migration-center-overview
+.. _Product Documentation:  https://cloud.google.com/migration-center/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Migration Center API.:  https://cloud.google.com/migration-center/docs/migration-center-overview
+.. _Enable the Migration Center API.:  https://cloud.google.com/migration-center/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Migration Center API Product documentation:  https://cloud.google.com/migration-center/docs/migration-center-overview
+.. _Migration Center API Product documentation:  https://cloud.google.com/migration-center/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-modelarmor/.repo-metadata.json
+++ b/packages/google-cloud-modelarmor/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-modelarmor",
     "name_pretty": "Model Armor API",
-    "product_documentation": "https://cloud.google.com/security-command-center/docs/model-armor-overview",
+    "product_documentation": "https://cloud.google.com/security-command-center/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-modelarmor/README.rst
+++ b/packages/google-cloud-modelarmor/README.rst
@@ -14,9 +14,9 @@ Python Client for Model Armor API
    :target: https://pypi.org/project/google-cloud-modelarmor/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-modelarmor.svg
    :target: https://pypi.org/project/google-cloud-modelarmor/
-.. _Model Armor API: https://cloud.google.com/security-command-center/docs/model-armor-overview
+.. _Model Armor API: https://cloud.google.com/security-command-center/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-modelarmor/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/security-command-center/docs/model-armor-overview
+.. _Product Documentation:  https://cloud.google.com/security-command-center/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Model Armor API.:  https://cloud.google.com/security-command-center/docs/model-armor-overview
+.. _Enable the Model Armor API.:  https://cloud.google.com/security-command-center/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Model Armor API Product documentation:  https://cloud.google.com/security-command-center/docs/model-armor-overview
+.. _Model Armor API Product documentation:  https://cloud.google.com/security-command-center/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-modelarmor/docs/README.rst
+++ b/packages/google-cloud-modelarmor/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Model Armor API
    :target: https://pypi.org/project/google-cloud-modelarmor/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-modelarmor.svg
    :target: https://pypi.org/project/google-cloud-modelarmor/
-.. _Model Armor API: https://cloud.google.com/security-command-center/docs/model-armor-overview
+.. _Model Armor API: https://cloud.google.com/security-command-center/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-modelarmor/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/security-command-center/docs/model-armor-overview
+.. _Product Documentation:  https://cloud.google.com/security-command-center/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Model Armor API.:  https://cloud.google.com/security-command-center/docs/model-armor-overview
+.. _Enable the Model Armor API.:  https://cloud.google.com/security-command-center/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Model Armor API Product documentation:  https://cloud.google.com/security-command-center/docs/model-armor-overview
+.. _Model Armor API Product documentation:  https://cloud.google.com/security-command-center/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-netapp/.repo-metadata.json
+++ b/packages/google-cloud-netapp/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "netapp",
     "name_pretty": "NetApp API",
-    "product_documentation": "https://cloud.google.com/netapp/volumes/docs/discover/overview",
+    "product_documentation": "https://cloud.google.com/netapp/volumes/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-netapp/README.rst
+++ b/packages/google-cloud-netapp/README.rst
@@ -14,9 +14,9 @@ Python Client for NetApp API
    :target: https://pypi.org/project/google-cloud-netapp/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-netapp.svg
    :target: https://pypi.org/project/google-cloud-netapp/
-.. _NetApp API: https://cloud.google.com/netapp/volumes/docs/discover/overview
+.. _NetApp API: https://cloud.google.com/netapp/volumes/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/netapp/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/netapp/volumes/docs/discover/overview
+.. _Product Documentation:  https://cloud.google.com/netapp/volumes/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the NetApp API.:  https://cloud.google.com/netapp/volumes/docs/discover/overview
+.. _Enable the NetApp API.:  https://cloud.google.com/netapp/volumes/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _NetApp API Product documentation:  https://cloud.google.com/netapp/volumes/docs/discover/overview
+.. _NetApp API Product documentation:  https://cloud.google.com/netapp/volumes/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-netapp/docs/README.rst
+++ b/packages/google-cloud-netapp/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for NetApp API
    :target: https://pypi.org/project/google-cloud-netapp/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-netapp.svg
    :target: https://pypi.org/project/google-cloud-netapp/
-.. _NetApp API: https://cloud.google.com/netapp/volumes/docs/discover/overview
+.. _NetApp API: https://cloud.google.com/netapp/volumes/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/netapp/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/netapp/volumes/docs/discover/overview
+.. _Product Documentation:  https://cloud.google.com/netapp/volumes/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the NetApp API.:  https://cloud.google.com/netapp/volumes/docs/discover/overview
+.. _Enable the NetApp API.:  https://cloud.google.com/netapp/volumes/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _NetApp API Product documentation:  https://cloud.google.com/netapp/volumes/docs/discover/overview
+.. _NetApp API Product documentation:  https://cloud.google.com/netapp/volumes/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-network-security/.repo-metadata.json
+++ b/packages/google-cloud-network-security/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "networksecurity",
     "name_pretty": "Network Security",
-    "product_documentation": "https://cloud.google.com/traffic-director/docs/reference/network-security/rest",
+    "product_documentation": "https://cloud.google.com/traffic-director/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-network-security/README.rst
+++ b/packages/google-cloud-network-security/README.rst
@@ -14,9 +14,9 @@ Python Client for Network Security
    :target: https://pypi.org/project/google-cloud-network-security/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-network-security.svg
    :target: https://pypi.org/project/google-cloud-network-security/
-.. _Network Security: https://cloud.google.com/traffic-director/docs/reference/network-security/rest
+.. _Network Security: https://cloud.google.com/traffic-director/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/networksecurity/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/traffic-director/docs/reference/network-security/rest
+.. _Product Documentation:  https://cloud.google.com/traffic-director/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Network Security.:  https://cloud.google.com/traffic-director/docs/reference/network-security/rest
+.. _Enable the Network Security.:  https://cloud.google.com/traffic-director/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Network Security Product documentation:  https://cloud.google.com/traffic-director/docs/reference/network-security/rest
+.. _Network Security Product documentation:  https://cloud.google.com/traffic-director/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-network-security/docs/README.rst
+++ b/packages/google-cloud-network-security/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Network Security
    :target: https://pypi.org/project/google-cloud-network-security/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-network-security.svg
    :target: https://pypi.org/project/google-cloud-network-security/
-.. _Network Security: https://cloud.google.com/traffic-director/docs/reference/network-security/rest
+.. _Network Security: https://cloud.google.com/traffic-director/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/networksecurity/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/traffic-director/docs/reference/network-security/rest
+.. _Product Documentation:  https://cloud.google.com/traffic-director/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Network Security.:  https://cloud.google.com/traffic-director/docs/reference/network-security/rest
+.. _Enable the Network Security.:  https://cloud.google.com/traffic-director/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Network Security Product documentation:  https://cloud.google.com/traffic-director/docs/reference/network-security/rest
+.. _Network Security Product documentation:  https://cloud.google.com/traffic-director/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-network-services/.repo-metadata.json
+++ b/packages/google-cloud-network-services/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "networkservices",
     "name_pretty": "Network Services",
-    "product_documentation": "https://cloud.google.com",
+    "product_documentation": "https://cloud.google.com/products/networking",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-network-services/README.rst
+++ b/packages/google-cloud-network-services/README.rst
@@ -14,9 +14,9 @@ Python Client for Network Services
    :target: https://pypi.org/project/google-cloud-network-services/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-network-services.svg
    :target: https://pypi.org/project/google-cloud-network-services/
-.. _Network Services: https://cloud.google.com
+.. _Network Services: https://cloud.google.com/products/networking
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/networkservices/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com
+.. _Product Documentation:  https://cloud.google.com/products/networking
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Network Services.:  https://cloud.google.com
+.. _Enable the Network Services.:  https://cloud.google.com/products/networking
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Network Services Product documentation:  https://cloud.google.com
+.. _Network Services Product documentation:  https://cloud.google.com/products/networking
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-network-services/docs/README.rst
+++ b/packages/google-cloud-network-services/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Network Services
    :target: https://pypi.org/project/google-cloud-network-services/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-network-services.svg
    :target: https://pypi.org/project/google-cloud-network-services/
-.. _Network Services: https://cloud.google.com
+.. _Network Services: https://cloud.google.com/products/networking
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/networkservices/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com
+.. _Product Documentation:  https://cloud.google.com/products/networking
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Network Services.:  https://cloud.google.com
+.. _Enable the Network Services.:  https://cloud.google.com/products/networking
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Network Services Product documentation:  https://cloud.google.com
+.. _Network Services Product documentation:  https://cloud.google.com/products/networking
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-notebooks/.repo-metadata.json
+++ b/packages/google-cloud-notebooks/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "notebooks",
     "name_pretty": "AI Platform Notebooks",
-    "product_documentation": "https://cloud.google.com/ai-platform/notebooks/",
+    "product_documentation": "https://cloud.google.com/vertex-ai/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-notebooks/README.rst
+++ b/packages/google-cloud-notebooks/README.rst
@@ -14,9 +14,9 @@ Python Client for AI Platform Notebooks
    :target: https://pypi.org/project/google-cloud-notebooks/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-notebooks.svg
    :target: https://pypi.org/project/google-cloud-notebooks/
-.. _AI Platform Notebooks: https://cloud.google.com/ai-platform/notebooks/
+.. _AI Platform Notebooks: https://cloud.google.com/vertex-ai/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/notebooks/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/ai-platform/notebooks/
+.. _Product Documentation:  https://cloud.google.com/vertex-ai/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the AI Platform Notebooks.:  https://cloud.google.com/ai-platform/notebooks/
+.. _Enable the AI Platform Notebooks.:  https://cloud.google.com/vertex-ai/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _AI Platform Notebooks Product documentation:  https://cloud.google.com/ai-platform/notebooks/
+.. _AI Platform Notebooks Product documentation:  https://cloud.google.com/vertex-ai/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-notebooks/docs/README.rst
+++ b/packages/google-cloud-notebooks/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for AI Platform Notebooks
    :target: https://pypi.org/project/google-cloud-notebooks/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-notebooks.svg
    :target: https://pypi.org/project/google-cloud-notebooks/
-.. _AI Platform Notebooks: https://cloud.google.com/ai-platform/notebooks/
+.. _AI Platform Notebooks: https://cloud.google.com/vertex-ai/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/notebooks/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/ai-platform/notebooks/
+.. _Product Documentation:  https://cloud.google.com/vertex-ai/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the AI Platform Notebooks.:  https://cloud.google.com/ai-platform/notebooks/
+.. _Enable the AI Platform Notebooks.:  https://cloud.google.com/vertex-ai/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _AI Platform Notebooks Product documentation:  https://cloud.google.com/ai-platform/notebooks/
+.. _AI Platform Notebooks Product documentation:  https://cloud.google.com/vertex-ai/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-org-policy/.repo-metadata.json
+++ b/packages/google-cloud-org-policy/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "orgpolicy",
     "name_pretty": "Organization Policy",
-    "product_documentation": "https://cloud.google.com/resource-manager/docs/organization-policy/overview",
+    "product_documentation": "https://cloud.google.com/resource-manager/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-org-policy/README.rst
+++ b/packages/google-cloud-org-policy/README.rst
@@ -14,9 +14,9 @@ Python Client for Organization Policy
    :target: https://pypi.org/project/google-cloud-org-policy/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-org-policy.svg
    :target: https://pypi.org/project/google-cloud-org-policy/
-.. _Organization Policy: https://cloud.google.com/resource-manager/docs/organization-policy/overview
+.. _Organization Policy: https://cloud.google.com/resource-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/orgpolicy/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/resource-manager/docs/organization-policy/overview
+.. _Product Documentation:  https://cloud.google.com/resource-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Organization Policy.:  https://cloud.google.com/resource-manager/docs/organization-policy/overview
+.. _Enable the Organization Policy.:  https://cloud.google.com/resource-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Organization Policy Product documentation:  https://cloud.google.com/resource-manager/docs/organization-policy/overview
+.. _Organization Policy Product documentation:  https://cloud.google.com/resource-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-org-policy/docs/README.rst
+++ b/packages/google-cloud-org-policy/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Organization Policy
    :target: https://pypi.org/project/google-cloud-org-policy/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-org-policy.svg
    :target: https://pypi.org/project/google-cloud-org-policy/
-.. _Organization Policy: https://cloud.google.com/resource-manager/docs/organization-policy/overview
+.. _Organization Policy: https://cloud.google.com/resource-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/orgpolicy/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/resource-manager/docs/organization-policy/overview
+.. _Product Documentation:  https://cloud.google.com/resource-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Organization Policy.:  https://cloud.google.com/resource-manager/docs/organization-policy/overview
+.. _Enable the Organization Policy.:  https://cloud.google.com/resource-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Organization Policy Product documentation:  https://cloud.google.com/resource-manager/docs/organization-policy/overview
+.. _Organization Policy Product documentation:  https://cloud.google.com/resource-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-os-config/.repo-metadata.json
+++ b/packages/google-cloud-os-config/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "osconfig",
     "name_pretty": "OS Config",
-    "product_documentation": "https://cloud.google.com/compute/docs/manage-os",
+    "product_documentation": "https://cloud.google.com/compute/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-os-config/README.rst
+++ b/packages/google-cloud-os-config/README.rst
@@ -14,9 +14,9 @@ Python Client for OS Config
    :target: https://pypi.org/project/google-cloud-os-config/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-os-config.svg
    :target: https://pypi.org/project/google-cloud-os-config/
-.. _OS Config: https://cloud.google.com/compute/docs/manage-os
+.. _OS Config: https://cloud.google.com/compute/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/osconfig/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/compute/docs/manage-os
+.. _Product Documentation:  https://cloud.google.com/compute/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the OS Config.:  https://cloud.google.com/compute/docs/manage-os
+.. _Enable the OS Config.:  https://cloud.google.com/compute/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _OS Config Product documentation:  https://cloud.google.com/compute/docs/manage-os
+.. _OS Config Product documentation:  https://cloud.google.com/compute/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-os-config/docs/README.rst
+++ b/packages/google-cloud-os-config/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for OS Config
    :target: https://pypi.org/project/google-cloud-os-config/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-os-config.svg
    :target: https://pypi.org/project/google-cloud-os-config/
-.. _OS Config: https://cloud.google.com/compute/docs/manage-os
+.. _OS Config: https://cloud.google.com/compute/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/osconfig/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/compute/docs/manage-os
+.. _Product Documentation:  https://cloud.google.com/compute/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the OS Config.:  https://cloud.google.com/compute/docs/manage-os
+.. _Enable the OS Config.:  https://cloud.google.com/compute/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _OS Config Product documentation:  https://cloud.google.com/compute/docs/manage-os
+.. _OS Config Product documentation:  https://cloud.google.com/compute/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-os-login/.repo-metadata.json
+++ b/packages/google-cloud-os-login/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "oslogin",
     "name_pretty": "Google Cloud OS Login",
-    "product_documentation": "https://cloud.google.com/compute/docs/oslogin/",
+    "product_documentation": "https://cloud.google.com/compute/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-os-login/README.rst
+++ b/packages/google-cloud-os-login/README.rst
@@ -14,9 +14,9 @@ Python Client for Google Cloud OS Login
    :target: https://pypi.org/project/google-cloud-os-login/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-os-login.svg
    :target: https://pypi.org/project/google-cloud-os-login/
-.. _Google Cloud OS Login: https://cloud.google.com/compute/docs/oslogin/
+.. _Google Cloud OS Login: https://cloud.google.com/compute/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/oslogin/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/compute/docs/oslogin/
+.. _Product Documentation:  https://cloud.google.com/compute/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud OS Login.:  https://cloud.google.com/compute/docs/oslogin/
+.. _Enable the Google Cloud OS Login.:  https://cloud.google.com/compute/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud OS Login Product documentation:  https://cloud.google.com/compute/docs/oslogin/
+.. _Google Cloud OS Login Product documentation:  https://cloud.google.com/compute/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-os-login/docs/README.rst
+++ b/packages/google-cloud-os-login/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Google Cloud OS Login
    :target: https://pypi.org/project/google-cloud-os-login/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-os-login.svg
    :target: https://pypi.org/project/google-cloud-os-login/
-.. _Google Cloud OS Login: https://cloud.google.com/compute/docs/oslogin/
+.. _Google Cloud OS Login: https://cloud.google.com/compute/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/oslogin/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/compute/docs/oslogin/
+.. _Product Documentation:  https://cloud.google.com/compute/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud OS Login.:  https://cloud.google.com/compute/docs/oslogin/
+.. _Enable the Google Cloud OS Login.:  https://cloud.google.com/compute/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud OS Login Product documentation:  https://cloud.google.com/compute/docs/oslogin/
+.. _Google Cloud OS Login Product documentation:  https://cloud.google.com/compute/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-parallelstore/.repo-metadata.json
+++ b/packages/google-cloud-parallelstore/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-parallelstore",
     "name_pretty": "Parallelstore API",
-    "product_documentation": "https://cloud.google.com/parallelstore",
+    "product_documentation": "https://cloud.google.com/parallelstore?hl=en",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-parallelstore/README.rst
+++ b/packages/google-cloud-parallelstore/README.rst
@@ -14,9 +14,9 @@ Python Client for Parallelstore API
    :target: https://pypi.org/project/google-cloud-parallelstore/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-parallelstore.svg
    :target: https://pypi.org/project/google-cloud-parallelstore/
-.. _Parallelstore API: https://cloud.google.com/parallelstore
+.. _Parallelstore API: https://cloud.google.com/parallelstore?hl=en
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-parallelstore/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/parallelstore
+.. _Product Documentation:  https://cloud.google.com/parallelstore?hl=en
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Parallelstore API.:  https://cloud.google.com/parallelstore
+.. _Enable the Parallelstore API.:  https://cloud.google.com/parallelstore?hl=en
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Parallelstore API Product documentation:  https://cloud.google.com/parallelstore
+.. _Parallelstore API Product documentation:  https://cloud.google.com/parallelstore?hl=en
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-parallelstore/docs/README.rst
+++ b/packages/google-cloud-parallelstore/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Parallelstore API
    :target: https://pypi.org/project/google-cloud-parallelstore/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-parallelstore.svg
    :target: https://pypi.org/project/google-cloud-parallelstore/
-.. _Parallelstore API: https://cloud.google.com/parallelstore
+.. _Parallelstore API: https://cloud.google.com/parallelstore?hl=en
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-parallelstore/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/parallelstore
+.. _Product Documentation:  https://cloud.google.com/parallelstore?hl=en
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Parallelstore API.:  https://cloud.google.com/parallelstore
+.. _Enable the Parallelstore API.:  https://cloud.google.com/parallelstore?hl=en
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Parallelstore API Product documentation:  https://cloud.google.com/parallelstore
+.. _Parallelstore API Product documentation:  https://cloud.google.com/parallelstore?hl=en
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-parametermanager/.repo-metadata.json
+++ b/packages/google-cloud-parametermanager/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-parametermanager",
     "name_pretty": "Parameter Manager API",
-    "product_documentation": "https://cloud.google.com/secret-manager/parameter-manager/docs/overview",
+    "product_documentation": "https://cloud.google.com/secret-manager/parameter-manager/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-parametermanager/README.rst
+++ b/packages/google-cloud-parametermanager/README.rst
@@ -14,9 +14,9 @@ Python Client for Parameter Manager API
    :target: https://pypi.org/project/google-cloud-parametermanager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-parametermanager.svg
    :target: https://pypi.org/project/google-cloud-parametermanager/
-.. _Parameter Manager API: https://cloud.google.com/secret-manager/parameter-manager/docs/overview
+.. _Parameter Manager API: https://cloud.google.com/secret-manager/parameter-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-parametermanager/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/secret-manager/parameter-manager/docs/overview
+.. _Product Documentation:  https://cloud.google.com/secret-manager/parameter-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Parameter Manager API.:  https://cloud.google.com/secret-manager/parameter-manager/docs/overview
+.. _Enable the Parameter Manager API.:  https://cloud.google.com/secret-manager/parameter-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Parameter Manager API Product documentation:  https://cloud.google.com/secret-manager/parameter-manager/docs/overview
+.. _Parameter Manager API Product documentation:  https://cloud.google.com/secret-manager/parameter-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-parametermanager/docs/README.rst
+++ b/packages/google-cloud-parametermanager/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Parameter Manager API
    :target: https://pypi.org/project/google-cloud-parametermanager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-parametermanager.svg
    :target: https://pypi.org/project/google-cloud-parametermanager/
-.. _Parameter Manager API: https://cloud.google.com/secret-manager/parameter-manager/docs/overview
+.. _Parameter Manager API: https://cloud.google.com/secret-manager/parameter-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-parametermanager/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/secret-manager/parameter-manager/docs/overview
+.. _Product Documentation:  https://cloud.google.com/secret-manager/parameter-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Parameter Manager API.:  https://cloud.google.com/secret-manager/parameter-manager/docs/overview
+.. _Enable the Parameter Manager API.:  https://cloud.google.com/secret-manager/parameter-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Parameter Manager API Product documentation:  https://cloud.google.com/secret-manager/parameter-manager/docs/overview
+.. _Parameter Manager API Product documentation:  https://cloud.google.com/secret-manager/parameter-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-phishing-protection/.repo-metadata.json
+++ b/packages/google-cloud-phishing-protection/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "phishingprotection",
     "name_pretty": "Phishing Protection",
-    "product_documentation": "https://cloud.google.com/phishing-protection/docs/",
+    "product_documentation": "https://cloud.google.com/phishing-protection/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-phishing-protection/README.rst
+++ b/packages/google-cloud-phishing-protection/README.rst
@@ -14,9 +14,9 @@ Python Client for Phishing Protection
    :target: https://pypi.org/project/google-cloud-phishing-protection/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-phishing-protection.svg
    :target: https://pypi.org/project/google-cloud-phishing-protection/
-.. _Phishing Protection: https://cloud.google.com/phishing-protection/docs/
+.. _Phishing Protection: https://cloud.google.com/phishing-protection/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/phishingprotection/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/phishing-protection/docs/
+.. _Product Documentation:  https://cloud.google.com/phishing-protection/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Phishing Protection.:  https://cloud.google.com/phishing-protection/docs/
+.. _Enable the Phishing Protection.:  https://cloud.google.com/phishing-protection/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Phishing Protection Product documentation:  https://cloud.google.com/phishing-protection/docs/
+.. _Phishing Protection Product documentation:  https://cloud.google.com/phishing-protection/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-phishing-protection/docs/README.rst
+++ b/packages/google-cloud-phishing-protection/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Phishing Protection
    :target: https://pypi.org/project/google-cloud-phishing-protection/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-phishing-protection.svg
    :target: https://pypi.org/project/google-cloud-phishing-protection/
-.. _Phishing Protection: https://cloud.google.com/phishing-protection/docs/
+.. _Phishing Protection: https://cloud.google.com/phishing-protection/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/phishingprotection/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/phishing-protection/docs/
+.. _Product Documentation:  https://cloud.google.com/phishing-protection/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Phishing Protection.:  https://cloud.google.com/phishing-protection/docs/
+.. _Enable the Phishing Protection.:  https://cloud.google.com/phishing-protection/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Phishing Protection Product documentation:  https://cloud.google.com/phishing-protection/docs/
+.. _Phishing Protection Product documentation:  https://cloud.google.com/phishing-protection/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-policy-troubleshooter/.repo-metadata.json
+++ b/packages/google-cloud-policy-troubleshooter/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "policytroubleshooter",
     "name_pretty": "IAM Policy Troubleshooter API",
-    "product_documentation": "https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/",
+    "product_documentation": "https://cloud.google.com/policy-intelligence/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-policy-troubleshooter/README.rst
+++ b/packages/google-cloud-policy-troubleshooter/README.rst
@@ -14,9 +14,9 @@ Python Client for IAM Policy Troubleshooter API
    :target: https://pypi.org/project/google-cloud-policy-troubleshooter/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-policy-troubleshooter.svg
    :target: https://pypi.org/project/google-cloud-policy-troubleshooter/
-.. _IAM Policy Troubleshooter API: https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/
+.. _IAM Policy Troubleshooter API: https://cloud.google.com/policy-intelligence/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/policytroubleshooter/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/
+.. _Product Documentation:  https://cloud.google.com/policy-intelligence/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the IAM Policy Troubleshooter API.:  https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/
+.. _Enable the IAM Policy Troubleshooter API.:  https://cloud.google.com/policy-intelligence/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _IAM Policy Troubleshooter API Product documentation:  https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/
+.. _IAM Policy Troubleshooter API Product documentation:  https://cloud.google.com/policy-intelligence/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-policy-troubleshooter/docs/README.rst
+++ b/packages/google-cloud-policy-troubleshooter/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for IAM Policy Troubleshooter API
    :target: https://pypi.org/project/google-cloud-policy-troubleshooter/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-policy-troubleshooter.svg
    :target: https://pypi.org/project/google-cloud-policy-troubleshooter/
-.. _IAM Policy Troubleshooter API: https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/
+.. _IAM Policy Troubleshooter API: https://cloud.google.com/policy-intelligence/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/policytroubleshooter/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/
+.. _Product Documentation:  https://cloud.google.com/policy-intelligence/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the IAM Policy Troubleshooter API.:  https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/
+.. _Enable the IAM Policy Troubleshooter API.:  https://cloud.google.com/policy-intelligence/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _IAM Policy Troubleshooter API Product documentation:  https://cloud.google.com/iam/docs/troubleshooting-access#rest-api/
+.. _IAM Policy Troubleshooter API Product documentation:  https://cloud.google.com/policy-intelligence/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-policysimulator/.repo-metadata.json
+++ b/packages/google-cloud-policysimulator/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "policysimulator",
     "name_pretty": "Policy Simulator API",
-    "product_documentation": "https://cloud.google.com/policy-intelligence/docs/iam-simulator-overview",
+    "product_documentation": "https://cloud.google.com/policy-intelligence/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-policysimulator/README.rst
+++ b/packages/google-cloud-policysimulator/README.rst
@@ -14,9 +14,9 @@ Python Client for Policy Simulator API
    :target: https://pypi.org/project/google-cloud-policysimulator/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-policysimulator.svg
    :target: https://pypi.org/project/google-cloud-policysimulator/
-.. _Policy Simulator API: https://cloud.google.com/policy-intelligence/docs/iam-simulator-overview
+.. _Policy Simulator API: https://cloud.google.com/policy-intelligence/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/policysimulator/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/policy-intelligence/docs/iam-simulator-overview
+.. _Product Documentation:  https://cloud.google.com/policy-intelligence/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Policy Simulator API.:  https://cloud.google.com/policy-intelligence/docs/iam-simulator-overview
+.. _Enable the Policy Simulator API.:  https://cloud.google.com/policy-intelligence/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Policy Simulator API Product documentation:  https://cloud.google.com/policy-intelligence/docs/iam-simulator-overview
+.. _Policy Simulator API Product documentation:  https://cloud.google.com/policy-intelligence/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-policysimulator/docs/README.rst
+++ b/packages/google-cloud-policysimulator/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Policy Simulator API
    :target: https://pypi.org/project/google-cloud-policysimulator/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-policysimulator.svg
    :target: https://pypi.org/project/google-cloud-policysimulator/
-.. _Policy Simulator API: https://cloud.google.com/policy-intelligence/docs/iam-simulator-overview
+.. _Policy Simulator API: https://cloud.google.com/policy-intelligence/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/policysimulator/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/policy-intelligence/docs/iam-simulator-overview
+.. _Product Documentation:  https://cloud.google.com/policy-intelligence/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Policy Simulator API.:  https://cloud.google.com/policy-intelligence/docs/iam-simulator-overview
+.. _Enable the Policy Simulator API.:  https://cloud.google.com/policy-intelligence/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Policy Simulator API Product documentation:  https://cloud.google.com/policy-intelligence/docs/iam-simulator-overview
+.. _Policy Simulator API Product documentation:  https://cloud.google.com/policy-intelligence/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-policytroubleshooter-iam/.repo-metadata.json
+++ b/packages/google-cloud-policytroubleshooter-iam/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "policytroubleshooter-iam",
     "name_pretty": "Policy Troubleshooter API",
-    "product_documentation": "https://cloud.google.com/policy-intelligence/docs/troubleshoot-access",
+    "product_documentation": "https://cloud.google.com/policy-intelligence/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-policytroubleshooter-iam/README.rst
+++ b/packages/google-cloud-policytroubleshooter-iam/README.rst
@@ -14,9 +14,9 @@ Python Client for Policy Troubleshooter API
    :target: https://pypi.org/project/google-cloud-policytroubleshooter-iam/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-policytroubleshooter-iam.svg
    :target: https://pypi.org/project/google-cloud-policytroubleshooter-iam/
-.. _Policy Troubleshooter API: https://cloud.google.com/policy-intelligence/docs/troubleshoot-access
+.. _Policy Troubleshooter API: https://cloud.google.com/policy-intelligence/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/policytroubleshooter-iam/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/policy-intelligence/docs/troubleshoot-access
+.. _Product Documentation:  https://cloud.google.com/policy-intelligence/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Policy Troubleshooter API.:  https://cloud.google.com/policy-intelligence/docs/troubleshoot-access
+.. _Enable the Policy Troubleshooter API.:  https://cloud.google.com/policy-intelligence/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Policy Troubleshooter API Product documentation:  https://cloud.google.com/policy-intelligence/docs/troubleshoot-access
+.. _Policy Troubleshooter API Product documentation:  https://cloud.google.com/policy-intelligence/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-policytroubleshooter-iam/docs/README.rst
+++ b/packages/google-cloud-policytroubleshooter-iam/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Policy Troubleshooter API
    :target: https://pypi.org/project/google-cloud-policytroubleshooter-iam/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-policytroubleshooter-iam.svg
    :target: https://pypi.org/project/google-cloud-policytroubleshooter-iam/
-.. _Policy Troubleshooter API: https://cloud.google.com/policy-intelligence/docs/troubleshoot-access
+.. _Policy Troubleshooter API: https://cloud.google.com/policy-intelligence/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/policytroubleshooter-iam/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/policy-intelligence/docs/troubleshoot-access
+.. _Product Documentation:  https://cloud.google.com/policy-intelligence/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Policy Troubleshooter API.:  https://cloud.google.com/policy-intelligence/docs/troubleshoot-access
+.. _Enable the Policy Troubleshooter API.:  https://cloud.google.com/policy-intelligence/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Policy Troubleshooter API Product documentation:  https://cloud.google.com/policy-intelligence/docs/troubleshoot-access
+.. _Policy Troubleshooter API Product documentation:  https://cloud.google.com/policy-intelligence/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-privilegedaccessmanager/.repo-metadata.json
+++ b/packages/google-cloud-privilegedaccessmanager/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-privilegedaccessmanager",
     "name_pretty": "Privileged Access Manager API",
-    "product_documentation": "https://cloud.google.com/iam/docs/pam-overview",
+    "product_documentation": "https://cloud.google.com/iam/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-privilegedaccessmanager/README.rst
+++ b/packages/google-cloud-privilegedaccessmanager/README.rst
@@ -14,9 +14,9 @@ Python Client for Privileged Access Manager API
    :target: https://pypi.org/project/google-cloud-privilegedaccessmanager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-privilegedaccessmanager.svg
    :target: https://pypi.org/project/google-cloud-privilegedaccessmanager/
-.. _Privileged Access Manager API: https://cloud.google.com/iam/docs/pam-overview
+.. _Privileged Access Manager API: https://cloud.google.com/iam/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-privilegedaccessmanager/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/iam/docs/pam-overview
+.. _Product Documentation:  https://cloud.google.com/iam/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Privileged Access Manager API.:  https://cloud.google.com/iam/docs/pam-overview
+.. _Enable the Privileged Access Manager API.:  https://cloud.google.com/iam/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Privileged Access Manager API Product documentation:  https://cloud.google.com/iam/docs/pam-overview
+.. _Privileged Access Manager API Product documentation:  https://cloud.google.com/iam/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-privilegedaccessmanager/docs/README.rst
+++ b/packages/google-cloud-privilegedaccessmanager/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Privileged Access Manager API
    :target: https://pypi.org/project/google-cloud-privilegedaccessmanager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-privilegedaccessmanager.svg
    :target: https://pypi.org/project/google-cloud-privilegedaccessmanager/
-.. _Privileged Access Manager API: https://cloud.google.com/iam/docs/pam-overview
+.. _Privileged Access Manager API: https://cloud.google.com/iam/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-privilegedaccessmanager/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/iam/docs/pam-overview
+.. _Product Documentation:  https://cloud.google.com/iam/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Privileged Access Manager API.:  https://cloud.google.com/iam/docs/pam-overview
+.. _Enable the Privileged Access Manager API.:  https://cloud.google.com/iam/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Privileged Access Manager API Product documentation:  https://cloud.google.com/iam/docs/pam-overview
+.. _Privileged Access Manager API Product documentation:  https://cloud.google.com/iam/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-pubsub/.repo-metadata.json
+++ b/packages/google-cloud-pubsub/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_COMBO",
     "name": "pubsub",
     "name_pretty": "Google Cloud Pub/Sub",
-    "product_documentation": "https://cloud.google.com/pubsub/docs/",
+    "product_documentation": "https://cloud.google.com/pubsub/docs",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-pubsub/README.rst
+++ b/packages/google-cloud-pubsub/README.rst
@@ -25,9 +25,9 @@ independently written applications.
    :target: https://pypi.org/project/google-cloud-pubsub/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-pubsub.svg
    :target: https://pypi.org/project/google-cloud-pubsub/
-.. _Google Cloud Pub/Sub: https://cloud.google.com/pubsub/docs/
+.. _Google Cloud Pub/Sub: https://cloud.google.com/pubsub/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/pubsub/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/pubsub/docs/
+.. _Product Documentation:  https://cloud.google.com/pubsub/docs
 
 Quick Start
 -----------
@@ -41,7 +41,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Pub/Sub.:  https://cloud.google.com/pubsub/docs/
+.. _Enable the Google Cloud Pub/Sub.:  https://cloud.google.com/pubsub/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -253,7 +253,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Pub/Sub Product documentation:  https://cloud.google.com/pubsub/docs/
+.. _Google Cloud Pub/Sub Product documentation:  https://cloud.google.com/pubsub/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-pubsub/docs/README.rst
+++ b/packages/google-cloud-pubsub/docs/README.rst
@@ -25,9 +25,9 @@ independently written applications.
    :target: https://pypi.org/project/google-cloud-pubsub/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-pubsub.svg
    :target: https://pypi.org/project/google-cloud-pubsub/
-.. _Google Cloud Pub/Sub: https://cloud.google.com/pubsub/docs/
+.. _Google Cloud Pub/Sub: https://cloud.google.com/pubsub/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/pubsub/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/pubsub/docs/
+.. _Product Documentation:  https://cloud.google.com/pubsub/docs
 
 Quick Start
 -----------
@@ -41,7 +41,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Pub/Sub.:  https://cloud.google.com/pubsub/docs/
+.. _Enable the Google Cloud Pub/Sub.:  https://cloud.google.com/pubsub/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -253,7 +253,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Pub/Sub Product documentation:  https://cloud.google.com/pubsub/docs/
+.. _Google Cloud Pub/Sub Product documentation:  https://cloud.google.com/pubsub/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-quotas/.repo-metadata.json
+++ b/packages/google-cloud-quotas/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-cloudquotas",
     "name_pretty": "Cloud Quotas API",
-    "product_documentation": "https://cloud.google.com/docs/quota/api-overview",
+    "product_documentation": "https://cloud.google.com/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-quotas/README.rst
+++ b/packages/google-cloud-quotas/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Quotas API
    :target: https://pypi.org/project/google-cloud-quotas/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-quotas.svg
    :target: https://pypi.org/project/google-cloud-quotas/
-.. _Cloud Quotas API: https://cloud.google.com/docs/quota/api-overview
+.. _Cloud Quotas API: https://cloud.google.com/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-cloudquotas/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/docs/quota/api-overview
+.. _Product Documentation:  https://cloud.google.com/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Quotas API.:  https://cloud.google.com/docs/quota/api-overview
+.. _Enable the Cloud Quotas API.:  https://cloud.google.com/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Quotas API Product documentation:  https://cloud.google.com/docs/quota/api-overview
+.. _Cloud Quotas API Product documentation:  https://cloud.google.com/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-quotas/docs/README.rst
+++ b/packages/google-cloud-quotas/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Quotas API
    :target: https://pypi.org/project/google-cloud-quotas/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-quotas.svg
    :target: https://pypi.org/project/google-cloud-quotas/
-.. _Cloud Quotas API: https://cloud.google.com/docs/quota/api-overview
+.. _Cloud Quotas API: https://cloud.google.com/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-cloudquotas/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/docs/quota/api-overview
+.. _Product Documentation:  https://cloud.google.com/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Quotas API.:  https://cloud.google.com/docs/quota/api-overview
+.. _Enable the Cloud Quotas API.:  https://cloud.google.com/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Quotas API Product documentation:  https://cloud.google.com/docs/quota/api-overview
+.. _Cloud Quotas API Product documentation:  https://cloud.google.com/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-redis-cluster/.repo-metadata.json
+++ b/packages/google-cloud-redis-cluster/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-redis-cluster",
     "name_pretty": "Google Cloud Memorystore for Redis API",
-    "product_documentation": "https://cloud.google.com/redis/docs",
+    "product_documentation": "https://cloud.google.com/memorystore/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-redis-cluster/README.rst
+++ b/packages/google-cloud-redis-cluster/README.rst
@@ -14,9 +14,9 @@ Python Client for Google Cloud Memorystore for Redis API
    :target: https://pypi.org/project/google-cloud-redis-cluster/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-redis-cluster.svg
    :target: https://pypi.org/project/google-cloud-redis-cluster/
-.. _Google Cloud Memorystore for Redis API: https://cloud.google.com/redis/docs
+.. _Google Cloud Memorystore for Redis API: https://cloud.google.com/memorystore/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-redis-cluster/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/redis/docs
+.. _Product Documentation:  https://cloud.google.com/memorystore/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Memorystore for Redis API.:  https://cloud.google.com/redis/docs
+.. _Enable the Google Cloud Memorystore for Redis API.:  https://cloud.google.com/memorystore/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Memorystore for Redis API Product documentation:  https://cloud.google.com/redis/docs
+.. _Google Cloud Memorystore for Redis API Product documentation:  https://cloud.google.com/memorystore/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-redis-cluster/docs/README.rst
+++ b/packages/google-cloud-redis-cluster/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Google Cloud Memorystore for Redis API
    :target: https://pypi.org/project/google-cloud-redis-cluster/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-redis-cluster.svg
    :target: https://pypi.org/project/google-cloud-redis-cluster/
-.. _Google Cloud Memorystore for Redis API: https://cloud.google.com/redis/docs
+.. _Google Cloud Memorystore for Redis API: https://cloud.google.com/memorystore/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-redis-cluster/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/redis/docs
+.. _Product Documentation:  https://cloud.google.com/memorystore/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Memorystore for Redis API.:  https://cloud.google.com/redis/docs
+.. _Enable the Google Cloud Memorystore for Redis API.:  https://cloud.google.com/memorystore/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Memorystore for Redis API Product documentation:  https://cloud.google.com/redis/docs
+.. _Google Cloud Memorystore for Redis API Product documentation:  https://cloud.google.com/memorystore/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-redis/.repo-metadata.json
+++ b/packages/google-cloud-redis/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "redis",
     "name_pretty": "Cloud Redis",
-    "product_documentation": "https://cloud.google.com/memorystore/docs/redis/",
+    "product_documentation": "https://cloud.google.com/memorystore/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-redis/README.rst
+++ b/packages/google-cloud-redis/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Redis
    :target: https://pypi.org/project/google-cloud-redis/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-redis.svg
    :target: https://pypi.org/project/google-cloud-redis/
-.. _Cloud Redis: https://cloud.google.com/memorystore/docs/redis/
+.. _Cloud Redis: https://cloud.google.com/memorystore/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/redis/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/memorystore/docs/redis/
+.. _Product Documentation:  https://cloud.google.com/memorystore/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Redis.:  https://cloud.google.com/memorystore/docs/redis/
+.. _Enable the Cloud Redis.:  https://cloud.google.com/memorystore/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Redis Product documentation:  https://cloud.google.com/memorystore/docs/redis/
+.. _Cloud Redis Product documentation:  https://cloud.google.com/memorystore/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-redis/docs/README.rst
+++ b/packages/google-cloud-redis/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Redis
    :target: https://pypi.org/project/google-cloud-redis/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-redis.svg
    :target: https://pypi.org/project/google-cloud-redis/
-.. _Cloud Redis: https://cloud.google.com/memorystore/docs/redis/
+.. _Cloud Redis: https://cloud.google.com/memorystore/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/redis/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/memorystore/docs/redis/
+.. _Product Documentation:  https://cloud.google.com/memorystore/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Redis.:  https://cloud.google.com/memorystore/docs/redis/
+.. _Enable the Cloud Redis.:  https://cloud.google.com/memorystore/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Redis Product documentation:  https://cloud.google.com/memorystore/docs/redis/
+.. _Cloud Redis Product documentation:  https://cloud.google.com/memorystore/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-retail/.repo-metadata.json
+++ b/packages/google-cloud-retail/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "retail",
     "name_pretty": "Retail",
-    "product_documentation": "https://cloud.google.com/retail/docs/",
+    "product_documentation": "https://cloud.google.com/retail/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-retail/README.rst
+++ b/packages/google-cloud-retail/README.rst
@@ -14,9 +14,9 @@ Python Client for Retail
    :target: https://pypi.org/project/google-cloud-retail/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-retail.svg
    :target: https://pypi.org/project/google-cloud-retail/
-.. _Retail: https://cloud.google.com/retail/docs/
+.. _Retail: https://cloud.google.com/retail/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/retail/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/retail/docs/
+.. _Product Documentation:  https://cloud.google.com/retail/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Retail.:  https://cloud.google.com/retail/docs/
+.. _Enable the Retail.:  https://cloud.google.com/retail/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Retail Product documentation:  https://cloud.google.com/retail/docs/
+.. _Retail Product documentation:  https://cloud.google.com/retail/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-retail/docs/README.rst
+++ b/packages/google-cloud-retail/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Retail
    :target: https://pypi.org/project/google-cloud-retail/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-retail.svg
    :target: https://pypi.org/project/google-cloud-retail/
-.. _Retail: https://cloud.google.com/retail/docs/
+.. _Retail: https://cloud.google.com/retail/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/retail/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/retail/docs/
+.. _Product Documentation:  https://cloud.google.com/retail/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Retail.:  https://cloud.google.com/retail/docs/
+.. _Enable the Retail.:  https://cloud.google.com/retail/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Retail Product documentation:  https://cloud.google.com/retail/docs/
+.. _Retail Product documentation:  https://cloud.google.com/retail/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-runtimeconfig/.repo-metadata.json
+++ b/packages/google-cloud-runtimeconfig/.repo-metadata.json
@@ -8,7 +8,6 @@
     "library_type": "GAPIC_MANUAL",
     "name": "runtimeconfig",
     "name_pretty": "Google Cloud Runtime Configurator",
-    "product_documentation": "https://cloud.google.com/deployment-manager/runtime-configurator/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-saasplatform-saasservicemgmt/.repo-metadata.json
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-saasplatform-saasservicemgmt",
     "name_pretty": "SaaS Runtime API",
-    "product_documentation": "https://cloud.google.com/saas-runtime/docs/overview",
+    "product_documentation": "https://cloud.google.com/saas-runtime/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-saasplatform-saasservicemgmt/README.rst
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/README.rst
@@ -14,9 +14,9 @@ Python Client for SaaS Runtime API
    :target: https://pypi.org/project/google-cloud-saasplatform-saasservicemgmt/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-saasplatform-saasservicemgmt.svg
    :target: https://pypi.org/project/google-cloud-saasplatform-saasservicemgmt/
-.. _SaaS Runtime API: https://cloud.google.com/saas-runtime/docs/overview
+.. _SaaS Runtime API: https://cloud.google.com/saas-runtime/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-saasplatform-saasservicemgmt/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/saas-runtime/docs/overview
+.. _Product Documentation:  https://cloud.google.com/saas-runtime/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the SaaS Runtime API.:  https://cloud.google.com/saas-runtime/docs/overview
+.. _Enable the SaaS Runtime API.:  https://cloud.google.com/saas-runtime/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _SaaS Runtime API Product documentation:  https://cloud.google.com/saas-runtime/docs/overview
+.. _SaaS Runtime API Product documentation:  https://cloud.google.com/saas-runtime/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-saasplatform-saasservicemgmt/docs/README.rst
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for SaaS Runtime API
    :target: https://pypi.org/project/google-cloud-saasplatform-saasservicemgmt/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-saasplatform-saasservicemgmt.svg
    :target: https://pypi.org/project/google-cloud-saasplatform-saasservicemgmt/
-.. _SaaS Runtime API: https://cloud.google.com/saas-runtime/docs/overview
+.. _SaaS Runtime API: https://cloud.google.com/saas-runtime/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-saasplatform-saasservicemgmt/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/saas-runtime/docs/overview
+.. _Product Documentation:  https://cloud.google.com/saas-runtime/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the SaaS Runtime API.:  https://cloud.google.com/saas-runtime/docs/overview
+.. _Enable the SaaS Runtime API.:  https://cloud.google.com/saas-runtime/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _SaaS Runtime API Product documentation:  https://cloud.google.com/saas-runtime/docs/overview
+.. _SaaS Runtime API Product documentation:  https://cloud.google.com/saas-runtime/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-securesourcemanager/.repo-metadata.json
+++ b/packages/google-cloud-securesourcemanager/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "securesourcemanager",
     "name_pretty": "Secure Source Manager API",
-    "product_documentation": "https://cloud.google.com/secure-source-manager/docs/overview",
+    "product_documentation": "https://cloud.google.com/secure-source-manager/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-securesourcemanager/README.rst
+++ b/packages/google-cloud-securesourcemanager/README.rst
@@ -14,9 +14,9 @@ Python Client for Secure Source Manager API
    :target: https://pypi.org/project/google-cloud-securesourcemanager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-securesourcemanager.svg
    :target: https://pypi.org/project/google-cloud-securesourcemanager/
-.. _Secure Source Manager API: https://cloud.google.com/secure-source-manager/docs/overview
+.. _Secure Source Manager API: https://cloud.google.com/secure-source-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/securesourcemanager/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/secure-source-manager/docs/overview
+.. _Product Documentation:  https://cloud.google.com/secure-source-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Secure Source Manager API.:  https://cloud.google.com/secure-source-manager/docs/overview
+.. _Enable the Secure Source Manager API.:  https://cloud.google.com/secure-source-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Secure Source Manager API Product documentation:  https://cloud.google.com/secure-source-manager/docs/overview
+.. _Secure Source Manager API Product documentation:  https://cloud.google.com/secure-source-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-securesourcemanager/docs/README.rst
+++ b/packages/google-cloud-securesourcemanager/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Secure Source Manager API
    :target: https://pypi.org/project/google-cloud-securesourcemanager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-securesourcemanager.svg
    :target: https://pypi.org/project/google-cloud-securesourcemanager/
-.. _Secure Source Manager API: https://cloud.google.com/secure-source-manager/docs/overview
+.. _Secure Source Manager API: https://cloud.google.com/secure-source-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/securesourcemanager/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/secure-source-manager/docs/overview
+.. _Product Documentation:  https://cloud.google.com/secure-source-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Secure Source Manager API.:  https://cloud.google.com/secure-source-manager/docs/overview
+.. _Enable the Secure Source Manager API.:  https://cloud.google.com/secure-source-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Secure Source Manager API Product documentation:  https://cloud.google.com/secure-source-manager/docs/overview
+.. _Secure Source Manager API Product documentation:  https://cloud.google.com/secure-source-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-security-publicca/.repo-metadata.json
+++ b/packages/google-cloud-security-publicca/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "publicca",
     "name_pretty": "Public Certificate Authority",
-    "product_documentation": "https://cloud.google.com/certificate-manager/docs/public-ca",
+    "product_documentation": "https://cloud.google.com/certificate-manager/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-security-publicca/README.rst
+++ b/packages/google-cloud-security-publicca/README.rst
@@ -14,9 +14,9 @@ Python Client for Public Certificate Authority
    :target: https://pypi.org/project/google-cloud-security-publicca/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-security-publicca.svg
    :target: https://pypi.org/project/google-cloud-security-publicca/
-.. _Public Certificate Authority: https://cloud.google.com/certificate-manager/docs/public-ca
+.. _Public Certificate Authority: https://cloud.google.com/certificate-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/publicca/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/certificate-manager/docs/public-ca
+.. _Product Documentation:  https://cloud.google.com/certificate-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Public Certificate Authority.:  https://cloud.google.com/certificate-manager/docs/public-ca
+.. _Enable the Public Certificate Authority.:  https://cloud.google.com/certificate-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Public Certificate Authority Product documentation:  https://cloud.google.com/certificate-manager/docs/public-ca
+.. _Public Certificate Authority Product documentation:  https://cloud.google.com/certificate-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-security-publicca/docs/README.rst
+++ b/packages/google-cloud-security-publicca/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Public Certificate Authority
    :target: https://pypi.org/project/google-cloud-security-publicca/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-security-publicca.svg
    :target: https://pypi.org/project/google-cloud-security-publicca/
-.. _Public Certificate Authority: https://cloud.google.com/certificate-manager/docs/public-ca
+.. _Public Certificate Authority: https://cloud.google.com/certificate-manager/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/publicca/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/certificate-manager/docs/public-ca
+.. _Product Documentation:  https://cloud.google.com/certificate-manager/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Public Certificate Authority.:  https://cloud.google.com/certificate-manager/docs/public-ca
+.. _Enable the Public Certificate Authority.:  https://cloud.google.com/certificate-manager/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Public Certificate Authority Product documentation:  https://cloud.google.com/certificate-manager/docs/public-ca
+.. _Public Certificate Authority Product documentation:  https://cloud.google.com/certificate-manager/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-securitycenter/.repo-metadata.json
+++ b/packages/google-cloud-securitycenter/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "securitycenter",
     "name_pretty": "Google Cloud Security Command Center",
-    "product_documentation": "https://cloud.google.com/security-command-center",
+    "product_documentation": "https://cloud.google.com/security-command-center/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-securitycenter/README.rst
+++ b/packages/google-cloud-securitycenter/README.rst
@@ -14,9 +14,9 @@ Python Client for Google Cloud Security Command Center
    :target: https://pypi.org/project/google-cloud-securitycenter/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-securitycenter.svg
    :target: https://pypi.org/project/google-cloud-securitycenter/
-.. _Google Cloud Security Command Center: https://cloud.google.com/security-command-center
+.. _Google Cloud Security Command Center: https://cloud.google.com/security-command-center/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/securitycenter/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/security-command-center
+.. _Product Documentation:  https://cloud.google.com/security-command-center/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Security Command Center.:  https://cloud.google.com/security-command-center
+.. _Enable the Google Cloud Security Command Center.:  https://cloud.google.com/security-command-center/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Security Command Center Product documentation:  https://cloud.google.com/security-command-center
+.. _Google Cloud Security Command Center Product documentation:  https://cloud.google.com/security-command-center/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-securitycenter/docs/README.rst
+++ b/packages/google-cloud-securitycenter/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Google Cloud Security Command Center
    :target: https://pypi.org/project/google-cloud-securitycenter/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-securitycenter.svg
    :target: https://pypi.org/project/google-cloud-securitycenter/
-.. _Google Cloud Security Command Center: https://cloud.google.com/security-command-center
+.. _Google Cloud Security Command Center: https://cloud.google.com/security-command-center/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/securitycenter/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/security-command-center
+.. _Product Documentation:  https://cloud.google.com/security-command-center/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Security Command Center.:  https://cloud.google.com/security-command-center
+.. _Enable the Google Cloud Security Command Center.:  https://cloud.google.com/security-command-center/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Security Command Center Product documentation:  https://cloud.google.com/security-command-center
+.. _Google Cloud Security Command Center Product documentation:  https://cloud.google.com/security-command-center/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-securitycentermanagement/.repo-metadata.json
+++ b/packages/google-cloud-securitycentermanagement/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-securitycentermanagement",
     "name_pretty": "Security Center Management API",
-    "product_documentation": "https://cloud.google.com/securitycentermanagement/docs/overview",
+    "product_documentation": "https://cloud.google.com/security-command-center/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-securitycentermanagement/README.rst
+++ b/packages/google-cloud-securitycentermanagement/README.rst
@@ -16,9 +16,9 @@ update the settings and configuration of Security Command Center.
    :target: https://pypi.org/project/google-cloud-securitycentermanagement/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-securitycentermanagement.svg
    :target: https://pypi.org/project/google-cloud-securitycentermanagement/
-.. _Security Center Management API: https://cloud.google.com/securitycentermanagement/docs/overview
+.. _Security Center Management API: https://cloud.google.com/security-command-center/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-securitycentermanagement/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/securitycentermanagement/docs/overview
+.. _Product Documentation:  https://cloud.google.com/security-command-center/
 
 Quick Start
 -----------
@@ -32,7 +32,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Security Center Management API.:  https://cloud.google.com/securitycentermanagement/docs/overview
+.. _Enable the Security Center Management API.:  https://cloud.google.com/security-command-center/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -106,7 +106,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Security Center Management API Product documentation:  https://cloud.google.com/securitycentermanagement/docs/overview
+.. _Security Center Management API Product documentation:  https://cloud.google.com/security-command-center/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-securitycentermanagement/docs/README.rst
+++ b/packages/google-cloud-securitycentermanagement/docs/README.rst
@@ -16,9 +16,9 @@ update the settings and configuration of Security Command Center.
    :target: https://pypi.org/project/google-cloud-securitycentermanagement/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-securitycentermanagement.svg
    :target: https://pypi.org/project/google-cloud-securitycentermanagement/
-.. _Security Center Management API: https://cloud.google.com/securitycentermanagement/docs/overview
+.. _Security Center Management API: https://cloud.google.com/security-command-center/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-securitycentermanagement/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/securitycentermanagement/docs/overview
+.. _Product Documentation:  https://cloud.google.com/security-command-center/
 
 Quick Start
 -----------
@@ -32,7 +32,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Security Center Management API.:  https://cloud.google.com/securitycentermanagement/docs/overview
+.. _Enable the Security Center Management API.:  https://cloud.google.com/security-command-center/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -106,7 +106,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Security Center Management API Product documentation:  https://cloud.google.com/securitycentermanagement/docs/overview
+.. _Security Center Management API Product documentation:  https://cloud.google.com/security-command-center/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-service-control/.repo-metadata.json
+++ b/packages/google-cloud-service-control/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "servicecontrol",
     "name_pretty": "Service Control",
-    "product_documentation": "https://cloud.google.com/service-infrastructure/docs/overview/",
+    "product_documentation": "https://cloud.google.com/service-infrastructure/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-service-control/README.rst
+++ b/packages/google-cloud-service-control/README.rst
@@ -14,9 +14,9 @@ Python Client for Service Control
    :target: https://pypi.org/project/google-cloud-service-control/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-service-control.svg
    :target: https://pypi.org/project/google-cloud-service-control/
-.. _Service Control: https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Service Control: https://cloud.google.com/service-infrastructure/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/servicecontrol/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Product Documentation:  https://cloud.google.com/service-infrastructure/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Service Control.:  https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Enable the Service Control.:  https://cloud.google.com/service-infrastructure/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Service Control Product documentation:  https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Service Control Product documentation:  https://cloud.google.com/service-infrastructure/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-service-control/docs/README.rst
+++ b/packages/google-cloud-service-control/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Service Control
    :target: https://pypi.org/project/google-cloud-service-control/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-service-control.svg
    :target: https://pypi.org/project/google-cloud-service-control/
-.. _Service Control: https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Service Control: https://cloud.google.com/service-infrastructure/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/servicecontrol/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Product Documentation:  https://cloud.google.com/service-infrastructure/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Service Control.:  https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Enable the Service Control.:  https://cloud.google.com/service-infrastructure/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Service Control Product documentation:  https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Service Control Product documentation:  https://cloud.google.com/service-infrastructure/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-service-management/.repo-metadata.json
+++ b/packages/google-cloud-service-management/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "servicemanagement",
     "name_pretty": "Service Management",
-    "product_documentation": "https://cloud.google.com/service-infrastructure/docs/overview/",
+    "product_documentation": "https://cloud.google.com/service-infrastructure/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-service-management/README.rst
+++ b/packages/google-cloud-service-management/README.rst
@@ -14,9 +14,9 @@ Python Client for Service Management
    :target: https://pypi.org/project/google-cloud-service-management/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-service-management.svg
    :target: https://pypi.org/project/google-cloud-service-management/
-.. _Service Management: https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Service Management: https://cloud.google.com/service-infrastructure/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/servicemanagement/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Product Documentation:  https://cloud.google.com/service-infrastructure/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Service Management.:  https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Enable the Service Management.:  https://cloud.google.com/service-infrastructure/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Service Management Product documentation:  https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Service Management Product documentation:  https://cloud.google.com/service-infrastructure/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-service-management/docs/README.rst
+++ b/packages/google-cloud-service-management/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Service Management
    :target: https://pypi.org/project/google-cloud-service-management/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-service-management.svg
    :target: https://pypi.org/project/google-cloud-service-management/
-.. _Service Management: https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Service Management: https://cloud.google.com/service-infrastructure/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/servicemanagement/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Product Documentation:  https://cloud.google.com/service-infrastructure/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Service Management.:  https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Enable the Service Management.:  https://cloud.google.com/service-infrastructure/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Service Management Product documentation:  https://cloud.google.com/service-infrastructure/docs/overview/
+.. _Service Management Product documentation:  https://cloud.google.com/service-infrastructure/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-servicehealth/.repo-metadata.json
+++ b/packages/google-cloud-servicehealth/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-servicehealth",
     "name_pretty": "Service Health API",
-    "product_documentation": "https://cloud.google.com/service-health/docs/overview",
+    "product_documentation": "https://cloud.google.com/service-health/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-servicehealth/README.rst
+++ b/packages/google-cloud-servicehealth/README.rst
@@ -14,9 +14,9 @@ Python Client for Service Health API
    :target: https://pypi.org/project/google-cloud-servicehealth/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-servicehealth.svg
    :target: https://pypi.org/project/google-cloud-servicehealth/
-.. _Service Health API: https://cloud.google.com/service-health/docs/overview
+.. _Service Health API: https://cloud.google.com/service-health/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-servicehealth/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/service-health/docs/overview
+.. _Product Documentation:  https://cloud.google.com/service-health/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Service Health API.:  https://cloud.google.com/service-health/docs/overview
+.. _Enable the Service Health API.:  https://cloud.google.com/service-health/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Service Health API Product documentation:  https://cloud.google.com/service-health/docs/overview
+.. _Service Health API Product documentation:  https://cloud.google.com/service-health/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-servicehealth/docs/README.rst
+++ b/packages/google-cloud-servicehealth/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Service Health API
    :target: https://pypi.org/project/google-cloud-servicehealth/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-servicehealth.svg
    :target: https://pypi.org/project/google-cloud-servicehealth/
-.. _Service Health API: https://cloud.google.com/service-health/docs/overview
+.. _Service Health API: https://cloud.google.com/service-health/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-servicehealth/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/service-health/docs/overview
+.. _Product Documentation:  https://cloud.google.com/service-health/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Service Health API.:  https://cloud.google.com/service-health/docs/overview
+.. _Enable the Service Health API.:  https://cloud.google.com/service-health/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Service Health API Product documentation:  https://cloud.google.com/service-health/docs/overview
+.. _Service Health API Product documentation:  https://cloud.google.com/service-health/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-spanner/.repo-metadata.json
+++ b/packages/google-cloud-spanner/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_COMBO",
     "name": "spanner",
     "name_pretty": "Cloud Spanner",
-    "product_documentation": "https://cloud.google.com/spanner/docs/",
+    "product_documentation": "https://cloud.google.com/spanner/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-spanner/README.rst
+++ b/packages/google-cloud-spanner/README.rst
@@ -20,9 +20,9 @@ workloads.
    :target: https://pypi.org/project/google-cloud-spanner/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-spanner.svg
    :target: https://pypi.org/project/google-cloud-spanner/
-.. _Cloud Spanner: https://cloud.google.com/spanner/docs/
+.. _Cloud Spanner: https://cloud.google.com/spanner/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/spanner/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/spanner/docs/
+.. _Product Documentation:  https://cloud.google.com/spanner/
 
 Quick Start
 -----------
@@ -36,7 +36,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Spanner.:  https://cloud.google.com/spanner/docs/
+.. _Enable the Cloud Spanner.:  https://cloud.google.com/spanner/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -291,7 +291,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Spanner Product documentation:  https://cloud.google.com/spanner/docs/
+.. _Cloud Spanner Product documentation:  https://cloud.google.com/spanner/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-spanner/docs/README.rst
+++ b/packages/google-cloud-spanner/docs/README.rst
@@ -20,9 +20,9 @@ workloads.
    :target: https://pypi.org/project/google-cloud-spanner/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-spanner.svg
    :target: https://pypi.org/project/google-cloud-spanner/
-.. _Cloud Spanner: https://cloud.google.com/spanner/docs/
+.. _Cloud Spanner: https://cloud.google.com/spanner/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/spanner/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/spanner/docs/
+.. _Product Documentation:  https://cloud.google.com/spanner/
 
 Quick Start
 -----------
@@ -36,7 +36,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Spanner.:  https://cloud.google.com/spanner/docs/
+.. _Enable the Cloud Spanner.:  https://cloud.google.com/spanner/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -291,7 +291,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Spanner Product documentation:  https://cloud.google.com/spanner/docs/
+.. _Cloud Spanner Product documentation:  https://cloud.google.com/spanner/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-speech/.repo-metadata.json
+++ b/packages/google-cloud-speech/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_COMBO",
     "name": "speech",
     "name_pretty": "Cloud Speech",
-    "product_documentation": "https://cloud.google.com/speech-to-text/docs/",
+    "product_documentation": "https://cloud.google.com/speech-to-text/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-speech/README.rst
+++ b/packages/google-cloud-speech/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Speech
    :target: https://pypi.org/project/google-cloud-speech/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-speech.svg
    :target: https://pypi.org/project/google-cloud-speech/
-.. _Cloud Speech: https://cloud.google.com/speech-to-text/docs/
+.. _Cloud Speech: https://cloud.google.com/speech-to-text/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/speech/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/speech-to-text/docs/
+.. _Product Documentation:  https://cloud.google.com/speech-to-text/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Speech.:  https://cloud.google.com/speech-to-text/docs/
+.. _Enable the Cloud Speech.:  https://cloud.google.com/speech-to-text/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Speech Product documentation:  https://cloud.google.com/speech-to-text/docs/
+.. _Cloud Speech Product documentation:  https://cloud.google.com/speech-to-text/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-speech/docs/README.rst
+++ b/packages/google-cloud-speech/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Speech
    :target: https://pypi.org/project/google-cloud-speech/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-speech.svg
    :target: https://pypi.org/project/google-cloud-speech/
-.. _Cloud Speech: https://cloud.google.com/speech-to-text/docs/
+.. _Cloud Speech: https://cloud.google.com/speech-to-text/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/speech/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/speech-to-text/docs/
+.. _Product Documentation:  https://cloud.google.com/speech-to-text/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Speech.:  https://cloud.google.com/speech-to-text/docs/
+.. _Enable the Cloud Speech.:  https://cloud.google.com/speech-to-text/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Speech Product documentation:  https://cloud.google.com/speech-to-text/docs/
+.. _Cloud Speech Product documentation:  https://cloud.google.com/speech-to-text/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-storage-control/.repo-metadata.json
+++ b/packages/google-cloud-storage-control/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-storage-control",
     "name_pretty": "Storage Control API",
-    "product_documentation": "https://cloud.google.com/storage/docs/reference/rpc/google.storage.control.v2",
+    "product_documentation": "https://cloud.google.com/storage/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-storage-control/README.rst
+++ b/packages/google-cloud-storage-control/README.rst
@@ -14,9 +14,9 @@ Python Client for Storage Control API
    :target: https://pypi.org/project/google-cloud-storage-control/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-storage-control.svg
    :target: https://pypi.org/project/google-cloud-storage-control/
-.. _Storage Control API: https://cloud.google.com/storage/docs/reference/rpc/google.storage.control.v2
+.. _Storage Control API: https://cloud.google.com/storage/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-storage-control/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/storage/docs/reference/rpc/google.storage.control.v2
+.. _Product Documentation:  https://cloud.google.com/storage/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Storage Control API.:  https://cloud.google.com/storage/docs/reference/rpc/google.storage.control.v2
+.. _Enable the Storage Control API.:  https://cloud.google.com/storage/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Storage Control API Product documentation:  https://cloud.google.com/storage/docs/reference/rpc/google.storage.control.v2
+.. _Storage Control API Product documentation:  https://cloud.google.com/storage/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-storage-control/docs/README.rst
+++ b/packages/google-cloud-storage-control/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Storage Control API
    :target: https://pypi.org/project/google-cloud-storage-control/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-storage-control.svg
    :target: https://pypi.org/project/google-cloud-storage-control/
-.. _Storage Control API: https://cloud.google.com/storage/docs/reference/rpc/google.storage.control.v2
+.. _Storage Control API: https://cloud.google.com/storage/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-storage-control/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/storage/docs/reference/rpc/google.storage.control.v2
+.. _Product Documentation:  https://cloud.google.com/storage/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Storage Control API.:  https://cloud.google.com/storage/docs/reference/rpc/google.storage.control.v2
+.. _Enable the Storage Control API.:  https://cloud.google.com/storage/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Storage Control API Product documentation:  https://cloud.google.com/storage/docs/reference/rpc/google.storage.control.v2
+.. _Storage Control API Product documentation:  https://cloud.google.com/storage/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-storage/.repo-metadata.json
+++ b/packages/google-cloud-storage/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_MANUAL",
     "name": "storage",
     "name_pretty": "Google Cloud Storage",
-    "product_documentation": "https://cloud.google.com/storage",
+    "product_documentation": "https://cloud.google.com/storage/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-storage/google/cloud/storage/asyncio/async_write_object_stream.py
+++ b/packages/google-cloud-storage/google/cloud/storage/asyncio/async_write_object_stream.py
@@ -18,8 +18,7 @@ import grpc
 from google.api_core.bidi_async import AsyncBidiRpc
 
 from google.cloud import _storage_v2
-from google.cloud.storage import Blob
-from google.cloud.storage import _grpc_conversions
+from google.cloud.storage import Blob, _grpc_conversions
 from google.cloud.storage.asyncio import _utils
 from google.cloud.storage.asyncio.async_abstract_object_stream import (
     _AsyncAbstractObjectStream,

--- a/packages/google-cloud-storagebatchoperations/.repo-metadata.json
+++ b/packages/google-cloud-storagebatchoperations/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-storagebatchoperations",
     "name_pretty": "Storage Batch Operations API",
-    "product_documentation": "https://cloud.google.com/storage/docs/batch-operations/overview",
+    "product_documentation": "https://cloud.google.com/storage/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-storagebatchoperations/README.rst
+++ b/packages/google-cloud-storagebatchoperations/README.rst
@@ -14,9 +14,9 @@ Python Client for Storage Batch Operations API
    :target: https://pypi.org/project/google-cloud-storagebatchoperations/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-storagebatchoperations.svg
    :target: https://pypi.org/project/google-cloud-storagebatchoperations/
-.. _Storage Batch Operations API: https://cloud.google.com/storage/docs/batch-operations/overview
+.. _Storage Batch Operations API: https://cloud.google.com/storage/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-storagebatchoperations/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/storage/docs/batch-operations/overview
+.. _Product Documentation:  https://cloud.google.com/storage/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Storage Batch Operations API.:  https://cloud.google.com/storage/docs/batch-operations/overview
+.. _Enable the Storage Batch Operations API.:  https://cloud.google.com/storage/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Storage Batch Operations API Product documentation:  https://cloud.google.com/storage/docs/batch-operations/overview
+.. _Storage Batch Operations API Product documentation:  https://cloud.google.com/storage/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-storagebatchoperations/docs/README.rst
+++ b/packages/google-cloud-storagebatchoperations/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Storage Batch Operations API
    :target: https://pypi.org/project/google-cloud-storagebatchoperations/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-storagebatchoperations.svg
    :target: https://pypi.org/project/google-cloud-storagebatchoperations/
-.. _Storage Batch Operations API: https://cloud.google.com/storage/docs/batch-operations/overview
+.. _Storage Batch Operations API: https://cloud.google.com/storage/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-storagebatchoperations/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/storage/docs/batch-operations/overview
+.. _Product Documentation:  https://cloud.google.com/storage/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Storage Batch Operations API.:  https://cloud.google.com/storage/docs/batch-operations/overview
+.. _Enable the Storage Batch Operations API.:  https://cloud.google.com/storage/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Storage Batch Operations API Product documentation:  https://cloud.google.com/storage/docs/batch-operations/overview
+.. _Storage Batch Operations API Product documentation:  https://cloud.google.com/storage/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-storageinsights/.repo-metadata.json
+++ b/packages/google-cloud-storageinsights/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "storageinsights",
     "name_pretty": "Storage Insights API",
-    "product_documentation": "https://cloud.google.com/storage/docs/insights/storage-insights",
+    "product_documentation": "https://cloud.google.com/storage/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-storageinsights/README.rst
+++ b/packages/google-cloud-storageinsights/README.rst
@@ -14,9 +14,9 @@ Python Client for Storage Insights API
    :target: https://pypi.org/project/google-cloud-storageinsights/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-storageinsights.svg
    :target: https://pypi.org/project/google-cloud-storageinsights/
-.. _Storage Insights API: https://cloud.google.com/storage/docs/insights/storage-insights
+.. _Storage Insights API: https://cloud.google.com/storage/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/storageinsights/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/storage/docs/insights/storage-insights
+.. _Product Documentation:  https://cloud.google.com/storage/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Storage Insights API.:  https://cloud.google.com/storage/docs/insights/storage-insights
+.. _Enable the Storage Insights API.:  https://cloud.google.com/storage/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Storage Insights API Product documentation:  https://cloud.google.com/storage/docs/insights/storage-insights
+.. _Storage Insights API Product documentation:  https://cloud.google.com/storage/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-storageinsights/docs/README.rst
+++ b/packages/google-cloud-storageinsights/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Storage Insights API
    :target: https://pypi.org/project/google-cloud-storageinsights/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-storageinsights.svg
    :target: https://pypi.org/project/google-cloud-storageinsights/
-.. _Storage Insights API: https://cloud.google.com/storage/docs/insights/storage-insights
+.. _Storage Insights API: https://cloud.google.com/storage/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/storageinsights/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/storage/docs/insights/storage-insights
+.. _Product Documentation:  https://cloud.google.com/storage/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Storage Insights API.:  https://cloud.google.com/storage/docs/insights/storage-insights
+.. _Enable the Storage Insights API.:  https://cloud.google.com/storage/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Storage Insights API Product documentation:  https://cloud.google.com/storage/docs/insights/storage-insights
+.. _Storage Insights API Product documentation:  https://cloud.google.com/storage/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-support/.repo-metadata.json
+++ b/packages/google-cloud-support/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "support",
     "name_pretty": "Google Cloud Support API",
-    "product_documentation": "https://cloud.google.com/support/docs/reference/support-api",
+    "product_documentation": "https://cloud.google.com/support/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-support/README.rst
+++ b/packages/google-cloud-support/README.rst
@@ -14,9 +14,9 @@ Python Client for Google Cloud Support API
    :target: https://pypi.org/project/google-cloud-support/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-support.svg
    :target: https://pypi.org/project/google-cloud-support/
-.. _Google Cloud Support API: https://cloud.google.com/support/docs/reference/support-api
+.. _Google Cloud Support API: https://cloud.google.com/support/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/support/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/support/docs/reference/support-api
+.. _Product Documentation:  https://cloud.google.com/support/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Support API.:  https://cloud.google.com/support/docs/reference/support-api
+.. _Enable the Google Cloud Support API.:  https://cloud.google.com/support/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Support API Product documentation:  https://cloud.google.com/support/docs/reference/support-api
+.. _Google Cloud Support API Product documentation:  https://cloud.google.com/support/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-support/docs/README.rst
+++ b/packages/google-cloud-support/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Google Cloud Support API
    :target: https://pypi.org/project/google-cloud-support/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-support.svg
    :target: https://pypi.org/project/google-cloud-support/
-.. _Google Cloud Support API: https://cloud.google.com/support/docs/reference/support-api
+.. _Google Cloud Support API: https://cloud.google.com/support/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/support/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/support/docs/reference/support-api
+.. _Product Documentation:  https://cloud.google.com/support/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Support API.:  https://cloud.google.com/support/docs/reference/support-api
+.. _Enable the Google Cloud Support API.:  https://cloud.google.com/support/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Support API Product documentation:  https://cloud.google.com/support/docs/reference/support-api
+.. _Google Cloud Support API Product documentation:  https://cloud.google.com/support/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-tasks/.repo-metadata.json
+++ b/packages/google-cloud-tasks/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "cloudtasks",
     "name_pretty": "Cloud Tasks",
-    "product_documentation": "https://cloud.google.com/tasks/docs/",
+    "product_documentation": "https://cloud.google.com/tasks/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-tasks/README.rst
+++ b/packages/google-cloud-tasks/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Tasks
    :target: https://pypi.org/project/google-cloud-tasks/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-tasks.svg
    :target: https://pypi.org/project/google-cloud-tasks/
-.. _Cloud Tasks: https://cloud.google.com/tasks/docs/
+.. _Cloud Tasks: https://cloud.google.com/tasks/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudtasks/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/tasks/docs/
+.. _Product Documentation:  https://cloud.google.com/tasks/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Tasks.:  https://cloud.google.com/tasks/docs/
+.. _Enable the Cloud Tasks.:  https://cloud.google.com/tasks/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Tasks Product documentation:  https://cloud.google.com/tasks/docs/
+.. _Cloud Tasks Product documentation:  https://cloud.google.com/tasks/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-tasks/docs/README.rst
+++ b/packages/google-cloud-tasks/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Tasks
    :target: https://pypi.org/project/google-cloud-tasks/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-tasks.svg
    :target: https://pypi.org/project/google-cloud-tasks/
-.. _Cloud Tasks: https://cloud.google.com/tasks/docs/
+.. _Cloud Tasks: https://cloud.google.com/tasks/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudtasks/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/tasks/docs/
+.. _Product Documentation:  https://cloud.google.com/tasks/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Tasks.:  https://cloud.google.com/tasks/docs/
+.. _Enable the Cloud Tasks.:  https://cloud.google.com/tasks/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Tasks Product documentation:  https://cloud.google.com/tasks/docs/
+.. _Cloud Tasks Product documentation:  https://cloud.google.com/tasks/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-translate/.repo-metadata.json
+++ b/packages/google-cloud-translate/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_COMBO",
     "name": "translate",
     "name_pretty": "Cloud Translation",
-    "product_documentation": "https://cloud.google.com/translate/docs/",
+    "product_documentation": "https://cloud.google.com/translate/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-translate/README.rst
+++ b/packages/google-cloud-translate/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Translation
    :target: https://pypi.org/project/google-cloud-translate/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-translate.svg
    :target: https://pypi.org/project/google-cloud-translate/
-.. _Cloud Translation: https://cloud.google.com/translate/docs/
+.. _Cloud Translation: https://cloud.google.com/translate/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/translate/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/translate/docs/
+.. _Product Documentation:  https://cloud.google.com/translate/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Translation.:  https://cloud.google.com/translate/docs/
+.. _Enable the Cloud Translation.:  https://cloud.google.com/translate/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Translation Product documentation:  https://cloud.google.com/translate/docs/
+.. _Cloud Translation Product documentation:  https://cloud.google.com/translate/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-translate/docs/README.rst
+++ b/packages/google-cloud-translate/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Translation
    :target: https://pypi.org/project/google-cloud-translate/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-translate.svg
    :target: https://pypi.org/project/google-cloud-translate/
-.. _Cloud Translation: https://cloud.google.com/translate/docs/
+.. _Cloud Translation: https://cloud.google.com/translate/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/translate/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/translate/docs/
+.. _Product Documentation:  https://cloud.google.com/translate/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Translation.:  https://cloud.google.com/translate/docs/
+.. _Enable the Cloud Translation.:  https://cloud.google.com/translate/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Translation Product documentation:  https://cloud.google.com/translate/docs/
+.. _Cloud Translation Product documentation:  https://cloud.google.com/translate/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-vectorsearch/.repo-metadata.json
+++ b/packages/google-cloud-vectorsearch/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-vectorsearch",
     "name_pretty": "Vector Search API",
-    "product_documentation": "https://docs.cloud.google.com/vertex-ai/docs/vector-search-2/overview",
+    "product_documentation": "https://docs.cloud.google.com/vertex-ai/",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-vectorsearch/README.rst
+++ b/packages/google-cloud-vectorsearch/README.rst
@@ -22,9 +22,9 @@ items at scale.
    :target: https://pypi.org/project/google-cloud-vectorsearch/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-vectorsearch.svg
    :target: https://pypi.org/project/google-cloud-vectorsearch/
-.. _Vector Search API: https://docs.cloud.google.com/vertex-ai/docs/vector-search-2/overview
+.. _Vector Search API: https://docs.cloud.google.com/vertex-ai/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-vectorsearch/latest/summary_overview
-.. _Product Documentation:  https://docs.cloud.google.com/vertex-ai/docs/vector-search-2/overview
+.. _Product Documentation:  https://docs.cloud.google.com/vertex-ai/
 
 Quick Start
 -----------
@@ -38,7 +38,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Vector Search API.:  https://docs.cloud.google.com/vertex-ai/docs/vector-search-2/overview
+.. _Enable the Vector Search API.:  https://docs.cloud.google.com/vertex-ai/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -112,7 +112,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Vector Search API Product documentation:  https://docs.cloud.google.com/vertex-ai/docs/vector-search-2/overview
+.. _Vector Search API Product documentation:  https://docs.cloud.google.com/vertex-ai/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-vectorsearch/docs/README.rst
+++ b/packages/google-cloud-vectorsearch/docs/README.rst
@@ -22,9 +22,9 @@ items at scale.
    :target: https://pypi.org/project/google-cloud-vectorsearch/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-vectorsearch.svg
    :target: https://pypi.org/project/google-cloud-vectorsearch/
-.. _Vector Search API: https://docs.cloud.google.com/vertex-ai/docs/vector-search-2/overview
+.. _Vector Search API: https://docs.cloud.google.com/vertex-ai/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-cloud-vectorsearch/latest/summary_overview
-.. _Product Documentation:  https://docs.cloud.google.com/vertex-ai/docs/vector-search-2/overview
+.. _Product Documentation:  https://docs.cloud.google.com/vertex-ai/
 
 Quick Start
 -----------
@@ -38,7 +38,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Vector Search API.:  https://docs.cloud.google.com/vertex-ai/docs/vector-search-2/overview
+.. _Enable the Vector Search API.:  https://docs.cloud.google.com/vertex-ai/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -112,7 +112,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Vector Search API Product documentation:  https://docs.cloud.google.com/vertex-ai/docs/vector-search-2/overview
+.. _Vector Search API Product documentation:  https://docs.cloud.google.com/vertex-ai/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-videointelligence/.repo-metadata.json
+++ b/packages/google-cloud-videointelligence/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "videointelligence",
     "name_pretty": "Video Intelligence",
-    "product_documentation": "https://cloud.google.com/video-intelligence/docs/",
+    "product_documentation": "https://cloud.google.com/video-intelligence/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-videointelligence/README.rst
+++ b/packages/google-cloud-videointelligence/README.rst
@@ -14,9 +14,9 @@ Python Client for Video Intelligence
    :target: https://pypi.org/project/google-cloud-videointelligence/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-videointelligence.svg
    :target: https://pypi.org/project/google-cloud-videointelligence/
-.. _Video Intelligence: https://cloud.google.com/video-intelligence/docs/
+.. _Video Intelligence: https://cloud.google.com/video-intelligence/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/videointelligence/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/video-intelligence/docs/
+.. _Product Documentation:  https://cloud.google.com/video-intelligence/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Video Intelligence.:  https://cloud.google.com/video-intelligence/docs/
+.. _Enable the Video Intelligence.:  https://cloud.google.com/video-intelligence/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Video Intelligence Product documentation:  https://cloud.google.com/video-intelligence/docs/
+.. _Video Intelligence Product documentation:  https://cloud.google.com/video-intelligence/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-videointelligence/docs/README.rst
+++ b/packages/google-cloud-videointelligence/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Video Intelligence
    :target: https://pypi.org/project/google-cloud-videointelligence/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-videointelligence.svg
    :target: https://pypi.org/project/google-cloud-videointelligence/
-.. _Video Intelligence: https://cloud.google.com/video-intelligence/docs/
+.. _Video Intelligence: https://cloud.google.com/video-intelligence/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/videointelligence/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/video-intelligence/docs/
+.. _Product Documentation:  https://cloud.google.com/video-intelligence/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Video Intelligence.:  https://cloud.google.com/video-intelligence/docs/
+.. _Enable the Video Intelligence.:  https://cloud.google.com/video-intelligence/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Video Intelligence Product documentation:  https://cloud.google.com/video-intelligence/docs/
+.. _Video Intelligence Product documentation:  https://cloud.google.com/video-intelligence/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-vision/.repo-metadata.json
+++ b/packages/google-cloud-vision/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_COMBO",
     "name": "vision",
     "name_pretty": "Cloud Vision",
-    "product_documentation": "https://cloud.google.com/vision/docs/",
+    "product_documentation": "https://cloud.google.com/vision/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-vision/README.rst
+++ b/packages/google-cloud-vision/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Vision
    :target: https://pypi.org/project/google-cloud-vision/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-vision.svg
    :target: https://pypi.org/project/google-cloud-vision/
-.. _Cloud Vision: https://cloud.google.com/vision/docs/
+.. _Cloud Vision: https://cloud.google.com/vision/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/vision/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/vision/docs/
+.. _Product Documentation:  https://cloud.google.com/vision/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Vision.:  https://cloud.google.com/vision/docs/
+.. _Enable the Cloud Vision.:  https://cloud.google.com/vision/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Vision Product documentation:  https://cloud.google.com/vision/docs/
+.. _Cloud Vision Product documentation:  https://cloud.google.com/vision/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-vision/docs/README.rst
+++ b/packages/google-cloud-vision/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Vision
    :target: https://pypi.org/project/google-cloud-vision/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-vision.svg
    :target: https://pypi.org/project/google-cloud-vision/
-.. _Cloud Vision: https://cloud.google.com/vision/docs/
+.. _Cloud Vision: https://cloud.google.com/vision/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/vision/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/vision/docs/
+.. _Product Documentation:  https://cloud.google.com/vision/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Vision.:  https://cloud.google.com/vision/docs/
+.. _Enable the Cloud Vision.:  https://cloud.google.com/vision/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Vision Product documentation:  https://cloud.google.com/vision/docs/
+.. _Cloud Vision Product documentation:  https://cloud.google.com/vision/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-webrisk/.repo-metadata.json
+++ b/packages/google-cloud-webrisk/.repo-metadata.json
@@ -9,7 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "webrisk",
     "name_pretty": "Web Risk",
-    "product_documentation": "https://cloud.google.com/web-risk/docs/",
+    "product_documentation": "https://cloud.google.com/web-risk/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-webrisk/README.rst
+++ b/packages/google-cloud-webrisk/README.rst
@@ -14,9 +14,9 @@ Python Client for Web Risk
    :target: https://pypi.org/project/google-cloud-webrisk/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-webrisk.svg
    :target: https://pypi.org/project/google-cloud-webrisk/
-.. _Web Risk: https://cloud.google.com/web-risk/docs/
+.. _Web Risk: https://cloud.google.com/web-risk/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/webrisk/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/web-risk/docs/
+.. _Product Documentation:  https://cloud.google.com/web-risk/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Web Risk.:  https://cloud.google.com/web-risk/docs/
+.. _Enable the Web Risk.:  https://cloud.google.com/web-risk/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Web Risk Product documentation:  https://cloud.google.com/web-risk/docs/
+.. _Web Risk Product documentation:  https://cloud.google.com/web-risk/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-webrisk/docs/README.rst
+++ b/packages/google-cloud-webrisk/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Web Risk
    :target: https://pypi.org/project/google-cloud-webrisk/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-webrisk.svg
    :target: https://pypi.org/project/google-cloud-webrisk/
-.. _Web Risk: https://cloud.google.com/web-risk/docs/
+.. _Web Risk: https://cloud.google.com/web-risk/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/webrisk/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/web-risk/docs/
+.. _Product Documentation:  https://cloud.google.com/web-risk/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Web Risk.:  https://cloud.google.com/web-risk/docs/
+.. _Enable the Web Risk.:  https://cloud.google.com/web-risk/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Web Risk Product documentation:  https://cloud.google.com/web-risk/docs/
+.. _Web Risk Product documentation:  https://cloud.google.com/web-risk/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-websecurityscanner/.repo-metadata.json
+++ b/packages/google-cloud-websecurityscanner/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "websecurityscanner",
     "name_pretty": "Cloud Security Scanner",
-    "product_documentation": "https://cloud.google.com/security-scanner/docs/",
+    "product_documentation": "https://cloud.google.com/security-scanner/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-websecurityscanner/README.rst
+++ b/packages/google-cloud-websecurityscanner/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Security Scanner
    :target: https://pypi.org/project/google-cloud-websecurityscanner/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-websecurityscanner.svg
    :target: https://pypi.org/project/google-cloud-websecurityscanner/
-.. _Cloud Security Scanner: https://cloud.google.com/security-scanner/docs/
+.. _Cloud Security Scanner: https://cloud.google.com/security-scanner/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/websecurityscanner/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/security-scanner/docs/
+.. _Product Documentation:  https://cloud.google.com/security-scanner/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Security Scanner.:  https://cloud.google.com/security-scanner/docs/
+.. _Enable the Cloud Security Scanner.:  https://cloud.google.com/security-scanner/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Security Scanner Product documentation:  https://cloud.google.com/security-scanner/docs/
+.. _Cloud Security Scanner Product documentation:  https://cloud.google.com/security-scanner/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-websecurityscanner/docs/README.rst
+++ b/packages/google-cloud-websecurityscanner/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Security Scanner
    :target: https://pypi.org/project/google-cloud-websecurityscanner/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-websecurityscanner.svg
    :target: https://pypi.org/project/google-cloud-websecurityscanner/
-.. _Cloud Security Scanner: https://cloud.google.com/security-scanner/docs/
+.. _Cloud Security Scanner: https://cloud.google.com/security-scanner/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/websecurityscanner/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/security-scanner/docs/
+.. _Product Documentation:  https://cloud.google.com/security-scanner/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Security Scanner.:  https://cloud.google.com/security-scanner/docs/
+.. _Enable the Cloud Security Scanner.:  https://cloud.google.com/security-scanner/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Security Scanner Product documentation:  https://cloud.google.com/security-scanner/docs/
+.. _Cloud Security Scanner Product documentation:  https://cloud.google.com/security-scanner/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-workstations/.repo-metadata.json
+++ b/packages/google-cloud-workstations/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "workstations",
     "name_pretty": "Cloud Workstations",
-    "product_documentation": "https://cloud.google.com/workstations/",
+    "product_documentation": "https://cloud.google.com/workstations/docs",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-cloud-workstations/README.rst
+++ b/packages/google-cloud-workstations/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Workstations
    :target: https://pypi.org/project/google-cloud-workstations/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-workstations.svg
    :target: https://pypi.org/project/google-cloud-workstations/
-.. _Cloud Workstations: https://cloud.google.com/workstations/
+.. _Cloud Workstations: https://cloud.google.com/workstations/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/workstations/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/workstations/
+.. _Product Documentation:  https://cloud.google.com/workstations/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Workstations.:  https://cloud.google.com/workstations/
+.. _Enable the Cloud Workstations.:  https://cloud.google.com/workstations/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Workstations Product documentation:  https://cloud.google.com/workstations/
+.. _Cloud Workstations Product documentation:  https://cloud.google.com/workstations/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-workstations/docs/README.rst
+++ b/packages/google-cloud-workstations/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Cloud Workstations
    :target: https://pypi.org/project/google-cloud-workstations/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-workstations.svg
    :target: https://pypi.org/project/google-cloud-workstations/
-.. _Cloud Workstations: https://cloud.google.com/workstations/
+.. _Cloud Workstations: https://cloud.google.com/workstations/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/workstations/latest/summary_overview
-.. _Product Documentation:  https://cloud.google.com/workstations/
+.. _Product Documentation:  https://cloud.google.com/workstations/docs
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Workstations.:  https://cloud.google.com/workstations/
+.. _Enable the Cloud Workstations.:  https://cloud.google.com/workstations/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Workstations Product documentation:  https://cloud.google.com/workstations/
+.. _Cloud Workstations Product documentation:  https://cloud.google.com/workstations/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-maps-mapsplatformdatasets/.repo-metadata.json
+++ b/packages/google-maps-mapsplatformdatasets/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "mapsplatformdatasets",
     "name_pretty": "Maps Platform Datasets API",
-    "product_documentation": "https://developers.google.com/maps",
+    "product_documentation": "https://developers.google.com/maps/documentation/datasets",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/google-maps-mapsplatformdatasets/README.rst
+++ b/packages/google-maps-mapsplatformdatasets/README.rst
@@ -14,9 +14,9 @@ Python Client for Maps Platform Datasets API
    :target: https://pypi.org/project/google-maps-mapsplatformdatasets/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-maps-mapsplatformdatasets.svg
    :target: https://pypi.org/project/google-maps-mapsplatformdatasets/
-.. _Maps Platform Datasets API: https://developers.google.com/maps
+.. _Maps Platform Datasets API: https://developers.google.com/maps/documentation/datasets
 .. _Client Library Documentation: https://googleapis.dev/python/mapsplatformdatasets/latest
-.. _Product Documentation:  https://developers.google.com/maps
+.. _Product Documentation:  https://developers.google.com/maps/documentation/datasets
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Maps Platform Datasets API.:  https://developers.google.com/maps
+.. _Enable the Maps Platform Datasets API.:  https://developers.google.com/maps/documentation/datasets
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Maps Platform Datasets API Product documentation:  https://developers.google.com/maps
+.. _Maps Platform Datasets API Product documentation:  https://developers.google.com/maps/documentation/datasets
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-maps-mapsplatformdatasets/docs/README.rst
+++ b/packages/google-maps-mapsplatformdatasets/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Maps Platform Datasets API
    :target: https://pypi.org/project/google-maps-mapsplatformdatasets/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-maps-mapsplatformdatasets.svg
    :target: https://pypi.org/project/google-maps-mapsplatformdatasets/
-.. _Maps Platform Datasets API: https://developers.google.com/maps
+.. _Maps Platform Datasets API: https://developers.google.com/maps/documentation/datasets
 .. _Client Library Documentation: https://googleapis.dev/python/mapsplatformdatasets/latest
-.. _Product Documentation:  https://developers.google.com/maps
+.. _Product Documentation:  https://developers.google.com/maps/documentation/datasets
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Maps Platform Datasets API.:  https://developers.google.com/maps
+.. _Enable the Maps Platform Datasets API.:  https://developers.google.com/maps/documentation/datasets
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Maps Platform Datasets API Product documentation:  https://developers.google.com/maps
+.. _Maps Platform Datasets API Product documentation:  https://developers.google.com/maps/documentation/datasets
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/googleapis-common-protos/.repo-metadata.json
+++ b/packages/googleapis-common-protos/.repo-metadata.json
@@ -10,7 +10,6 @@
     "library_type": "CORE",
     "name": "googleapis-common-protos",
     "name_pretty": "Google APIs Common Protos",
-    "product_documentation": "https://github.com/googleapis/googleapis/tree/master/google",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/googleapis-common-protos/README.rst
+++ b/packages/googleapis-common-protos/README.rst
@@ -14,9 +14,9 @@ Python Client for Google APIs Common Protos
    :target: https://pypi.org/project/googleapis-common-protos/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/googleapis-common-protos.svg
    :target: https://pypi.org/project/googleapis-common-protos/
-.. _Google APIs Common Protos: https://github.com/googleapis/googleapis/tree/master/google
+.. _Google APIs Common Protos: 
 .. _Client Library Documentation: https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos/summary_overview
-.. _Product Documentation:  https://github.com/googleapis/googleapis/tree/master/google
+.. _Product Documentation:  
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google APIs Common Protos.:  https://github.com/googleapis/googleapis/tree/master/google
+.. _Enable the Google APIs Common Protos.:  
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google APIs Common Protos Product documentation:  https://github.com/googleapis/googleapis/tree/master/google
+.. _Google APIs Common Protos Product documentation:  
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/googleapis-common-protos/docs/README.rst
+++ b/packages/googleapis-common-protos/docs/README.rst
@@ -14,9 +14,9 @@ Python Client for Google APIs Common Protos
    :target: https://pypi.org/project/googleapis-common-protos/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/googleapis-common-protos.svg
    :target: https://pypi.org/project/googleapis-common-protos/
-.. _Google APIs Common Protos: https://github.com/googleapis/googleapis/tree/master/google
+.. _Google APIs Common Protos: 
 .. _Client Library Documentation: https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos/summary_overview
-.. _Product Documentation:  https://github.com/googleapis/googleapis/tree/master/google
+.. _Product Documentation:  
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google APIs Common Protos.:  https://github.com/googleapis/googleapis/tree/master/google
+.. _Enable the Google APIs Common Protos.:  
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google APIs Common Protos Product documentation:  https://github.com/googleapis/googleapis/tree/master/google
+.. _Google APIs Common Protos Product documentation:  
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/grpc-google-iam-v1/.repo-metadata.json
+++ b/packages/grpc-google-iam-v1/.repo-metadata.json
@@ -10,7 +10,7 @@
     "library_type": "GAPIC_AUTO",
     "name": "grpc-iam",
     "name_pretty": "Cloud Identity and Access Management",
-    "product_documentation": "https://cloud.google.com/iam/docs/",
-    "release_level": "stable",
+    "product_documentation": "https://cloud.google.com/iam/",
+    "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/grpc-google-iam-v1/README.rst
+++ b/packages/grpc-google-iam-v1/README.rst
@@ -1,22 +1,22 @@
 Python Client for Cloud Identity and Access Management
 ======================================================
 
-|stable| |pypi| |versions|
+|preview| |pypi| |versions|
 
 `Cloud Identity and Access Management`_: Manages access control for Google Cloud Platform resources.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |stable| image:: https://img.shields.io/badge/support-stable-gold.svg
+.. |preview| image:: https://img.shields.io/badge/support-preview-orange.svg
    :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#stability-levels
 .. |pypi| image:: https://img.shields.io/pypi/v/grpc-google-iam-v1.svg
    :target: https://pypi.org/project/grpc-google-iam-v1/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/grpc-google-iam-v1.svg
    :target: https://pypi.org/project/grpc-google-iam-v1/
-.. _Cloud Identity and Access Management: https://cloud.google.com/iam/docs/
+.. _Cloud Identity and Access Management: https://cloud.google.com/iam/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/grpc-iam/latest
-.. _Product Documentation:  https://cloud.google.com/iam/docs/
+.. _Product Documentation:  https://cloud.google.com/iam/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Identity and Access Management.:  https://cloud.google.com/iam/docs/
+.. _Enable the Cloud Identity and Access Management.:  https://cloud.google.com/iam/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Identity and Access Management Product documentation:  https://cloud.google.com/iam/docs/
+.. _Cloud Identity and Access Management Product documentation:  https://cloud.google.com/iam/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/grpc-google-iam-v1/docs/README.rst
+++ b/packages/grpc-google-iam-v1/docs/README.rst
@@ -1,22 +1,22 @@
 Python Client for Cloud Identity and Access Management
 ======================================================
 
-|stable| |pypi| |versions|
+|preview| |pypi| |versions|
 
 `Cloud Identity and Access Management`_: Manages access control for Google Cloud Platform resources.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |stable| image:: https://img.shields.io/badge/support-stable-gold.svg
+.. |preview| image:: https://img.shields.io/badge/support-preview-orange.svg
    :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#stability-levels
 .. |pypi| image:: https://img.shields.io/pypi/v/grpc-google-iam-v1.svg
    :target: https://pypi.org/project/grpc-google-iam-v1/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/grpc-google-iam-v1.svg
    :target: https://pypi.org/project/grpc-google-iam-v1/
-.. _Cloud Identity and Access Management: https://cloud.google.com/iam/docs/
+.. _Cloud Identity and Access Management: https://cloud.google.com/iam/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/grpc-iam/latest
-.. _Product Documentation:  https://cloud.google.com/iam/docs/
+.. _Product Documentation:  https://cloud.google.com/iam/
 
 Quick Start
 -----------
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Identity and Access Management.:  https://cloud.google.com/iam/docs/
+.. _Enable the Cloud Identity and Access Management.:  https://cloud.google.com/iam/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -104,7 +104,7 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Identity and Access Management Product documentation:  https://cloud.google.com/iam/docs/
+.. _Cloud Identity and Access Management Product documentation:  https://cloud.google.com/iam/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/pandas-gbq/.repo-metadata.json
+++ b/packages/pandas-gbq/.repo-metadata.json
@@ -7,7 +7,6 @@
     "library_type": "INTEGRATION",
     "name": "pandas-gbq",
     "name_pretty": "Google BigQuery connector for pandas",
-    "product_documentation": "https://cloud.google.com/bigquery",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/sqlalchemy-spanner/.repo-metadata.json
+++ b/packages/sqlalchemy-spanner/.repo-metadata.json
@@ -7,7 +7,6 @@
     "library_type": "INTEGRATION",
     "name": "sqlalchemy-spanner",
     "name_pretty": "Spanner dialect for SQLAlchemy",
-    "product_documentation": "https://cloud.google.com/spanner/docs",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }


### PR DESCRIPTION
This is a version of https://github.com/googleapis/google-cloud-python/pull/16791 generated with a local version of Librarian that includes https://github.com/googleapis/librarian/pull/5573.

We still expect to lose documentation URIs from .repo-metadata.json files, but we shouldn't (hopefully) be removing any where there's a generated README.rst.

It would be reasonable to just review the README.rst changes.