### PR TITLE
fix(bigquery-storage): populate write_stream routing header in append_rows

### DIFF
--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/client.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import itertools
 import json
 import logging as std_logging
 import os
@@ -995,7 +996,18 @@ class BigQueryWriteClient(metaclass=BigQueryWriteClientMeta):
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (gapic_v1.routing_header.to_grpc_metadata(()),)
+        write_stream = ""
+        if requests is not None:
+            requests = iter(requests)
+            try:
+                first_request = next(requests)
+                write_stream = first_request.write_stream
+                requests = itertools.chain([first_request], requests)
+            except StopIteration:
+                pass
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata((("write_stream", write_stream),)),
+        )
 
         # Validate the universe domain.
         self._validate_universe_domain()

--- a/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/client.py
+++ b/packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/client.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import itertools
 import json
 import logging as std_logging
 import os
@@ -980,7 +981,18 @@ class BigQueryWriteClient(metaclass=BigQueryWriteClientMeta):
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (gapic_v1.routing_header.to_grpc_metadata(()),)
+        write_stream = ""
+        if requests is not None:
+            requests = iter(requests)
+            try:
+                first_request = next(requests)
+                write_stream = first_request.write_stream
+                requests = itertools.chain([first_request], requests)
+            except StopIteration:
+                pass
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata((("write_stream", write_stream),)),
+        )
 
         # Validate the universe domain.
         self._validate_universe_domain()


### PR DESCRIPTION
## Summary

- `append_rows()` in both `v1` and `v1beta2` sync clients passed an empty tuple `()` to `to_grpc_metadata()`, leaving the routing header blank
- On reconnect (idle timeout / load balancing), the gateway cannot route and returns `400 Cannot route on empty project id`
- Fix peeks at the first request from the iterator to extract `write_stream`, chains it back without consuming the iterator, and passes the correct routing key — matching the pattern used by `create_write_stream`, `get_write_stream`, and `finalize_write_stream`

## Files changed

- `packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1/services/big_query_write/client.py`
- `packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage_v1beta2/services/big_query_write/client.py`

## Known gaps

`async_client.py` in both `v1` and `v1beta2` has the same bug. Because `append_rows` there is a sync `def` accepting `AsyncIterator`, peeking requires making the method `async def` — left as a follow-up.

## Test plan

- [ ] Unit test: verify routing metadata contains `write_stream` value from first request
- [ ] Integration test: `append_rows` survives idle-timeout reconnect without `400 Cannot route on empty project id`
- [ ] Confirm `v1beta2` behaves identically
