### PR TITLE
chore: reenable generation for google-cloud-bigquery

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -98,11 +98,6 @@ libraries:
       - path: google/ads/admanager/v1
     description_override: Manage your Ad Manager inventory, run reports and more.
     python:
-      opt_args_by_api:
-        google/ads/admanager/v1:
-          - python-gapic-namespace=google.ads
-          - python-gapic-name=admanager
-          - warehouse-package-name=google-ads-admanager
       default_version: v1
   - name: google-ads-datamanager
     version: 0.8.0
@@ -112,11 +107,6 @@ libraries:
       A unified ingestion API for data partners, agencies and advertisers to
       connect first-party data across Google advertising products.
     python:
-      opt_args_by_api:
-        google/ads/datamanager/v1:
-          - python-gapic-namespace=google.ads
-          - python-gapic-name=datamanager
-          - warehouse-package-name=google-ads-datamanager
       name_pretty_override: Data Manager API
       client_documentation_override: https://cloud.google.com/python/docs/reference/google-ads-datamanager/latest
       default_version: v1
@@ -130,7 +120,6 @@ libraries:
         google/marketingplatform/admin/v1alpha:
           - python-gapic-namespace=google.ads
           - python-gapic-name=marketingplatform_admin
-          - warehouse-package-name=google-ads-marketingplatform-admin
       name_pretty_override: Google Marketing Platform Admin API
       default_version: v1alpha
   - name: google-ai-generativelanguage
@@ -143,27 +132,6 @@ libraries:
       - path: google/ai/generativelanguage/v1alpha
     description_override: The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.
     python:
-      opt_args_by_api:
-        google/ai/generativelanguage/v1:
-          - python-gapic-namespace=google.ai
-          - python-gapic-name=generativelanguage
-          - warehouse-package-name=google-ai-generativelanguage
-        google/ai/generativelanguage/v1alpha:
-          - python-gapic-namespace=google.ai
-          - python-gapic-name=generativelanguage
-          - warehouse-package-name=google-ai-generativelanguage
-        google/ai/generativelanguage/v1beta:
-          - python-gapic-namespace=google.ai
-          - python-gapic-name=generativelanguage
-          - warehouse-package-name=google-ai-generativelanguage
-        google/ai/generativelanguage/v1beta2:
-          - python-gapic-namespace=google.ai
-          - python-gapic-name=generativelanguage
-          - warehouse-package-name=google-ai-generativelanguage
-        google/ai/generativelanguage/v1beta3:
-          - python-gapic-namespace=google.ai
-          - python-gapic-name=generativelanguage
-          - warehouse-package-name=google-ai-generativelanguage
       name_pretty_override: Generative Language API
       metadata_name_override: generativelanguage
       default_version: v1beta
@@ -177,13 +145,6 @@ libraries:
       opt_args_by_api:
         google/analytics/admin/v1alpha:
           - autogen-snippets=False
-          - python-gapic-namespace=google.analytics
-          - python-gapic-name=admin
-          - warehouse-package-name=google-analytics-admin
-        google/analytics/admin/v1beta:
-          - python-gapic-namespace=google.analytics
-          - python-gapic-name=admin
-          - warehouse-package-name=google-analytics-admin
       name_pretty_override: Analytics Admin
       metadata_name_override: analyticsadmin
       default_version: v1alpha
@@ -194,15 +155,6 @@ libraries:
       - path: google/analytics/data/v1alpha
     description_override: provides programmatic methods to access report data in Google Analytics App+Web properties.
     python:
-      opt_args_by_api:
-        google/analytics/data/v1alpha:
-          - python-gapic-namespace=google.analytics
-          - python-gapic-name=data
-          - warehouse-package-name=google-analytics-data
-        google/analytics/data/v1beta:
-          - python-gapic-namespace=google.analytics
-          - python-gapic-name=data
-          - warehouse-package-name=google-analytics-data
       name_pretty_override: Analytics Data
       metadata_name_override: analyticsdata
       default_version: v1beta
@@ -220,11 +172,6 @@ libraries:
     keep:
       - tests/unit/gapic/card_v1/test_card.py
     python:
-      opt_args_by_api:
-        google/apps/card/v1:
-          - python-gapic-namespace=google.apps
-          - python-gapic-name=card
-          - warehouse-package-name=google-apps-card
       name_pretty_override: Google Apps Card Protos
       default_version: v1
   - name: google-apps-chat
@@ -236,7 +183,6 @@ libraries:
         google/chat/v1:
           - proto-plus-deps=google.apps.card.v1
           - python-gapic-namespace=google.apps
-          - warehouse-package-name=google-apps-chat
           - python-gapic-name=chat
       name_pretty_override: Chat API
       default_version: v1
@@ -247,15 +193,6 @@ libraries:
       - path: google/apps/events/subscriptions/v1beta
     description_override: The Google Workspace Events API lets you subscribe to events and manage change notifications across Google Workspace applications.
     python:
-      opt_args_by_api:
-        google/apps/events/subscriptions/v1:
-          - python-gapic-namespace=google.apps
-          - python-gapic-name=events_subscriptions
-          - warehouse-package-name=google-apps-events-subscriptions
-        google/apps/events/subscriptions/v1beta:
-          - python-gapic-namespace=google.apps
-          - python-gapic-name=events_subscriptions
-          - warehouse-package-name=google-apps-events-subscriptions
       name_pretty_override: Google Workspace Events API
       default_version: v1
   - name: google-apps-meet
@@ -265,15 +202,6 @@ libraries:
       - path: google/apps/meet/v2beta
     description_override: Create and manage meetings in Google Meet.
     python:
-      opt_args_by_api:
-        google/apps/meet/v2:
-          - python-gapic-namespace=google.apps
-          - python-gapic-name=meet
-          - warehouse-package-name=google-apps-meet
-        google/apps/meet/v2beta:
-          - python-gapic-namespace=google.apps
-          - python-gapic-name=meet
-          - warehouse-package-name=google-apps-meet
       name_pretty_override: Google Meet API
       default_version: v2
   - name: google-apps-script-type
@@ -299,37 +227,30 @@ libraries:
         google/apps/script/type:
           - python-gapic-namespace=google.apps.script
           - python-gapic-name=type
-          - warehouse-package-name=google-apps-script-type
         google/apps/script/type/calendar:
           - proto-plus-deps=google.apps.script.type
           - python-gapic-namespace=google.apps.script.type
           - python-gapic-name=calendar
-          - warehouse-package-name=google-apps-script-type
         google/apps/script/type/docs:
           - proto-plus-deps=google.apps.script.type
           - python-gapic-namespace=google.apps.script.type
           - python-gapic-name=docs
-          - warehouse-package-name=google-apps-script-type
         google/apps/script/type/drive:
           - proto-plus-deps=google.apps.script.type
           - python-gapic-namespace=google.apps.script.type
           - python-gapic-name=drive
-          - warehouse-package-name=google-apps-script-type
         google/apps/script/type/gmail:
           - proto-plus-deps=google.apps.script.type
           - python-gapic-namespace=google.apps.script.type
           - python-gapic-name=gmail
-          - warehouse-package-name=google-apps-script-type
         google/apps/script/type/sheets:
           - proto-plus-deps=google.apps.script.type
           - python-gapic-namespace=google.apps.script.type
           - python-gapic-name=sheets
-          - warehouse-package-name=google-apps-script-type
         google/apps/script/type/slides:
           - proto-plus-deps=google.apps.script.type
           - python-gapic-namespace=google.apps.script.type
           - python-gapic-name=slides
-          - warehouse-package-name=google-apps-script-type
       name_pretty_override: Google Apps Script Type Protos
       metadata_name_override: type
       default_version: apiVersion
@@ -339,11 +260,6 @@ libraries:
       - path: google/area120/tables/v1alpha1
     description_override: provides programmatic methods to the Area 120 Tables API.
     python:
-      opt_args_by_api:
-        google/area120/tables/v1alpha1:
-          - python-gapic-namespace=google.area120
-          - python-gapic-name=tables
-          - warehouse-package-name=google-area120-tables
       name_pretty_override: Area 120 Tables
       metadata_name_override: area120tables
       default_version: v1alpha1
@@ -370,11 +286,6 @@ libraries:
       - path: google/cloud/accessapproval/v1
     description_override: enables controlling access to your organization's data by Google personnel.
     python:
-      opt_args_by_api:
-        google/cloud/accessapproval/v1:
-          - warehouse-package-name=google-cloud-access-approval
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=accessapproval
       metadata_name_override: accessapproval
       default_version: v1
   - name: google-cloud-access-context-manager
@@ -395,11 +306,6 @@ libraries:
       - path: google/cloud/advisorynotifications/v1
     description_override: Advisory Notifications provides well-targeted, timely, and compliant communications about critical security and privacy events in the Google Cloud console and allows you to securely investigate the event, take action, and get support.
     python:
-      opt_args_by_api:
-        google/cloud/advisorynotifications/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=advisorynotifications
-          - warehouse-package-name=google-cloud-advisorynotifications
       metadata_name_override: advisorynotifications
       default_version: v1
   - name: google-cloud-alloydb
@@ -409,19 +315,6 @@ libraries:
       - path: google/cloud/alloydb/v1beta
       - path: google/cloud/alloydb/v1alpha
     python:
-      opt_args_by_api:
-        google/cloud/alloydb/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=alloydb
-          - warehouse-package-name=google-cloud-alloydb
-        google/cloud/alloydb/v1alpha:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=alloydb
-          - warehouse-package-name=google-cloud-alloydb
-        google/cloud/alloydb/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=alloydb
-          - warehouse-package-name=google-cloud-alloydb
       metadata_name_override: alloydb
       default_version: v1
   - name: google-cloud-alloydb-connectors
@@ -438,15 +331,12 @@ libraries:
         google/cloud/alloydb/connectors/v1:
           - python-gapic-namespace=google.cloud.alloydb
           - python-gapic-name=connectors
-          - warehouse-package-name=google-cloud-alloydb-connectors
         google/cloud/alloydb/connectors/v1alpha:
           - python-gapic-namespace=google.cloud.alloydb
           - python-gapic-name=connectors
-          - warehouse-package-name=google-cloud-alloydb-connectors
         google/cloud/alloydb/connectors/v1beta:
           - python-gapic-namespace=google.cloud.alloydb
           - python-gapic-name=connectors
-          - warehouse-package-name=google-cloud-alloydb-connectors
       metadata_name_override: connectors
       default_version: v1
   - name: google-cloud-api-gateway
@@ -455,11 +345,6 @@ libraries:
       - path: google/cloud/apigateway/v1
     description_override: enables you to provide secure access to your backend services through a well-defined REST API that is consistent across all of your services, regardless of the service implementation. Clients consume your REST APIS to implement standalone apps for a mobile device or tablet, through apps running in a browser, or through any other type of app that can make a request to an HTTP endpoint.
     python:
-      opt_args_by_api:
-        google/cloud/apigateway/v1:
-          - warehouse-package-name=google-cloud-api-gateway
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=apigateway
       metadata_name_override: apigateway
       default_version: v1
   - name: google-cloud-api-keys
@@ -471,7 +356,6 @@ libraries:
         google/api/apikeys/v2:
           - python-gapic-name=api_keys
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-api-keys
       metadata_name_override: apikeys
       default_version: v2
   - name: google-cloud-apigee-connect
@@ -480,11 +364,6 @@ libraries:
       - path: google/cloud/apigeeconnect/v1
     description_override: allows the Apigee hybrid management plane to connect securely to the MART service in the runtime plane without requiring you to expose the MART endpoint on the internet.
     python:
-      opt_args_by_api:
-        google/cloud/apigeeconnect/v1:
-          - warehouse-package-name=google-cloud-apigee-connect
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=apigeeconnect
       metadata_name_override: apigeeconnect
       default_version: v1
   - name: google-cloud-apigee-registry
@@ -495,8 +374,6 @@ libraries:
     python:
       opt_args_by_api:
         google/cloud/apigeeregistry/v1:
-          - warehouse-package-name=google-cloud-apigee-registry
-          - python-gapic-namespace=google.cloud
           - python-gapic-name=apigee_registry
       name_pretty_override: Apigee Registry API
       metadata_name_override: apigeeregistry
@@ -507,11 +384,6 @@ libraries:
       - path: google/cloud/apihub/v1
     description_override: API hub lets you consolidate and organize information about all of the APIs of interest to your organization. API hub lets you capture critical information about APIs that allows developers to discover and evaluate them easily and leverage the work of other teams wherever possible. API platform teams can use API hub to have visibility into and manage their portfolio of APIs.
     python:
-      opt_args_by_api:
-        google/cloud/apihub/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=apihub
-          - warehouse-package-name=google-cloud-apihub
       name_pretty_override: API Hub API
       default_version: v1
   - name: google-cloud-apiregistry
@@ -519,11 +391,6 @@ libraries:
     apis:
       - path: google/cloud/apiregistry/v1beta
     python:
-      opt_args_by_api:
-        google/cloud/apiregistry/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=apiregistry
-          - warehouse-package-name=google-cloud-apiregistry
       name_pretty_override: Cloud API Registry API
       default_version: v1beta
   - name: google-cloud-appengine-admin
@@ -534,7 +401,6 @@ libraries:
     python:
       opt_args_by_api:
         google/appengine/v1:
-          - warehouse-package-name=google-cloud-appengine-admin
           - python-gapic-namespace=google.cloud
           - python-gapic-name=appengine_admin
       metadata_name_override: appengine
@@ -549,7 +415,6 @@ libraries:
       library_type: OTHER
       opt_args_by_api:
         google/appengine/logging/v1:
-          - warehouse-package-name=google-cloud-appengine-logging
           - python-gapic-namespace=google.cloud
           - python-gapic-name=appengine_logging
       name_pretty_override: App Engine Logging Protos
@@ -561,11 +426,6 @@ libraries:
       - path: google/cloud/apphub/v1
     description_override: 'null '
     python:
-      opt_args_by_api:
-        google/cloud/apphub/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=apphub
-          - warehouse-package-name=google-cloud-apphub
       name_pretty_override: App Hub API
       default_version: v1
   - name: google-cloud-appoptimize
@@ -577,11 +437,6 @@ libraries:
       monitor, analyze, and improve the performance and cost-efficiency of their
       cloud applications.
     python:
-      opt_args_by_api:
-        google/cloud/appoptimize/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=appoptimize
-          - warehouse-package-name=google-cloud-appoptimize
       name_pretty_override: App Optimize API
       default_version: v1beta
   - name: google-cloud-artifact-registry
@@ -593,13 +448,9 @@ libraries:
     python:
       opt_args_by_api:
         google/devtools/artifactregistry/v1:
-          - python-gapic-name=artifactregistry
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-artifact-registry
         google/devtools/artifactregistry/v1beta2:
-          - python-gapic-name=artifactregistry
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-artifact-registry
       metadata_name_override: artifactregistry
       default_version: v1
   - name: google-cloud-asset
@@ -614,21 +465,6 @@ libraries:
       opt_args_by_api:
         google/cloud/asset/v1:
           - proto-plus-deps=google.cloud.osconfig.v1
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=asset
-          - warehouse-package-name=google-cloud-asset
-        google/cloud/asset/v1p1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=asset
-          - warehouse-package-name=google-cloud-asset
-        google/cloud/asset/v1p2beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=asset
-          - warehouse-package-name=google-cloud-asset
-        google/cloud/asset/v1p5beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=asset
-          - warehouse-package-name=google-cloud-asset
       name_pretty_override: Cloud Asset Inventory
       metadata_name_override: cloudasset
       default_version: v1
@@ -639,15 +475,6 @@ libraries:
       - path: google/cloud/assuredworkloads/v1beta1
     description_override: allows you to secure your government workloads and accelerate your path to running compliant workloads on Google Cloud with Assured Workloads for Government.
     python:
-      opt_args_by_api:
-        google/cloud/assuredworkloads/v1:
-          - warehouse-package-name=google-cloud-assured-workloads
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=assuredworkloads
-        google/cloud/assuredworkloads/v1beta1:
-          - warehouse-package-name=google-cloud-assured-workloads
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=assuredworkloads
       name_pretty_override: Assured Workloads for Government
       metadata_name_override: assuredworkloads
       default_version: v1
