### PR TITLE
chore: remove remaining api_shortname_override from bigframes

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -58,7 +58,6 @@ libraries:
     python:
       library_type: INTEGRATION
       name_pretty_override: A unified Python API in BigQuery
-      api_shortname_override: bigquery
       client_documentation_override: https://cloud.google.com/python/docs/reference/bigframes/latest
   - name: bigquery-magics
     version: 0.14.0

--- a/packages/bigframes/.repo-metadata.json
+++ b/packages/bigframes/.repo-metadata.json
@@ -1,5 +1,4 @@
 {
-    "api_shortname": "bigquery",
     "client_documentation": "https://cloud.google.com/python/docs/reference/bigframes/latest",
     "distribution_name": "bigframes",
     "language": "python",


### PR DESCRIPTION
This should have been removed along with the others; likely a rebase failure.