### PR TITLE
chore: fix pylint error in async rest transport

### DIFF
--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -78,6 +78,7 @@ from .transports.grpc_asyncio import {{ service.grpc_asyncio_transport_name }}
 from .transports.rest import {{ service.name }}RestTransport
 {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2121): Remove this condition when async rest is GA. #}
 {% if rest_async_io_enabled %}
+ASYNC_REST_EXCEPTION = None
 try:
     from .transports.rest_asyncio import Async{{ service.name }}RestTransport
     HAS_ASYNC_REST_DEPENDENCIES = True

--- a/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -61,6 +61,7 @@ from .transports.base import CloudRedisTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc import CloudRedisGrpcTransport
 from .transports.grpc_asyncio import CloudRedisGrpcAsyncIOTransport
 from .transports.rest import CloudRedisRestTransport
+ASYNC_REST_EXCEPTION = None
 try:
     from .transports.rest_asyncio import AsyncCloudRedisRestTransport
     HAS_ASYNC_REST_DEPENDENCIES = True

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -61,6 +61,7 @@ from .transports.base import CloudRedisTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc import CloudRedisGrpcTransport
 from .transports.grpc_asyncio import CloudRedisGrpcAsyncIOTransport
 from .transports.rest import CloudRedisRestTransport
+ASYNC_REST_EXCEPTION = None
 try:
     from .transports.rest_asyncio import AsyncCloudRedisRestTransport
     HAS_ASYNC_REST_DEPENDENCIES = True


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-python/issues/16863. 

`pylint` was recently enabled in https://github.com/googleapis/google-cloud-python/pull/16808. This error `used-before-assignment` did not appear in https://github.com/googleapis/google-cloud-python/pull/16808, but failed consistently as per https://github.com/googleapis/google-cloud-python/issues/16863.