### PR TITLE
chore: enable generation for gapic-generator

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -76,7 +76,6 @@ libraries:
       library_type: INTEGRATION
   - name: gapic-generator
     version: 1.30.14
-    skip_generate: true
     python:
       library_type: CORE
       skip_readme_copy: true

--- a/packages/gapic-generator/.repo-metadata.json
+++ b/packages/gapic-generator/.repo-metadata.json
@@ -4,7 +4,6 @@
     "language": "python",
     "library_type": "CORE",
     "name": "gapic-generator",
-    "name_pretty": "Google API Client Generator for Python",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }


### PR DESCRIPTION
This PR re-enables generation for `gapic-generator` which was temporarily skipped due to https://github.com/googleapis/google-cloud-python/issues/16863

This PR was created using

```
export V=v0.11.0
go run github.com/googleapis/librarian/tool/cmd/builddockerimages@${V} --version ${V} --language python
docker run -u $(id -u):$(id -g) -v .:/repo -v ~/.cache:/.cache -w /repo docker.io/library/librarian-python:${V} generate -v gapic-generator
```