### PR TITLE
chore(bigframes): fix ai multimodal tests

### DIFF
--- a/packages/bigframes/tests/system/small/bigquery/test_ai.py
+++ b/packages/bigframes/tests/system/small/bigquery/test_ai.py
@@ -337,7 +337,7 @@ def test_ai_if_multi_model(session, bq_connection):
     df = session.from_glob_path(
         "gs://bigframes-dev-testing/a_multimodel/images/*",
         name="image",
-        connection = bq_connection
+        connection=bq_connection,
     )
 
     result = bbq.ai.if_((df["image"], " contains an animal"))

--- a/packages/bigframes/tests/system/small/bigquery/test_ai.py
+++ b/packages/bigframes/tests/system/small/bigquery/test_ai.py
@@ -333,11 +333,10 @@ def test_ai_if(session):
     assert result.dtype == dtypes.BOOL_DTYPE
 
 
-def test_ai_if_multi_model(session, bq_connection):
+def test_ai_if_multi_model(session):
     df = session.from_glob_path(
         "gs://bigframes-dev-testing/a_multimodel/images/*",
         name="image",
-        connection=bq_connection,
     )
 
     result = bbq.ai.if_((df["image"], " contains an animal"))
@@ -355,11 +354,10 @@ def test_ai_classify(session):
     assert result.dtype == dtypes.STRING_DTYPE
 
 
-def test_ai_classify_multi_model(session, bq_connection):
+def test_ai_classify_multi_model(session):
     df = session.from_glob_path(
         "gs://bigframes-dev-testing/a_multimodel/images/*",
         name="image",
-        connection=bq_connection,
     )
 
     result = bbq.ai.classify(df["image"], ["photo", "cartoon"])

--- a/packages/bigframes/tests/system/small/bigquery/test_ai.py
+++ b/packages/bigframes/tests/system/small/bigquery/test_ai.py
@@ -359,6 +359,7 @@ def test_ai_classify_multi_model(session, bq_connection):
     df = session.from_glob_path(
         "gs://bigframes-dev-testing/a_multimodel/images/*",
         name="image",
+        connection=bq_connection,
     )
 
     result = bbq.ai.classify(df["image"], ["photo", "cartoon"])

--- a/packages/bigframes/tests/system/small/bigquery/test_ai.py
+++ b/packages/bigframes/tests/system/small/bigquery/test_ai.py
@@ -333,10 +333,11 @@ def test_ai_if(session):
     assert result.dtype == dtypes.BOOL_DTYPE
 
 
-def test_ai_if_multi_model(session):
+def test_ai_if_multi_model(session, bq_connection):
     df = session.from_glob_path(
         "gs://bigframes-dev-testing/a_multimodel/images/*",
         name="image",
+        connection = bq_connection
     )
 
     result = bbq.ai.if_((df["image"], " contains an animal"))
@@ -354,7 +355,7 @@ def test_ai_classify(session):
     assert result.dtype == dtypes.STRING_DTYPE
 
 
-def test_ai_classify_multi_model(session):
+def test_ai_classify_multi_model(session, bq_connection):
     df = session.from_glob_path(
         "gs://bigframes-dev-testing/a_multimodel/images/*",
         name="image",

--- a/packages/bigframes/tests/system/small/bigquery/test_ai.py
+++ b/packages/bigframes/tests/system/small/bigquery/test_ai.py
@@ -341,7 +341,7 @@ def test_ai_if_multi_model(session):
 
     result = bbq.ai.if_((df["image"], " contains an animal"))
 
-    assert _contains_no_nulls(result)
+    assert len(result) == len(df)
     assert result.dtype == dtypes.BOOL_DTYPE
 
 
@@ -362,7 +362,7 @@ def test_ai_classify_multi_model(session):
 
     result = bbq.ai.classify(df["image"], ["photo", "cartoon"])
 
-    assert _contains_no_nulls(result)
+    assert len(result) == len(df)
     assert result.dtype == dtypes.STRING_DTYPE
 
 
@@ -384,7 +384,7 @@ def test_ai_score_multi_model(session):
 
     result = bbq.ai.score(prompt)
 
-    assert _contains_no_nulls(result)
+    assert len(result) == len(df)
     assert result.dtype == dtypes.FLOAT_DTYPE
 
 

--- a/packages/bigframes/tests/system/small/bigquery/test_ai.py
+++ b/packages/bigframes/tests/system/small/bigquery/test_ai.py
@@ -329,7 +329,7 @@ def test_ai_if(session):
         max_error_ratio=0.5,
     )
 
-    assert _contains_no_nulls(result)
+    assert len(result) == len(s1)
     assert result.dtype == dtypes.BOOL_DTYPE
 
 
@@ -350,7 +350,7 @@ def test_ai_classify(session):
 
     result = bbq.ai.classify(s, ["animal", "plant"])
 
-    assert _contains_no_nulls(result)
+    assert len(result) == len(s)
     assert result.dtype == dtypes.STRING_DTYPE
 
 
@@ -372,7 +372,7 @@ def test_ai_score(session):
 
     result = bbq.ai.score(prompt)
 
-    assert _contains_no_nulls(result)
+    assert len(result) == len(s)
     assert result.dtype == dtypes.FLOAT_DTYPE
 
 


### PR DESCRIPTION
For ai.if, ai.score and ai.classify, it's not guaranteed that the result entries are not NULL.