### PR TITLE
chore: remove name_pretty_override from selected packages

### DIFF
--- a/.librarian/generator-input/client-post-processing/bigquery-storage-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/bigquery-storage-integration.yaml
@@ -476,7 +476,7 @@ replacements:
     before: |
       .. include:: README.rst\n
       .. include:: multiprocessing.rst\n
-      This package includes clients for multiple versions of Google BigQuery Storage.
+      This package includes clients for multiple versions of BigQuery Storage.
       By default, you will get version ``bigquery_storage_v1``.\n\n
       API Reference
       -------------

--- a/.librarian/generator-input/client-post-processing/googleapis-common-protos-docs.yaml
+++ b/.librarian/generator-input/client-post-processing/googleapis-common-protos-docs.yaml
@@ -17,7 +17,7 @@ replacements:
   - paths: [
       packages/googleapis-common-protos/README.rst
     ]
-    before: "`Google APIs Common Protos`_: Lets you define and config your API service.\n\n"
+    before: "`Service Config`_: Lets you define and config your API service.\n\n"
     after: ""
     count: 1
   - paths: [
@@ -29,7 +29,7 @@ replacements:
   - paths: [
       packages/googleapis-common-protos/README.rst
     ]
-    before: ".. _Google APIs Common Protos: \n"
+    before: ".. _Service Config: \n"
     after: ""
     count: 1
   - paths: [
@@ -42,7 +42,7 @@ replacements:
       packages/googleapis-common-protos/README.rst
     ]
     before: |
-      3. `Enable the Google APIs Common Protos.`_
+      3. `Enable the Service Config.`_
       4. `Set up Authentication.`_
     after: |
       3. `Set up Authentication.`_
@@ -50,20 +50,20 @@ replacements:
   - paths: [
       packages/googleapis-common-protos/README.rst
     ]
-    before: ".. _Enable the Google APIs Common Protos.:  \n"
+    before: ".. _Enable the Service Config.:  \n"
     after: ""
     count: 1
   - paths: [
       packages/googleapis-common-protos/README.rst
     ]
     before: |
-      -  Read the `Google APIs Common Protos Product documentation`_ to learn
+      -  Read the `Service Config Product documentation`_ to learn
          more about the product and see How-to Guides.
     after: ""
     count: 1
   - paths: [
       packages/googleapis-common-protos/README.rst
     ]
-    before: ".. _Google APIs Common Protos Product documentation:  \n"
+    before: ".. _Service Config Product documentation:  \n"
     after: ""
     count: 1

--- a/.librarian/generator-input/client-post-processing/pubsub-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/pubsub-integration.yaml
@@ -178,9 +178,9 @@ replacements:
   # --- FIX: Restore custom README.rst Introduction ---
   - paths:
       - "packages/google-cloud-pubsub/README.rst"
-    before: '`Google Cloud Pub/Sub`_: is designed to provide reliable, many-to-many, asynchronous messaging between applications\. Publisher applications can send messages to a topic and other applications can subscribe to that topic to receive the messages\. By decoupling senders and receivers, Google Cloud Pub/Sub allows developers to communicate between independently written applications\.'
+    before: '`Cloud Pub/Sub`_: is designed to provide reliable, many-to-many, asynchronous messaging between applications\. Publisher applications can send messages to a topic and other applications can subscribe to that topic to receive the messages\. By decoupling senders and receivers, Google Cloud Pub/Sub allows developers to communicate between independently written applications\.'
     after: |-
-      'Google Cloud Pub/Sub:' is a fully-managed real-time messaging service that
+      'Cloud Pub/Sub:' is a fully-managed real-time messaging service that
       allows you to send and receive messages between independent applications. You
       can leverage Cloud Pub/Sub’s flexibility to decouple systems and components
       hosted on Google Cloud Platform or elsewhere on the Internet. By building on

--- a/.librarian/generator-input/client-post-processing/storage-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/storage-integration.yaml
@@ -287,11 +287,11 @@ replacements:
       packages/google-cloud-storage/README.rst,
     ]
     before: |
