### PR TITLE
chore: address product documentation in googleapis-common-protos

### DIFF
--- a/.librarian/generator-input/client-post-processing/googleapis-common-protos-docs.yaml
+++ b/.librarian/generator-input/client-post-processing/googleapis-common-protos-docs.yaml
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description: Remove inappropriate product documentation lines in googleapis-common-protos readme
+url: https://github.com/googleapis/librarian/issues/5670
+replacements:
+  - paths: [
+      packages/googleapis-common-protos/README.rst
+    ]
+    before: "`Google APIs Common Protos`_: Lets you define and config your API service.\n\n"
+    after: ""
+    count: 1
+  - paths: [
+      packages/googleapis-common-protos/README.rst
+    ]
+    before: "- `Product Documentation`_\n"
+    after: ""
+    count: 1
+  - paths: [
+      packages/googleapis-common-protos/README.rst
+    ]
+    before: ".. _Google APIs Common Protos: \n"
+    after: ""
+    count: 1
+  - paths: [
+      packages/googleapis-common-protos/README.rst
+    ]
+    before: ".. _Product Documentation:  \n"
+    after: ""
+    count: 1
+  - paths: [
+      packages/googleapis-common-protos/README.rst
+    ]
+    before: |
+      3. `Enable the Google APIs Common Protos.`_
+      4. `Set up Authentication.`_
+    after: |
+      3. `Set up Authentication.`_
+    count: 1
+  - paths: [
+      packages/googleapis-common-protos/README.rst
+    ]
+    before: ".. _Enable the Google APIs Common Protos.:  \n"
+    after: ""
+    count: 1
+  - paths: [
+      packages/googleapis-common-protos/README.rst
+    ]
+    before: |
+      -  Read the `Google APIs Common Protos Product documentation`_ to learn
+         more about the product and see How-to Guides.
+    after: ""
+    count: 1
+  - paths: [
+      packages/googleapis-common-protos/README.rst
+    ]
+    before: ".. _Google APIs Common Protos Product documentation:  \n"
+    after: ""
+    count: 1

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2958,7 +2958,6 @@ libraries:
         - google/logging/type
         - google/rpc/context
       name_pretty_override: Google APIs Common Protos
-      product_documentation_override: https://github.com/googleapis/googleapis/tree/master/google
       client_documentation_override: https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos
       default_version: apiVersion
   - name: grafeas

--- a/packages/googleapis-common-protos/.repo-metadata.json
+++ b/packages/googleapis-common-protos/.repo-metadata.json
@@ -9,7 +9,6 @@
     "library_type": "CORE",
     "name": "googleapis-common-protos",
     "name_pretty": "Google APIs Common Protos",
-    "product_documentation": "https://github.com/googleapis/googleapis/tree/master/google",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/googleapis-common-protos/README.rst
+++ b/packages/googleapis-common-protos/README.rst
@@ -3,10 +3,7 @@ Python Client for Google APIs Common Protos
 
 |stable| |pypi| |versions|
 
-`Google APIs Common Protos`_: Lets you define and config your API service.
-
 - `Client Library Documentation`_
-- `Product Documentation`_
 
 .. |stable| image:: https://img.shields.io/badge/support-stable-gold.svg
    :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#stability-levels
@@ -14,9 +11,7 @@ Python Client for Google APIs Common Protos
    :target: https://pypi.org/project/googleapis-common-protos/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/googleapis-common-protos.svg
    :target: https://pypi.org/project/googleapis-common-protos/
-.. _Google APIs Common Protos: https://github.com/googleapis/googleapis/tree/master/google
 .. _Client Library Documentation: https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos/summary_overview
-.. _Product Documentation:  https://github.com/googleapis/googleapis/tree/master/google
 
 Quick Start
 -----------
@@ -25,12 +20,10 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. `Enable the Google APIs Common Protos.`_
-4. `Set up Authentication.`_
+3. `Set up Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google APIs Common Protos.:  https://github.com/googleapis/googleapis/tree/master/google
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -99,12 +92,9 @@ Next Steps
 
 -  Read the `Client Library Documentation`_ for Google APIs Common Protos
    to see other available methods on the client.
--  Read the `Google APIs Common Protos Product documentation`_ to learn
-   more about the product and see How-to Guides.
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google APIs Common Protos Product documentation:  https://github.com/googleapis/googleapis/tree/master/google
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/googleapis-common-protos/docs/README.rst
+++ b/packages/googleapis-common-protos/docs/README.rst
@@ -3,10 +3,7 @@ Python Client for Google APIs Common Protos
 
 |stable| |pypi| |versions|
 
-`Google APIs Common Protos`_: Lets you define and config your API service.
-
 - `Client Library Documentation`_
-- `Product Documentation`_
 
 .. |stable| image:: https://img.shields.io/badge/support-stable-gold.svg
    :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#stability-levels
@@ -14,9 +11,7 @@ Python Client for Google APIs Common Protos
    :target: https://pypi.org/project/googleapis-common-protos/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/googleapis-common-protos.svg
    :target: https://pypi.org/project/googleapis-common-protos/
-.. _Google APIs Common Protos: https://github.com/googleapis/googleapis/tree/master/google
 .. _Client Library Documentation: https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos/summary_overview
-.. _Product Documentation:  https://github.com/googleapis/googleapis/tree/master/google
 
 Quick Start
 -----------
@@ -25,12 +20,10 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. `Enable the Google APIs Common Protos.`_
-4. `Set up Authentication.`_
+3. `Set up Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google APIs Common Protos.:  https://github.com/googleapis/googleapis/tree/master/google
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -99,12 +92,9 @@ Next Steps
 
 -  Read the `Client Library Documentation`_ for Google APIs Common Protos
    to see other available methods on the client.
--  Read the `Google APIs Common Protos Product documentation`_ to learn
-   more about the product and see How-to Guides.
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google APIs Common Protos Product documentation:  https://github.com/googleapis/googleapis/tree/master/google
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging


### PR DESCRIPTION
- Remove the product_documentation_override
- Add a string replacement to remove inappropriate lines

Completes the google-cloud-python part of https://github.com/googleapis/google-cloud-python/pull/5466

Filed https://github.com/googleapis/librarian/issues/5670 to remove the need for the string replacement when we migrate synthtool code into librarian.