### PR TITLE
feat: add value_bitmask_filter to the read API

### DIFF
--- a/packages/google-cloud-bigtable/google/cloud/bigtable_v2/__init__.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_v2/__init__.py
@@ -80,6 +80,7 @@ from .types.data import (
     StreamPartition,
     TimestampRange,
     Value,
+    ValueBitmask,
     ValueRange,
 )
 from .types.feature_flags import FeatureFlags
@@ -245,5 +246,6 @@ __all__ = (
     "TimestampRange",
     "Type",
     "Value",
+    "ValueBitmask",
     "ValueRange",
 )

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_v2/types/__init__.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_v2/types/__init__.py
@@ -63,6 +63,7 @@ from .data import (
     StreamPartition,
     TimestampRange,
     Value,
+    ValueBitmask,
     ValueRange,
 )
 from .feature_flags import (
@@ -132,6 +133,7 @@ __all__ = (
     "StreamPartition",
     "TimestampRange",
     "Value",
+    "ValueBitmask",
     "ValueRange",
     "FeatureFlags",
     "PeerInfo",

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_v2/types/data.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_v2/types/data.py
@@ -37,6 +37,7 @@ __protobuf__ = proto.module(
         "ColumnRange",
         "TimestampRange",
         "ValueRange",
+        "ValueBitmask",
         "RowFilter",
         "Mutation",
         "ReadModifyWriteRule",
@@ -558,6 +559,24 @@ class ValueRange(proto.Message):
     )
 
 
+class ValueBitmask(proto.Message):
+    r"""Restricts the output to cells whose values match the given
+    bitmask.
+
+    Attributes:
+        mask (bytes):
+            Required. Mask applied to the value. Evaluated as:
+            ``(value & mask) == mask`` The mask length must exactly
+            match the value length, otherwise the cell is not considered
+            a match.
+    """
+
+    mask: bytes = proto.Field(
+        proto.BYTES,
+        number=1,
+    )
+
+
 class RowFilter(proto.Message):
     r"""Takes a row as input and produces an alternate view of the row based
     on specified rules. For example, a RowFilter might trim down a row
@@ -806,6 +825,13 @@ class RowFilter(proto.Message):
             relaxed in the future.
 
             This field is a member of `oneof`_ ``filter``.
+        value_bitmask_filter (google.cloud.bigtable_v2.types.ValueBitmask):
+            Matches only cells with values that satisfy the condition
+            ``(value & mask) == mask``. The mask length must exactly
+            match the value length, otherwise the cell is not considered
+            a match.
+
+            This field is a member of `oneof`_ ``filter``.
     """
 
     class Chain(proto.Message):
@@ -1011,6 +1037,12 @@ class RowFilter(proto.Message):
         proto.STRING,
         number=19,
         oneof="filter",
+    )
+    value_bitmask_filter: "ValueBitmask" = proto.Field(
+        proto.MESSAGE,
+        number=20,
+        oneof="filter",
+        message="ValueBitmask",
     )
 
 


### PR DESCRIPTION
This PR was created outside of librarian due to b/501132869. b/501132869 should be resolved soon. In the meantime, we need to publish `value_bitmask_filter` to avoid blocking other teams.

Steps used to create this PR

- Clone [googleapis/googleapis](https://github.com/googleapis/googleapis) and checkout the last generated commit  `a6cbf809c4c165e618ee23a059442af90a80a0f5` which matches what we have in .librarian/state.yaml

https://github.com/googleapis/google-cloud-python/blob/8fa0f81cb35f93210ffb2020a8bc822a9eee5ec4/.librarian/state.yaml#L1169

- Apply this diff

```
(py392) partheniou@partheniou-vm-3:~/git/googleapis$ git diff
diff --git a/google/bigtable/v2/data.proto b/google/bigtable/v2/data.proto
index 8320a0c22f..af354b05a2 100644
--- a/google/bigtable/v2/data.proto
+++ b/google/bigtable/v2/data.proto
@@ -255,6 +255,15 @@ message ValueRange {
   }
 }
 
+// Restricts the output to cells whose values match the given bitmask.
+message ValueBitmask {
+  // Required. Mask applied to the value.
+  // Evaluated as: `(value & mask) == mask`
+  // The mask length must exactly match the value length, otherwise the cell is
+  // not considered a match.
+  bytes mask = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
 // Takes a row as input and produces an alternate view of the row based on
 // specified rules. For example, a RowFilter might trim down a row to include
 // just the cells from columns matching a given regular expression, or might
@@ -514,6 +523,12 @@ message RowFilter {
     // will be applied to separate copies of the input. This may be relaxed in
     // the future.
     string apply_label_transformer = 19;
+
+    // Matches only cells with values that satisfy the condition `(value & mask)
+    // == mask`.
+    // The mask length must exactly match the value length, otherwise the cell
+    // is not considered a match.
+    ValueBitmask value_bitmask_filter = 20;
   }
 }
```

- Clone this repo. Checkout commit `6cb5af5227e09e99ee12bb3542374f683b75d4b4` which is the last commit where generation was run:
 https://github.com/googleapis/google-cloud-python/commits/main/packages/google-cloud-bigtable

- Run `legacylibrarian generate --api-source=<path/to/clone/of/googleapis> --library=google-cloud-bigtable` to regenerate the library using the local version of googleapis

- Revert changes to `.librarian/state.yaml`

Closes https://github.com/googleapis/google-cloud-python/pull/16884