-      Python Client for Google Cloud Storage
+      Python Client for Cloud Storage
       [\s\S]*?\(This is the reason for 2.i. above.\)
     after: |
-      Python Client for Google Cloud Storage
-      ======================================
+      Python Client for Cloud Storage
+      ===============================
 
       |stable| |pypi| |versions|
 

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -709,7 +709,6 @@ libraries:
       - docs/bigquery_storage_v1beta2/library.rst
     python:
       library_type: GAPIC_COMBO
-      name_pretty_override: Google BigQuery Storage
       metadata_name_override: bigquerystorage
       default_version: v1
   - name: google-cloud-bigtable
@@ -1962,7 +1961,6 @@ libraries:
         google/pubsub/v1:
           - python-gapic-namespace=google
           - python-gapic-name=pubsub
-      name_pretty_override: Google Cloud Pub/Sub
       metadata_name_override: pubsub
       default_version: v1
   - name: google-cloud-quotas
@@ -2278,7 +2276,6 @@ libraries:
         google/storage/v2:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=_storage
-      name_pretty_override: Google Cloud Storage
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559782
       metadata_name_override: storage
       default_version: v2
@@ -2948,7 +2945,6 @@ libraries:
         - google/cloud/location
         - google/logging/type
         - google/rpc/context
-      name_pretty_override: Google APIs Common Protos
       client_documentation_override: https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos
       default_version: apiVersion
   - name: grafeas

--- a/packages/google-cloud-bigquery-storage/.repo-metadata.json
+++ b/packages/google-cloud-bigquery-storage/.repo-metadata.json
@@ -8,7 +8,7 @@
     "language": "python",
     "library_type": "GAPIC_COMBO",
     "name": "bigquerystorage",
-    "name_pretty": "Google BigQuery Storage",
+    "name_pretty": "BigQuery Storage",
     "product_documentation": "https://cloud.google.com/bigquery/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"

--- a/packages/google-cloud-bigquery-storage/README.rst
+++ b/packages/google-cloud-bigquery-storage/README.rst
@@ -1,9 +1,9 @@
-Python Client for Google BigQuery Storage
-=========================================
+Python Client for BigQuery Storage
+==================================
 
 |stable| |pypi| |versions|
 
-`Google BigQuery Storage`_: 
+`BigQuery Storage`_: 
 
 - `Client Library Documentation`_
 - `Product Documentation`_
@@ -14,7 +14,7 @@ Python Client for Google BigQuery Storage
    :target: https://pypi.org/project/google-cloud-bigquery-storage/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-storage.svg
    :target: https://pypi.org/project/google-cloud-bigquery-storage/
-.. _Google BigQuery Storage: https://cloud.google.com/bigquery/
+.. _BigQuery Storage: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerystorage/latest/summary_overview
 .. _Product Documentation:  https://cloud.google.com/bigquery/
 
@@ -25,12 +25,12 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. `Enable the Google BigQuery Storage.`_
+3. `Enable the BigQuery Storage.`_
 4. `Set up Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google BigQuery Storage.:  https://cloud.google.com/bigquery/
+.. _Enable the BigQuery Storage.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -97,14 +97,14 @@ Windows
 Next Steps
 ~~~~~~~~~~
 
--  Read the `Client Library Documentation`_ for Google BigQuery Storage
+-  Read the `Client Library Documentation`_ for BigQuery Storage
    to see other available methods on the client.
--  Read the `Google BigQuery Storage Product documentation`_ to learn
+-  Read the `BigQuery Storage Product documentation`_ to learn
    more about the product and see How-to Guides.
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google BigQuery Storage Product documentation:  https://cloud.google.com/bigquery/
+.. _BigQuery Storage Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-storage/docs/README.rst
+++ b/packages/google-cloud-bigquery-storage/docs/README.rst
@@ -1,9 +1,9 @@
-Python Client for Google BigQuery Storage
-=========================================
+Python Client for BigQuery Storage
+==================================
 
 |stable| |pypi| |versions|
 
-`Google BigQuery Storage`_: 
+`BigQuery Storage`_: 
 
 - `Client Library Documentation`_
 - `Product Documentation`_
@@ -14,7 +14,7 @@ Python Client for Google BigQuery Storage
    :target: https://pypi.org/project/google-cloud-bigquery-storage/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-storage.svg
    :target: https://pypi.org/project/google-cloud-bigquery-storage/
-.. _Google BigQuery Storage: https://cloud.google.com/bigquery/
+.. _BigQuery Storage: https://cloud.google.com/bigquery/
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerystorage/latest/summary_overview
 .. _Product Documentation:  https://cloud.google.com/bigquery/
 
@@ -25,12 +25,12 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. `Enable the Google BigQuery Storage.`_
+3. `Enable the BigQuery Storage.`_
 4. `Set up Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google BigQuery Storage.:  https://cloud.google.com/bigquery/
