### PR TITLE
chore: remove issue_tracker_override from librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -3892,6 +3892,7 @@ libraries:
       default_version: v1
   - name: google-crc32c
     version: 1.8.0
+    skip_generate: true
     python:
       library_type: OTHER
       name_pretty_override: A python wrapper of the C library 'Google CRC32C'

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1291,6 +1291,7 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=compute
       name_pretty_override: Compute Engine
+      issue_tracker_override: https://issuetracker.google.com/issues/new?component=187134&template=0
       default_version: v1beta
   - name: google-cloud-confidentialcomputing
     version: 0.9.0

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -60,14 +60,12 @@ libraries:
       name_pretty_override: A unified Python API in BigQuery
       api_shortname_override: bigquery
       client_documentation_override: https://cloud.google.com/python/docs/reference/bigframes/latest
-      issue_tracker_override: https://github.com/googleapis/python-bigquery-dataframes/issues
   - name: bigquery-magics
     version: 0.14.0
     python:
       library_type: INTEGRATION
       name_pretty_override: Google BigQuery connector for Jupyter and IPython
       client_documentation_override: https://googleapis.dev/python/bigquery-magics/latest/
-      issue_tracker_override: https://github.com/googleapis/python-bigquery-magics/issues
   - name: db-dtypes
     version: 1.5.1
     description_override: Pandas extension data types for data from SQL systems such as BigQuery.
@@ -81,14 +79,12 @@ libraries:
     python:
       library_type: INTEGRATION
       name_pretty_override: Cloud Spanner Django
-      issue_tracker_override: https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open
   - name: gapic-generator
     version: 1.30.14
     python:
       library_type: CORE
       name_pretty_override: Google API Client Generator for Python
       client_documentation_override: https://gapic-generator-python.readthedocs.io/en/stable/
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       skip_readme_copy: true
   - name: gcp-sphinx-docfx-yaml
     version: 3.2.5
@@ -96,7 +92,6 @@ libraries:
       library_type: OTHER
       name_pretty_override: Sphinx DocFX YAML Generator
       client_documentation_override: https://github.com/googleapis/sphinx-docfx-yaml
-      issue_tracker_override: https://github.com/googleapis/sphinx-docfx-yaml/issues
       skip_readme_copy: true
   - name: google-ads-admanager
     version: 0.9.0
@@ -138,7 +133,6 @@ libraries:
           - python-gapic-name=marketingplatform_admin
           - warehouse-package-name=google-ads-marketingplatform-admin
       name_pretty_override: Google Marketing Platform Admin API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1alpha
   - name: google-ai-generativelanguage
     version: 0.11.0
@@ -233,7 +227,6 @@ libraries:
           - python-gapic-name=card
           - warehouse-package-name=google-apps-card
       name_pretty_override: Google Apps Card Protos
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-apps-chat
     version: 0.8.0
@@ -247,7 +240,6 @@ libraries:
           - warehouse-package-name=google-apps-chat
           - python-gapic-name=chat
       name_pretty_override: Chat API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-apps-events-subscriptions
     version: 0.5.0
@@ -266,7 +258,6 @@ libraries:
           - python-gapic-name=events_subscriptions
           - warehouse-package-name=google-apps-events-subscriptions
       name_pretty_override: Google Workspace Events API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-apps-meet
     version: 0.4.0
@@ -341,7 +332,6 @@ libraries:
           - python-gapic-name=slides
           - warehouse-package-name=google-apps-script-type
       name_pretty_override: Google Apps Script Type Protos
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: type
       default_version: apiVersion
   - name: google-area120-tables
@@ -363,20 +353,17 @@ libraries:
     python:
       library_type: AUTH
       name_pretty_override: Google Auth Python Library
-      issue_tracker_override: https://github.com/googleapis/google-auth-library-python/issues
       skip_readme_copy: true
   - name: google-auth-httplib2
     version: 0.3.1
     python:
       library_type: AUTH
       name_pretty_override: Google Auth httplib2
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
   - name: google-auth-oauthlib
     version: 1.3.1
     python:
       library_type: AUTH
       name_pretty_override: Google Auth OAuthlib
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       skip_readme_copy: true
   - name: google-cloud-access-approval
     version: 1.19.0
@@ -401,7 +388,6 @@ libraries:
         - google/identity/accesscontextmanager/v1
         - google/identity/accesscontextmanager/type
       client_documentation_override: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-access-context-manager
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: accesscontextmanager
       default_version: apiVersion
   - name: google-cloud-advisorynotifications
@@ -415,7 +401,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=advisorynotifications
           - warehouse-package-name=google-cloud-advisorynotifications
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: advisorynotifications
       default_version: v1
   - name: google-cloud-alloydb
@@ -438,7 +423,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=alloydb
           - warehouse-package-name=google-cloud-alloydb
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: alloydb
       default_version: v1
   - name: google-cloud-alloydb-connectors
@@ -570,7 +554,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=appengine_logging
       name_pretty_override: App Engine Logging Protos
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: appenginelogging
       default_version: v1
   - name: google-cloud-apphub
@@ -844,7 +827,6 @@ libraries:
           - python-gapic-name=biglake
           - warehouse-package-name=google-cloud-biglake
       name_pretty_override: BigLake API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-cloud-biglake-hive
     version: 0.1.0
@@ -872,7 +854,6 @@ libraries:
     python:
       library_type: GAPIC_COMBO
       name_pretty_override: Google Cloud BigQuery
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/559654
       metadata_name_override: bigquery
       default_version: v2
   - name: google-cloud-bigquery-analyticshub
@@ -990,7 +971,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigquery_logging
       name_pretty_override: BigQuery Logging Protos
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: bigquerylogging
       default_version: v1
   - name: google-cloud-bigquery-migration
@@ -1054,7 +1034,6 @@ libraries:
           - python-gapic-name=bigquery_storage
           - warehouse-package-name=google-cloud-bigquery-storage
       name_pretty_override: Google BigQuery Storage
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/559654
       metadata_name_override: bigquerystorage
       default_version: v1
   - name: google-cloud-bigtable
@@ -1080,7 +1059,6 @@ libraries:
           - python-gapic-name=bigtable
           - warehouse-package-name=google-cloud-bigtable
       name_pretty_override: Google Cloud Bigtable
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/559777
       metadata_name_override: bigtable
       default_version: v2
   - name: google-cloud-billing
