### PR TITLE
chore: disable compute autorelease

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -37,3 +37,7 @@ libraries:
   # TODO(b/501132869): Disabling automatic releases until resolved.
   - id: "google-cloud-bigtable"
     release_blocked: true
+  # TODO(https://github.com/googleapis/google-cloud-python/issues/16780): Disabling automatic releases until resolved.
+  - id: "google-cloud-compute"
+    release_blocked: true
+

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -747,6 +747,8 @@ libraries:
     python:
       metadata_name_override: compute
       default_version: v1
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/16780): Disabling automatic releases until resolved.
+    skip_release: true
   - name: google-cloud-compute-v1beta
     version: 0.10.0
     apis:


### PR DESCRIPTION
Towards https://github.com/googleapis/google-cloud-python/issues/16780

Disable autorelease for `google-cloud-compute`. https://github.com/googleapis/google-cloud-python/pull/16751 included changes to make use of the [service config file ](https://github.com/googleapis/googleapis/blob/master/google/cloud/compute/v1/compute_grpc_service_config.json). As per https://github.com/googleapis/google-cloud-python/issues/16780. we would like to release `google-cloud-compute-v1beta` first. Let's skip `google-cloud-compute` for this week.