### PR TITLE
chore: librarian release pull request: 20260430T202055Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1165,7 +1165,7 @@ libraries:
       - packages/google-cloud-bigquery-storage/docs/README.rst
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigtable
-    version: 2.36.0
+    version: 2.37.0
     last_generated_commit: a6cbf809c4c165e618ee23a059442af90a80a0f5
     apis:
       - path: google/bigtable/admin/v2

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -612,12 +612,11 @@ libraries:
       metadata_name_override: bigquerystorage
       default_version: v1
   - name: google-cloud-bigtable
-    version: 2.36.0
+    version: 2.37.0
     apis:
       - path: google/bigtable/v2
       - path: google/bigtable/admin/v2
     skip_generate: true
-    # TODO(b/501132869): Disabling automatic releases until resolved.
     skip_release: true
     python:
       library_type: GAPIC_COMBO

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/gapic_version.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.36.0"  # {x-release-please-version}
+__version__ = "2.37.0"  # {x-release-please-version}

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin/gapic_version.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.36.0"  # {x-release-please-version}
+__version__ = "2.37.0"  # {x-release-please-version}

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/gapic_version.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.36.0"  # {x-release-please-version}
+__version__ = "2.37.0"  # {x-release-please-version}

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_v2/gapic_version.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_v2/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.36.0"  # {x-release-please-version}
+__version__ = "2.37.0"  # {x-release-please-version}

--- a/packages/google-cloud-bigtable/samples/generated_samples/snippet_metadata_google.bigtable.admin.v2.json
+++ b/packages/google-cloud-bigtable/samples/generated_samples/snippet_metadata_google.bigtable.admin.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-bigtable-admin",
-    "version": "2.36.0"
+    "version": "2.37.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.11.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-cloud-bigtable: v2.37.0</summary>

## [v2.37.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigtable-v2.36.0...google-cloud-bigtable-v2.37.0) (2026-04-30)

</details>