### PR TITLE
chore: enable generation for google-crc32c

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2200,7 +2200,6 @@ libraries:
       default_version: v1
   - name: google-crc32c
     version: 1.8.0
-    skip_generate: true
     python:
       library_type: OTHER
       skip_readme_copy: true

--- a/packages/google-crc32c/.repo-metadata.json
+++ b/packages/google-crc32c/.repo-metadata.json
@@ -1,11 +1,9 @@
 {
-    "client_documentation": "https://github.com/googleapis/python-crc32c",
+    "client_documentation": "https://googleapis.dev/python/google-crc32c/latest",
     "distribution_name": "google-crc32c",
-    "issue_tracker": "https://github.com/googleapis/python-crc32c/issues",
     "language": "python",
     "library_type": "OTHER",
     "name": "google-crc32c",
-    "name_pretty": "A python wrapper of the C library 'Google CRC32C'",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-python"
 }


### PR DESCRIPTION
This isn't really generated, but this change will get `.repo-metadata.json` up-to-date.

The package previously had generation disabled due to test failures.