### PR TITLE
chore: librarian release pull request: 20260430T200912Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -330,7 +330,7 @@ libraries:
       - packages/google-area120-tables/docs/README.rst
     tag_format: '{id}-v{version}'
   - id: google-auth
-    version: 2.49.2
+    version: 2.50.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -226,7 +226,7 @@ libraries:
       metadata_name_override: area120tables
       default_version: v1alpha1
   - name: google-auth
-    version: 2.49.2
+    version: 2.50.0
     python:
       library_type: AUTH
       skip_readme_copy: true
@@ -617,7 +617,6 @@ libraries:
       - path: google/bigtable/v2
       - path: google/bigtable/admin/v2
     skip_generate: true
-    # TODO(b/501132869): Disabling automatic releases until resolved.
     skip_release: true
     python:
       library_type: GAPIC_COMBO

--- a/packages/google-auth/google/auth/version.py
+++ b/packages/google-auth/google/auth/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.49.2"
+__version__ = "2.50.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.11.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-auth: v2.50.0</summary>

## [v2.50.0](https://github.com/googleapis/google-cloud-python/compare/google-auth-v2.49.2...google-auth-v2.50.0) (2026-04-30)

</details>