### PR TITLE
chore: update librarian to version v0.11.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: python
-version: v0.10.2-0.20260424173850-5f413ac088a6
+version: v0.11.0
 repo: googleapis/google-cloud-python
 sources:
   googleapis:


### PR DESCRIPTION
Regular update to `librarian` version on weekly cadence.

`generate --all` produced no diffs.