### PR TITLE
fix(google-crc32c): add explicit license declaration to pyproject.toml

### DIFF
--- a/packages/google-crc32c/pyproject.toml
+++ b/packages/google-crc32c/pyproject.toml
@@ -22,3 +22,4 @@ version = "1.8.0"
 description = "A python wrapper of the C library 'Google CRC32C'"
 readme = "README.md"
 requires-python = ">=3.8"
+license = { text = "Apache 2.0" }


### PR DESCRIPTION
The `google-crc32c` package was missing a `license` field in the `[project]` section of `pyproject.toml` after being migrated from `setup.py`. Without this field, PyPI cannot display license metadata for the package, which breaks compliance checking workflows that validate open-source licenses during installation.

The fix adds `license = { text = "Apache 2.0" }` to `packages/google-crc32c/pyproject.toml`, matching the license declaration format used by other libraries in this repo (e.g., `google-api-core`). An audit of the other `pyproject.toml` files in `packages/` found that `google-crc32c` is the only package with a `[project]` section that was missing this field.

- [x] Open an issue (bug/issue) before writing code to discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure tests and linter pass
- [ ] Code coverage does not decrease (if source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #16603
