### PR TITLE
chore: remove unnecessary client_documentation_override fields

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -58,20 +58,17 @@ libraries:
     python:
       library_type: INTEGRATION
       name_pretty_override: A unified Python API in BigQuery
-      client_documentation_override: https://cloud.google.com/python/docs/reference/bigframes/latest
   - name: bigquery-magics
     version: 0.14.0
     python:
       library_type: INTEGRATION
       name_pretty_override: Google BigQuery connector for Jupyter and IPython
-      client_documentation_override: https://googleapis.dev/python/bigquery-magics/latest/
   - name: db-dtypes
     version: 1.5.1
     description_override: Pandas extension data types for data from SQL systems such as BigQuery.
     python:
       library_type: INTEGRATION
       name_pretty_override: Pandas Data Types for SQL systems (BigQuery, Spanner)
-      client_documentation_override: https://googleapis.dev/python/db-dtypes/latest/index.html
   - name: django-google-spanner
     version: 4.0.3
     python:
@@ -82,14 +79,12 @@ libraries:
     python:
       library_type: CORE
       name_pretty_override: Google API Client Generator for Python
-      client_documentation_override: https://gapic-generator-python.readthedocs.io/en/stable/
       skip_readme_copy: true
   - name: gcp-sphinx-docfx-yaml
     version: 3.2.5
     python:
       library_type: OTHER
       name_pretty_override: Sphinx DocFX YAML Generator
-      client_documentation_override: https://github.com/googleapis/sphinx-docfx-yaml
       skip_readme_copy: true
   - name: google-ads-admanager
     version: 0.9.0
@@ -1733,7 +1728,6 @@ libraries:
     python:
       library_type: GAPIC_MANUAL
       name_pretty_override: NDB Client Library for Google Cloud Datastore
-      client_documentation_override: https://googleapis.dev/python/python-ndb/latest
       metadata_name_override: python-ndb
       skip_readme_copy: true
   - name: google-cloud-netapp
@@ -2374,7 +2368,6 @@ libraries:
     python:
       library_type: OTHER
       name_pretty_override: Python Test Utils for Google Cloud
-      client_documentation_override: https://github.com/googleapis/google-cloud-python/packages/google-cloud-testutils
       metadata_name_override: google-cloud-test-utils
   - name: google-cloud-texttospeech
     version: 2.36.0
@@ -2601,7 +2594,6 @@ libraries:
     python:
       library_type: OTHER
       name_pretty_override: A python wrapper of the C library 'Google CRC32C'
-      client_documentation_override: https://github.com/googleapis/python-crc32c
       skip_readme_copy: true
   - name: google-geo-type
     version: 0.6.0
@@ -2987,7 +2979,6 @@ libraries:
     python:
       library_type: INTEGRATION
       name_pretty_override: Google BigQuery connector for pandas
-      client_documentation_override: https://googleapis.dev/python/pandas-gbq/latest/
       skip_readme_copy: true
   - name: proto-plus
     version: 1.27.2
@@ -3000,11 +2991,9 @@ libraries:
     python:
       library_type: INTEGRATION
       name_pretty_override: SQLAlchemy dialect for BigQuery
-      client_documentation_override: https://googleapis.dev/python/sqlalchemy-bigquery/latest/index.html
   - name: sqlalchemy-spanner
     version: 1.17.3
     python:
       library_type: INTEGRATION
       name_pretty_override: Spanner dialect for SQLAlchemy
-      client_documentation_override: https://github.com/googleapis/python-spanner-sqlalchemy
       skip_readme_copy: true

--- a/packages/bigframes/.repo-metadata.json
+++ b/packages/bigframes/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-    "client_documentation": "https://cloud.google.com/python/docs/reference/bigframes/latest",
+    "client_documentation": "https://googleapis.dev/python/bigframes/latest",
     "distribution_name": "bigframes",
     "language": "python",
     "library_type": "INTEGRATION",