+.. _Enable the BigQuery Storage.:  https://cloud.google.com/bigquery/
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -97,14 +97,14 @@ Windows
 Next Steps
 ~~~~~~~~~~
 
--  Read the `Client Library Documentation`_ for Google BigQuery Storage
+-  Read the `Client Library Documentation`_ for BigQuery Storage
    to see other available methods on the client.
--  Read the `Google BigQuery Storage Product documentation`_ to learn
+-  Read the `BigQuery Storage Product documentation`_ to learn
    more about the product and see How-to Guides.
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google BigQuery Storage Product documentation:  https://cloud.google.com/bigquery/
+.. _BigQuery Storage Product documentation:  https://cloud.google.com/bigquery/
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-bigquery-storage/docs/summary_overview.md
+++ b/packages/google-cloud-bigquery-storage/docs/summary_overview.md
@@ -5,14 +5,14 @@ reverted. Instead, if you want to place additional content, create an
 pick up on the content and merge the content.
 ]: #
 
-# Google BigQuery Storage API
+# BigQuery Storage API
 
-Overview of the APIs available for Google BigQuery Storage API.
+Overview of the APIs available for BigQuery Storage API.
 
 ## All entries
 
 Classes, methods and properties & attributes for
-Google BigQuery Storage API.
+BigQuery Storage API.
 
 [classes](https://cloud.google.com/python/docs/reference/bigquerystorage/latest/summary_class.html)
 

--- a/packages/google-cloud-pubsub/.repo-metadata.json
+++ b/packages/google-cloud-pubsub/.repo-metadata.json
@@ -9,7 +9,7 @@
     "language": "python",
     "library_type": "GAPIC_COMBO",
     "name": "pubsub",
-    "name_pretty": "Google Cloud Pub/Sub",
+    "name_pretty": "Cloud Pub/Sub",
     "product_documentation": "https://cloud.google.com/pubsub/docs",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"

--- a/packages/google-cloud-pubsub/README.rst
+++ b/packages/google-cloud-pubsub/README.rst
@@ -1,9 +1,9 @@
-Python Client for Google Cloud Pub/Sub
-======================================
+Python Client for Cloud Pub/Sub
+===============================
 
 |stable| |pypi| |versions|
 
-'Google Cloud Pub/Sub:' is a fully-managed real-time messaging service that
+'Cloud Pub/Sub:' is a fully-managed real-time messaging service that
 allows you to send and receive messages between independent applications. You
 can leverage Cloud Pub/Sub’s flexibility to decouple systems and components
 hosted on Google Cloud Platform or elsewhere on the Internet. By building on
@@ -25,7 +25,7 @@ independently written applications.
    :target: https://pypi.org/project/google-cloud-pubsub/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-pubsub.svg
    :target: https://pypi.org/project/google-cloud-pubsub/
-.. _Google Cloud Pub/Sub: https://cloud.google.com/pubsub/docs
+.. _Cloud Pub/Sub: https://cloud.google.com/pubsub/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/pubsub/latest/summary_overview
 .. _Product Documentation:  https://cloud.google.com/pubsub/docs
 
@@ -36,12 +36,12 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. `Enable the Google Cloud Pub/Sub.`_
+3. `Enable the Cloud Pub/Sub.`_
 4. `Set up Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Pub/Sub.:  https://cloud.google.com/pubsub/docs
+.. _Enable the Cloud Pub/Sub.:  https://cloud.google.com/pubsub/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -246,14 +246,14 @@ Apache 2.0 - See `the LICENSE`_ for more information.
 Next Steps
 ~~~~~~~~~~
 
--  Read the `Client Library Documentation`_ for Google Cloud Pub/Sub
+-  Read the `Client Library Documentation`_ for Cloud Pub/Sub
    to see other available methods on the client.
--  Read the `Google Cloud Pub/Sub Product documentation`_ to learn
+-  Read the `Cloud Pub/Sub Product documentation`_ to learn
    more about the product and see How-to Guides.
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Pub/Sub Product documentation:  https://cloud.google.com/pubsub/docs
+.. _Cloud Pub/Sub Product documentation:  https://cloud.google.com/pubsub/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-pubsub/docs/README.rst
+++ b/packages/google-cloud-pubsub/docs/README.rst
@@ -1,9 +1,9 @@
-Python Client for Google Cloud Pub/Sub
-======================================
+Python Client for Cloud Pub/Sub
+===============================
 
 |stable| |pypi| |versions|
 
-'Google Cloud Pub/Sub:' is a fully-managed real-time messaging service that
+'Cloud Pub/Sub:' is a fully-managed real-time messaging service that
 allows you to send and receive messages between independent applications. You
 can leverage Cloud Pub/Sub’s flexibility to decouple systems and components
 hosted on Google Cloud Platform or elsewhere on the Internet. By building on
@@ -25,7 +25,7 @@ independently written applications.
    :target: https://pypi.org/project/google-cloud-pubsub/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-pubsub.svg
    :target: https://pypi.org/project/google-cloud-pubsub/
-.. _Google Cloud Pub/Sub: https://cloud.google.com/pubsub/docs
+.. _Cloud Pub/Sub: https://cloud.google.com/pubsub/docs
 .. _Client Library Documentation: https://cloud.google.com/python/docs/reference/pubsub/latest/summary_overview
 .. _Product Documentation:  https://cloud.google.com/pubsub/docs
 
@@ -36,12 +36,12 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. `Enable the Google Cloud Pub/Sub.`_
+3. `Enable the Cloud Pub/Sub.`_
 4. `Set up Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Google Cloud Pub/Sub.:  https://cloud.google.com/pubsub/docs
+.. _Enable the Cloud Pub/Sub.:  https://cloud.google.com/pubsub/docs
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -246,14 +246,14 @@ Apache 2.0 - See `the LICENSE`_ for more information.
 Next Steps
 ~~~~~~~~~~
 
--  Read the `Client Library Documentation`_ for Google Cloud Pub/Sub
+-  Read the `Client Library Documentation`_ for Cloud Pub/Sub
    to see other available methods on the client.
--  Read the `Google Cloud Pub/Sub Product documentation`_ to learn
+-  Read the `Cloud Pub/Sub Product documentation`_ to learn
    more about the product and see How-to Guides.
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Google Cloud Pub/Sub Product documentation:  https://cloud.google.com/pubsub/docs
+.. _Cloud Pub/Sub Product documentation:  https://cloud.google.com/pubsub/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 
 Logging

--- a/packages/google-cloud-pubsub/docs/summary_overview.md
+++ b/packages/google-cloud-pubsub/docs/summary_overview.md
@@ -5,14 +5,14 @@ reverted. Instead, if you want to place additional content, create an
 pick up on the content and merge the content.
 ]: #
 