@@ -1237,7 +1215,6 @@ libraries:
           - python-gapic-name=cloudcontrolspartner
           - warehouse-package-name=google-cloud-cloudcontrolspartner
       name_pretty_override: Cloud Controls Partner API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-cloud-cloudsecuritycompliance
     version: 0.6.0
@@ -1314,7 +1291,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=compute
       name_pretty_override: Compute Engine
-      issue_tracker_override: https://issuetracker.google.com/issues/new?component=187134&template=0
       default_version: v1beta
   - name: google-cloud-confidentialcomputing
     version: 0.9.0
@@ -1328,7 +1304,6 @@ libraries:
           - python-gapic-name=confidentialcomputing
           - warehouse-package-name=google-cloud-confidentialcomputing
       name_pretty_override: Confidential Computing API
-      issue_tracker_override: https://issuetracker.google.com/issues/new?component=1166820
       metadata_name_override: confidentialcomputing
       default_version: v1
   - name: google-cloud-config
@@ -1367,7 +1342,6 @@ libraries:
           - python-gapic-name=configdelivery
           - warehouse-package-name=google-cloud-configdelivery
       name_pretty_override: Config Delivery API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1alpha
   - name: google-cloud-contact-center-insights
     version: 1.26.0
@@ -1424,7 +1398,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=contentwarehouse
           - warehouse-package-name=google-cloud-contentwarehouse
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: contentwarehouse
       default_version: v1
   - name: google-cloud-core
@@ -1432,7 +1405,6 @@ libraries:
     python:
       library_type: CORE
       name_pretty_override: Google API client core library
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
   - name: google-cloud-data-fusion
     version: 1.16.0
     apis:
@@ -1509,7 +1481,6 @@ libraries:
           - python-gapic-name=datacatalog_lineage
           - warehouse-package-name=google-cloud-datacatalog-lineage
       name_pretty_override: Data Lineage API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: lineage
       default_version: v1
   - name: google-cloud-datacatalog-lineage-configmanagement
@@ -1642,7 +1613,6 @@ libraries:
           - python-gapic-name=datastore
           - warehouse-package-name=google-cloud-datastore
       name_pretty_override: Google Cloud Datastore API
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/559768
       metadata_name_override: datastore
       default_version: v1
   - name: google-cloud-datastream
@@ -1720,7 +1690,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=dialogflow
           - warehouse-package-name=google-cloud-dialogflow
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/5300385
       metadata_name_override: dialogflow
       default_version: v2
   - name: google-cloud-dialogflow-cx
@@ -1762,7 +1731,6 @@ libraries:
           - python-gapic-name=discoveryengine
           - warehouse-package-name=google-cloud-discoveryengine
       name_pretty_override: Discovery Engine API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: discoveryengine
       default_version: v1beta
   - name: google-cloud-dlp
@@ -1825,7 +1793,6 @@ libraries:
     python:
       library_type: OTHER
       name_pretty_override: Document AI Toolbox
-      issue_tracker_override: https://github.com/googleapis/python-documentai-toolbox/issues
       metadata_name_override: documentai-toolbox
       default_version: v1
   - name: google-cloud-domains
@@ -1882,7 +1849,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=enterpriseknowledgegraph
           - warehouse-package-name=google-cloud-enterpriseknowledgegraph
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: enterpriseknowledgegraph
       default_version: v1
   - name: google-cloud-error-reporting
@@ -1966,7 +1932,6 @@ libraries:
           - python-gapic-name=financialservices
           - warehouse-package-name=google-cloud-financialservices
       name_pretty_override: Anti Money Laundering AI API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-cloud-firestore
     version: 2.27.0
@@ -2004,7 +1969,6 @@ libraries:
           - python-gapic-name=firestore
           - warehouse-package-name=google-cloud-firestore
       name_pretty_override: Cloud Firestore API
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/5337669
       metadata_name_override: firestore
       default_version: v1
   - name: google-cloud-functions
@@ -2054,7 +2018,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=geminidataanalytics
           - warehouse-package-name=google-cloud-geminidataanalytics
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1alpha
   - name: google-cloud-gke-backup
     version: 0.8.0
@@ -2211,7 +2174,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-iam
       name_pretty_override: Cloud Identity and Access Management
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/559761
       metadata_name_override: iam
       default_version: v2
   - name: google-cloud-iam-logging
@@ -2228,7 +2190,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=iam_logging
       name_pretty_override: IAM Logging Protos
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: iamlogging
       default_version: v1
   - name: google-cloud-iamconnectorcredentials
@@ -2376,7 +2337,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - warehouse-package-name=google-cloud-logging
       name_pretty_override: Cloud Logging API
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/559764
       metadata_name_override: logging
       default_version: v2
   - name: google-cloud-lustre
@@ -2495,7 +2455,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=memorystore
           - warehouse-package-name=google-cloud-memorystore
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-cloud-migrationcenter
     version: 0.4.0
@@ -2509,7 +2468,6 @@ libraries:
           - python-gapic-name=migrationcenter
           - warehouse-package-name=google-cloud-migrationcenter
       name_pretty_override: Migration Center API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: migrationcenter
       default_version: v1
   - name: google-cloud-modelarmor
@@ -2581,7 +2539,6 @@ libraries:
       library_type: GAPIC_MANUAL
       name_pretty_override: NDB Client Library for Google Cloud Datastore
       client_documentation_override: https://googleapis.dev/python/python-ndb/latest
-      issue_tracker_override: https://github.com/googleapis/python-ndb/issues
       metadata_name_override: python-ndb
       skip_readme_copy: true
   - name: google-cloud-netapp
@@ -2804,7 +2761,6 @@ libraries:
           - python-gapic-name=parallelstore
           - warehouse-package-name=google-cloud-parallelstore
       name_pretty_override: Parallelstore API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1beta
   - name: google-cloud-parametermanager
     version: 0.4.0
@@ -2818,7 +2774,6 @@ libraries:
           - python-gapic-name=parametermanager
           - warehouse-package-name=google-cloud-parametermanager
       name_pretty_override: Parameter Manager API
-      issue_tracker_override: https://issuetracker.google.com/issues/new?component=1442085&template=2002674
       default_version: v1
   - name: google-cloud-phishing-protection
     version: 1.17.0
