### PR TITLE
chore: add a post-submit check that regenerating doesn't change anything

### DIFF
--- a/.github/workflows/regenerate-all.yml
+++ b/.github/workflows/regenerate-all.yml
@@ -1,0 +1,69 @@
+name: Regenerate all packages after merging to main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    env:
+      PANDOC_VERSION: 3.8.2
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "25.3"
+
+      - name: Install pandoc
+        run: |
+          mkdir /tmp/pandoc
+          curl -fsSL --retry 5 --retry-delay 15 -o /tmp/pandoc.tar.gz \
+            https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz
+          tar -xvf /tmp/pandoc.tar.gz -C /tmp/pandoc --strip-components=1
+
+      - name: Install Python packages for Librarian
+        run: |
+          version=$(sed -n 's/^version: *//p' librarian.yaml)
+          go run "github.com/googleapis/librarian/cmd/librarian@${version}" install
+
+      - name: Regenerate
+        run: |
+          version=$(sed -n 's/^version: *//p' librarian.yaml)
+          PATH=$PATH:/tmp/pandoc/bin
+          go run "github.com/googleapis/librarian/cmd/librarian@${version}" generate -all -v
+
+      - name: Create issue on diff
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            TITLE="Regeneration check found diff"
+            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            DIFF_STAT=$(git diff --stat)
+            BODY="The post-submit [regeneration check]($RUN_URL) found a diff.
+
+            Diff summary:
+            \`\`\`
+            $DIFF_STAT
+            \`\`\`"
+
+            EXISTING_ISSUE=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
+            if [ -z "$EXISTING_ISSUE" ]; then
+              gh issue create --title "$TITLE" --body "$BODY"
+            else
+              echo "Issue #$EXISTING_ISSUE already exists, adding a comment."
+              gh issue comment "$EXISTING_ISSUE" --body "Another failure with diff occurred: $RUN_URL"
+            fi
+          fi

--- a/.github/workflows/regenerate-all.yml
+++ b/.github/workflows/regenerate-all.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   regenerate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a post-submit as it takes a while (~25 minutes). We could *potentially* make it a pre-submit and only generate packages which have changed, but that would be more fiddly.

It would be nice not to specify the protoc or pandoc version here, but that will require improvements in librarian (tracked in https://github.com/googleapis/librarian/issues/5818).

Fixes https://github.com/googleapis/librarian/issues/4800
