### PR TITLE
chore: enable generation for django-google-spanner

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -71,7 +71,6 @@ libraries:
       name_pretty_override: Pandas Data Types for SQL systems (BigQuery, Spanner)
   - name: django-google-spanner
     version: 4.0.3
-    skip_generate: true
     python:
       library_type: INTEGRATION
   - name: gapic-generator

--- a/packages/django-google-spanner/.repo-metadata.json
+++ b/packages/django-google-spanner/.repo-metadata.json
@@ -4,7 +4,6 @@
     "language": "python",
     "library_type": "INTEGRATION",
     "name": "django-google-spanner",
-    "name_pretty": "Cloud Spanner Django",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }


### PR DESCRIPTION
This PR re-enables generation for `django-google-spanner` which was temporarily skipped due to https://github.com/googleapis/google-cloud-python/issues/16839

This PR was created using

```
export V=v0.11.0
go run github.com/googleapis/librarian/tool/cmd/builddockerimages@${V} --version ${V} --language python
docker run -u $(id -u):$(id -g) -v .:/repo -v ~/.cache:/.cache -w /repo docker.io/library/librarian-python:${V} generate -v django-google-spanner
```