@@ -2860,7 +2815,6 @@ libraries:
           - python-gapic-name=policysimulator
           - warehouse-package-name=google-cloud-policysimulator
       name_pretty_override: Policy Simulator API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: policysimulator
       default_version: v1
   - name: google-cloud-policytroubleshooter-iam
@@ -2921,7 +2875,6 @@ libraries:
           - python-gapic-name=privilegedaccessmanager
           - warehouse-package-name=google-cloud-privilegedaccessmanager
       name_pretty_override: Privileged Access Manager API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-cloud-pubsub
     version: 2.37.0
@@ -2936,7 +2889,6 @@ libraries:
           - python-gapic-namespace=google
           - python-gapic-name=pubsub
       name_pretty_override: Google Cloud Pub/Sub
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/559741
       metadata_name_override: pubsub
       default_version: v1
   - name: google-cloud-quotas
@@ -2970,7 +2922,6 @@ libraries:
           - python-gapic-name=rapidmigrationassessment
           - warehouse-package-name=google-cloud-rapidmigrationassessment
       name_pretty_override: Rapid Migration Assessment API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: rapidmigrationassessment
       default_version: v1
   - name: google-cloud-recaptcha-enterprise
@@ -3035,7 +2986,6 @@ libraries:
           - python-gapic-name=redis
           - warehouse-package-name=google-cloud-redis
       name_pretty_override: Cloud Redis
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/5169231
       metadata_name_override: redis
       default_version: v1
   - name: google-cloud-redis-cluster
@@ -3113,7 +3063,6 @@ libraries:
     python:
       library_type: GAPIC_MANUAL
       name_pretty_override: Google Cloud Runtime Configurator
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/559663
       metadata_name_override: runtimeconfig
   - name: google-cloud-saasplatform-saasservicemgmt
     version: 0.5.0
@@ -3127,7 +3076,6 @@ libraries:
           - python-gapic-name=saasplatform_saasservicemgmt
           - warehouse-package-name=google-cloud-saasplatform-saasservicemgmt
       name_pretty_override: SaaS Runtime API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1beta1
   - name: google-cloud-scheduler
     version: 2.19.0
@@ -3182,7 +3130,6 @@ libraries:
           - python-gapic-name=securesourcemanager
           - warehouse-package-name=google-cloud-securesourcemanager
       name_pretty_override: Secure Source Manager API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: securesourcemanager
       default_version: v1
   - name: google-cloud-security-publicca
@@ -3230,7 +3177,6 @@ libraries:
           - python-gapic-name=securitycenter
           - warehouse-package-name=google-cloud-securitycenter
       name_pretty_override: Google Cloud Security Command Center
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/559748
       metadata_name_override: securitycenter
       default_version: v1
   - name: google-cloud-securitycentermanagement
@@ -3244,7 +3190,6 @@ libraries:
           - python-gapic-name=securitycentermanagement
           - warehouse-package-name=google-cloud-securitycentermanagement
       name_pretty_override: Security Center Management API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-cloud-service-control
     version: 1.19.0
@@ -3348,7 +3293,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=source_context
       name_pretty_override: Source Context
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: source
       default_version: v1
   - name: google-cloud-spanner
@@ -3385,7 +3329,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=spanner
           - warehouse-package-name=google-cloud-spanner
-      issue_tracker_override: https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open
       metadata_name_override: spanner
       default_version: v1
   - name: google-cloud-speech
@@ -3426,7 +3369,6 @@ libraries:
           - python-gapic-name=_storage
           - warehouse-package-name=google-cloud-storage
       name_pretty_override: Google Cloud Storage
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/559782
       metadata_name_override: storage
       default_version: v2
   - name: google-cloud-storage-control
@@ -3500,7 +3442,6 @@ libraries:
           - python-gapic-name=support
           - warehouse-package-name=google-cloud-support
       name_pretty_override: Google Cloud Support API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: support
       default_version: v2
   - name: google-cloud-talent
@@ -3569,7 +3510,6 @@ libraries:
       library_type: OTHER
       name_pretty_override: Python Test Utils for Google Cloud
       client_documentation_override: https://github.com/googleapis/google-cloud-python/packages/google-cloud-testutils
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: google-cloud-test-utils
   - name: google-cloud-texttospeech
     version: 2.36.0
@@ -3801,7 +3741,6 @@ libraries:
           - python-gapic-name=visionai
           - warehouse-package-name=google-cloud-visionai
       name_pretty_override: Vision AI API
-      issue_tracker_override: https://issuetracker.google.com/issues/new?component=187174&pli=1&template=1161261
       default_version: v1
   - name: google-cloud-vm-migration
     version: 1.16.0
@@ -3828,7 +3767,6 @@ libraries:
           - python-gapic-name=vmwareengine
           - warehouse-package-name=google-cloud-vmwareengine
       name_pretty_override: Google Cloud VMware Engine
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: vmwareengine
       default_version: v1
   - name: google-cloud-vpc-access
@@ -3947,7 +3885,6 @@ libraries:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=workstations
           - warehouse-package-name=google-cloud-workstations
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: workstations
       default_version: v1
   - name: google-crc32c
@@ -3956,7 +3893,6 @@ libraries:
       library_type: OTHER
       name_pretty_override: A python wrapper of the C library 'Google CRC32C'
       client_documentation_override: https://github.com/googleapis/python-crc32c
-      issue_tracker_override: https://github.com/googleapis/python-crc32c/issues
       skip_readme_copy: true
   - name: google-geo-type
     version: 0.6.0
@@ -3972,7 +3908,6 @@ libraries:
           - python-gapic-name=type
           - warehouse-package-name=google-geo-type
       name_pretty_override: Geo Type Protos
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: geotype
       default_version: apiVersion
   - name: google-maps-addressvalidation
@@ -3988,7 +3923,6 @@ libraries:
           - python-gapic-name=addressvalidation
           - warehouse-package-name=google-maps-addressvalidation
       name_pretty_override: Address Validation API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: addressvalidation
       default_version: v1
   - name: google-maps-areainsights
@@ -4017,7 +3951,6 @@ libraries:
           - python-gapic-name=fleetengine
           - warehouse-package-name=google-maps-fleetengine
       name_pretty_override: Local Rides and Deliveries API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: fleetengine
       default_version: v1
   - name: google-maps-fleetengine-delivery