--- a/packages/bigquery-magics/.repo-metadata.json
+++ b/packages/bigquery-magics/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-    "client_documentation": "https://googleapis.dev/python/bigquery-magics/latest/",
+    "client_documentation": "https://googleapis.dev/python/bigquery-magics/latest",
     "distribution_name": "bigquery-magics",
     "language": "python",
     "library_type": "INTEGRATION",

--- a/packages/db-dtypes/.repo-metadata.json
+++ b/packages/db-dtypes/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-    "client_documentation": "https://googleapis.dev/python/db-dtypes/latest/index.html",
+    "client_documentation": "https://googleapis.dev/python/db-dtypes/latest",
     "distribution_name": "db-dtypes",
     "language": "python",
     "library_type": "INTEGRATION",

--- a/packages/django-google-spanner/.repo-metadata.json
+++ b/packages/django-google-spanner/.repo-metadata.json
@@ -1,8 +1,6 @@
 {
-    "api_shortname": "django-google-spanner",
     "client_documentation": "https://googleapis.dev/python/django-google-spanner/latest",
     "distribution_name": "django-google-spanner",
-    "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open",
     "language": "python",
     "library_type": "INTEGRATION",
     "name": "django-google-spanner",

--- a/packages/gapic-generator/.repo-metadata.json
+++ b/packages/gapic-generator/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-    "client_documentation": "https://gapic-generator-python.readthedocs.io/en/stable/",
+    "client_documentation": "https://googleapis.dev/python/gapic-generator/latest",
     "distribution_name": "gapic-generator",
     "language": "python",
     "library_type": "CORE",

--- a/packages/gcp-sphinx-docfx-yaml/.repo-metadata.json
+++ b/packages/gcp-sphinx-docfx-yaml/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-    "client_documentation": "https://github.com/googleapis/sphinx-docfx-yaml",
+    "client_documentation": "https://googleapis.dev/python/gcp-sphinx-docfx-yaml/latest",
     "distribution_name": "gcp-sphinx-docfx-yaml",
     "language": "python",
     "library_type": "OTHER",

--- a/packages/google-cloud-ndb/.repo-metadata.json
+++ b/packages/google-cloud-ndb/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-    "client_documentation": "https://googleapis.dev/python/python-ndb/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/python-ndb/latest",
     "distribution_name": "google-cloud-ndb",
     "language": "python",
     "library_type": "GAPIC_MANUAL",

--- a/packages/google-cloud-testutils/.repo-metadata.json
+++ b/packages/google-cloud-testutils/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-    "client_documentation": "https://github.com/googleapis/google-cloud-python/packages/google-cloud-testutils",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-test-utils/latest",
     "distribution_name": "google-cloud-testutils",
     "language": "python",
     "library_type": "OTHER",

--- a/packages/pandas-gbq/.repo-metadata.json
+++ b/packages/pandas-gbq/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-    "client_documentation": "https://googleapis.dev/python/pandas-gbq/latest/",
+    "client_documentation": "https://googleapis.dev/python/pandas-gbq/latest",
     "distribution_name": "pandas-gbq",
     "language": "python",
     "library_type": "INTEGRATION",

--- a/packages/sqlalchemy-bigquery/.repo-metadata.json
+++ b/packages/sqlalchemy-bigquery/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-    "client_documentation": "https://googleapis.dev/python/sqlalchemy-bigquery/latest/index.html",
+    "client_documentation": "https://googleapis.dev/python/sqlalchemy-bigquery/latest",
     "distribution_name": "sqlalchemy-bigquery",
     "language": "python",
     "library_type": "INTEGRATION",

--- a/packages/sqlalchemy-spanner/.repo-metadata.json
+++ b/packages/sqlalchemy-spanner/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-    "client_documentation": "https://github.com/googleapis/python-spanner-sqlalchemy",
+    "client_documentation": "https://googleapis.dev/python/sqlalchemy-spanner/latest",
     "distribution_name": "sqlalchemy-spanner",
     "language": "python",
     "library_type": "INTEGRATION",


### PR DESCRIPTION
These are only required when we're generating a README.rst; they're
irrelevant for handwritten libraries.

Towards https://github.com/googleapis/librarian/issues/5467