@@ -668,11 +495,6 @@ libraries:
     apis:
       - path: google/cloud/auditmanager/v1
     python:
-      opt_args_by_api:
-        google/cloud/auditmanager/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=auditmanager
-          - warehouse-package-name=google-cloud-auditmanager
       name_pretty_override: Audit Manager API
       default_version: v1
   - name: google-cloud-automl
@@ -688,15 +510,6 @@ libraries:
       - google/cloud/automl_v1beta1/services/tables/tables_client.py
     python:
       library_type: GAPIC_COMBO
-      opt_args_by_api:
-        google/cloud/automl/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=automl
-          - warehouse-package-name=google-cloud-automl
-        google/cloud/automl/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=automl
-          - warehouse-package-name=google-cloud-automl
       metadata_name_override: automl
       default_version: v1
   - name: google-cloud-backupdr
@@ -705,11 +518,6 @@ libraries:
       - path: google/cloud/backupdr/v1
     description_override: Backup and DR Service ensures that your data is managed, protected, and accessible using both hybrid and cloud-based backup/recovery appliances that are managed using the Backup and DR management console.
     python:
-      opt_args_by_api:
-        google/cloud/backupdr/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=backupdr
-          - warehouse-package-name=google-cloud-backupdr
       name_pretty_override: Backup and DR Service API
       metadata_name_override: backupdr
       default_version: v1
@@ -722,8 +530,6 @@ libraries:
       opt_args_by_api:
         google/cloud/baremetalsolution/v2:
           - python-gapic-name=bare_metal_solution
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-bare-metal-solution
       metadata_name_override: baremetalsolution
       default_version: v2
   - name: google-cloud-batch
@@ -732,15 +538,6 @@ libraries:
       - path: google/cloud/batch/v1
       - path: google/cloud/batch/v1alpha
     python:
-      opt_args_by_api:
-        google/cloud/batch/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=batch
-          - warehouse-package-name=google-cloud-batch
-        google/cloud/batch/v1alpha:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=batch
-          - warehouse-package-name=google-cloud-batch
       name_pretty_override: Cloud Batch
       metadata_name_override: batch
       default_version: v1
@@ -750,11 +547,6 @@ libraries:
       - path: google/cloud/beyondcorp/appconnections/v1
     description_override: Beyondcorp Enterprise provides identity and context aware access controls for enterprise resources and enables zero-trust access. Using the Beyondcorp Enterprise APIs, enterprises can set up multi-cloud and on-prem connectivity using the App Connector hybrid connectivity solution.
     python:
-      opt_args_by_api:
-        google/cloud/beyondcorp/appconnections/v1:
-          - warehouse-package-name=google-cloud-beyondcorp-appconnections
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=beyondcorp_appconnections
       name_pretty_override: BeyondCorp AppConnections
       metadata_name_override: beyondcorpappconnections
       default_version: v1
@@ -764,11 +556,6 @@ libraries:
       - path: google/cloud/beyondcorp/appconnectors/v1
     description_override: Beyondcorp Enterprise provides identity and context aware access controls for enterprise resources and enables zero-trust access. Using the Beyondcorp Enterprise APIs, enterprises can set up multi-cloud and on-prem connectivity using the App Connector hybrid connectivity solution.
     python:
-      opt_args_by_api:
-        google/cloud/beyondcorp/appconnectors/v1:
-          - warehouse-package-name=google-cloud-beyondcorp-appconnectors
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=beyondcorp_appconnectors
       name_pretty_override: BeyondCorp AppConnectors
       metadata_name_override: beyondcorpappconnectors
       default_version: v1
@@ -778,11 +565,6 @@ libraries:
       - path: google/cloud/beyondcorp/appgateways/v1
     description_override: Beyondcorp Enterprise provides identity and context aware access controls for enterprise resources and enables zero-trust access. Using the Beyondcorp Enterprise APIs, enterprises can set up multi-cloud and on-prem connectivity using the App Connector hybrid connectivity solution.
     python:
-      opt_args_by_api:
-        google/cloud/beyondcorp/appgateways/v1:
-          - warehouse-package-name=google-cloud-beyondcorp-appgateways
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=beyondcorp_appgateways
       name_pretty_override: BeyondCorp AppGateways
       metadata_name_override: beyondcorpappgateways
       default_version: v1
@@ -792,11 +574,6 @@ libraries:
       - path: google/cloud/beyondcorp/clientconnectorservices/v1
     description_override: Beyondcorp Enterprise provides identity and context aware access controls for enterprise resources and enables zero-trust access. Using the Beyondcorp Enterprise APIs, enterprises can set up multi-cloud and on-prem connectivity using the App Connector hybrid connectivity solution.
     python:
-      opt_args_by_api:
-        google/cloud/beyondcorp/clientconnectorservices/v1:
-          - warehouse-package-name=google-cloud-beyondcorp-clientconnectorservices
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=beyondcorp_clientconnectorservices
       name_pretty_override: BeyondCorp ClientConnectorServices
       metadata_name_override: beyondcorpclientconnectorservices
       default_version: v1
@@ -806,11 +583,6 @@ libraries:
       - path: google/cloud/beyondcorp/clientgateways/v1
     description_override: Beyondcorp Enterprise provides identity and context aware access controls for enterprise resources and enables zero-trust access. Using the Beyondcorp Enterprise APIs, enterprises can set up multi-cloud and on-prem connectivity using the App Connector hybrid connectivity solution.
     python:
-      opt_args_by_api:
-        google/cloud/beyondcorp/clientgateways/v1:
-          - warehouse-package-name=google-cloud-beyondcorp-clientgateways
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=beyondcorp_clientgateways
       name_pretty_override: BeyondCorp ClientGateways
       metadata_name_override: beyondcorpclientgateways
       default_version: v1
@@ -820,11 +592,6 @@ libraries:
       - path: google/cloud/biglake/v1
     description_override: The BigLake API provides access to BigLake Metastore, a serverless, fully managed, and highly available metastore for open-source data that can be used for querying Apache Iceberg tables in BigQuery.
     python:
-      opt_args_by_api:
-        google/cloud/biglake/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=biglake
-          - warehouse-package-name=google-cloud-biglake
       name_pretty_override: BigLake API
       default_version: v1
   - name: google-cloud-biglake-hive
@@ -836,11 +603,6 @@ libraries:
       managed, and highly available metastore for open-source data that can be
       used for querying Apache Iceberg tables in BigQuery.
     python:
-      opt_args_by_api:
-        google/cloud/biglake/hive/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=biglake_hive
-          - warehouse-package-name=google-cloud-biglake-hive
       name_pretty_override: BigLake API
       default_version: v1beta
   - name: google-cloud-bigquery
@@ -861,11 +623,6 @@ libraries:
       - path: google/cloud/bigquery/analyticshub/v1
     description_override: Analytics Hub is a data exchange that allows you to efficiently and securely exchange data assets across organizations to address challenges of data reliability and cost. Curate a library of internal and external assets, including unique datasets like Google Trends, backed by the power of BigQuery.
     python:
-      opt_args_by_api:
-        google/cloud/bigquery/analyticshub/v1:
-          - python-gapic-name=bigquery_analyticshub
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-bigquery-analyticshub
       name_pretty_override: BigQuery Analytics Hub
       metadata_name_override: analyticshub
       default_version: v1
@@ -876,15 +633,6 @@ libraries:
       - path: google/cloud/bigquery/biglake/v1alpha1
     description_override: BigLake API
     python:
-      opt_args_by_api:
-        google/cloud/bigquery/biglake/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=bigquery_biglake
-          - warehouse-package-name=google-cloud-bigquery-biglake
-        google/cloud/bigquery/biglake/v1alpha1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=bigquery_biglake
-          - warehouse-package-name=google-cloud-bigquery-biglake
       name_pretty_override: BigLake API
       metadata_name_override: biglake
       default_version: v1
@@ -894,11 +642,6 @@ libraries:
       - path: google/cloud/bigquery/connection/v1
     description_override: Manage BigQuery connections to external data sources.
     python:
-      opt_args_by_api:
-        google/cloud/bigquery/connection/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=bigquery_connection
-          - warehouse-package-name=google-cloud-bigquery-connection
       metadata_name_override: bigqueryconnection
       default_version: v1
   - name: google-cloud-bigquery-data-exchange
@@ -910,8 +653,6 @@ libraries:
       opt_args_by_api:
         google/cloud/bigquery/dataexchange/v1beta1:
           - python-gapic-name=bigquery_data_exchange
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-bigquery-data-exchange
       name_pretty_override: BigQuery Analytics Hub
       metadata_name_override: analyticshub
       default_version: v1beta1
@@ -924,23 +665,6 @@ libraries:
       - path: google/cloud/bigquery/datapolicies/v1beta1
     description_override: Allows users to manage BigQuery data policies.
     python:
-      opt_args_by_api:
-        google/cloud/bigquery/datapolicies/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=bigquery_datapolicies
-          - warehouse-package-name=google-cloud-bigquery-datapolicies
-        google/cloud/bigquery/datapolicies/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=bigquery_datapolicies
-          - warehouse-package-name=google-cloud-bigquery-datapolicies
-        google/cloud/bigquery/datapolicies/v2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=bigquery_datapolicies
-          - warehouse-package-name=google-cloud-bigquery-datapolicies
-        google/cloud/bigquery/datapolicies/v2beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=bigquery_datapolicies
-          - warehouse-package-name=google-cloud-bigquery-datapolicies
       metadata_name_override: bigquerydatapolicy
       default_version: v1
   - name: google-cloud-bigquery-datatransfer
@@ -949,11 +673,6 @@ libraries:
       - path: google/cloud/bigquery/datatransfer/v1
     description_override: allows users to transfer data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.
     python:
-      opt_args_by_api:
-        google/cloud/bigquery/datatransfer/v1:
-          - python-gapic-name=bigquery_datatransfer
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-bigquery-datatransfer
       metadata_name_override: bigquerydatatransfer
       default_version: v1
   - name: google-cloud-bigquery-logging
@@ -964,11 +683,6 @@ libraries:
       - tests/unit/gapic/bigquery_logging_v1/test_bigquery_logging_v1.py
     python:
       library_type: OTHER
-      opt_args_by_api:
-        google/cloud/bigquery/logging/v1:
-          - warehouse-package-name=google-cloud-bigquery-logging
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=bigquery_logging
       name_pretty_override: BigQuery Logging Protos
       metadata_name_override: bigquerylogging
       default_version: v1
@@ -978,15 +692,6 @@ libraries:
       - path: google/cloud/bigquery/migration/v2
       - path: google/cloud/bigquery/migration/v2alpha
     python:
-      opt_args_by_api:
-        google/cloud/bigquery/migration/v2:
-          - python-gapic-name=bigquery_migration
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-bigquery-migration
-        google/cloud/bigquery/migration/v2alpha:
-          - python-gapic-name=bigquery_migration
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-bigquery-migration
       name_pretty_override: Google BigQuery Migration
       metadata_name_override: bigquerymigration
       default_version: v2
@@ -996,11 +701,6 @@ libraries:
       - path: google/cloud/bigquery/reservation/v1
     description_override: Modify BigQuery flat-rate reservations.
     python:
-      opt_args_by_api:
-        google/cloud/bigquery/reservation/v1:
-          - python-gapic-name=bigquery_reservation
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-bigquery-reservation
       metadata_name_override: bigqueryreservation
       default_version: v1
   - name: google-cloud-bigquery-storage
@@ -1015,23 +715,6 @@ libraries:
       - docs/bigquery_storage_v1beta2/library.rst
     python:
       library_type: GAPIC_COMBO
-      opt_args_by_api:
-        google/cloud/bigquery/storage/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=bigquery_storage
-          - warehouse-package-name=google-cloud-bigquery-storage
-        google/cloud/bigquery/storage/v1alpha:
-          - python-gapic-name=bigquery_storage
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-bigquery-storage
-        google/cloud/bigquery/storage/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=bigquery_storage
-          - warehouse-package-name=google-cloud-bigquery-storage
-        google/cloud/bigquery/storage/v1beta2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=bigquery_storage
-          - warehouse-package-name=google-cloud-bigquery-storage
       name_pretty_override: Google BigQuery Storage
       metadata_name_override: bigquerystorage
       default_version: v1
@@ -1051,12 +734,10 @@ libraries:
         google/bigtable/admin/v2:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=bigtable_admin
-          - warehouse-package-name=google-cloud-bigtable
         google/bigtable/v2:
           - python-gapic-namespace=google.cloud
           - autogen-snippets=False
           - python-gapic-name=bigtable
-          - warehouse-package-name=google-cloud-bigtable
       name_pretty_override: Google Cloud Bigtable
       metadata_name_override: bigtable
       default_version: v2
@@ -1066,11 +747,6 @@ libraries:
       - path: google/cloud/billing/v1
     description_override: allows developers to manage their billing accounts or browse the catalog of SKUs and pricing.
     python:
-      opt_args_by_api:
-        google/cloud/billing/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=billing
-          - warehouse-package-name=google-cloud-billing
       metadata_name_override: cloudbilling
       default_version: v1
   - name: google-cloud-billing-budgets
@@ -1084,11 +760,9 @@ libraries:
         google/cloud/billing/budgets/v1:
           - python-gapic-namespace=google.cloud.billing
           - python-gapic-name=budgets
-          - warehouse-package-name=google-cloud-billing-budgets
         google/cloud/billing/budgets/v1beta1:
           - python-gapic-namespace=google.cloud.billing
           - python-gapic-name=budgets
-          - warehouse-package-name=google-cloud-billing-budgets
       metadata_name_override: billingbudgets
       default_version: v1
   - name: google-cloud-binary-authorization
@@ -1098,15 +772,6 @@ libraries:
       - path: google/cloud/binaryauthorization/v1beta1
     description_override: ' is a service on Google Cloud that provides centralized software supply-chain security for applications that run on Google Kubernetes Engine (GKE) and Anthos clusters on VMware'
     python:
-      opt_args_by_api:
-        google/cloud/binaryauthorization/v1:
-          - warehouse-package-name=google-cloud-binary-authorization
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=binaryauthorization
-        google/cloud/binaryauthorization/v1beta1:
-          - warehouse-package-name=google-cloud-binary-authorization
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=binaryauthorization
       metadata_name_override: binaryauthorization
       default_version: v1
   - name: google-cloud-build
@@ -1119,12 +784,8 @@ libraries:
       opt_args_by_api:
         google/devtools/cloudbuild/v1:
           - python-gapic-namespace=google.cloud.devtools
-          - warehouse-package-name=google-cloud-build
-          - python-gapic-name=cloudbuild
         google/devtools/cloudbuild/v2:
-          - warehouse-package-name=google-cloud-build
           - python-gapic-namespace=google.cloud.devtools
-          - python-gapic-name=cloudbuild
       metadata_name_override: cloudbuild
       default_version: v1
   - name: google-cloud-capacityplanner
@@ -1133,11 +794,6 @@ libraries:
       - path: google/cloud/capacityplanner/v1beta
     description_override: Provides programmatic access to Capacity Planner features.
     python:
-      opt_args_by_api:
-        google/cloud/capacityplanner/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=capacityplanner
-          - warehouse-package-name=google-cloud-capacityplanner
       name_pretty_override: Capacity Planner API
       default_version: v1beta
   - name: google-cloud-certificate-manager
@@ -1149,8 +805,6 @@ libraries:
       opt_args_by_api:
         google/cloud/certificatemanager/v1:
           - python-gapic-name=certificate_manager
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-certificate-manager
       metadata_name_override: certificatemanager
       default_version: v1
   - name: google-cloud-ces
@@ -1159,15 +813,6 @@ libraries:
       - path: google/cloud/ces/v1
       - path: google/cloud/ces/v1beta
     python:
-      opt_args_by_api:
-        google/cloud/ces/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=ces
-          - warehouse-package-name=google-cloud-ces
-        google/cloud/ces/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=ces
-          - warehouse-package-name=google-cloud-ces
       name_pretty_override: Gemini Enterprise for Customer Experience API
       default_version: v1
   - name: google-cloud-channel
