### PR TITLE
chore(proto-plus): update Python version and clean up enums.py

### DIFF
--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -79,8 +79,13 @@ case ${TEST_TYPE} in
             retval=$?
             ;;
         "3.9")
-            nox -s unit-3.9
-            retval=$?
+            if nox --list-sessions | grep -q "unit-3.9"; then
+                nox -s unit-3.9
+                retval=$?
+            else
+                echo "Skipping unit-3.9 as it is not supported by this package."
+                retval=0
+            fi
             ;;
         "3.10")
             nox -s unit-3.10

--- a/packages/proto-plus/docs/fields.rst
+++ b/packages/proto-plus/docs/fields.rst
@@ -81,7 +81,7 @@ Declare them in Python using the :class:`~.RepeatedField` class:
         >>> row.values = [struct_pb2.Value(string_value="hello")]
         Traceback (most recent call last):
         File "<stdin>", line 1, in <module>
-        File "/usr/local/google/home/busunkim/github/python-automl/.nox/unit-3-8/lib/python3.8/site-packages/proto/message.py", line 543, in __setattr__
+        File "/usr/local/google/home/busunkim/github/python-automl/.nox/unit-3-10/lib/python3.10/site-packages/proto/message.py", line 543, in __setattr__
             self._pb.MergeFrom(self._meta.pb(**{key: pb_value}))
         TypeError: Value must be iterable
 

--- a/packages/proto-plus/noxfile.py
+++ b/packages/proto-plus/noxfile.py
@@ -30,7 +30,6 @@ CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 DEFAULT_PYTHON_VERSION = "3.14"
 
 PYTHON_VERSIONS = [
-    "3.9",
     "3.10",
     "3.11",
     "3.12",

--- a/packages/proto-plus/proto/enums.py
+++ b/packages/proto-plus/proto/enums.py
@@ -55,8 +55,7 @@ class ProtoEnumMeta(enum.EnumMeta):
         opts = attrs.pop(pb_options, {})
         # This is the only portable way to remove the _pb_options name
         # from the enum attrs.
-        # In 3.7 onwards, we can define an _ignore_ attribute and do some
-        # mucking around with that.
+        # TODO: Use _ignore_ attribute to ignore _pb_options (Issue #16911)
         if pb_options in attrs._member_names:
             if isinstance(attrs._member_names, list):
                 idx = attrs._member_names.index(pb_options)

--- a/packages/proto-plus/proto/marshal/collections/repeated.py
+++ b/packages/proto-plus/proto/marshal/collections/repeated.py
@@ -166,10 +166,10 @@ class RepeatedComposite(Repeated):
             else:  # Is an extended slice.
                 indices = range(start, stop, step)
 
-                if len(value) != len(indices):  # XXX: Use PEP 572 on 3.8+
+                if (v_len := len(value)) != len(indices):
                     raise ValueError(
                         f"attempt to assign sequence of size "
-                        f"{len(value)} to extended slice of size "
+                        f"{v_len} to extended slice of size "
                         f"{len(indices)}"
                     )
 

--- a/packages/proto-plus/pyproject.toml
+++ b/packages/proto-plus/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 name = "proto-plus"
 authors = [{ name = "Google LLC", email = "googleapis-packages@google.com" }]
 license = { text = "Apache 2.0" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 description = "Beautiful, Pythonic protocol buffers"
 readme = "README.rst"
 classifiers = [
@@ -29,7 +29,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
This PR updates `proto-plus` to establish Python 3.10 as the minimum supported version, dropping support for Python 3.9 and below.

### Changes

* Configuration: Updated `pyproject.toml` and `noxfile.py` to require Python 3.10+ and remove references to Python 3.9.
* Code: Refactored `repeated.py` to use the walrus operator (PEP 572).
Documentation: Updated a traceback example in `docs/fields.rst` to reference Python 3.10.
* Cleanup: Replaced a stale comment regarding Python 3.7 features in proto/enums.py with a tracked TODO referencing Issue #16911.

> [!note]
> Also includes a conditional in the `run_single_test.sh` file to manage the chicken OR the egg problem of managing failing tests when a `unit-3.9` nox session is not present. Because we are migrating handwritten libs one at a time, we are in a transition period were we must still test for 3.9 in libraries that still support it but cannot have a failing presubmit in libraries that don't support it.

### Blocking

- [x] This PR is blocked by PR #16910