### PR TITLE
chore(librarian): update post processing for google-cloud-spanner

### DIFF
--- a/.librarian/generator-input/client-post-processing/spanner-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/spanner-integration.yaml
@@ -1251,6 +1251,12 @@ replacements:
           system_test_path = os.path.join("tests", "system.py")
           system_test_folder_path = os.path.join("tests", "system")
 
+          system_test_exists = os.path.exists(system_test_path)
+          system_test_folder_exists = os.path.exists(system_test_folder_path)
+          # Sanity check: only run tests if found.
+          if not system_test_exists and not system_test_folder_exists:
+              session.skip("System tests were not found")
+
           if os.environ.get("SPANNER_EMULATOR_HOST"):
               # Run tests against the emulator
               run_system = True
@@ -1271,24 +1277,77 @@ replacements:
               run_system = False
 
           if run_system:
-              # Run the tests (deduplicated logic)
-              test_path = (
-                  system_test_path
-                  if os.path.exists(system_test_path)
-                  else system_test_folder_path
-              )
-              session.run(
-                  "py.test",
-                  "--verbose",
-                  f"--junitxml=system_{session.python}_sponge_log.xml",
-                  test_path,
-                  *session.posargs,
-                  env={
-                      "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
-                      "SPANNER_DATABASE_DIALECT": database_dialect,
-                      "SKIP_BACKUP_TESTS": "true",
-                  },
-              )
+              # Run py.test against the system tests.
+              if system_test_exists:
+                  args = [
+                      "py.test",
+                      "--quiet",
+                      "-o",
+                      "asyncio_mode=auto",
+                      f"--junitxml=system_{session.python}_sponge_log.xml",
+                  ]
+                  if not session.posargs:
+                      args.append(system_test_path)
+                  args.extend(session.posargs)
+  
+                  session.run(
+                      *args,
+                      env={
+                          "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
+                          "SPANNER_DATABASE_DIALECT": database_dialect,
+                          "SKIP_BACKUP_TESTS": "true",
+                      },
+                  )
+              elif system_test_folder_exists:
+                  # Run sync tests
+                  sync_args = [
+                      "py.test",
+                      "--quiet",
+                      "-o",
+                      "asyncio_mode=auto",
+                      f"--junitxml=system_{session.python}_sync_sponge_log.xml",
+                  ]
+                  if not session.posargs:
+                      sync_args.append(system_test_folder_path)
+                      sync_args.append(
+                          f"--ignore={os.path.join(system_test_folder_path, '_async')}"
+                      )
+                  else:
+                      sync_args.extend(session.posargs)
+
+                  session.run(
+                      *sync_args,
+                      env={
+                          "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
+                          "SPANNER_DATABASE_DIALECT": database_dialect,
+                          "SKIP_BACKUP_TESTS": "true",
+                      },
+                  )
+
+                  # Run async tests
+                  async_args = [
+                      "py.test",
+                      "--quiet",
+                      "-o",
+                      "asyncio_mode=auto",
+                      f"--junitxml=system_{session.python}_async_sponge_log.xml",
+                  ]
+                  if not session.posargs:
+                      async_args.append(os.path.join(system_test_folder_path, "_async"))
+                  else:
+                      # If posargs are provided, only run if they match async tests
+                      # or just skip if they were already run in sync.
+                      # For simplicity, we only run async folder if no posargs.
+                      return
+
+                  session.run(
+                      *async_args,
+                      env={
+                          "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
+                          "SPANNER_DATABASE_DIALECT": database_dialect,
+                          "SKIP_BACKUP_TESTS": "true",
+                      },
+                  )
 
 
       @nox.session(python=ALL_PYTHON)


### PR DESCRIPTION
Update post processing for noxfile.py following the manual changes in https://github.com/googleapis/google-cloud-python/pull/16764

Validate the changes by generating the client library for `google-cloud-spanner` using these commands:

- `export V=v0.10.2-0.20260423145805-fa79d1c1732d`
- `go run github.com/googleapis/librarian/tool/cmd/builddockerimages@${V} --version ${V} --language python --revision=fa79d1c1732df4d5d932b64f49fd909d43581ce6`
- `docker run -u $(id -u):$(id -g) -v .:/repo -v ~/.cache:/.cache -w /repo docker.io/library/librarian-python:${V} generate -v google-cloud-spanner`