@@ -1176,11 +821,6 @@ libraries:
       - path: google/cloud/channel/v1
     description_override: With Channel Services, Google Cloud partners and resellers have a single unified resale platform, with a unified resale catalog, customer management, order management, billing management, policy and authorization management, and cost management.
     python:
-      opt_args_by_api:
-        google/cloud/channel/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=channel
-          - warehouse-package-name=google-cloud-channel
       name_pretty_override: Channel Services
       metadata_name_override: cloudchannel
       default_version: v1
@@ -1190,11 +830,6 @@ libraries:
       - path: google/cloud/chronicle/v1
     description_override: The Google Cloud Security Operations API, popularly known as the Chronicle API, serves endpoints that enable security analysts to analyze and mitigate a security threat throughout its lifecycle
     python:
-      opt_args_by_api:
-        google/cloud/chronicle/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=chronicle
-          - warehouse-package-name=google-cloud-chronicle
       name_pretty_override: Chronicle API
       default_version: v1
   - name: google-cloud-cloudcontrolspartner
@@ -1204,15 +839,6 @@ libraries:
       - path: google/cloud/cloudcontrolspartner/v1beta
     description_override: Provides insights about your customers and their Assured Workloads based on your Sovereign Controls by Partners offering.
     python:
-      opt_args_by_api:
-        google/cloud/cloudcontrolspartner/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=cloudcontrolspartner
-          - warehouse-package-name=google-cloud-cloudcontrolspartner
-        google/cloud/cloudcontrolspartner/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=cloudcontrolspartner
-          - warehouse-package-name=google-cloud-cloudcontrolspartner
       name_pretty_override: Cloud Controls Partner API
       default_version: v1
   - name: google-cloud-cloudsecuritycompliance
@@ -1221,11 +847,6 @@ libraries:
       - path: google/cloud/cloudsecuritycompliance/v1
     description_override: 'null '
     python:
-      opt_args_by_api:
-        google/cloud/cloudsecuritycompliance/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=cloudsecuritycompliance
-          - warehouse-package-name=google-cloud-cloudsecuritycompliance
       name_pretty_override: Cloud Security Compliance API
       default_version: v1
   - name: google-cloud-commerce-consumer-procurement
@@ -1235,15 +856,6 @@ libraries:
       - path: google/cloud/commerce/consumer/procurement/v1alpha1
     description_override: Cloud Commerce Consumer Procurement API
     python:
-      opt_args_by_api:
-        google/cloud/commerce/consumer/procurement/v1:
-          - python-gapic-name=commerce_consumer_procurement
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-commerce-consumer-procurement
-        google/cloud/commerce/consumer/procurement/v1alpha1:
-          - python-gapic-name=commerce_consumer_procurement
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-commerce-consumer-procurement
       name_pretty_override: Cloud Commerce Consumer Procurement API
       metadata_name_override: procurement
       default_version: v1
@@ -1256,11 +868,6 @@ libraries:
       - tests/unit/gapic/common/test_common.py
     python:
       library_type: CORE
-      opt_args_by_api:
-        google/cloud/common:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=common
-          - warehouse-package-name=google-cloud-common
       name_pretty_override: Google Cloud Common
       metadata_name_override: common
       default_version: apiVersion
@@ -1270,11 +877,6 @@ libraries:
       - path: google/cloud/compute/v1
     description_override: delivers virtual machines running in Google's innovative data centers and worldwide fiber network. Compute Engine's tooling and workflow support enable scaling from single instances to global, load-balanced cloud computing. Compute Engine's VMs boot quickly, come with persistent disk storage, deliver consistent performance and are available in many configurations.
     python:
-      opt_args_by_api:
-        google/cloud/compute/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=compute
-          - warehouse-package-name=google-cloud-compute
       name_pretty_override: Compute Engine
       metadata_name_override: compute
       default_version: v1
@@ -1284,11 +886,6 @@ libraries:
       - path: google/cloud/compute/v1beta
     description_override: delivers virtual machines running in Google's innovative data centers and worldwide fiber network. Compute Engine's tooling and workflow support enable scaling from single instances to global, load-balanced cloud computing. Compute Engine's VMs boot quickly, come with persistent disk storage, deliver consistent performance and are available in many configurations.
     python:
-      opt_args_by_api:
-        google/cloud/compute/v1beta:
-          - warehouse-package-name=google-cloud-compute-v1beta
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=compute
       name_pretty_override: Compute Engine
       issue_tracker_override: https://issuetracker.google.com/issues/new?component=187134&template=0
       default_version: v1beta
@@ -1298,11 +895,6 @@ libraries:
       - path: google/cloud/confidentialcomputing/v1
     description_override: Protect data in-use with Confidential VMs, Confidential GKE, Confidential Dataproc, and Confidential Space.
     python:
-      opt_args_by_api:
-        google/cloud/confidentialcomputing/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=confidentialcomputing
-          - warehouse-package-name=google-cloud-confidentialcomputing
       name_pretty_override: Confidential Computing API
       metadata_name_override: confidentialcomputing
       default_version: v1
@@ -1312,11 +904,6 @@ libraries:
       - path: google/cloud/config/v1
     description_override: Infrastructure Manager API
     python:
-      opt_args_by_api:
-        google/cloud/config/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=config
-          - warehouse-package-name=google-cloud-config
       name_pretty_override: Infrastructure Manager API
       metadata_name_override: config
       default_version: v1
@@ -1328,19 +915,6 @@ libraries:
       - path: google/cloud/configdelivery/v1alpha
     description_override: ConfigDelivery service manages the deployment of kubernetes configuration to a fleet of kubernetes clusters.
     python:
-      opt_args_by_api:
-        google/cloud/configdelivery/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=configdelivery
-          - warehouse-package-name=google-cloud-configdelivery
-        google/cloud/configdelivery/v1alpha:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=configdelivery
-          - warehouse-package-name=google-cloud-configdelivery
-        google/cloud/configdelivery/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=configdelivery
-          - warehouse-package-name=google-cloud-configdelivery
       name_pretty_override: Config Delivery API
       default_version: v1alpha
   - name: google-cloud-contact-center-insights
@@ -1351,8 +925,6 @@ libraries:
     python:
       opt_args_by_api:
         google/cloud/contactcenterinsights/v1:
-          - warehouse-package-name=google-cloud-contact-center-insights
-          - python-gapic-namespace=google.cloud
           - python-gapic-name=contact_center_insights
       metadata_name_override: contactcenterinsights
       default_version: v1
@@ -1366,11 +938,9 @@ libraries:
       opt_args_by_api:
         google/container/v1:
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-container
           - python-gapic-name=container
         google/container/v1beta1:
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-container
           - python-gapic-name=container
       metadata_name_override: container
       default_version: v1
@@ -1383,8 +953,6 @@ libraries:
       opt_args_by_api:
         google/devtools/containeranalysis/v1:
           - python-gapic-namespace=google.cloud.devtools
-          - warehouse-package-name=google-cloud-containeranalysis
-          - python-gapic-name=containeranalysis
       metadata_name_override: containeranalysis
       default_version: v1
   - name: google-cloud-contentwarehouse
@@ -1395,9 +963,6 @@ libraries:
       opt_args_by_api:
         google/cloud/contentwarehouse/v1:
           - proto-plus-deps=google.cloud.documentai.v1
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=contentwarehouse
-          - warehouse-package-name=google-cloud-contentwarehouse
       metadata_name_override: contentwarehouse
       default_version: v1
   - name: google-cloud-core
@@ -1413,8 +978,6 @@ libraries:
     python:
       opt_args_by_api:
         google/cloud/datafusion/v1:
-          - warehouse-package-name=google-cloud-data-fusion
-          - python-gapic-namespace=google.cloud
           - python-gapic-name=data_fusion
       metadata_name_override: datafusion
       default_version: v1
@@ -1424,11 +987,6 @@ libraries:
       - path: google/cloud/dataqna/v1alpha
     description_override: Data QnA is a natural language question and answer service for BigQuery data.
     python:
-      opt_args_by_api:
-        google/cloud/dataqna/v1alpha:
-          - warehouse-package-name=google-cloud-data-qna
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=dataqna
       metadata_name_override: dataqna
       default_version: v1alpha
   - name: google-cloud-databasecenter
@@ -1444,11 +1002,6 @@ libraries:
       focused on reliability, compliance, security, cost, and administration to
       quickly identify and address relevant issues within their database fleets.
     python:
-      opt_args_by_api:
-        google/cloud/databasecenter/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=databasecenter
-          - warehouse-package-name=google-cloud-databasecenter
       name_pretty_override: Database Center API
       default_version: v1beta
   - name: google-cloud-datacatalog
@@ -1458,15 +1011,6 @@ libraries:
       - path: google/cloud/datacatalog/v1beta1
     description_override: is a fully managed and highly scalable data discovery and metadata management service.
     python:
-      opt_args_by_api:
-        google/cloud/datacatalog/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=datacatalog
-          - warehouse-package-name=google-cloud-datacatalog
-        google/cloud/datacatalog/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=datacatalog
-          - warehouse-package-name=google-cloud-datacatalog
       metadata_name_override: datacatalog
       default_version: v1
   - name: google-cloud-datacatalog-lineage
@@ -1475,11 +1019,6 @@ libraries:
       - path: google/cloud/datacatalog/lineage/v1
     description_override: 'Data lineage is a Dataplex feature that lets you track how data moves through your systems: where it comes from, where it is passed to, and what transformations are applied to it.'
     python:
-      opt_args_by_api:
-        google/cloud/datacatalog/lineage/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=datacatalog_lineage
-          - warehouse-package-name=google-cloud-datacatalog-lineage
       name_pretty_override: Data Lineage API
       metadata_name_override: lineage
       default_version: v1
@@ -1488,11 +1027,6 @@ libraries:
     apis:
       - path: google/cloud/datacatalog/lineage/configmanagement/v1
     python:
-      opt_args_by_api:
-        google/cloud/datacatalog/lineage/configmanagement/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=datacatalog_lineage_configmanagement
-          - warehouse-package-name=google-cloud-datacatalog-lineage-configmanagement
       name_pretty_override: Data Lineage API
       default_version: v1
   - name: google-cloud-dataflow-client
@@ -1505,7 +1039,6 @@ libraries:
         google/dataflow/v1beta3:
           - python-gapic-name=dataflow
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-dataflow-client
       metadata_name_override: dataflow
       default_version: v1beta3
   - name: google-cloud-dataform
@@ -1514,15 +1047,6 @@ libraries:
       - path: google/cloud/dataform/v1
       - path: google/cloud/dataform/v1beta1
     python:
-      opt_args_by_api:
-        google/cloud/dataform/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=dataform
-          - warehouse-package-name=google-cloud-dataform
-        google/cloud/dataform/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=dataform
-          - warehouse-package-name=google-cloud-dataform
       name_pretty_override: Cloud Dataform
       metadata_name_override: dataform
       default_version: v1beta1
@@ -1532,11 +1056,6 @@ libraries:
       - path: google/cloud/datalabeling/v1beta1
     description_override: is a service that lets you work with human labelers to generate highly accurate labels for a collection of data that you can use to train your machine learning models.
     python:
-      opt_args_by_api:
-        google/cloud/datalabeling/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=datalabeling
-          - warehouse-package-name=google-cloud-datalabeling
       name_pretty_override: Google Cloud Data Labeling
       metadata_name_override: datalabeling
       default_version: v1beta1
@@ -1546,11 +1065,6 @@ libraries:
       - path: google/cloud/dataplex/v1
     description_override: provides intelligent data fabric that enables organizations to centrally manage, monitor, and govern their data across data lakes, data warehouses, and data marts with consistent controls, providing access to trusted data and powering analytics at scale.
     python:
-      opt_args_by_api:
-        google/cloud/dataplex/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=dataplex
-          - warehouse-package-name=google-cloud-dataplex
       metadata_name_override: dataplex
       default_version: v1
   - name: google-cloud-dataproc
@@ -1559,11 +1073,6 @@ libraries:
       - path: google/cloud/dataproc/v1
     description_override: is a faster, easier, more cost-effective way to run Apache Spark and Apache Hadoop.
     python:
-      opt_args_by_api:
-        google/cloud/dataproc/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=dataproc
-          - warehouse-package-name=google-cloud-dataproc
       name_pretty_override: Google Cloud Dataproc
       metadata_name_override: dataproc
       default_version: v1
@@ -1575,19 +1084,6 @@ libraries:
       - path: google/cloud/metastore/v1alpha
     description_override: is a fully managed, highly available, autoscaled, autohealing, OSS-native metastore service that greatly simplifies technical metadata management. Dataproc Metastore service is based on Apache Hive metastore and serves as a critical component towards enterprise data lakes.
     python:
-      opt_args_by_api:
-        google/cloud/metastore/v1:
-          - warehouse-package-name=google-cloud-dataproc-metastore
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=metastore
-        google/cloud/metastore/v1alpha:
-          - warehouse-package-name=google-cloud-dataproc-metastore
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=metastore
-        google/cloud/metastore/v1beta:
-          - warehouse-package-name=google-cloud-dataproc-metastore
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=metastore
       metadata_name_override: metastore
       default_version: v1
   - name: google-cloud-datastore
@@ -1607,11 +1103,9 @@ libraries:
         google/datastore/admin/v1:
           - python-gapic-name=datastore_admin
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-datastore
         google/datastore/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=datastore
-          - warehouse-package-name=google-cloud-datastore
       name_pretty_override: Google Cloud Datastore API
       metadata_name_override: datastore
       default_version: v1
@@ -1622,15 +1116,6 @@ libraries:
       - path: google/cloud/datastream/v1alpha1
     description_override: is a serverless and easy-to-use change data capture (CDC) and replication service. It allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.
     python:
-      opt_args_by_api:
-        google/cloud/datastream/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=datastream
-          - warehouse-package-name=google-cloud-datastream
-        google/cloud/datastream/v1alpha1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=datastream
-          - warehouse-package-name=google-cloud-datastream
       metadata_name_override: datastream
       default_version: v1
   - name: google-cloud-deploy
@@ -1639,11 +1124,6 @@ libraries:
       - path: google/cloud/deploy/v1
     description_override: is a service that automates delivery of your applications to a series of target environments in a defined sequence
     python:
-      opt_args_by_api:
-        google/cloud/deploy/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=deploy
-          - warehouse-package-name=google-cloud-deploy
       name_pretty_override: Google Cloud Deploy
       metadata_name_override: clouddeploy
       default_version: v1
@@ -1653,11 +1133,6 @@ libraries:
       - path: google/cloud/developerconnect/v1
     description_override: Developer Connect streamlines integration with third-party source code management platforms by simplifying authentication, authorization, and networking configuration.
     python:
-      opt_args_by_api:
-        google/cloud/developerconnect/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=developerconnect
-          - warehouse-package-name=google-cloud-developerconnect
       name_pretty_override: Developer Connect API
       default_version: v1
   - name: google-cloud-devicestreaming
@@ -1666,11 +1141,6 @@ libraries:
       - path: google/cloud/devicestreaming/v1
     description_override: The Cloud API for device streaming usage.
     python:
-      opt_args_by_api:
-        google/cloud/devicestreaming/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=devicestreaming
-          - warehouse-package-name=google-cloud-devicestreaming
       name_pretty_override: Device Streaming API
       default_version: v1
   - name: google-cloud-dialogflow
@@ -1681,15 +1151,6 @@ libraries:
     description_override: is an end-to-end, build-once deploy-everywhere development suite for creating conversational interfaces for websites, mobile applications, popular messaging platforms, and IoT devices. You can use it to build interfaces (such as chatbots and conversational IVR) that enable natural and rich interactions between your users and your business. Dialogflow Enterprise Edition users have access to Google Cloud Support and a service level agreement (SLA) for production deployments.
     skip_generate: true
     python:
-      opt_args_by_api:
-        google/cloud/dialogflow/v2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=dialogflow
-          - warehouse-package-name=google-cloud-dialogflow
-        google/cloud/dialogflow/v2beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=dialogflow
-          - warehouse-package-name=google-cloud-dialogflow
       metadata_name_override: dialogflow
       default_version: v2
   - name: google-cloud-dialogflow-cx
