### PR TITLE
Add fixed-key metadata support in AAOW

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/_grpc_conversions.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_grpc_conversions.py
@@ -19,6 +19,10 @@ _BLOB_ATTR_TO_PROTO_FIELD = {
     "content_type": "content_type",
     "metadata": "metadata",
     "kms_key_name": "kms_key",
+    "cache_control": "cache_control",
+    "content_disposition": "content_disposition",
+    "content_encoding": "content_encoding",
+    "content_language": "content_language",
 }
 
 

--- a/packages/google-cloud-storage/tests/system/test_zonal.py
+++ b/packages/google-cloud-storage/tests/system/test_zonal.py
@@ -348,6 +348,10 @@ def test_write_from_blob(
     object_name = f"test_from_blob-{str(uuid.uuid4())[:4]}"
     content_type = "text/plain"
     metadata = {"environment": "system-test"}
+    cache_control = "public, max-age=3600"
+    content_disposition = "attachment; filename=test.txt"
+    content_encoding = "gzip"
+    content_language = "en"
     test_data = b"system-test-data"
 
     async def _run():
@@ -355,6 +359,10 @@ def test_write_from_blob(
         blob = storage_client.bucket(_ZONAL_BUCKET).blob(object_name)
         blob.content_type = content_type
         blob.metadata = metadata
+        blob.cache_control = cache_control
+        blob.content_disposition = content_disposition
+        blob.content_encoding = content_encoding
+        blob.content_language = content_language
 
         # 2. Use from_blob to create the writer
         writer = AsyncAppendableObjectWriter.from_blob(grpc_client, blob)
@@ -370,6 +378,10 @@ def test_write_from_blob(
 
         assert obj.content_type == content_type
         assert obj.metadata["environment"] == "system-test"
+        assert obj.cache_control == cache_control
+        assert obj.content_disposition == content_disposition
+        assert obj.content_encoding == content_encoding
+        assert obj.content_language == content_language
 
         blobs_to_delete.append(blob)
 

--- a/packages/google-cloud-storage/tests/unit/test__grpc_conversions.py
+++ b/packages/google-cloud-storage/tests/unit/test__grpc_conversions.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import Mock
+from google.cloud.storage import _grpc_conversions
+
+
+class Test_blob_to_proto(unittest.TestCase):
+    def test_blob_to_proto_all_fields(self):
+        from google.cloud.storage.blob import Blob
+        from google.cloud.storage.bucket import Bucket
+
+        bucket = Mock(spec=Bucket)
+        bucket.name = "bucket-name"
+        blob = Blob("blob-name", bucket)
+        blob.content_type = "text/plain"
+        blob.metadata = {"foo": "bar"}
+        blob.kms_key_name = "kms-key-name"
+        blob.cache_control = "cache-control"
+        blob.content_disposition = "content-disposition"
+        blob.content_encoding = "content-encoding"
+        blob.content_language = "content-language"
+
+        proto = _grpc_conversions.blob_to_proto(blob)
+
+        self.assertEqual(proto.name, "blob-name")
+        self.assertEqual(proto.bucket, "projects/_/buckets/bucket-name")
+        self.assertEqual(proto.content_type, "text/plain")
+        self.assertEqual(proto.metadata, {"foo": "bar"})
+        self.assertEqual(proto.kms_key, "kms-key-name")
+        self.assertEqual(proto.cache_control, "cache-control")
+        self.assertEqual(proto.content_disposition, "content-disposition")
+        self.assertEqual(proto.content_encoding, "content-encoding")
+        self.assertEqual(proto.content_language, "content-language")


### PR DESCRIPTION
This change adds support for fixed-key metadata (Cache-Control, Content-Disposition, Content-Encoding, and Content-Language) in the `AsyncAppendableObjectWriter` (AAOW). It achieves this by updating the `_BLOB_ATTR_TO_PROTO_FIELD` mapping in `google/cloud/storage/_grpc_conversions.py`, which is used to convert `Blob` instances to GCS V2 Object protos.

New unit tests were added in `packages/google-cloud-storage/tests/unit/test__grpc_conversions.py` and the system test `test_write_from_blob` in `packages/google-cloud-storage/tests/system/test_zonal.py` was updated to verify the functionality end-to-end.

---
*PR created automatically by Jules for task [17431433800443681077](https://jules.google.com/task/17431433800443681077) started by @nidhiii-27*