@@ -4033,7 +3966,6 @@ libraries:
           - proto-plus-deps=google.geo.type
           - warehouse-package-name=google-maps-fleetengine-delivery
       name_pretty_override: Last Mile Fleet Solution Delivery API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: fleetengine-delivery
       default_version: v1
   - name: google-maps-geocode
@@ -4066,7 +3998,6 @@ libraries:
           - python-gapic-name=mapsplatformdatasets
           - warehouse-package-name=google-maps-mapsplatformdatasets
       name_pretty_override: Maps Platform Datasets API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: mapsplatformdatasets
       default_version: v1
   - name: google-maps-navconnect
@@ -4097,7 +4028,6 @@ libraries:
           - python-gapic-name=places
           - warehouse-package-name=google-maps-places
       name_pretty_override: Places API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: places
       default_version: v1
   - name: google-maps-routeoptimization
@@ -4126,7 +4056,6 @@ libraries:
           - python-gapic-name=routing
           - warehouse-package-name=google-maps-routing
       name_pretty_override: Google Maps Routing
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       metadata_name_override: routing
       default_version: v2
   - name: google-maps-solar
@@ -4181,7 +4110,6 @@ libraries:
           - python-gapic-namespace=google.shopping
           - warehouse-package-name=google-shopping-merchant-accounts
       name_pretty_override: Merchant API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-shopping-merchant-conversions
     version: 1.3.0
@@ -4200,7 +4128,6 @@ libraries:
           - python-gapic-namespace=google.shopping
           - warehouse-package-name=google-shopping-merchant-conversions
       name_pretty_override: Merchant API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-shopping-merchant-datasources
     version: 1.4.0
@@ -4221,7 +4148,6 @@ libraries:
           - python-gapic-namespace=google.shopping
           - warehouse-package-name=google-shopping-merchant-datasources
       name_pretty_override: Merchant API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-shopping-merchant-inventories
     version: 1.3.0
@@ -4282,7 +4208,6 @@ libraries:
           - python-gapic-namespace=google.shopping
           - warehouse-package-name=google-shopping-merchant-lfp
       name_pretty_override: Merchant API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-shopping-merchant-notifications
     version: 1.3.0
@@ -4302,7 +4227,6 @@ libraries:
           - python-gapic-name=merchant_notifications
           - warehouse-package-name=google-shopping-merchant-notifications
       name_pretty_override: Merchant API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-shopping-merchant-ordertracking
     version: 1.3.0
@@ -4343,7 +4267,6 @@ libraries:
           - python-gapic-name=merchant_products
           - warehouse-package-name=google-shopping-merchant-products
       name_pretty_override: Merchant API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-shopping-merchant-productstudio
     version: 0.4.0
@@ -4357,7 +4280,6 @@ libraries:
           - python-gapic-namespace=google.shopping
           - warehouse-package-name=google-shopping-merchant-productstudio
       name_pretty_override: Merchant ProductStudio API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1alpha
   - name: google-shopping-merchant-promotions
     version: 1.3.0
@@ -4378,7 +4300,6 @@ libraries:
           - python-gapic-name=merchant_promotions
           - warehouse-package-name=google-shopping-merchant-promotions
       name_pretty_override: Merchant API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1
   - name: google-shopping-merchant-quota
     version: 1.4.0
@@ -4437,7 +4358,6 @@ libraries:
           - python-gapic-namespace=google.shopping
           - warehouse-package-name=google-shopping-merchant-reviews
       name_pretty_override: Merchant Reviews API
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: v1beta
   - name: google-shopping-type
     version: 1.4.0
@@ -4452,7 +4372,6 @@ libraries:
           - python-gapic-name=type
           - warehouse-package-name=google-shopping-type
       name_pretty_override: Shopping Type Protos
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       default_version: apiVersion
   - name: googleapis-common-protos
     version: 1.74.0
@@ -4476,7 +4395,6 @@ libraries:
         - google/rpc/context
       name_pretty_override: Google APIs Common Protos
       client_documentation_override: https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       product_documentation_override: https://github.com/googleapis/googleapis/tree/master/google
       default_version: apiVersion
   - name: grafeas
@@ -4510,14 +4428,12 @@ libraries:
       library_type: INTEGRATION
       name_pretty_override: Google BigQuery connector for pandas
       client_documentation_override: https://googleapis.dev/python/pandas-gbq/latest/
-      issue_tracker_override: https://github.com/googleapis/python-bigquery-pandas/issues
       skip_readme_copy: true
   - name: proto-plus
     version: 1.27.2
     python:
       library_type: CORE
       name_pretty_override: Proto Plus
-      issue_tracker_override: https://github.com/googleapis/google-cloud-python/issues
       skip_readme_copy: true
   - name: sqlalchemy-bigquery
     version: 1.16.0
@@ -4531,5 +4447,4 @@ libraries:
       library_type: INTEGRATION
       name_pretty_override: Spanner dialect for SQLAlchemy
       client_documentation_override: https://github.com/googleapis/python-spanner-sqlalchemy
-      issue_tracker_override: https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open
       skip_readme_copy: true

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -3064,6 +3064,7 @@ libraries:
     python:
       library_type: GAPIC_MANUAL
       name_pretty_override: Google Cloud Runtime Configurator
+      issue_tracker_override: https://issuetracker.google.com/savedsearches/559663
       metadata_name_override: runtimeconfig
   - name: google-cloud-saasplatform-saasservicemgmt
     version: 0.5.0
@@ -3370,6 +3371,7 @@ libraries:
           - python-gapic-name=_storage
           - warehouse-package-name=google-cloud-storage
       name_pretty_override: Google Cloud Storage
+      issue_tracker_override: https://issuetracker.google.com/savedsearches/559782
       metadata_name_override: storage
       default_version: v2
   - name: google-cloud-storage-control

--- a/packages/bigframes/.repo-metadata.json
+++ b/packages/bigframes/.repo-metadata.json
@@ -2,7 +2,6 @@
     "api_shortname": "bigquery",
     "client_documentation": "https://cloud.google.com/python/docs/reference/bigframes/latest",
     "distribution_name": "bigframes",
-    "issue_tracker": "https://github.com/googleapis/python-bigquery-dataframes/issues",
     "language": "python",
     "library_type": "INTEGRATION",
     "name": "bigframes",

--- a/packages/bigquery-magics/.repo-metadata.json
+++ b/packages/bigquery-magics/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://googleapis.dev/python/bigquery-magics/latest/",
     "distribution_name": "bigquery-magics",