-# Google Cloud Pub/Sub API
+# Cloud Pub/Sub API
 
-Overview of the APIs available for Google Cloud Pub/Sub API.
+Overview of the APIs available for Cloud Pub/Sub API.
 
 ## All entries
 
 Classes, methods and properties & attributes for
-Google Cloud Pub/Sub API.
+Cloud Pub/Sub API.
 
 [classes](https://cloud.google.com/python/docs/reference/pubsub/latest/summary_class.html)
 

--- a/packages/google-cloud-storage/.repo-metadata.json
+++ b/packages/google-cloud-storage/.repo-metadata.json
@@ -9,7 +9,7 @@
     "language": "python",
     "library_type": "GAPIC_MANUAL",
     "name": "storage",
-    "name_pretty": "Google Cloud Storage",
+    "name_pretty": "Cloud Storage",
     "product_documentation": "https://cloud.google.com/storage/",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"

--- a/packages/google-cloud-storage/README.rst
+++ b/packages/google-cloud-storage/README.rst
@@ -1,5 +1,5 @@
-Python Client for Google Cloud Storage
-======================================
+Python Client for Cloud Storage
+===============================
 
 |stable| |pypi| |versions|
 

--- a/packages/google-cloud-storage/docs/README.rst
+++ b/packages/google-cloud-storage/docs/README.rst
@@ -1,5 +1,5 @@
-Python Client for Google Cloud Storage
-======================================
+Python Client for Cloud Storage
+===============================
 
 |stable| |pypi| |versions|
 

--- a/packages/google-cloud-storage/docs/summary_overview.md
+++ b/packages/google-cloud-storage/docs/summary_overview.md
@@ -5,14 +5,14 @@ reverted. Instead, if you want to place additional content, create an
 pick up on the content and merge the content.
 ]: #
 
