### PR TITLE
chore: fix Bigtable integration replacements

### DIFF
--- a/.librarian/generator-input/client-post-processing/bigtable-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/bigtable-integration.yaml
@@ -247,7 +247,7 @@ replacements:
   - paths: [
       packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/__init__.py
     ]
-    before: '"UpdateTableRequest",\n\)\n\z'
+    before: '"UpdateTableRequest",\n\)\n\Z'
     after: |
       "UpdateTableRequest",
       )
@@ -259,7 +259,7 @@ replacements:
   - paths: [
       packages/google-cloud-bigtable/google/cloud/bigtable_admin/__init__.py
     ]
-    before: '"Type",\n\)\n\z'
+    before: '"Type",\n\)\n\Z'
     after: |
       "Type",
       )
@@ -325,7 +325,7 @@ replacements:
       packages/google-cloud-bigtable/README.rst
     ]
     before: |
-      .. _Product Documentation:  https://cloud.google.com/bigtable\n
+      .. _Product Documentation:  https://cloud.google.com/bigtable/docs\n
       Quick Start
     after: |
       .. _Product Documentation:  https://cloud.google.com/bigtable/docs


### PR DESCRIPTION
Librarian is currently using an older version of Python; changing the regex is simpler than updating Python. The generated docs link has changed now that we've removed overrides.

This does not re-enable Bigtable generation, but means it'll be simpler to get it generating again when other aspects are ready.