-    "issue_tracker": "https://github.com/googleapis/python-bigquery-magics/issues",
     "language": "python",
     "library_type": "INTEGRATION",
     "name": "bigquery-magics",

--- a/packages/gapic-generator/.repo-metadata.json
+++ b/packages/gapic-generator/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://gapic-generator-python.readthedocs.io/en/stable/",
     "distribution_name": "gapic-generator",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "CORE",
     "name": "gapic-generator",

--- a/packages/gcp-sphinx-docfx-yaml/.repo-metadata.json
+++ b/packages/gcp-sphinx-docfx-yaml/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://github.com/googleapis/sphinx-docfx-yaml",
     "distribution_name": "gcp-sphinx-docfx-yaml",
-    "issue_tracker": "https://github.com/googleapis/sphinx-docfx-yaml/issues",
     "language": "python",
     "library_type": "OTHER",
     "name": "gcp-sphinx-docfx-yaml",

--- a/packages/google-ads-marketingplatform-admin/.repo-metadata.json
+++ b/packages/google-ads-marketingplatform-admin/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/google-ads-marketingplatform-admin/latest",
     "default_version": "v1alpha",
     "distribution_name": "google-ads-marketingplatform-admin",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1603054",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-ads-marketingplatform-admin",

--- a/packages/google-apps-card/.repo-metadata.json
+++ b/packages/google-apps-card/.repo-metadata.json
@@ -3,7 +3,6 @@
     "client_documentation": "https://googleapis.dev/python/google-apps-card/latest",
     "default_version": "v1",
     "distribution_name": "google-apps-card",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-apps-card",

--- a/packages/google-apps-chat/.repo-metadata.json
+++ b/packages/google-apps-chat/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/google-apps-chat/latest",
     "default_version": "v1",
     "distribution_name": "google-apps-chat",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=350158\u0026template=1047346",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-apps-chat",

--- a/packages/google-apps-events-subscriptions/.repo-metadata.json
+++ b/packages/google-apps-events-subscriptions/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/google-apps-events-subscriptions/latest",
     "default_version": "v1",
     "distribution_name": "google-apps-events-subscriptions",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1208006\u0026template=1723043",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-apps-events-subscriptions",

--- a/packages/google-apps-script-type/.repo-metadata.json
+++ b/packages/google-apps-script-type/.repo-metadata.json
@@ -2,7 +2,6 @@
     "client_documentation": "https://googleapis.dev/python/type/latest",
     "default_version": "apiVersion",
     "distribution_name": "google-apps-script-type",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "type",

--- a/packages/google-auth-httplib2/.repo-metadata.json
+++ b/packages/google-auth-httplib2/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://googleapis.dev/python/google-auth-httplib2/latest",
     "distribution_name": "google-auth-httplib2",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "AUTH",
     "name": "google-auth-httplib2",

--- a/packages/google-auth-oauthlib/.repo-metadata.json
+++ b/packages/google-auth-oauthlib/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://googleapis.dev/python/google-auth-oauthlib/latest",
     "distribution_name": "google-auth-oauthlib",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "AUTH",
     "name": "google-auth-oauthlib",

--- a/packages/google-auth/.repo-metadata.json
+++ b/packages/google-auth/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://googleapis.dev/python/google-auth/latest",
     "distribution_name": "google-auth",
-    "issue_tracker": "https://github.com/googleapis/google-auth-library-python/issues",
     "language": "python",
     "library_type": "AUTH",
     "name": "google-auth",

--- a/packages/google-cloud-access-context-manager/.repo-metadata.json
+++ b/packages/google-cloud-access-context-manager/.repo-metadata.json
@@ -5,7 +5,6 @@
     "client_documentation": "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-access-context-manager",
     "default_version": "apiVersion",
     "distribution_name": "google-cloud-access-context-manager",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "accesscontextmanager",

--- a/packages/google-cloud-advisorynotifications/.repo-metadata.json
+++ b/packages/google-cloud-advisorynotifications/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/advisorynotifications/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-advisorynotifications",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1009495",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "advisorynotifications",

--- a/packages/google-cloud-alloydb/.repo-metadata.json
+++ b/packages/google-cloud-alloydb/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/alloydb/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-alloydb",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1194526\u0026template=1689942",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "alloydb",

--- a/packages/google-cloud-appengine-logging/.repo-metadata.json
+++ b/packages/google-cloud-appengine-logging/.repo-metadata.json
@@ -2,7 +2,6 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/appenginelogging/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-appengine-logging",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "OTHER",
     "name": "appenginelogging",

--- a/packages/google-cloud-biglake/.repo-metadata.json
+++ b/packages/google-cloud-biglake/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-biglake/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-biglake",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187149\u0026template=1019829",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-biglake",

--- a/packages/google-cloud-bigquery-logging/.repo-metadata.json
+++ b/packages/google-cloud-bigquery-logging/.repo-metadata.json
@@ -2,7 +2,6 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/bigquerylogging/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-bigquery-logging",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "OTHER",
     "name": "bigquerylogging",

--- a/packages/google-cloud-bigquery-storage/.repo-metadata.json
+++ b/packages/google-cloud-bigquery-storage/.repo-metadata.json
@@ -4,7 +4,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/bigquerystorage/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-bigquery-storage",
-    "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187149\u0026template=1162659",
     "language": "python",
     "library_type": "GAPIC_COMBO",
     "name": "bigquerystorage",

--- a/packages/google-cloud-cloudcontrolspartner/.repo-metadata.json
+++ b/packages/google-cloud-cloudcontrolspartner/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-cloudcontrolspartner/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-cloudcontrolspartner",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1504051",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-cloudcontrolspartner",

--- a/packages/google-cloud-compute-v1beta/.repo-metadata.json
+++ b/packages/google-cloud-compute-v1beta/.repo-metadata.json
@@ -5,7 +5,6 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-compute-v1beta/latest",
     "default_version": "v1beta",
     "distribution_name": "google-cloud-compute-v1beta",
-    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187134\u0026template=0",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-compute-v1beta",

--- a/packages/google-cloud-compute-v1beta/.repo-metadata.json
+++ b/packages/google-cloud-compute-v1beta/.repo-metadata.json
@@ -5,6 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-compute-v1beta/latest",
     "default_version": "v1beta",
     "distribution_name": "google-cloud-compute-v1beta",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187134\u0026template=0",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-compute-v1beta",