-# Google Cloud Storage API
+# Cloud Storage API
 
-Overview of the APIs available for Google Cloud Storage API.
+Overview of the APIs available for Cloud Storage API.
 
 ## All entries
 
 Classes, methods and properties & attributes for
-Google Cloud Storage API.
+Cloud Storage API.
 
 [classes](https://cloud.google.com/python/docs/reference/storage/latest/summary_class.html)
 

--- a/packages/googleapis-common-protos/.repo-metadata.json
+++ b/packages/googleapis-common-protos/.repo-metadata.json
@@ -8,7 +8,7 @@
     "language": "python",
     "library_type": "CORE",
     "name": "googleapis-common-protos",
-    "name_pretty": "Google APIs Common Protos",
+    "name_pretty": "Service Config",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }

--- a/packages/googleapis-common-protos/README.rst
+++ b/packages/googleapis-common-protos/README.rst
@@ -1,5 +1,5 @@
-Python Client for Google APIs Common Protos
-===========================================
+Python Client for Service Config
+================================
 
 |stable| |pypi| |versions|
 
@@ -90,7 +90,7 @@ Windows
 Next Steps
 ~~~~~~~~~~
 
--  Read the `Client Library Documentation`_ for Google APIs Common Protos
+-  Read the `Client Library Documentation`_ for Service Config
    to see other available methods on the client.
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.

--- a/packages/googleapis-common-protos/docs/README.rst
+++ b/packages/googleapis-common-protos/docs/README.rst
@@ -1,5 +1,5 @@
-Python Client for Google APIs Common Protos
-===========================================
+Python Client for Service Config
+================================
 
 |stable| |pypi| |versions|
 
@@ -90,7 +90,7 @@ Windows
 Next Steps
 ~~~~~~~~~~
 
--  Read the `Client Library Documentation`_ for Google APIs Common Protos
+-  Read the `Client Library Documentation`_ for Service Config
    to see other available methods on the client.
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.

--- a/packages/googleapis-common-protos/docs/summary_overview.md
+++ b/packages/googleapis-common-protos/docs/summary_overview.md
@@ -5,14 +5,14 @@ reverted. Instead, if you want to place additional content, create an
 pick up on the content and merge the content.
 ]: #
 
-# Google APIs Common Protos API
+# Service Config API
 
-Overview of the APIs available for Google APIs Common Protos API.
+Overview of the APIs available for Service Config API.
 
 ## All entries
 
 Classes, methods and properties & attributes for
-Google APIs Common Protos API.
+Service Config API.
 
 [classes](https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos/summary_class.html)
 


### PR DESCRIPTION
This removes name_pretty_override from just four packages:

- google-cloud-storage
- google-cloud-bigquery-storage
- google-cloud-pubsub
- googleapis-common-protos

These are the packages with post-processing files that need changing at the same time.