@@ -1701,12 +1162,8 @@ libraries:
       opt_args_by_api:
         google/cloud/dialogflow/cx/v3:
           - python-gapic-name=dialogflowcx
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-dialogflow-cx
         google/cloud/dialogflow/cx/v3beta1:
           - python-gapic-name=dialogflowcx
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-dialogflow-cx
       name_pretty_override: Dialogflow CX
       metadata_name_override: dialogflow-cx
       default_version: v3
@@ -1717,19 +1174,6 @@ libraries:
       - path: google/cloud/discoveryengine/v1beta
       - path: google/cloud/discoveryengine/v1alpha
     python:
-      opt_args_by_api:
-        google/cloud/discoveryengine/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=discoveryengine
-          - warehouse-package-name=google-cloud-discoveryengine
-        google/cloud/discoveryengine/v1alpha:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=discoveryengine
-          - warehouse-package-name=google-cloud-discoveryengine
-        google/cloud/discoveryengine/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=discoveryengine
-          - warehouse-package-name=google-cloud-discoveryengine
       name_pretty_override: Discovery Engine API
       metadata_name_override: discoveryengine
       default_version: v1beta
@@ -1742,8 +1186,6 @@ libraries:
       opt_args_by_api:
         google/privacy/dlp/v2:
           - python-gapic-namespace=google.cloud
-          - python-gapic-name=dlp
-          - warehouse-package-name=google-cloud-dlp
       name_pretty_override: Cloud Data Loss Prevention
       metadata_name_override: dlp
       default_version: v2
@@ -1753,11 +1195,6 @@ libraries:
       - path: google/cloud/clouddms/v1
     description_override: makes it easier for you to migrate your data to Google Cloud. This service helps you lift and shift your MySQL and PostgreSQL workloads into Cloud SQL.
     python:
-      opt_args_by_api:
-        google/cloud/clouddms/v1:
-          - warehouse-package-name=google-cloud-dms
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=clouddms
       name_pretty_override: Cloud Database Migration Service
       metadata_name_override: datamigration
       default_version: v1
@@ -1776,15 +1213,6 @@ libraries:
       - path: google/cloud/documentai/v1beta3
     description_override: Service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.
     python:
-      opt_args_by_api:
-        google/cloud/documentai/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=documentai
-          - warehouse-package-name=google-cloud-documentai
-        google/cloud/documentai/v1beta3:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=documentai
-          - warehouse-package-name=google-cloud-documentai
       name_pretty_override: Document AI
       metadata_name_override: documentai
       default_version: v1
@@ -1802,15 +1230,6 @@ libraries:
       - path: google/cloud/domains/v1beta1
     description_override: allows you to register and manage domains by using Cloud Domains.
     python:
-      opt_args_by_api:
-        google/cloud/domains/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=domains
-          - warehouse-package-name=google-cloud-domains
-        google/cloud/domains/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=domains
-          - warehouse-package-name=google-cloud-domains
       metadata_name_override: domains
       default_version: v1
   - name: google-cloud-edgecontainer
@@ -1819,11 +1238,6 @@ libraries:
       - path: google/cloud/edgecontainer/v1
     description_override: Google Distributed Cloud Edge allows you to run Kubernetes clusters on dedicated hardware provided and maintained by Google that is separate from the Google Cloud data center.
     python:
-      opt_args_by_api:
-        google/cloud/edgecontainer/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=edgecontainer
-          - warehouse-package-name=google-cloud-edgecontainer
       metadata_name_override: edgecontainer
       default_version: v1
   - name: google-cloud-edgenetwork
@@ -1832,11 +1246,6 @@ libraries:
       - path: google/cloud/edgenetwork/v1
     description_override: Network management API for Distributed Cloud Edge
     python:
-      opt_args_by_api:
-        google/cloud/edgenetwork/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=edgenetwork
-          - warehouse-package-name=google-cloud-edgenetwork
       name_pretty_override: Distributed Cloud Edge Network API
       default_version: v1
   - name: google-cloud-enterpriseknowledgegraph
@@ -1844,11 +1253,6 @@ libraries:
     apis:
       - path: google/cloud/enterpriseknowledgegraph/v1
     python:
-      opt_args_by_api:
-        google/cloud/enterpriseknowledgegraph/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=enterpriseknowledgegraph
-          - warehouse-package-name=google-cloud-enterpriseknowledgegraph
       metadata_name_override: enterpriseknowledgegraph
       default_version: v1
   - name: google-cloud-error-reporting
@@ -1862,7 +1266,6 @@ libraries:
         google/devtools/clouderrorreporting/v1beta1:
           - python-gapic-name=errorreporting
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-error-reporting
       name_pretty_override: Error Reporting API
       metadata_name_override: clouderrorreporting
       default_version: v1beta1
@@ -1874,8 +1277,6 @@ libraries:
     python:
       opt_args_by_api:
         google/cloud/essentialcontacts/v1:
-          - warehouse-package-name=google-cloud-essential-contacts
-          - python-gapic-namespace=google.cloud
           - python-gapic-name=essential_contacts
       metadata_name_override: essentialcontacts
       default_version: v1
@@ -1885,11 +1286,6 @@ libraries:
       - path: google/cloud/eventarc/v1
     description_override: lets you asynchronously deliver events from Google services, SaaS, and your own apps using loosely coupled services that react to state changes. Eventarc requires no infrastructure management, you can optimize productivity and costs while building a modern, event-driven solution.
     python:
-      opt_args_by_api:
-        google/cloud/eventarc/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=eventarc
-          - warehouse-package-name=google-cloud-eventarc
       metadata_name_override: eventarc
       default_version: v1
   - name: google-cloud-eventarc-publishing
@@ -1898,11 +1294,6 @@ libraries:
       - path: google/cloud/eventarc/publishing/v1
     description_override: lets you asynchronously deliver events from Google services, SaaS, and your own apps using loosely coupled services that react to state changes.
     python:
-      opt_args_by_api:
-        google/cloud/eventarc/publishing/v1:
-          - python-gapic-name=eventarc_publishing
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-eventarc-publishing
       metadata_name_override: eventarcpublishing
       default_version: v1
   - name: google-cloud-filestore
@@ -1914,9 +1305,6 @@ libraries:
       opt_args_by_api:
         google/cloud/filestore/v1:
           - proto-plus-deps=google.cloud.common
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=filestore
-          - warehouse-package-name=google-cloud-filestore
       name_pretty_override: Filestore
       metadata_name_override: file
       default_version: v1
@@ -1926,11 +1314,6 @@ libraries:
       - path: google/cloud/financialservices/v1
     description_override: Google Cloud's Anti Money Laundering AI (AML AI) product is an API that scores AML risk. Use it to identify more risk, more defensibly, with fewer false positives and reduced time per review.
     python:
-      opt_args_by_api:
-        google/cloud/financialservices/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=financialservices
-          - warehouse-package-name=google-cloud-financialservices
       name_pretty_override: Anti Money Laundering AI API
       default_version: v1
   - name: google-cloud-firestore
@@ -1959,15 +1342,12 @@ libraries:
         google/firestore/admin/v1:
           - python-gapic-name=firestore_admin
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-firestore
         google/firestore/bundle:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=firestore_bundle
-          - warehouse-package-name=google-cloud-firestore
         google/firestore/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=firestore
-          - warehouse-package-name=google-cloud-firestore
       name_pretty_override: Cloud Firestore API
       metadata_name_override: firestore
       default_version: v1
@@ -1978,15 +1358,6 @@ libraries:
       - path: google/cloud/functions/v1
     description_override: is a scalable pay as you go Functions-as-a-Service (FaaS) to run your code with zero server management.
     python:
-      opt_args_by_api:
-        google/cloud/functions/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=functions
-          - warehouse-package-name=google-cloud-functions
-        google/cloud/functions/v2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=functions
-          - warehouse-package-name=google-cloud-functions
       metadata_name_override: cloudfunctions
       default_version: v1
   - name: google-cloud-gdchardwaremanagement
@@ -1995,11 +1366,6 @@ libraries:
       - path: google/cloud/gdchardwaremanagement/v1alpha
     description_override: Google Distributed Cloud connected allows you to run Kubernetes clusters on dedicated hardware provided and maintained by Google that is separate from the Google Cloud data center.
     python:
-      opt_args_by_api:
-        google/cloud/gdchardwaremanagement/v1alpha:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=gdchardwaremanagement
-          - warehouse-package-name=google-cloud-gdchardwaremanagement
       name_pretty_override: GDC Hardware Management API
       default_version: v1alpha
   - name: google-cloud-geminidataanalytics
@@ -2009,15 +1375,6 @@ libraries:
       - path: google/cloud/geminidataanalytics/v1alpha
     description_override: Developers can use the Conversational Analytics API, accessed through geminidataanalytics.googleapis.com, to build an artificial intelligence (AI)-powered chat interface, or data agent, that answers questions about structured data in BigQuery, Looker, and Looker Studio using natural language.
     python:
-      opt_args_by_api:
-        google/cloud/geminidataanalytics/v1alpha:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=geminidataanalytics
-          - warehouse-package-name=google-cloud-geminidataanalytics
-        google/cloud/geminidataanalytics/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=geminidataanalytics
-          - warehouse-package-name=google-cloud-geminidataanalytics
       default_version: v1alpha
   - name: google-cloud-gke-backup
     version: 0.8.0
@@ -2028,8 +1385,6 @@ libraries:
       opt_args_by_api:
         google/cloud/gkebackup/v1:
           - python-gapic-name=gke_backup
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-gke-backup
       metadata_name_override: gkebackup
       default_version: v1
   - name: google-cloud-gke-connect-gateway
@@ -2041,11 +1396,9 @@ libraries:
     python:
       opt_args_by_api:
         google/cloud/gkeconnect/gateway/v1:
-          - warehouse-package-name=google-cloud-gke-connect-gateway
           - python-gapic-namespace=google.cloud.gkeconnect
           - python-gapic-name=gateway
         google/cloud/gkeconnect/gateway/v1beta1:
-          - warehouse-package-name=google-cloud-gke-connect-gateway
           - python-gapic-namespace=google.cloud.gkeconnect
           - python-gapic-name=gateway
       name_pretty_override: GKE Connect Gateway
@@ -2066,15 +1419,6 @@ libraries:
       - docs/gkehub_v1/rbacrolebindingactuation_v1/services_.rst
       - docs/gkehub_v1/rbacrolebindingactuation_v1/types_.rst
     python:
-      opt_args_by_api:
-        google/cloud/gkehub/v1:
-          - warehouse-package-name=google-cloud-gke-hub
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=gkehub
-        google/cloud/gkehub/v1beta1:
-          - warehouse-package-name=google-cloud-gke-hub
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=gkehub
       metadata_name_override: gkehub
       default_version: v1
   - name: google-cloud-gke-multicloud
@@ -2086,8 +1430,6 @@ libraries:
       opt_args_by_api:
         google/cloud/gkemulticloud/v1:
           - python-gapic-name=gke_multicloud
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-gke-multicloud
       name_pretty_override: Anthos Multicloud
       metadata_name_override: gkemulticloud
       default_version: v1
@@ -2097,11 +1439,6 @@ libraries:
       - path: google/cloud/gkerecommender/v1
     description_override: GKE Recommender API
     python:
-      opt_args_by_api:
-        google/cloud/gkerecommender/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=gkerecommender
-          - warehouse-package-name=google-cloud-gkerecommender
       name_pretty_override: GKE Recommender API
       default_version: v1
   - name: google-cloud-gsuiteaddons
@@ -2113,9 +1450,6 @@ libraries:
       opt_args_by_api:
         google/cloud/gsuiteaddons/v1:
           - proto-plus-deps=google.apps.script.type.calendar+google.apps.script.type.docs+google.apps.script.type.drive+google.apps.script.type.gmail+google.apps.script.type.sheets+google.apps.script.type.slides+google.apps.script.type
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=gsuiteaddons
-          - warehouse-package-name=google-cloud-gsuiteaddons
       name_pretty_override: Google Workspace Add-ons API
       metadata_name_override: gsuiteaddons
       default_version: v1
@@ -2126,15 +1460,6 @@ libraries:
       - path: google/cloud/hypercomputecluster/v1beta
     description_override: The Cluster Director API allows you to deploy, manage, and monitor clusters that run AI, ML, or HPC workloads.
     python:
-      opt_args_by_api:
-        google/cloud/hypercomputecluster/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=hypercomputecluster
-          - warehouse-package-name=google-cloud-hypercomputecluster
-        google/cloud/hypercomputecluster/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=hypercomputecluster
-          - warehouse-package-name=google-cloud-hypercomputecluster
       name_pretty_override: Cluster Director API
       default_version: v1
   - name: google-cloud-iam
@@ -2152,27 +1477,21 @@ libraries:
         google/iam/admin/v1:
           - python-gapic-name=iam_admin
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-iam
         google/iam/credentials/v1:
-          - warehouse-package-name=google-cloud-iam
           - python-gapic-namespace=google.cloud
           - python-gapic-name=iam_credentials
         google/iam/v2:
           - python-gapic-name=iam
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-iam
         google/iam/v2beta:
           - python-gapic-name=iam
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-iam
         google/iam/v3:
           - python-gapic-name=iam
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-iam
         google/iam/v3beta:
           - python-gapic-name=iam
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-iam
       name_pretty_override: Cloud Identity and Access Management
       metadata_name_override: iam
       default_version: v2
@@ -2186,7 +1505,6 @@ libraries:
       library_type: OTHER
       opt_args_by_api:
         google/iam/v1/logging:
-          - warehouse-package-name=google-cloud-iam-logging
           - python-gapic-namespace=google.cloud
           - python-gapic-name=iam_logging
       name_pretty_override: IAM Logging Protos
@@ -2198,11 +1516,6 @@ libraries:
       - path: google/cloud/iamconnectorcredentials/v1alpha
     description_override: iamconnectorcredentials.googleapis.com API.
     python:
-      opt_args_by_api:
-        google/cloud/iamconnectorcredentials/v1alpha:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=iamconnectorcredentials
-          - warehouse-package-name=google-cloud-iamconnectorcredentials
       name_pretty_override: iamconnectorcredentials.googleapis.com API
       default_version: v1alpha
   - name: google-cloud-iap
@@ -2211,11 +1524,6 @@ libraries:
       - path: google/cloud/iap/v1
     description_override: Identity-Aware Proxy includes a number of features that can be used to protect access to Google Cloud hosted resources and applications hosted on Google Cloud.
     python:
-      opt_args_by_api:
-        google/cloud/iap/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=iap
-          - warehouse-package-name=google-cloud-iap
       name_pretty_override: Identity-Aware Proxy
       metadata_name_override: iap
       default_version: v1
@@ -2225,11 +1533,6 @@ libraries:
       - path: google/cloud/ids/v1
     description_override: Cloud IDS is an intrusion detection service that provides threat detection for intrusions, malware, spyware, and command-and-control attacks on your network. Cloud IDS works by creating a Google-managed peered network with mirrored VMs. Traffic in the peered network is mirrored, and then inspected by Palo Alto Networks threat protection technologies to provide advanced threat detection.
     python:
-      opt_args_by_api:
-        google/cloud/ids/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=ids
-          - warehouse-package-name=google-cloud-ids
       metadata_name_override: ids
       default_version: v1
   - name: google-cloud-kms
@@ -2238,11 +1541,6 @@ libraries:
       - path: google/cloud/kms/v1
     description_override: a cloud-hosted key management service that lets you manage cryptographic keys for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256, RSA 2048, RSA 3072, RSA 4096, EC P256, and EC P384 cryptographic keys. Cloud KMS is integrated with Cloud IAM and Cloud Audit Logging so that you can manage permissions on individual keys and monitor how these are used. Use Cloud KMS to protect secrets and other sensitive data that you need to store in Google Cloud Platform.
     python:
-      opt_args_by_api:
-        google/cloud/kms/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=kms
-          - warehouse-package-name=google-cloud-kms
       name_pretty_override: Google Cloud Key Management Service
       metadata_name_override: cloudkms
       default_version: v1