--- a/packages/google-cloud-confidentialcomputing/.repo-metadata.json
+++ b/packages/google-cloud-confidentialcomputing/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/confidentialcomputing/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-confidentialcomputing",
-    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1166820",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1134314\u0026template=1640550",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "confidentialcomputing",

--- a/packages/google-cloud-configdelivery/.repo-metadata.json
+++ b/packages/google-cloud-configdelivery/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-configdelivery/latest",
     "default_version": "v1alpha",
     "distribution_name": "google-cloud-configdelivery",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1400250",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-configdelivery",

--- a/packages/google-cloud-contentwarehouse/.repo-metadata.json
+++ b/packages/google-cloud-contentwarehouse/.repo-metadata.json
@@ -4,7 +4,6 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/contentwarehouse/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-contentwarehouse",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "contentwarehouse",

--- a/packages/google-cloud-core/.repo-metadata.json
+++ b/packages/google-cloud-core/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-core/latest",
     "distribution_name": "google-cloud-core",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "CORE",
     "name": "google-cloud-core",

--- a/packages/google-cloud-datacatalog-lineage/.repo-metadata.json
+++ b/packages/google-cloud-datacatalog-lineage/.repo-metadata.json
@@ -5,7 +5,6 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/lineage/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-datacatalog-lineage",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "lineage",

--- a/packages/google-cloud-discoveryengine/.repo-metadata.json
+++ b/packages/google-cloud-discoveryengine/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/discoveryengine/latest",
     "default_version": "v1beta",
     "distribution_name": "google-cloud-discoveryengine",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=911831\u0026template=1480251",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "discoveryengine",

--- a/packages/google-cloud-documentai-toolbox/.repo-metadata.json
+++ b/packages/google-cloud-documentai-toolbox/.repo-metadata.json
@@ -2,7 +2,6 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/documentai-toolbox/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-documentai-toolbox",
-    "issue_tracker": "https://github.com/googleapis/python-documentai-toolbox/issues",
     "language": "python",
     "library_type": "OTHER",
     "name": "documentai-toolbox",

--- a/packages/google-cloud-enterpriseknowledgegraph/.repo-metadata.json
+++ b/packages/google-cloud-enterpriseknowledgegraph/.repo-metadata.json
@@ -4,7 +4,6 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/enterpriseknowledgegraph/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-enterpriseknowledgegraph",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "enterpriseknowledgegraph",

--- a/packages/google-cloud-financialservices/.repo-metadata.json
+++ b/packages/google-cloud-financialservices/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-financialservices/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-financialservices",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=933093",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-financialservices",

--- a/packages/google-cloud-geminidataanalytics/.repo-metadata.json
+++ b/packages/google-cloud-geminidataanalytics/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-geminidataanalytics/latest",
     "default_version": "v1alpha",
     "distribution_name": "google-cloud-geminidataanalytics",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1604598\u0026template=2061286",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-geminidataanalytics",

--- a/packages/google-cloud-iam-logging/.repo-metadata.json
+++ b/packages/google-cloud-iam-logging/.repo-metadata.json
@@ -2,7 +2,6 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/iamlogging/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-iam-logging",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "OTHER",
     "name": "iamlogging",

--- a/packages/google-cloud-iam/.repo-metadata.json
+++ b/packages/google-cloud-iam/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/iam/latest",
     "default_version": "v2",
     "distribution_name": "google-cloud-iam",
-    "issue_tracker": "https://issuetracker.google.com/savedsearches/559761",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1077618",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "iam",

--- a/packages/google-cloud-memorystore/.repo-metadata.json
+++ b/packages/google-cloud-memorystore/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-memorystore/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-memorystore",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1669139",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-memorystore",

--- a/packages/google-cloud-migrationcenter/.repo-metadata.json
+++ b/packages/google-cloud-migrationcenter/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/migrationcenter/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-migrationcenter",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1360713",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "migrationcenter",

--- a/packages/google-cloud-ndb/.repo-metadata.json
+++ b/packages/google-cloud-ndb/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://googleapis.dev/python/python-ndb/latest",
     "distribution_name": "google-cloud-ndb",
-    "issue_tracker": "https://github.com/googleapis/python-ndb/issues",
     "language": "python",
     "library_type": "GAPIC_MANUAL",
     "name": "python-ndb",

--- a/packages/google-cloud-parallelstore/.repo-metadata.json
+++ b/packages/google-cloud-parallelstore/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-parallelstore/latest",
     "default_version": "v1beta",
     "distribution_name": "google-cloud-parallelstore",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1181190",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-parallelstore",

--- a/packages/google-cloud-parametermanager/.repo-metadata.json
+++ b/packages/google-cloud-parametermanager/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-parametermanager/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-parametermanager",
-    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1442085\u0026template=2002674",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1706749\u0026template=0",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-parametermanager",

--- a/packages/google-cloud-policysimulator/.repo-metadata.json
+++ b/packages/google-cloud-policysimulator/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/policysimulator/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-policysimulator",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=690790\u0026template=1814512",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "policysimulator",

--- a/packages/google-cloud-privilegedaccessmanager/.repo-metadata.json
+++ b/packages/google-cloud-privilegedaccessmanager/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-privilegedaccessmanager/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-privilegedaccessmanager",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1587284\u0026template=2001118",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-privilegedaccessmanager",

--- a/packages/google-cloud-pubsub/.repo-metadata.json
+++ b/packages/google-cloud-pubsub/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/pubsub/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-pubsub",
-    "issue_tracker": "https://issuetracker.google.com/savedsearches/559741",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187173",
     "language": "python",
     "library_type": "GAPIC_COMBO",
     "name": "pubsub",

--- a/packages/google-cloud-rapidmigrationassessment/.repo-metadata.json
+++ b/packages/google-cloud-rapidmigrationassessment/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/rapidmigrationassessment/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-rapidmigrationassessment",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1360914",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "rapidmigrationassessment",

--- a/packages/google-cloud-redis/.repo-metadata.json
+++ b/packages/google-cloud-redis/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/redis/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-redis",
-    "issue_tracker": "https://issuetracker.google.com/savedsearches/5169231",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1288776\u0026template=1161103",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "redis",

