### PR TITLE
chore: remove incorrect client_documentation_override values

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -102,7 +102,6 @@ libraries:
       connect first-party data across Google advertising products.
     python:
       name_pretty_override: Data Manager API
-      client_documentation_override: https://cloud.google.com/python/docs/reference/google-ads-datamanager/latest
       default_version: v1
   - name: google-ads-marketingplatform-admin
     version: 0.5.0
@@ -2663,7 +2662,6 @@ libraries:
         google/maps/geocode/v4:
           - proto-plus-deps=google.geo.type
       name_pretty_override: Geocoding API
-      client_documentation_override: https://cloud.google.com/python/docs/reference/google-maps-geocode/latest
       default_version: v4
   - name: google-maps-mapsplatformdatasets
     version: 0.7.0
@@ -2681,7 +2679,6 @@ libraries:
     description_override: Navigation Connect API.
     python:
       name_pretty_override: Navigation Connect API
-      client_documentation_override: https://cloud.google.com/python/docs/reference/google-maps-navconnect/latest
       default_version: v1
   - name: google-maps-places
     version: 0.8.0

--- a/packages/google-ads-datamanager/.repo-metadata.json
+++ b/packages/google-ads-datamanager/.repo-metadata.json
@@ -2,7 +2,7 @@
     "api_description": "A unified ingestion API for data partners, agencies and advertisers to\nconnect first-party data across Google advertising products.",
     "api_id": "datamanager.googleapis.com",
     "api_shortname": "datamanager",
-    "client_documentation": "https://cloud.google.com/python/docs/reference/google-ads-datamanager/latest",
+    "client_documentation": "https://googleapis.dev/python/google-ads-datamanager/latest",
     "default_version": "v1",
     "distribution_name": "google-ads-datamanager",
     "issue_tracker": "https://issuetracker.google.com/issues/new?component=1812065",

--- a/packages/google-ads-datamanager/README.rst
+++ b/packages/google-ads-datamanager/README.rst
@@ -16,7 +16,7 @@ connect first-party data across Google advertising products.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-ads-datamanager.svg
    :target: https://pypi.org/project/google-ads-datamanager/
 .. _Data Manager API: https://developers.google.com/data-manager
-.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-ads-datamanager/latest
+.. _Client Library Documentation: https://googleapis.dev/python/google-ads-datamanager/latest
 .. _Product Documentation:  https://developers.google.com/data-manager
 
 Quick Start

--- a/packages/google-ads-datamanager/docs/README.rst
+++ b/packages/google-ads-datamanager/docs/README.rst
@@ -16,7 +16,7 @@ connect first-party data across Google advertising products.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-ads-datamanager.svg
    :target: https://pypi.org/project/google-ads-datamanager/
 .. _Data Manager API: https://developers.google.com/data-manager
-.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-ads-datamanager/latest
+.. _Client Library Documentation: https://googleapis.dev/python/google-ads-datamanager/latest
 .. _Product Documentation:  https://developers.google.com/data-manager
 
 Quick Start

--- a/packages/google-maps-geocode/.repo-metadata.json
+++ b/packages/google-maps-geocode/.repo-metadata.json
@@ -2,7 +2,7 @@
     "api_description": "Convert addresses into geographic coordinates (geocoding), which you can\nuse     to place markers or position the map. This API also allows you to\nconvert     geographic coordinates into an address (reverse geocoding).",
     "api_id": "geocoding-backend.googleapis.com",
     "api_shortname": "geocode",
-    "client_documentation": "https://cloud.google.com/python/docs/reference/google-maps-geocode/latest",
+    "client_documentation": "https://googleapis.dev/python/google-maps-geocode/latest",
     "default_version": "v4",
     "distribution_name": "google-maps-geocode",
     "issue_tracker": "https://issuetracker.google.com/issues/new?component=188871\u0026template=788907",

--- a/packages/google-maps-geocode/README.rst
+++ b/packages/google-maps-geocode/README.rst
@@ -17,7 +17,7 @@ convert     geographic coordinates into an address (reverse geocoding).
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-maps-geocode.svg
    :target: https://pypi.org/project/google-maps-geocode/
 .. _Geocoding API: https://developers.google.com/maps/documentation/geocoding/overview
-.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-maps-geocode/latest
+.. _Client Library Documentation: https://googleapis.dev/python/google-maps-geocode/latest
 .. _Product Documentation:  https://developers.google.com/maps/documentation/geocoding/overview
 
 Quick Start

--- a/packages/google-maps-geocode/docs/README.rst
+++ b/packages/google-maps-geocode/docs/README.rst
@@ -17,7 +17,7 @@ convert     geographic coordinates into an address (reverse geocoding).
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-maps-geocode.svg
    :target: https://pypi.org/project/google-maps-geocode/
 .. _Geocoding API: https://developers.google.com/maps/documentation/geocoding/overview
-.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-maps-geocode/latest
+.. _Client Library Documentation: https://googleapis.dev/python/google-maps-geocode/latest
 .. _Product Documentation:  https://developers.google.com/maps/documentation/geocoding/overview
 
 Quick Start

--- a/packages/google-maps-navconnect/.repo-metadata.json
+++ b/packages/google-maps-navconnect/.repo-metadata.json
@@ -2,7 +2,7 @@
     "api_description": "Navigation Connect API.",
     "api_id": "navigationconnect.googleapis.com",
     "api_shortname": "navigationconnect",
-    "client_documentation": "https://cloud.google.com/python/docs/reference/google-maps-navconnect/latest",
+    "client_documentation": "https://googleapis.dev/python/google-maps-navconnect/latest",
     "default_version": "v1",
     "distribution_name": "google-maps-navconnect",
     "issue_tracker": "https://issuetracker.google.com/issues/new?component=1180397\u0026template=1812135",

--- a/packages/google-maps-navconnect/README.rst
+++ b/packages/google-maps-navconnect/README.rst
@@ -15,7 +15,7 @@ Python Client for Navigation Connect API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-maps-navconnect.svg
    :target: https://pypi.org/project/google-maps-navconnect/
 .. _Navigation Connect API: https://developers.google.com/maps/documentation/mobility/navigationconnect
-.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-maps-navconnect/latest
+.. _Client Library Documentation: https://googleapis.dev/python/google-maps-navconnect/latest
 .. _Product Documentation:  https://developers.google.com/maps/documentation/mobility/navigationconnect
 
 Quick Start

--- a/packages/google-maps-navconnect/docs/README.rst
+++ b/packages/google-maps-navconnect/docs/README.rst
@@ -15,7 +15,7 @@ Python Client for Navigation Connect API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-maps-navconnect.svg
    :target: https://pypi.org/project/google-maps-navconnect/
 .. _Navigation Connect API: https://developers.google.com/maps/documentation/mobility/navigationconnect
-.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/google-maps-navconnect/latest
+.. _Client Library Documentation: https://googleapis.dev/python/google-maps-navconnect/latest
 .. _Product Documentation:  https://developers.google.com/maps/documentation/mobility/navigationconnect
 
 Quick Start


### PR DESCRIPTION
These incorrectly linked to cloud.google.com, whereas the documentation is on googleapis.dev.