@@ -2254,10 +1552,7 @@ libraries:
     python:
       opt_args_by_api:
         google/cloud/kms/inventory/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=kms_inventory
           - proto-plus-deps=google.cloud.kms.v1
-          - warehouse-package-name=google-cloud-kms-inventory
       name_pretty_override: KMS Inventory API
       metadata_name_override: inventory
       default_version: v1
@@ -2269,19 +1564,6 @@ libraries:
       - path: google/cloud/language/v1beta2
     description_override: provides natural language understanding technologies to developers, including sentiment analysis, entity analysis, entity sentiment analysis, content classification, and syntax analysis. This API is part of the larger Cloud Machine Learning API family.
     python:
-      opt_args_by_api:
-        google/cloud/language/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=language
-          - warehouse-package-name=google-cloud-language
-        google/cloud/language/v1beta2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=language
-          - warehouse-package-name=google-cloud-language
-        google/cloud/language/v2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=language
-          - warehouse-package-name=google-cloud-language
       name_pretty_override: Natural Language
       metadata_name_override: language
       default_version: v1
@@ -2291,11 +1573,6 @@ libraries:
       - path: google/cloud/licensemanager/v1
     description_override: 'License Manager is a tool to manage and track third-party licenses on Google Cloud. '
     python:
-      opt_args_by_api:
-        google/cloud/licensemanager/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=licensemanager
-          - warehouse-package-name=google-cloud-licensemanager
       name_pretty_override: License Manager API
       default_version: v1
   - name: google-cloud-life-sciences
@@ -2304,11 +1581,6 @@ libraries:
       - path: google/cloud/lifesciences/v2beta
     description_override: is a suite of services and tools for managing, processing, and transforming life sciences data.
     python:
-      opt_args_by_api:
-        google/cloud/lifesciences/v2beta:
-          - warehouse-package-name=google-cloud-life-sciences
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=lifesciences
       metadata_name_override: lifesciences
       default_version: v2beta
   - name: google-cloud-locationfinder
@@ -2317,11 +1589,6 @@ libraries:
       - path: google/cloud/locationfinder/v1
     description_override: Cloud Location Finder lets you identify and filter cloud locations in regions and zones across Google Cloud, Google Distributed Cloud, Microsoft Azure, Amazon Web Services, and Oracle Cloud Infrastructure based on proximity, geographic location, and carbon footprint.
     python:
-      opt_args_by_api:
-        google/cloud/locationfinder/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=locationfinder
-          - warehouse-package-name=google-cloud-locationfinder
       name_pretty_override: Cloud Location Finder API
       default_version: v1
   - name: google-cloud-logging
@@ -2335,7 +1602,6 @@ libraries:
         google/logging/v2:
           - python-gapic-name=logging
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-logging
       name_pretty_override: Cloud Logging API
       metadata_name_override: logging
       default_version: v2
@@ -2345,11 +1611,6 @@ libraries:
       - path: google/cloud/lustre/v1
     description_override: 'null '
     python:
-      opt_args_by_api:
-        google/cloud/lustre/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=lustre
-          - warehouse-package-name=google-cloud-lustre
       name_pretty_override: Google Cloud Managed Lustre API
       default_version: v1
   - name: google-cloud-maintenance-api
@@ -2359,15 +1620,6 @@ libraries:
       - path: google/cloud/maintenance/api/v1beta
     description_override: The Maintenance API provides a centralized view of planned disruptive maintenance events across supported Google Cloud products. It offers users visibility into upcoming, ongoing, and completed maintenance, along with controls to manage certain maintenance activities, such as mainteance windows, rescheduling, and on-demand updates.
     python:
-      opt_args_by_api:
-        google/cloud/maintenance/api/v1:
-          - python-gapic-name=maintenance_api
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-maintenance-api
-        google/cloud/maintenance/api/v1beta:
-          - python-gapic-name=maintenance_api
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-maintenance-api
       name_pretty_override: Maintenance API
       default_version: v1
   - name: google-cloud-managed-identities
@@ -2376,11 +1628,6 @@ libraries:
       - path: google/cloud/managedidentities/v1
     description_override: is a highly available, hardened Google Cloud service running actual Microsoft AD that enables you to manage authentication and authorization for your AD-dependent workloads, automate AD server maintenance and security configuration, and connect your on-premises AD domain to the cloud.
     python:
-      opt_args_by_api:
-        google/cloud/managedidentities/v1:
-          - warehouse-package-name=google-cloud-managed-identities
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=managedidentities
       metadata_name_override: managedidentities
       default_version: v1
   - name: google-cloud-managedkafka
@@ -2389,11 +1636,6 @@ libraries:
       - path: google/cloud/managedkafka/v1
     description_override: Managed Service for Apache Kafka API is a managed cloud service that lets you ingest Kafka streams directly into Google Cloud.
     python:
-      opt_args_by_api:
-        google/cloud/managedkafka/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=managedkafka
-          - warehouse-package-name=google-cloud-managedkafka
       default_version: v1
   - name: google-cloud-managedkafka-schemaregistry
     version: 0.4.0
@@ -2401,11 +1643,6 @@ libraries:
       - path: google/cloud/managedkafka/schemaregistry/v1
     description_override: 'Manage Apache Kafka clusters and resources. '
     python:
-      opt_args_by_api:
-        google/cloud/managedkafka/schemaregistry/v1:
-          - python-gapic-name=managedkafka_schemaregistry
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-managedkafka-schemaregistry
       name_pretty_override: Managed Service for Apache Kafka API
       default_version: v1
   - name: google-cloud-media-translation
@@ -2414,11 +1651,6 @@ libraries:
       - path: google/cloud/mediatranslation/v1beta1
     description_override: provides enterprise quality translation from/to various media types.
     python:
-      opt_args_by_api:
-        google/cloud/mediatranslation/v1beta1:
-          - warehouse-package-name=google-cloud-media-translation
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=mediatranslation
       metadata_name_override: mediatranslation
       default_version: v1beta1
   - name: google-cloud-memcache
@@ -2428,15 +1660,6 @@ libraries:
       - path: google/cloud/memcache/v1beta2
     description_override: is a fully-managed in-memory data store service for Memcache.
     python:
-      opt_args_by_api:
-        google/cloud/memcache/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=memcache
-          - warehouse-package-name=google-cloud-memcache
-        google/cloud/memcache/v1beta2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=memcache
-          - warehouse-package-name=google-cloud-memcache
       metadata_name_override: memcache
       default_version: v1
   - name: google-cloud-memorystore
@@ -2446,15 +1669,6 @@ libraries:
       - path: google/cloud/memorystore/v1beta
     description_override: Memorystore for Valkey is a fully managed Valkey Cluster service for Google Cloud. Applications running on Google Cloud can achieve extreme performance by leveraging the highly scalable, available, secure Valkey service without the burden of managing complex Valkey deployments.
     python:
-      opt_args_by_api:
-        google/cloud/memorystore/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=memorystore
-          - warehouse-package-name=google-cloud-memorystore
-        google/cloud/memorystore/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=memorystore
-          - warehouse-package-name=google-cloud-memorystore
       default_version: v1
   - name: google-cloud-migrationcenter
     version: 0.4.0
@@ -2462,11 +1676,6 @@ libraries:
       - path: google/cloud/migrationcenter/v1
     description_override: A unified platform that helps you accelerate your end-to-end cloud journey from your current on-premises or cloud environments to Google Cloud.
     python:
-      opt_args_by_api:
-        google/cloud/migrationcenter/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=migrationcenter
-          - warehouse-package-name=google-cloud-migrationcenter
       name_pretty_override: Migration Center API
       metadata_name_override: migrationcenter
       default_version: v1
@@ -2477,15 +1686,6 @@ libraries:
       - path: google/cloud/modelarmor/v1beta
     description_override: Model Armor helps you protect against risks like prompt injection, harmful content, and data leakage in generative AI applications by letting you define policies that filter user prompts and model responses.
     python:
-      opt_args_by_api:
-        google/cloud/modelarmor/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=modelarmor
-          - warehouse-package-name=google-cloud-modelarmor
-        google/cloud/modelarmor/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=modelarmor
-          - warehouse-package-name=google-cloud-modelarmor
       name_pretty_override: Model Armor API
       default_version: v1
   - name: google-cloud-monitoring
@@ -2499,7 +1699,6 @@ libraries:
         google/monitoring/v3:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=monitoring
-          - warehouse-package-name=google-cloud-monitoring
       name_pretty_override: Stackdriver Monitoring
       metadata_name_override: monitoring
       default_version: v3
@@ -2516,7 +1715,6 @@ libraries:
         google/monitoring/dashboard/v1:
           - python-gapic-name=monitoring_dashboard
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-monitoring-dashboards
       name_pretty_override: Monitoring Dashboards
       metadata_name_override: monitoring-dashboards
       default_version: v1
@@ -2530,7 +1728,6 @@ libraries:
         google/monitoring/metricsscope/v1:
           - python-gapic-name=monitoring_metrics_scope
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-monitoring-metrics-scopes
       name_pretty_override: Metrics Scopes
       default_version: v1
   - name: google-cloud-ndb
@@ -2547,11 +1744,6 @@ libraries:
       - path: google/cloud/netapp/v1
     description_override: NetApp API
     python:
-      opt_args_by_api:
-        google/cloud/netapp/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=netapp
-          - warehouse-package-name=google-cloud-netapp
       name_pretty_override: NetApp API
       metadata_name_override: netapp
       default_version: v1
@@ -2563,19 +1755,6 @@ libraries:
       - path: google/cloud/networkconnectivity/v1alpha1
     description_override: The Network Connectivity API will be home to various services which provide information pertaining to network connectivity.  This includes information like interconnects, VPNs, VPCs, routing information, ip address details, etc. This information will help customers verify their network configurations and helps them to discover misconfigurations, inconsistencies, etc.
     python:
-      opt_args_by_api:
-        google/cloud/networkconnectivity/v1:
-          - warehouse-package-name=google-cloud-network-connectivity
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=networkconnectivity
-        google/cloud/networkconnectivity/v1alpha1:
-          - warehouse-package-name=google-cloud-network-connectivity
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=networkconnectivity
-        google/cloud/networkconnectivity/v1beta:
-          - warehouse-package-name=google-cloud-network-connectivity
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=networkconnectivity
       name_pretty_override: Network Connectivity Center
       metadata_name_override: networkconnectivity
       default_version: v1
@@ -2588,8 +1767,6 @@ libraries:
       opt_args_by_api:
         google/cloud/networkmanagement/v1:
           - python-gapic-name=network_management
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-network-management
       metadata_name_override: networkmanagement
       default_version: v1
   - name: google-cloud-network-security
@@ -2602,15 +1779,9 @@ libraries:
       opt_args_by_api:
         google/cloud/networksecurity/v1:
           - python-gapic-name=network_security
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-network-security
         google/cloud/networksecurity/v1alpha1:
           - python-gapic-name=network_security
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-network-security
         google/cloud/networksecurity/v1beta1:
-          - warehouse-package-name=google-cloud-network-security
-          - python-gapic-namespace=google.cloud
           - python-gapic-name=network_security
       metadata_name_override: networksecurity
       default_version: v1
@@ -2622,8 +1793,6 @@ libraries:
       opt_args_by_api:
         google/cloud/networkservices/v1:
           - python-gapic-name=network_services
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-network-services
       metadata_name_override: networkservices
       default_version: v1
   - name: google-cloud-notebooks
@@ -2634,19 +1803,6 @@ libraries:
       - path: google/cloud/notebooks/v1beta1
     description_override: is a managed service that offers an integrated and secure JupyterLab environment for data scientists and machine learning developers to experiment, develop, and deploy models into production. Users can create instances running JupyterLab that come pre-installed with the latest data science and machine learning frameworks in a single click.
     python:
-      opt_args_by_api:
-        google/cloud/notebooks/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=notebooks
-          - warehouse-package-name=google-cloud-notebooks
-        google/cloud/notebooks/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=notebooks
-          - warehouse-package-name=google-cloud-notebooks
-        google/cloud/notebooks/v2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=notebooks
-          - warehouse-package-name=google-cloud-notebooks
       name_pretty_override: AI Platform Notebooks
       metadata_name_override: notebooks
       default_version: v1
@@ -2656,11 +1812,6 @@ libraries:
       - path: google/cloud/optimization/v1
     description_override: is a managed routing service that takes your list of orders, vehicles, constraints, and objectives and returns the most efficient plan for your entire fleet in near real-time.
     python:
-      opt_args_by_api:
-        google/cloud/optimization/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=optimization
-          - warehouse-package-name=google-cloud-optimization
       metadata_name_override: optimization
       default_version: v1
   - name: google-cloud-oracledatabase
@@ -2669,11 +1820,6 @@ libraries:
       - path: google/cloud/oracledatabase/v1
     description_override: The Oracle Database@Google Cloud API provides a set of APIs to manage Oracle database services, such as Exadata and Autonomous Databases.
     python:
-      opt_args_by_api:
-        google/cloud/oracledatabase/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=oracledatabase
-          - warehouse-package-name=google-cloud-oracledatabase
       name_pretty_override: Oracle Database@Google Cloud API
       default_version: v1
   - name: google-cloud-orchestration-airflow
@@ -2685,13 +1831,11 @@ libraries:
     python:
       opt_args_by_api:
         google/cloud/orchestration/airflow/service/v1:
-          - warehouse-package-name=google-cloud-orchestration-airflow
           - python-gapic-namespace=google.cloud.orchestration.airflow
           - python-gapic-name=service
         google/cloud/orchestration/airflow/service/v1beta1:
           - python-gapic-namespace=google.cloud.orchestration.airflow
           - python-gapic-name=service
-          - warehouse-package-name=google-cloud-orchestration-airflow
       metadata_name_override: composer
       default_version: v1
   - name: google-cloud-org-policy
@@ -2701,11 +1845,6 @@ libraries:
       - path: google/cloud/orgpolicy/v1
     description_override: The Organization Policy API allows users to configure governance rules on their GCP resources across the Cloud Resource Hierarchy.
     python:
-      opt_args_by_api:
-        google/cloud/orgpolicy/v2:
-          - warehouse-package-name=google-cloud-org-policy
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=orgpolicy
       proto_only_apis:
         - google/cloud/orgpolicy/v1
       metadata_name_override: orgpolicy
@@ -2717,15 +1856,6 @@ libraries:
       - path: google/cloud/osconfig/v1alpha
     description_override: provides OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.
     python:
-      opt_args_by_api:
-        google/cloud/osconfig/v1:
-          - warehouse-package-name=google-cloud-os-config
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=osconfig
-        google/cloud/osconfig/v1alpha:
-          - warehouse-package-name=google-cloud-os-config
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=osconfig
       metadata_name_override: osconfig
       default_version: v1
   - name: google-cloud-os-login
@@ -2737,10 +1867,7 @@ libraries:
     python:
       opt_args_by_api:
         google/cloud/oslogin/v1:
-          - warehouse-package-name=google-cloud-os-login
           - proto-plus-deps=google.cloud.oslogin.common
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=oslogin
       name_pretty_override: Google Cloud OS Login
       metadata_name_override: oslogin
       default_version: v1
@@ -2751,15 +1878,6 @@ libraries:
       - path: google/cloud/parallelstore/v1beta
     description_override: Parallelstore is based on Intel DAOS and delivers up to 6.3x greater read throughput performance compared to competitive Lustre scratch offerings.
     python:
-      opt_args_by_api:
-        google/cloud/parallelstore/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=parallelstore
-          - warehouse-package-name=google-cloud-parallelstore
-        google/cloud/parallelstore/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=parallelstore
-          - warehouse-package-name=google-cloud-parallelstore
       name_pretty_override: Parallelstore API
       default_version: v1beta
   - name: google-cloud-parametermanager
@@ -2768,11 +1886,6 @@ libraries:
       - path: google/cloud/parametermanager/v1
     description_override: '(Public Preview) Parameter Manager is a single source of truth to store, access and manage the lifecycle of your workload parameters. Parameter Manager aims to make management of sensitive application parameters effortless for customers without diminishing focus on security. '
     python:
-      opt_args_by_api:
-        google/cloud/parametermanager/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=parametermanager
-          - warehouse-package-name=google-cloud-parametermanager
       name_pretty_override: Parameter Manager API
       default_version: v1
   - name: google-cloud-phishing-protection
@@ -2781,11 +1894,6 @@ libraries:
       - path: google/cloud/phishingprotection/v1beta1
     description_override: helps prevent users from accessing phishing sites by identifying various signals associated with malicious content, including the use of your brand assets, classifying malicious content that uses your brand and reporting the unsafe URLs to Google Safe Browsing. Once a site is propagated to Safe Browsing, users will see warnings across more than 4 billion devices.
     python:
-      opt_args_by_api:
-        google/cloud/phishingprotection/v1beta1:
-          - warehouse-package-name=google-cloud-phishing-protection
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=phishingprotection
       metadata_name_override: phishingprotection
       default_version: v1beta1
   - name: google-cloud-policy-troubleshooter
@@ -2794,11 +1902,6 @@ libraries:
       - path: google/cloud/policytroubleshooter/v1
     description_override: makes it easier to understand why a user has access to a resource or doesn't have permission to call an API. Given an email, resource, and permission, Policy Troubleshooter examines all Identity and Access Management (IAM) policies that apply to the resource. It then reveals whether the member's roles include the permission on that resource and, if so, which policies bind the member to those roles.
     python:
-      opt_args_by_api:
-        google/cloud/policytroubleshooter/v1:
-          - warehouse-package-name=google-cloud-policy-troubleshooter
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=policytroubleshooter
       name_pretty_override: IAM Policy Troubleshooter API
       metadata_name_override: policytroubleshooter
       default_version: v1
@@ -2811,9 +1914,6 @@ libraries:
       opt_args_by_api:
         google/cloud/policysimulator/v1:
           - proto-plus-deps=google.cloud.orgpolicy.v2
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=policysimulator
-          - warehouse-package-name=google-cloud-policysimulator
       name_pretty_override: Policy Simulator API
       metadata_name_override: policysimulator
       default_version: v1
@@ -2822,11 +1922,6 @@ libraries:
     apis:
       - path: google/cloud/policytroubleshooter/iam/v3
     python:
-      opt_args_by_api:
-        google/cloud/policytroubleshooter/iam/v3:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=policytroubleshooter_iam
-          - warehouse-package-name=google-cloud-policytroubleshooter-iam
       name_pretty_override: Policy Troubleshooter API
       metadata_name_override: policytroubleshooter-iam
       default_version: v3
@@ -2839,11 +1934,9 @@ libraries:
     python:
       opt_args_by_api:
         google/cloud/security/privateca/v1:
-          - warehouse-package-name=google-cloud-private-ca
           - python-gapic-namespace=google.cloud.security
           - python-gapic-name=privateca
         google/cloud/security/privateca/v1beta1:
-          - warehouse-package-name=google-cloud-private-ca
           - python-gapic-namespace=google.cloud.security
           - python-gapic-name=privateca
       name_pretty_override: Private Certificate Authority
@@ -2855,11 +1948,6 @@ libraries:
       - path: google/cloud/privatecatalog/v1beta1
     description_override: allows developers and cloud admins to make their solutions discoverable to their internal enterprise users. Cloud admins can manage their solutions and ensure their users are always launching the latest versions.
     python:
-      opt_args_by_api:
-        google/cloud/privatecatalog/v1beta1:
-          - warehouse-package-name=google-cloud-private-catalog
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=privatecatalog
       name_pretty_override: Private Catalog
       metadata_name_override: cloudprivatecatalog
       default_version: v1beta1
@@ -2869,11 +1957,6 @@ libraries:
       - path: google/cloud/privilegedaccessmanager/v1
     description_override: Privileged Access Manager (PAM) helps you on your journey towards least privilege and helps mitigate risks tied to privileged access misuse or abuse. PAM allows you to shift from always-on standing privileges towards on-demand access with just-in-time, time-bound, and approval-based access elevations. PAM allows IAM administrators to create entitlements that can grant just-in-time, temporary access to any resource scope. Requesters can explore eligible entitlements and request the access needed for their task. Approvers are notified when approvals await their decision. Streamlined workflows facilitated by using PAM can support various use cases, including emergency access for incident responders, time-boxed access for developers for critical deployment or maintenance, temporary access for operators for data ingestion and audits, JIT access to service accounts for automated tasks, and more.
     python:
-      opt_args_by_api:
-        google/cloud/privilegedaccessmanager/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=privilegedaccessmanager
-          - warehouse-package-name=google-cloud-privilegedaccessmanager
       name_pretty_override: Privileged Access Manager API
       default_version: v1
   - name: google-cloud-pubsub
@@ -2885,7 +1968,6 @@ libraries:
       library_type: GAPIC_COMBO
       opt_args_by_api:
         google/pubsub/v1:
-          - warehouse-package-name=google-cloud-pubsub
           - python-gapic-namespace=google
           - python-gapic-name=pubsub
       name_pretty_override: Google Cloud Pub/Sub
@@ -2901,12 +1983,8 @@ libraries:
       opt_args_by_api:
         google/api/cloudquotas/v1:
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-quotas
-          - python-gapic-name=cloudquotas
         google/api/cloudquotas/v1beta:
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-quotas
-          - python-gapic-name=cloudquotas
       name_pretty_override: Cloud Quotas API
       metadata_name_override: google-cloud-cloudquotas
       default_version: v1
@@ -2916,11 +1994,6 @@ libraries:
       - path: google/cloud/rapidmigrationassessment/v1
     description_override: The Rapid Migration Assessment service is our first-party migration assessment and planning tool.
     python:
-      opt_args_by_api:
-        google/cloud/rapidmigrationassessment/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=rapidmigrationassessment
-          - warehouse-package-name=google-cloud-rapidmigrationassessment
       name_pretty_override: Rapid Migration Assessment API
       metadata_name_override: rapidmigrationassessment
       default_version: v1
@@ -2930,11 +2003,6 @@ libraries:
       - path: google/cloud/recaptchaenterprise/v1
     description_override: protect your website from fraudulent activity like scraping, credential stuffing, and automated account creation.
     python:
-      opt_args_by_api:
-        google/cloud/recaptchaenterprise/v1:
-          - warehouse-package-name=google-cloud-recaptcha-enterprise
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=recaptchaenterprise
       metadata_name_override: recaptchaenterprise
       default_version: v1
   - name: google-cloud-recommendations-ai
@@ -2943,11 +2011,6 @@ libraries:
       - path: google/cloud/recommendationengine/v1beta1
     description_override: delivers highly personalized product recommendations at scale.
     python:
-      opt_args_by_api:
-        google/cloud/recommendationengine/v1beta1:
-          - warehouse-package-name=google-cloud-recommendations-ai
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=recommendationengine
       metadata_name_override: recommendationengine
       default_version: v1beta1
   - name: google-cloud-recommender
@@ -2957,15 +2020,6 @@ libraries:
       - path: google/cloud/recommender/v1beta1
     description_override: delivers highly personalized product recommendations at scale.
     python:
-      opt_args_by_api:
-        google/cloud/recommender/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=recommender
-          - warehouse-package-name=google-cloud-recommender
-        google/cloud/recommender/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=recommender
-          - warehouse-package-name=google-cloud-recommender
       name_pretty_override: Cloud Recommender
       metadata_name_override: recommender
       default_version: v1
@@ -2976,15 +2030,6 @@ libraries:
       - path: google/cloud/redis/v1beta1
     description_override: is a fully managed Redis service for the Google Cloud. Applications running on Google Cloud can achieve extreme performance by leveraging the highly scalable, available, secure Redis service without the burden of managing complex Redis deployments.
     python:
-      opt_args_by_api:
-        google/cloud/redis/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=redis
-          - warehouse-package-name=google-cloud-redis
-        google/cloud/redis/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=redis
-          - warehouse-package-name=google-cloud-redis
       name_pretty_override: Cloud Redis
       metadata_name_override: redis
       default_version: v1
@@ -2995,15 +2040,6 @@ libraries:
       - path: google/cloud/redis/cluster/v1beta1
     description_override: Creates and manages Redis instances on the Google Cloud Platform.
     python:
-      opt_args_by_api:
-        google/cloud/redis/cluster/v1:
-          - python-gapic-name=redis_cluster
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-redis-cluster
-        google/cloud/redis/cluster/v1beta1:
-          - python-gapic-name=redis_cluster
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-redis-cluster
       name_pretty_override: Google Cloud Memorystore for Redis API
       default_version: v1
   - name: google-cloud-resource-manager
@@ -3012,11 +2048,6 @@ libraries:
       - path: google/cloud/resourcemanager/v3
     description_override: provides methods that you can use to programmatically manage your projects in the Google Cloud Platform.
     python:
-      opt_args_by_api:
-        google/cloud/resourcemanager/v3:
-          - warehouse-package-name=google-cloud-resource-manager
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=resourcemanager
       name_pretty_override: Resource Manager
       metadata_name_override: cloudresourcemanager
       default_version: v3
@@ -3028,19 +2059,6 @@ libraries:
       - path: google/cloud/retail/v2alpha
     description_override: Cloud Retail service enables customers to build end-to-end personalized recommendation systems without requiring a high level of expertise in machine learning, recommendation system, or Google Cloud.
     python:
-      opt_args_by_api:
-        google/cloud/retail/v2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=retail
-          - warehouse-package-name=google-cloud-retail
-        google/cloud/retail/v2alpha:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=retail
-          - warehouse-package-name=google-cloud-retail
-        google/cloud/retail/v2beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=retail
-          - warehouse-package-name=google-cloud-retail
       name_pretty_override: Retail
       metadata_name_override: retail
       default_version: v2
@@ -3050,11 +2068,6 @@ libraries:
       - path: google/cloud/run/v2
     description_override: is a managed compute platform that enables you to run containers that are invocable via requests or events.
     python:
-      opt_args_by_api:
-        google/cloud/run/v2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=run
-          - warehouse-package-name=google-cloud-run
       name_pretty_override: Cloud Run
       metadata_name_override: run
       default_version: v2
@@ -3071,11 +2084,6 @@ libraries:
       - path: google/cloud/saasplatform/saasservicemgmt/v1beta1
     description_override: SaaS Runtime lets you store, host, manage, and monitor software as a service (SaaS) applications on Google Cloud.
     python:
-      opt_args_by_api:
-        google/cloud/saasplatform/saasservicemgmt/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=saasplatform_saasservicemgmt
-          - warehouse-package-name=google-cloud-saasplatform-saasservicemgmt
       name_pretty_override: SaaS Runtime API
       default_version: v1beta1
   - name: google-cloud-scheduler
@@ -3085,15 +2093,6 @@ libraries:
       - path: google/cloud/scheduler/v1beta1
     description_override: lets you set up scheduled units of work to be executed at defined times or regular intervals. These work units are commonly known as cron jobs. Typical use cases might include sending out a report email on a daily basis, updating some cached data every 10 minutes, or updating some summary information once an hour.
     python:
-      opt_args_by_api:
-        google/cloud/scheduler/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=scheduler
-          - warehouse-package-name=google-cloud-scheduler
-        google/cloud/scheduler/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=scheduler
-          - warehouse-package-name=google-cloud-scheduler
       metadata_name_override: cloudscheduler
       default_version: v1
   - name: google-cloud-secret-manager
@@ -3105,18 +2104,8 @@ libraries:
     description_override: Stores, manages, and secures access to application secrets.
     python:
       opt_args_by_api:
-        google/cloud/secretmanager/v1:
-          - warehouse-package-name=google-cloud-secret-manager
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=secretmanager
-        google/cloud/secretmanager/v1beta2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=secretmanager
-          - warehouse-package-name=google-cloud-secret-manager
         google/cloud/secrets/v1beta1:
-          - python-gapic-namespace=google.cloud
           - python-gapic-name=secretmanager
-          - warehouse-package-name=google-cloud-secret-manager
       metadata_name_override: secretmanager
       default_version: v1
   - name: google-cloud-securesourcemanager
@@ -3125,11 +2114,6 @@ libraries:
       - path: google/cloud/securesourcemanager/v1
     description_override: Regionally deployed, single-tenant managed source code repository hosted on Google Cloud.
     python:
-      opt_args_by_api:
-        google/cloud/securesourcemanager/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=securesourcemanager
-          - warehouse-package-name=google-cloud-securesourcemanager
       name_pretty_override: Secure Source Manager API
       metadata_name_override: securesourcemanager
       default_version: v1
@@ -3144,7 +2128,6 @@ libraries:
         google/cloud/security/publicca/v1:
           - python-gapic-namespace=google.cloud.security
           - python-gapic-name=publicca
-          - warehouse-package-name=google-cloud-security-publicca
         google/cloud/security/publicca/v1beta1:
           - warehouse-package-name=google-cloud-public-ca
           - python-gapic-namespace=google.cloud.security
@@ -3160,23 +2143,6 @@ libraries:
       - path: google/cloud/securitycenter/v1beta1
     description_override: makes it easier for you to prevent, detect, and respond to threats. Identify security misconfigurations in virtual machines, networks, applications, and storage buckets from a centralized dashboard. Take action on them before they can potentially result in business damage or loss. Built-in capabilities can quickly surface suspicious activity in your Stackdriver security logs or indicate compromised virtual machines. Respond to threats by following actionable recommendations or exporting logs to your SIEM for further investigation.
     python:
-      opt_args_by_api:
-        google/cloud/securitycenter/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=securitycenter
-          - warehouse-package-name=google-cloud-securitycenter
-        google/cloud/securitycenter/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=securitycenter
-          - warehouse-package-name=google-cloud-securitycenter
-        google/cloud/securitycenter/v1p1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=securitycenter
-          - warehouse-package-name=google-cloud-securitycenter
-        google/cloud/securitycenter/v2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=securitycenter
-          - warehouse-package-name=google-cloud-securitycenter
       name_pretty_override: Google Cloud Security Command Center
       metadata_name_override: securitycenter
       default_version: v1
@@ -3185,11 +2151,6 @@ libraries:
     apis:
       - path: google/cloud/securitycentermanagement/v1
     python:
-      opt_args_by_api:
-        google/cloud/securitycentermanagement/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=securitycentermanagement
-          - warehouse-package-name=google-cloud-securitycentermanagement
       name_pretty_override: Security Center Management API
       default_version: v1
   - name: google-cloud-service-control
@@ -3201,13 +2162,9 @@ libraries:
     python:
       opt_args_by_api:
         google/api/servicecontrol/v1:
-          - python-gapic-name=servicecontrol
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-service-control
         google/api/servicecontrol/v2:
-          - python-gapic-name=servicecontrol
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-service-control
       metadata_name_override: servicecontrol
       default_version: v1
   - name: google-cloud-service-directory
@@ -3217,15 +2174,6 @@ libraries:
       - path: google/cloud/servicedirectory/v1beta1
     description_override: Allows the registration and lookup of services.
     python:
-      opt_args_by_api:
-        google/cloud/servicedirectory/v1:
-          - warehouse-package-name=google-cloud-service-directory
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=servicedirectory
-        google/cloud/servicedirectory/v1beta1:
-          - warehouse-package-name=google-cloud-service-directory
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=servicedirectory
       metadata_name_override: servicedirectory
       default_version: v1
   - name: google-cloud-service-management
@@ -3236,9 +2184,7 @@ libraries:
     python:
       opt_args_by_api:
         google/api/servicemanagement/v1:
-          - python-gapic-name=servicemanagement
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-service-management
       metadata_name_override: servicemanagement
       default_version: v1
   - name: google-cloud-service-usage
@@ -3251,7 +2197,6 @@ libraries:
         google/api/serviceusage/v1:
           - python-gapic-name=service_usage
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-service-usage
       metadata_name_override: serviceusage
       default_version: v1
   - name: google-cloud-servicehealth
@@ -3260,11 +2205,6 @@ libraries:
       - path: google/cloud/servicehealth/v1
     description_override: Personalized Service Health helps you gain visibility into disruptive events impacting Google Cloud products.
     python:
-      opt_args_by_api:
-        google/cloud/servicehealth/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=servicehealth
-          - warehouse-package-name=google-cloud-servicehealth
       name_pretty_override: Service Health API
       default_version: v1
   - name: google-cloud-shell
@@ -3273,11 +2213,6 @@ libraries:
       - path: google/cloud/shell/v1
     description_override: is an interactive shell environment for Google Cloud that makes it easy for you to learn and experiment with Google Cloud and manage your projects and resources from your web browser.
     python:
-      opt_args_by_api:
-        google/cloud/shell/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=shell
-          - warehouse-package-name=google-cloud-shell
       metadata_name_override: cloudshell
       default_version: v1
   - name: google-cloud-source-context
@@ -3290,7 +2225,6 @@ libraries:
       library_type: OTHER
       opt_args_by_api:
         google/devtools/source/v1:
-          - warehouse-package-name=google-cloud-source-context
           - python-gapic-namespace=google.cloud
           - python-gapic-name=source_context
       name_pretty_override: Source Context
@@ -3321,15 +2255,12 @@ libraries:
         google/spanner/admin/database/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=spanner_admin_database
-          - warehouse-package-name=google-cloud-spanner
         google/spanner/admin/instance/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=spanner_admin_instance
-          - warehouse-package-name=google-cloud-spanner
         google/spanner/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=spanner
-          - warehouse-package-name=google-cloud-spanner
       metadata_name_override: spanner
       default_version: v1
   - name: google-cloud-speech
@@ -3341,19 +2272,6 @@ libraries:
     description_override: enables easy integration of Google speech recognition technologies into developer applications. Send audio and receive a text transcription from the Speech-to-Text API service.
     python:
       library_type: GAPIC_COMBO
-      opt_args_by_api:
-        google/cloud/speech/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=speech
-          - warehouse-package-name=google-cloud-speech
-        google/cloud/speech/v1p1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=speech
-          - warehouse-package-name=google-cloud-speech
-        google/cloud/speech/v2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=speech
-          - warehouse-package-name=google-cloud-speech
       name_pretty_override: Cloud Speech
       metadata_name_override: speech
       default_version: v1
@@ -3368,7 +2286,6 @@ libraries:
         google/storage/v2:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=_storage
-          - warehouse-package-name=google-cloud-storage
       name_pretty_override: Google Cloud Storage
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559782
       metadata_name_override: storage
@@ -3383,7 +2300,6 @@ libraries:
         google/storage/control/v2:
           - python-gapic-name=storage_control
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-storage-control
       name_pretty_override: Storage Control API
       default_version: v2
   - name: google-cloud-storage-transfer
@@ -3396,7 +2312,6 @@ libraries:
         google/storagetransfer/v1:
           - python-gapic-name=storage_transfer
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-storage-transfer
       name_pretty_override: Storage Transfer Service
       metadata_name_override: storagetransfer
       default_version: v1
@@ -3406,11 +2321,6 @@ libraries:
       - path: google/cloud/storagebatchoperations/v1
     description_override: 'null '
     python:
-      opt_args_by_api:
-        google/cloud/storagebatchoperations/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=storagebatchoperations
-          - warehouse-package-name=google-cloud-storagebatchoperations
       name_pretty_override: Storage Batch Operations API
       default_version: v1
   - name: google-cloud-storageinsights
@@ -3419,11 +2329,6 @@ libraries:
       - path: google/cloud/storageinsights/v1
     description_override: The Storage Insights inventory report feature helps you manage your object storage at scale.
     python:
-      opt_args_by_api:
-        google/cloud/storageinsights/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=storageinsights
-          - warehouse-package-name=google-cloud-storageinsights
       name_pretty_override: Storage Insights API
       metadata_name_override: storageinsights
       default_version: v1
@@ -3434,15 +2339,6 @@ libraries:
       - path: google/cloud/support/v2beta
     description_override: Manages Google Cloud technical support cases for Customer Care support offerings.
     python:
-      opt_args_by_api:
-        google/cloud/support/v2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=support
-          - warehouse-package-name=google-cloud-support
-        google/cloud/support/v2beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=support
-          - warehouse-package-name=google-cloud-support
       name_pretty_override: Google Cloud Support API
       metadata_name_override: support
       default_version: v2
@@ -3453,15 +2349,6 @@ libraries:
       - path: google/cloud/talent/v4beta1
     description_override: Cloud Talent Solution provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.
     python:
-      opt_args_by_api:
-        google/cloud/talent/v4:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=talent
-          - warehouse-package-name=google-cloud-talent
-        google/cloud/talent/v4beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=talent
-          - warehouse-package-name=google-cloud-talent
       name_pretty_override: Talent Solution
       metadata_name_override: talent
       default_version: v4
@@ -3473,19 +2360,6 @@ libraries:
       - path: google/cloud/tasks/v2beta2
     description_override: a fully managed service that allows you to manage the execution, dispatch and delivery of a large number of distributed tasks. You can asynchronously perform work outside of a user request. Your tasks can be executed on App Engine or any arbitrary HTTP endpoint.
     python:
-      opt_args_by_api:
-        google/cloud/tasks/v2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=tasks
-          - warehouse-package-name=google-cloud-tasks
-        google/cloud/tasks/v2beta2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=tasks
-          - warehouse-package-name=google-cloud-tasks
-        google/cloud/tasks/v2beta3:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=tasks
-          - warehouse-package-name=google-cloud-tasks
       metadata_name_override: cloudtasks
       default_version: v2
   - name: google-cloud-telcoautomation
@@ -3495,15 +2369,6 @@ libraries:
       - path: google/cloud/telcoautomation/v1alpha1
     description_override: APIs to automate 5G deployment and management of cloud infrastructure and network functions.
     python:
-      opt_args_by_api:
-        google/cloud/telcoautomation/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=telcoautomation
-          - warehouse-package-name=google-cloud-telcoautomation
-        google/cloud/telcoautomation/v1alpha1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=telcoautomation
-          - warehouse-package-name=google-cloud-telcoautomation
       name_pretty_override: Telco Automation API
       default_version: v1
   - name: google-cloud-testutils
@@ -3520,15 +2385,6 @@ libraries:
       - path: google/cloud/texttospeech/v1beta1
     description_override: enables easy integration of Google text recognition technologies into developer applications. Send text and receive synthesized audio output from the Cloud Text-to-Speech API service.
     python:
-      opt_args_by_api:
-        google/cloud/texttospeech/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=texttospeech
-          - warehouse-package-name=google-cloud-texttospeech
-        google/cloud/texttospeech/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=texttospeech
-          - warehouse-package-name=google-cloud-texttospeech
       name_pretty_override: Google Cloud Text-to-Speech
       metadata_name_override: texttospeech
       default_version: v1
@@ -3540,19 +2396,6 @@ libraries:
       - path: google/cloud/tpu/v2alpha1
     description_override: Cloud Tensor Processing Units (TPUs) are Google's custom-developed application-specific integrated circuits (ASICs) used to accelerate machine learning workloads.
     python:
-      opt_args_by_api:
-        google/cloud/tpu/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=tpu
-          - warehouse-package-name=google-cloud-tpu
-        google/cloud/tpu/v2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=tpu
-          - warehouse-package-name=google-cloud-tpu
-        google/cloud/tpu/v2alpha1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=tpu
-          - warehouse-package-name=google-cloud-tpu
       metadata_name_override: tpu
       default_version: v1
   - name: google-cloud-trace
@@ -3566,11 +2409,9 @@ libraries:
         google/devtools/cloudtrace/v1:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=trace
-          - warehouse-package-name=google-cloud-trace
         google/devtools/cloudtrace/v2:
           - python-gapic-name=trace
           - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-trace
       metadata_name_override: cloudtrace
       default_version: v2
   - name: google-cloud-translate
@@ -3581,15 +2422,6 @@ libraries:
     description_override: can dynamically translate text between thousands of language pairs. Translation lets websites and programs programmatically integrate with the translation service.
     python:
       library_type: GAPIC_COMBO
-      opt_args_by_api:
-        google/cloud/translate/v3:
-          - python-gapic-name=translate
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-translate
-        google/cloud/translate/v3beta1:
-          - python-gapic-name=translate
-          - python-gapic-namespace=google.cloud
-          - warehouse-package-name=google-cloud-translate
       metadata_name_override: translate
       default_version: v3
   - name: google-cloud-vectorsearch
@@ -3608,15 +2440,6 @@ libraries:
       approximate nearest neighbor (ANN) searches to find semantically similar
       items at scale.
     python:
-      opt_args_by_api:
-        google/cloud/vectorsearch/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=vectorsearch
-          - warehouse-package-name=google-cloud-vectorsearch
-        google/cloud/vectorsearch/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=vectorsearch
-          - warehouse-package-name=google-cloud-vectorsearch
       name_pretty_override: Vector Search API
       default_version: v1
   - name: google-cloud-video-live-stream
@@ -3629,7 +2452,6 @@ libraries:
         google/cloud/video/livestream/v1:
           - python-gapic-name=live_stream
           - python-gapic-namespace=google.cloud.video
-          - warehouse-package-name=google-cloud-video-live-stream
       metadata_name_override: livestream
       default_version: v1
   - name: google-cloud-video-stitcher
@@ -3642,7 +2464,6 @@ libraries:
         google/cloud/video/stitcher/v1:
           - python-gapic-namespace=google.cloud.video
           - python-gapic-name=stitcher
-          - warehouse-package-name=google-cloud-video-stitcher
       metadata_name_override: videostitcher
       default_version: v1
   - name: google-cloud-video-transcoder
@@ -3655,7 +2476,6 @@ libraries:
         google/cloud/video/transcoder/v1:
           - python-gapic-namespace=google.cloud.video
           - python-gapic-name=transcoder
-          - warehouse-package-name=google-cloud-video-transcoder
       metadata_name_override: transcoder
       default_version: v1
   - name: google-cloud-videointelligence
@@ -3668,27 +2488,6 @@ libraries:
       - path: google/cloud/videointelligence/v1beta2
     description_override: makes videos searchable, and discoverable, by extracting metadata with an easy to use API. You can now search every moment of every video file in your catalog and find every occurrence as well as its significance. It quickly annotates videos stored in Google Cloud Storage, and helps you identify key nouns entities of your video, and when they occur within the video. Separate signal from noise, by retrieving relevant information at the video, shot or per frame.
     python:
-      opt_args_by_api:
-        google/cloud/videointelligence/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=videointelligence
-          - warehouse-package-name=google-cloud-videointelligence
-        google/cloud/videointelligence/v1beta2:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=videointelligence
-          - warehouse-package-name=google-cloud-videointelligence
-        google/cloud/videointelligence/v1p1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=videointelligence
-          - warehouse-package-name=google-cloud-videointelligence
-        google/cloud/videointelligence/v1p2beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=videointelligence
-          - warehouse-package-name=google-cloud-videointelligence
-        google/cloud/videointelligence/v1p3beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=videointelligence
-          - warehouse-package-name=google-cloud-videointelligence
       name_pretty_override: Video Intelligence
       metadata_name_override: videointelligence
       default_version: v1
@@ -3703,27 +2502,6 @@ libraries:
     description_override: allows developers to easily integrate vision detection features within applications, including image labeling, face and landmark detection, optical character recognition (OCR), and tagging of explicit content.
     python:
       library_type: GAPIC_COMBO
-      opt_args_by_api:
-        google/cloud/vision/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=vision
-          - warehouse-package-name=google-cloud-vision
-        google/cloud/vision/v1p1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=vision
-          - warehouse-package-name=google-cloud-vision
-        google/cloud/vision/v1p2beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=vision
-          - warehouse-package-name=google-cloud-vision
-        google/cloud/vision/v1p3beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=vision
-          - warehouse-package-name=google-cloud-vision
-        google/cloud/vision/v1p4beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=vision
-          - warehouse-package-name=google-cloud-vision
       metadata_name_override: vision
       default_version: v1
   - name: google-cloud-visionai
@@ -3733,15 +2511,6 @@ libraries:
       - path: google/cloud/visionai/v1alpha1
     description_override: Easily build and deploy Vertex AI Vision applications using a single platform.
     python:
-      opt_args_by_api:
-        google/cloud/visionai/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=visionai
-          - warehouse-package-name=google-cloud-visionai
-        google/cloud/visionai/v1alpha1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=visionai
-          - warehouse-package-name=google-cloud-visionai
       name_pretty_override: Vision AI API
       default_version: v1
   - name: google-cloud-vm-migration
@@ -3750,11 +2519,6 @@ libraries:
       - path: google/cloud/vmmigration/v1
     description_override: ' for Compute Engine migrates VMs from your on-premises data center into Compute Engine.'
     python:
-      opt_args_by_api:
-        google/cloud/vmmigration/v1:
-          - warehouse-package-name=google-cloud-vm-migration
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=vmmigration
       name_pretty_override: Cloud VM Migration
       metadata_name_override: vmmigration
       default_version: v1
@@ -3763,11 +2527,6 @@ libraries:
     apis:
       - path: google/cloud/vmwareengine/v1
     python:
-      opt_args_by_api:
-        google/cloud/vmwareengine/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=vmwareengine
-          - warehouse-package-name=google-cloud-vmwareengine
       name_pretty_override: Google Cloud VMware Engine
       metadata_name_override: vmwareengine
       default_version: v1
@@ -3777,11 +2536,6 @@ libraries:
       - path: google/cloud/vpcaccess/v1
     description_override: provides networking functionality to Compute Engine virtual machine (VM) instances, Google Kubernetes Engine (GKE) containers, and the App Engine flexible environment. VPC provides networking for your cloud-based services that is global, scalable, and flexible.
     python:
-      opt_args_by_api:
-        google/cloud/vpcaccess/v1:
-          - warehouse-package-name=google-cloud-vpc-access
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=vpcaccess
       name_pretty_override: Virtual Private Cloud
       metadata_name_override: vpcaccess
       default_version: v1
@@ -3792,15 +2546,6 @@ libraries:
       - path: google/cloud/webrisk/v1beta1
     description_override: is a Google Cloud service that lets client applications check URLs against Google's constantly updated lists of unsafe web resources. Unsafe web resources include social engineering sites—such as phishing and deceptive sites—and sites that host malware or unwanted software. With the Web Risk API, you can quickly identify known bad sites, warn users before they click infected links, and prevent users from posting links to known infected pages from your site. The Web Risk API includes data on more than a million unsafe URLs and stays up to date by examining billions of URLs each day.
     python:
-      opt_args_by_api:
-        google/cloud/webrisk/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=webrisk
-          - warehouse-package-name=google-cloud-webrisk
-        google/cloud/webrisk/v1beta1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=webrisk
-          - warehouse-package-name=google-cloud-webrisk
       metadata_name_override: webrisk
       default_version: v1
   - name: google-cloud-websecurityscanner
@@ -3811,19 +2556,6 @@ libraries:
       - path: google/cloud/websecurityscanner/v1alpha
     description_override: identifies security vulnerabilities in your App Engine, Compute Engine, and Google Kubernetes Engine web applications. It crawls your application, following all links within the scope of your starting URLs, and attempts to exercise as many user inputs and event handlers as possible.
     python:
-      opt_args_by_api:
-        google/cloud/websecurityscanner/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=websecurityscanner
-          - warehouse-package-name=google-cloud-websecurityscanner
-        google/cloud/websecurityscanner/v1alpha:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=websecurityscanner
-          - warehouse-package-name=google-cloud-websecurityscanner
-        google/cloud/websecurityscanner/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=websecurityscanner
-          - warehouse-package-name=google-cloud-websecurityscanner
       name_pretty_override: Cloud Security Scanner
       metadata_name_override: websecurityscanner
       default_version: v1
@@ -3840,19 +2572,9 @@ libraries:
         google/cloud/workflows/executions/v1:
           - python-gapic-namespace=google.cloud.workflows
           - python-gapic-name=executions
-          - warehouse-package-name=google-cloud-workflows
         google/cloud/workflows/executions/v1beta:
           - python-gapic-namespace=google.cloud.workflows
           - python-gapic-name=executions