--- a/packages/google-cloud-runtimeconfig/.repo-metadata.json
+++ b/packages/google-cloud-runtimeconfig/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://cloud.google.com/python/docs/reference/runtimeconfig/latest",
     "distribution_name": "google-cloud-runtimeconfig",
-    "issue_tracker": "https://issuetracker.google.com/savedsearches/559663",
     "language": "python",
     "library_type": "GAPIC_MANUAL",
     "name": "runtimeconfig",

--- a/packages/google-cloud-runtimeconfig/.repo-metadata.json
+++ b/packages/google-cloud-runtimeconfig/.repo-metadata.json
@@ -1,6 +1,7 @@
 {
     "client_documentation": "https://cloud.google.com/python/docs/reference/runtimeconfig/latest",
     "distribution_name": "google-cloud-runtimeconfig",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559663",
     "language": "python",
     "library_type": "GAPIC_MANUAL",
     "name": "runtimeconfig",

--- a/packages/google-cloud-saasplatform-saasservicemgmt/.repo-metadata.json
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-saasplatform-saasservicemgmt/latest",
     "default_version": "v1beta1",
     "distribution_name": "google-cloud-saasplatform-saasservicemgmt",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1863319",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-saasplatform-saasservicemgmt",

--- a/packages/google-cloud-securesourcemanager/.repo-metadata.json
+++ b/packages/google-cloud-securesourcemanager/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/securesourcemanager/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-securesourcemanager",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1434461",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "securesourcemanager",

--- a/packages/google-cloud-securitycenter/.repo-metadata.json
+++ b/packages/google-cloud-securitycenter/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/securitycenter/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-securitycenter",
-    "issue_tracker": "https://issuetracker.google.com/savedsearches/559748",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=709980\u0026template=1322867",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "securitycenter",

--- a/packages/google-cloud-securitycentermanagement/.repo-metadata.json
+++ b/packages/google-cloud-securitycentermanagement/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-securitycentermanagement/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-securitycentermanagement",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=709980",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-securitycentermanagement",

--- a/packages/google-cloud-source-context/.repo-metadata.json
+++ b/packages/google-cloud-source-context/.repo-metadata.json
@@ -2,7 +2,6 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/source/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-source-context",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "OTHER",
     "name": "source",

--- a/packages/google-cloud-spanner/.repo-metadata.json
+++ b/packages/google-cloud-spanner/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/spanner/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-spanner",
-    "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=190851\u0026template=0",
     "language": "python",
     "library_type": "GAPIC_COMBO",
     "name": "spanner",

--- a/packages/google-cloud-storage/.repo-metadata.json
+++ b/packages/google-cloud-storage/.repo-metadata.json
@@ -5,6 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/storage/latest",
     "default_version": "v2",
     "distribution_name": "google-cloud-storage",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559782",
     "language": "python",
     "library_type": "GAPIC_MANUAL",
     "name": "storage",

--- a/packages/google-cloud-storage/.repo-metadata.json
+++ b/packages/google-cloud-storage/.repo-metadata.json
@@ -5,7 +5,6 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/storage/latest",
     "default_version": "v2",
     "distribution_name": "google-cloud-storage",
-    "issue_tracker": "https://issuetracker.google.com/savedsearches/559782",
     "language": "python",
     "library_type": "GAPIC_MANUAL",
     "name": "storage",

--- a/packages/google-cloud-support/.repo-metadata.json
+++ b/packages/google-cloud-support/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/support/latest",
     "default_version": "v2",
     "distribution_name": "google-cloud-support",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1051180",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "support",

--- a/packages/google-cloud-testutils/.repo-metadata.json
+++ b/packages/google-cloud-testutils/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://github.com/googleapis/google-cloud-python/packages/google-cloud-testutils",
     "distribution_name": "google-cloud-testutils",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "OTHER",
     "name": "google-cloud-test-utils",

--- a/packages/google-cloud-visionai/.repo-metadata.json
+++ b/packages/google-cloud-visionai/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-visionai/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-visionai",
-    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187174\u0026pli=1\u0026template=1161261",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187174\u0026template=1161261",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-cloud-visionai",

--- a/packages/google-cloud-vmwareengine/.repo-metadata.json
+++ b/packages/google-cloud-vmwareengine/.repo-metadata.json
@@ -5,7 +5,6 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/vmwareengine/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-vmwareengine",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "vmwareengine",

--- a/packages/google-cloud-workstations/.repo-metadata.json
+++ b/packages/google-cloud-workstations/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/workstations/latest",
     "default_version": "v1",
     "distribution_name": "google-cloud-workstations",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1328344",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "workstations",

--- a/packages/google-crc32c/.repo-metadata.json
+++ b/packages/google-crc32c/.repo-metadata.json
@@ -1,6 +1,7 @@
 {
     "client_documentation": "https://github.com/googleapis/python-crc32c",
     "distribution_name": "google-crc32c",
+    "issue_tracker": "https://github.com/googleapis/python-crc32c/issues",
     "language": "python",
     "library_type": "OTHER",
     "name": "google-crc32c",

--- a/packages/google-crc32c/.repo-metadata.json
+++ b/packages/google-crc32c/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://github.com/googleapis/python-crc32c",
     "distribution_name": "google-crc32c",
-    "issue_tracker": "https://github.com/googleapis/python-crc32c/issues",
     "language": "python",
     "library_type": "OTHER",
     "name": "google-crc32c",

--- a/packages/google-geo-type/.repo-metadata.json
+++ b/packages/google-geo-type/.repo-metadata.json
@@ -5,7 +5,6 @@
     "client_documentation": "https://googleapis.dev/python/geotype/latest",
     "default_version": "apiVersion",
     "distribution_name": "google-geo-type",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "OTHER",
     "name": "geotype",

--- a/packages/google-maps-addressvalidation/.repo-metadata.json
+++ b/packages/google-maps-addressvalidation/.repo-metadata.json
@@ -5,7 +5,6 @@
     "client_documentation": "https://googleapis.dev/python/addressvalidation/latest",
     "default_version": "v1",
     "distribution_name": "google-maps-addressvalidation",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "addressvalidation",

--- a/packages/google-maps-fleetengine-delivery/.repo-metadata.json
+++ b/packages/google-maps-fleetengine-delivery/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/fleetengine-delivery/latest",
     "default_version": "v1",
     "distribution_name": "google-maps-fleetengine-delivery",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1180397\u0026template=1812135",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "fleetengine-delivery",

--- a/packages/google-maps-fleetengine/.repo-metadata.json
+++ b/packages/google-maps-fleetengine/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/fleetengine/latest",
     "default_version": "v1",
     "distribution_name": "google-maps-fleetengine",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1180397\u0026template=1812135",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "fleetengine",

--- a/packages/google-maps-mapsplatformdatasets/.repo-metadata.json
+++ b/packages/google-maps-mapsplatformdatasets/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/mapsplatformdatasets/latest",
     "default_version": "v1",
     "distribution_name": "google-maps-mapsplatformdatasets",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1356770",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "mapsplatformdatasets",

--- a/packages/google-maps-places/.repo-metadata.json
+++ b/packages/google-maps-places/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/places/latest",
     "default_version": "v1",
     "distribution_name": "google-maps-places",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=188872\u0026template=1815671",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "places",

--- a/packages/google-maps-routing/.repo-metadata.json
+++ b/packages/google-maps-routing/.repo-metadata.json
@@ -5,7 +5,6 @@
     "client_documentation": "https://googleapis.dev/python/routing/latest",
     "default_version": "v2",
     "distribution_name": "google-maps-routing",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "routing",

--- a/packages/google-shopping-merchant-accounts/.repo-metadata.json
+++ b/packages/google-shopping-merchant-accounts/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-accounts/latest",
     "default_version": "v1",
     "distribution_name": "google-shopping-merchant-accounts",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=171084\u0026template=555201",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-shopping-merchant-accounts",

--- a/packages/google-shopping-merchant-conversions/.repo-metadata.json
+++ b/packages/google-shopping-merchant-conversions/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-conversions/latest",
     "default_version": "v1",
     "distribution_name": "google-shopping-merchant-conversions",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=171084\u0026template=555201",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-shopping-merchant-conversions",

--- a/packages/google-shopping-merchant-datasources/.repo-metadata.json
+++ b/packages/google-shopping-merchant-datasources/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-datasources/latest",
     "default_version": "v1",
     "distribution_name": "google-shopping-merchant-datasources",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=171084\u0026template=555201",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-shopping-merchant-datasources",

--- a/packages/google-shopping-merchant-lfp/.repo-metadata.json
+++ b/packages/google-shopping-merchant-lfp/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-lfp/latest",
     "default_version": "v1",
     "distribution_name": "google-shopping-merchant-lfp",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=171084\u0026template=555201",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-shopping-merchant-lfp",

--- a/packages/google-shopping-merchant-notifications/.repo-metadata.json
+++ b/packages/google-shopping-merchant-notifications/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-notifications/latest",
     "default_version": "v1",
     "distribution_name": "google-shopping-merchant-notifications",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=171084\u0026template=555201",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-shopping-merchant-notifications",

--- a/packages/google-shopping-merchant-products/.repo-metadata.json
+++ b/packages/google-shopping-merchant-products/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-products/latest",
     "default_version": "v1",
     "distribution_name": "google-shopping-merchant-products",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=171084\u0026template=555201",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-shopping-merchant-products",

--- a/packages/google-shopping-merchant-productstudio/.repo-metadata.json
+++ b/packages/google-shopping-merchant-productstudio/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-productstudio/latest",
     "default_version": "v1alpha",
     "distribution_name": "google-shopping-merchant-productstudio",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=171084\u0026template=555201",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-shopping-merchant-productstudio",

--- a/packages/google-shopping-merchant-promotions/.repo-metadata.json
+++ b/packages/google-shopping-merchant-promotions/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-promotions/latest",
     "default_version": "v1",
     "distribution_name": "google-shopping-merchant-promotions",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=171084\u0026template=555201",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-shopping-merchant-promotions",

--- a/packages/google-shopping-merchant-reviews/.repo-metadata.json
+++ b/packages/google-shopping-merchant-reviews/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://googleapis.dev/python/google-shopping-merchant-reviews/latest",
     "default_version": "v1beta",
     "distribution_name": "google-shopping-merchant-reviews",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=171084\u0026template=555201",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-shopping-merchant-reviews",

--- a/packages/google-shopping-type/.repo-metadata.json
+++ b/packages/google-shopping-type/.repo-metadata.json
@@ -2,7 +2,6 @@
     "client_documentation": "https://googleapis.dev/python/google-shopping-type/latest",
     "default_version": "apiVersion",
     "distribution_name": "google-shopping-type",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "GAPIC_AUTO",
     "name": "google-shopping-type",

--- a/packages/googleapis-common-protos/.repo-metadata.json
+++ b/packages/googleapis-common-protos/.repo-metadata.json
@@ -5,7 +5,6 @@
     "client_documentation": "https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos",
     "default_version": "apiVersion",
     "distribution_name": "googleapis-common-protos",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "CORE",
     "name": "googleapis-common-protos",

--- a/packages/pandas-gbq/.repo-metadata.json
+++ b/packages/pandas-gbq/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://googleapis.dev/python/pandas-gbq/latest/",
     "distribution_name": "pandas-gbq",
-    "issue_tracker": "https://github.com/googleapis/python-bigquery-pandas/issues",
     "language": "python",
     "library_type": "INTEGRATION",
     "name": "pandas-gbq",

--- a/packages/proto-plus/.repo-metadata.json
+++ b/packages/proto-plus/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://googleapis.dev/python/proto-plus/latest",
     "distribution_name": "proto-plus",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "python",
     "library_type": "CORE",
     "name": "proto-plus",

--- a/packages/sqlalchemy-spanner/.repo-metadata.json
+++ b/packages/sqlalchemy-spanner/.repo-metadata.json
@@ -1,7 +1,6 @@
 {
     "client_documentation": "https://github.com/googleapis/python-spanner-sqlalchemy",
     "distribution_name": "sqlalchemy-spanner",
-    "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open",
     "language": "python",
     "library_type": "INTEGRATION",
     "name": "sqlalchemy-spanner",


### PR DESCRIPTION
Issue tracker overrides are retained for:

- google-cloud-dns
- google-cloud-storage
- google-cloud-runtimeconfig
- google-cloud-compute-v1beta (needs sdk.yaml update in Librarian)

This also skips generation for google-crc32c, as Kokoro tests are failing at the moment (#16512)

Towards https://github.com/googleapis/librarian/issues/5465