### PR TITLE
chore: allow releases for django-google-spanner

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -15,10 +15,6 @@ global_files_allowlist:
 libraries:
   # libraries have "release_blocked: true" so that releases are
   # explicitly initiated.
-  # TODO(https://github.com/googleapis/google-cloud-python/issues/16180):
-  # `google-django-spanner` is blocked until the presubmits are green.
-  - id: "google-django-spanner"
-    release_blocked: true
   # TODO(https://github.com/googleapis/google-cloud-python/issues/16487):
   # Allow releases for google-cloud-storage once this bug is fixed.
   - id: "google-cloud-storage"


### PR DESCRIPTION
Tests are passing as of https://github.com/googleapis/google-cloud-python/pull/16624. Some tests are flaky but that is tracked in https://github.com/googleapis/google-cloud-python/issues/16839 and doesn't block releases.