-          - warehouse-package-name=google-cloud-workflows
-        google/cloud/workflows/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=workflows
-          - warehouse-package-name=google-cloud-workflows
-        google/cloud/workflows/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=workflows
-          - warehouse-package-name=google-cloud-workflows
       name_pretty_override: Cloud Workflows
       metadata_name_override: workflows
       default_version: v1
@@ -3865,11 +2587,6 @@ libraries:
       workloads to automate the deployment and validation of your workloads
       against best practices and recommendations.
     python:
-      opt_args_by_api:
-        google/cloud/workloadmanager/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=workloadmanager
-          - warehouse-package-name=google-cloud-workloadmanager
       name_pretty_override: Workload Manager API
       default_version: v1
   - name: google-cloud-workstations
@@ -3878,15 +2595,6 @@ libraries:
       - path: google/cloud/workstations/v1
       - path: google/cloud/workstations/v1beta
     python:
-      opt_args_by_api:
-        google/cloud/workstations/v1:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=workstations
-          - warehouse-package-name=google-cloud-workstations
-        google/cloud/workstations/v1beta:
-          - python-gapic-namespace=google.cloud
-          - python-gapic-name=workstations
-          - warehouse-package-name=google-cloud-workstations
       metadata_name_override: workstations
       default_version: v1
   - name: google-crc32c
@@ -3905,11 +2613,6 @@ libraries:
       - tests/unit/gapic/type/test_type.py
     python:
       library_type: OTHER
-      opt_args_by_api:
-        google/geo/type:
-          - python-gapic-namespace=google.geo
-          - python-gapic-name=type
-          - warehouse-package-name=google-geo-type
       name_pretty_override: Geo Type Protos
       metadata_name_override: geotype
       default_version: apiVersion
@@ -3922,9 +2625,6 @@ libraries:
       opt_args_by_api:
         google/maps/addressvalidation/v1:
           - proto-plus-deps=google.geo.type
-          - python-gapic-namespace=google.maps
-          - python-gapic-name=addressvalidation
-          - warehouse-package-name=google-maps-addressvalidation
       name_pretty_override: Address Validation API
       metadata_name_override: addressvalidation
       default_version: v1
@@ -3934,11 +2634,6 @@ libraries:
       - path: google/maps/areainsights/v1
     description_override: 'Places Insights API. '
     python:
-      opt_args_by_api:
-        google/maps/areainsights/v1:
-          - python-gapic-namespace=google.maps
-          - python-gapic-name=areainsights
-          - warehouse-package-name=google-maps-areainsights
       name_pretty_override: Places Insights API
       default_version: v1
   - name: google-maps-fleetengine
@@ -3949,10 +2644,7 @@ libraries:
     python:
       opt_args_by_api:
         google/maps/fleetengine/v1:
-          - python-gapic-namespace=google.maps
           - proto-plus-deps=google.geo.type
-          - python-gapic-name=fleetengine
-          - warehouse-package-name=google-maps-fleetengine
       name_pretty_override: Local Rides and Deliveries API
       metadata_name_override: fleetengine
       default_version: v1
@@ -3964,10 +2656,7 @@ libraries:
     python:
       opt_args_by_api:
         google/maps/fleetengine/delivery/v1:
-          - python-gapic-namespace=google.maps
-          - python-gapic-name=fleetengine_delivery
           - proto-plus-deps=google.geo.type
-          - warehouse-package-name=google-maps-fleetengine-delivery
       name_pretty_override: Last Mile Fleet Solution Delivery API
       metadata_name_override: fleetengine-delivery
       default_version: v1
@@ -3983,9 +2672,6 @@ libraries:
       opt_args_by_api:
         google/maps/geocode/v4:
           - proto-plus-deps=google.geo.type
-          - python-gapic-namespace=google.maps
-          - python-gapic-name=geocode
-          - warehouse-package-name=google-maps-geocode
       name_pretty_override: Geocoding API
       client_documentation_override: https://cloud.google.com/python/docs/reference/google-maps-geocode/latest
       default_version: v4
@@ -3995,11 +2681,6 @@ libraries:
       - path: google/maps/mapsplatformdatasets/v1
     description_override: Maps Platform Datasets API
     python:
-      opt_args_by_api:
-        google/maps/mapsplatformdatasets/v1:
-          - python-gapic-namespace=google.maps
-          - python-gapic-name=mapsplatformdatasets
-          - warehouse-package-name=google-maps-mapsplatformdatasets
       name_pretty_override: Maps Platform Datasets API
       metadata_name_override: mapsplatformdatasets
       default_version: v1
@@ -4009,11 +2690,6 @@ libraries:
       - path: google/maps/navconnect/v1
     description_override: Navigation Connect API.
     python:
-      opt_args_by_api:
-        google/maps/navconnect/v1:
-          - python-gapic-namespace=google.maps
-          - python-gapic-name=navconnect
-          - warehouse-package-name=google-maps-navconnect
       name_pretty_override: Navigation Connect API
       client_documentation_override: https://cloud.google.com/python/docs/reference/google-maps-navconnect/latest
       default_version: v1
@@ -4027,9 +2703,6 @@ libraries:
         google/maps/places/v1:
           - autogen-snippets=False
           - proto-plus-deps=google.geo.type
-          - python-gapic-namespace=google.maps
-          - python-gapic-name=places
-          - warehouse-package-name=google-maps-places
       name_pretty_override: Places API
       metadata_name_override: places
       default_version: v1
@@ -4039,11 +2712,6 @@ libraries:
       - path: google/maps/routeoptimization/v1
     description_override: The Route Optimization API assigns tasks and routes to a vehicle fleet, optimizing against the objectives and constraints that you supply for your transportation goals.
     python:
-      opt_args_by_api:
-        google/maps/routeoptimization/v1:
-          - python-gapic-namespace=google.maps
-          - python-gapic-name=routeoptimization
-          - warehouse-package-name=google-maps-routeoptimization
       name_pretty_override: Route Optimization API
       default_version: v1
   - name: google-maps-routing
@@ -4055,9 +2723,6 @@ libraries:
       opt_args_by_api:
         google/maps/routing/v2:
           - proto-plus-deps=google.geo.type
-          - python-gapic-namespace=google.maps
-          - python-gapic-name=routing
-          - warehouse-package-name=google-maps-routing
       name_pretty_override: Google Maps Routing
       metadata_name_override: routing
       default_version: v2
@@ -4067,11 +2732,6 @@ libraries:
       - path: google/maps/solar/v1
     description_override: The Google Maps Platform Solar API is a service focused on helping accelerate solar and energy system installations.
     python:
-      opt_args_by_api:
-        google/maps/solar/v1:
-          - python-gapic-namespace=google.maps
-          - python-gapic-name=solar
-          - warehouse-package-name=google-maps-solar
       name_pretty_override: Solar API
       default_version: v1
   - name: google-resumable-media
@@ -4089,9 +2749,6 @@ libraries:
       opt_args_by_api:
         google/shopping/css/v1:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-namespace=google.shopping
-          - python-gapic-name=css
-          - warehouse-package-name=google-shopping-css
       name_pretty_override: CSS API
       default_version: v1
   - name: google-shopping-merchant-accounts
@@ -4104,14 +2761,8 @@ libraries:
       opt_args_by_api:
         google/shopping/merchant/accounts/v1:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_accounts
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-accounts
         google/shopping/merchant/accounts/v1beta:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_accounts
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-accounts
       name_pretty_override: Merchant API
       default_version: v1
   - name: google-shopping-merchant-conversions
@@ -4121,15 +2772,6 @@ libraries:
       - path: google/shopping/merchant/conversions/v1beta
     description_override: Programmatically manage your Merchant Center accounts.
     python:
-      opt_args_by_api:
-        google/shopping/merchant/conversions/v1:
-          - python-gapic-namespace=google.shopping
-          - python-gapic-name=merchant_conversions
-          - warehouse-package-name=google-shopping-merchant-conversions
-        google/shopping/merchant/conversions/v1beta:
-          - python-gapic-name=merchant_conversions
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-conversions
       name_pretty_override: Merchant API
       default_version: v1
   - name: google-shopping-merchant-datasources
@@ -4142,14 +2784,8 @@ libraries:
       opt_args_by_api:
         google/shopping/merchant/datasources/v1:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_datasources
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-datasources
         google/shopping/merchant/datasources/v1beta:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_datasources
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-datasources
       name_pretty_override: Merchant API
       default_version: v1
   - name: google-shopping-merchant-inventories
@@ -4162,14 +2798,8 @@ libraries:
       opt_args_by_api:
         google/shopping/merchant/inventories/v1:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_inventories
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-inventories
         google/shopping/merchant/inventories/v1beta:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-namespace=google.shopping
-          - python-gapic-name=merchant_inventories
-          - warehouse-package-name=google-shopping-merchant-inventories
       name_pretty_override: Merchant Inventories API
       default_version: v1
   - name: google-shopping-merchant-issueresolution
@@ -4182,14 +2812,8 @@ libraries:
       opt_args_by_api:
         google/shopping/merchant/issueresolution/v1:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_issueresolution
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-issueresolution
         google/shopping/merchant/issueresolution/v1beta:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-namespace=google.shopping
-          - python-gapic-name=merchant_issueresolution
-          - warehouse-package-name=google-shopping-merchant-issueresolution
       name_pretty_override: Merchant API
       default_version: v1
   - name: google-shopping-merchant-lfp
@@ -4202,14 +2826,8 @@ libraries:
       opt_args_by_api:
         google/shopping/merchant/lfp/v1:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_lfp
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-lfp
         google/shopping/merchant/lfp/v1beta:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_lfp
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-lfp
       name_pretty_override: Merchant API
       default_version: v1
   - name: google-shopping-merchant-notifications
@@ -4220,15 +2838,8 @@ libraries:
     description_override: Programmatically manage your Merchant Center accounts.
     python:
       opt_args_by_api:
-        google/shopping/merchant/notifications/v1:
-          - python-gapic-namespace=google.shopping
-          - python-gapic-name=merchant_notifications
-          - warehouse-package-name=google-shopping-merchant-notifications
         google/shopping/merchant/notifications/v1beta:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-namespace=google.shopping
-          - python-gapic-name=merchant_notifications
-          - warehouse-package-name=google-shopping-merchant-notifications
       name_pretty_override: Merchant API
       default_version: v1
   - name: google-shopping-merchant-ordertracking
@@ -4241,14 +2852,8 @@ libraries:
       opt_args_by_api:
         google/shopping/merchant/ordertracking/v1:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_ordertracking
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-ordertracking
         google/shopping/merchant/ordertracking/v1beta:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-namespace=google.shopping
-          - python-gapic-name=merchant_ordertracking
-          - warehouse-package-name=google-shopping-merchant-ordertracking
       name_pretty_override: Merchant API
       default_version: v1
   - name: google-shopping-merchant-products
@@ -4261,14 +2866,8 @@ libraries:
       opt_args_by_api:
         google/shopping/merchant/products/v1:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_products
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-products
         google/shopping/merchant/products/v1beta:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-namespace=google.shopping
-          - python-gapic-name=merchant_products
-          - warehouse-package-name=google-shopping-merchant-products
       name_pretty_override: Merchant API
       default_version: v1
   - name: google-shopping-merchant-productstudio
@@ -4277,11 +2876,6 @@ libraries:
       - path: google/shopping/merchant/productstudio/v1alpha
     description_override: Programmatically manage your Merchant Center accounts.
     python:
-      opt_args_by_api:
-        google/shopping/merchant/productstudio/v1alpha:
-          - python-gapic-name=merchant_productstudio
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-productstudio
       name_pretty_override: Merchant ProductStudio API
       default_version: v1alpha
   - name: google-shopping-merchant-promotions
@@ -4294,14 +2888,8 @@ libraries:
       opt_args_by_api:
         google/shopping/merchant/promotions/v1:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_promotions
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-promotions
         google/shopping/merchant/promotions/v1beta:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-namespace=google.shopping
-          - python-gapic-name=merchant_promotions
-          - warehouse-package-name=google-shopping-merchant-promotions
       name_pretty_override: Merchant API
       default_version: v1
   - name: google-shopping-merchant-quota
@@ -4311,15 +2899,6 @@ libraries:
       - path: google/shopping/merchant/quota/v1beta
     description_override: Programmatically manage your Merchant Center accounts.
     python:
-      opt_args_by_api:
-        google/shopping/merchant/quota/v1:
-          - python-gapic-namespace=google.shopping
-          - python-gapic-name=merchant_quota
-          - warehouse-package-name=google-shopping-merchant-quota
-        google/shopping/merchant/quota/v1beta:
-          - python-gapic-namespace=google.shopping
-          - python-gapic-name=merchant_quota
-          - warehouse-package-name=google-shopping-merchant-quota
       name_pretty_override: Shopping Merchant Quota
       default_version: v1
   - name: google-shopping-merchant-reports
@@ -4333,19 +2912,10 @@ libraries:
       opt_args_by_api:
         google/shopping/merchant/reports/v1:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_reports
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-reports
         google/shopping/merchant/reports/v1alpha:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_reports
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-reports
         google/shopping/merchant/reports/v1beta:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_reports
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-reports
       name_pretty_override: Merchant Reports API
       default_version: v1
   - name: google-shopping-merchant-reviews
@@ -4357,9 +2927,6 @@ libraries:
       opt_args_by_api:
         google/shopping/merchant/reviews/v1beta:
           - proto-plus-deps=google.shopping.type
-          - python-gapic-name=merchant_reviews
-          - python-gapic-namespace=google.shopping
-          - warehouse-package-name=google-shopping-merchant-reviews
       name_pretty_override: Merchant Reviews API
       default_version: v1beta
   - name: google-shopping-type
@@ -4369,11 +2936,6 @@ libraries:
     keep:
       - tests/unit/gapic/type/test_type.py
     python:
-      opt_args_by_api:
-        google/shopping/type:
-          - python-gapic-namespace=google.shopping
-          - python-gapic-name=type
-          - warehouse-package-name=google-shopping-type
       name_pretty_override: Shopping Type Protos
       default_version: apiVersion
   - name: googleapis-common-protos
@@ -4397,8 +2959,8 @@ libraries:
         - google/logging/type
         - google/rpc/context
       name_pretty_override: Google APIs Common Protos
-      client_documentation_override: https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos
       product_documentation_override: https://github.com/googleapis/googleapis/tree/master/google
+      client_documentation_override: https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos
       default_version: apiVersion
   - name: grafeas
     version: 1.22.0
@@ -4409,8 +2971,6 @@ libraries:
       library_type: GAPIC_COMBO
       opt_args_by_api:
         grafeas/v1:
-          - python-gapic-namespace=grafeas
-          - warehouse-package-name=grafeas
           - python-gapic-name=grafeas
       name_pretty_override: Grafeas
       default_version: v1

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -611,10 +611,10 @@ libraries:
       is a fully managed, NoOps, low cost data analytics service.
       Data can be streamed into BigQuery at millions of rows per second to enable real-time analysis.
       With BigQuery you can easily deploy Petabyte-scale Databases.
-    skip_generate: true
     python:
       library_type: GAPIC_COMBO
       name_pretty_override: Google Cloud BigQuery
+      issue_tracker_override: https://issuetracker.google.com/savedsearches/559654
       metadata_name_override: bigquery
       default_version: v2
   - name: google-cloud-bigquery-analyticshub

--- a/packages/google-cloud-bigquery/.repo-metadata.json
+++ b/packages/google-cloud-bigquery/.repo-metadata.json
@@ -1,6 +1,4 @@
 {
-    "api_id": "bigquery.googleapis.com",
-    "api_shortname": "bigquery",
     "client_documentation": "https://cloud.google.com/python/docs/reference/bigquery/latest",
     "default_version": "v2",
     "distribution_name": "google-cloud-bigquery",
@@ -9,7 +7,6 @@
     "library_type": "GAPIC_COMBO",
     "name": "bigquery",
     "name_pretty": "Google Cloud BigQuery",
-    "product_documentation": "https://cloud.google.com/bigquery",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }


### PR DESCRIPTION
This reintroduces the issue tracker override, as we can't derive that from sdk.yaml (as nothing is generated here).