### PR TITLE
chore: remove unnecessary overrides in librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -748,7 +748,6 @@ libraries:
     apis:
       - path: google/cloud/compute/v1beta
     python:
-      issue_tracker_override: https://issuetracker.google.com/issues/new?component=187134&template=0
       default_version: v1beta
   - name: google-cloud-confidentialcomputing
     version: 0.9.0
@@ -1939,7 +1938,6 @@ libraries:
         google/storage/v2:
           - python-gapic-namespace=google.cloud
           - python-gapic-name=_storage
-      issue_tracker_override: https://issuetracker.google.com/savedsearches/559782
       metadata_name_override: storage
       default_version: v2
   - name: google-cloud-storage-control

--- a/packages/google-cloud-storage/.repo-metadata.json
+++ b/packages/google-cloud-storage/.repo-metadata.json
@@ -5,7 +5,7 @@
     "client_documentation": "https://cloud.google.com/python/docs/reference/storage/latest",
     "default_version": "v2",
     "distribution_name": "google-cloud-storage",
-    "issue_tracker": "https://issuetracker.google.com/savedsearches/559782",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187243\u0026template=1162869",
     "language": "python",
     "library_type": "GAPIC_MANUAL",
     "name": "storage",

--- a/packages/google-cloud-storage/tests/perf/microbenchmarks/time_based/reads/test_reads.py
+++ b/packages/google-cloud-storage/tests/perf/microbenchmarks/time_based/reads/test_reads.py
@@ -20,6 +20,7 @@ import os
 import random
 import time
 from typing import List, NamedTuple, Optional
+
 import pytest
 
 import tests.perf.microbenchmarks.time_based.reads.config as config


### PR DESCRIPTION
Compute v1beta and Storage v2 now have issue trackers in Librarian's sdk.yaml.

This PR includes regeneration of all libraries - the Compute package is entirely unchanged; the tracker for Storage is changed (but still present, and checked for correctness).

Fixes https://github.com/googleapis/librarian/issues/5465