### PR TITLE
chore: disable librarian generation of google-cloud-bigquery temporarily

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -903,6 +903,7 @@ libraries:
       is a fully managed, NoOps, low cost data analytics service.
       Data can be streamed into BigQuery at millions of rows per second to enable real-time analysis.
       With BigQuery you can easily deploy Petabyte-scale Databases.
+    skip_generate: true
     python:
       library_type: GAPIC_COMBO
       name_pretty_override: Google Cloud BigQuery


### PR DESCRIPTION
This should be reverted when #16811 fixed.
