### PR TITLE
fix(dataproc): add mising fields in yarnApplication proto

### DIFF
--- a/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/jobs.py
+++ b/packages/google-cloud-dataproc/google/cloud/dataproc_v1/types/jobs.py
@@ -1140,6 +1140,10 @@ class YarnApplication(proto.Message):
             application-specific information. The URL uses
             the internal hostname, and requires a proxy
             server for resolution and, possibly, access.
+        vcore_seconds (int):
+            Optional. The cumulative CPU time consumed by the application for a job, measured in vcore-seconds.
+        memory_mb_seconds (int):
+            Optional. The cumulative memory usage of the application for a job, measured in mb-seconds.
     """
 
     class State(proto.Enum):
@@ -1193,6 +1197,16 @@ class YarnApplication(proto.Message):
     tracking_url: str = proto.Field(
         proto.STRING,
         number=4,
+    )
+    vcore_seconds: int = proto.Field(
+        proto.INT64,
+        number=5,
+        optional=True,
+    )
+    memory_mb_seconds: int = proto.Field(
+        proto.INT64,
+        number=6,
+        optional=True,
     )
 
 


### PR DESCRIPTION
Two fields in `YarnApplicationProto` is missing:

1. `vcore_sconds`
2. `memory_mb_seconds`

This Pr, is a fix for missing these fields.

Reference: 
https://docs.cloud.google.com/dataproc/docs/reference/rpc/google.cloud.dataproc.v1#google.cloud.dataproc.v1.YarnApplication

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