### PR TITLE
fix: pass resource aliases to file-level CommonResources

### DIFF
--- a/packages/gapic-generator/gapic/schema/api.py
+++ b/packages/gapic-generator/gapic/schema/api.py
@@ -101,6 +101,7 @@ class Proto:
     meta: metadata.Metadata = dataclasses.field(
         default_factory=metadata.Metadata,
     )
+    resource_name_aliases: Mapping[str, str] = dataclasses.field(default_factory=dict)
 
     def __getattr__(self, name: str):
         return getattr(self.file_pb2, name)
@@ -159,7 +160,7 @@ class Proto:
     def resource_messages(self) -> Mapping[str, wrappers.MessageType]:
         """Return the file level resources of the proto."""
         file_resource_messages = (
-            (res.type, wrappers.CommonResource.build(res).message_type)
+            (res.type, wrappers.CommonResource.build(res, aliases=self.resource_name_aliases).message_type)
             for res in self.file_pb2.options.Extensions[
                 resource_pb2.resource_definition
             ]
@@ -1214,6 +1215,7 @@ class _ProtoBuilder:
             meta=metadata.Metadata(
                 address=self.address,
             ),
+            resource_name_aliases=self.opts.resource_name_aliases,
         )
 
         # If this is not a file being generated, we do not need to

--- a/packages/gapic-generator/gapic/schema/wrappers.py
+++ b/packages/gapic-generator/gapic/schema/wrappers.py
@@ -2081,10 +2081,11 @@ class Method:
 class CommonResource:
     type_name: str
     pattern: str
+    resource_name_aliases: Mapping[str, str] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def build(cls, resource: resource_pb2.ResourceDescriptor):
-        return cls(type_name=resource.type, pattern=next(iter(resource.pattern)))
+    def build(cls, resource: resource_pb2.ResourceDescriptor, aliases: Optional[Mapping[str, str]] = None):
+        return cls(type_name=resource.type, pattern=next(iter(resource.pattern)), resource_name_aliases=aliases or {})
 
     @utils.cached_property
     def message_type(self):
@@ -2098,6 +2099,7 @@ class CommonResource:
             fields={},
             nested_enums={},
             nested_messages={},
+            resource_name_aliases=self.resource_name_aliases,
         )
 
 
@@ -2343,6 +2345,7 @@ class Service:
                     f"To protect backward compatibility, explicitly alias one of these using "
                     f"the `--resource-name-alias` CLI parameter.\n"
                     f"Example: --resource-name-alias={msg.resource_type_full_path}:CustomName\n"
+                    f"{seen_types}"
                 )
             seen_types[res_type] = msg
 

--- a/packages/gapic-generator/gapic/schema/wrappers.py
+++ b/packages/gapic-generator/gapic/schema/wrappers.py
@@ -2345,7 +2345,6 @@ class Service:
                     f"To protect backward compatibility, explicitly alias one of these using "
                     f"the `--resource-name-alias` CLI parameter.\n"
                     f"Example: --resource-name-alias={msg.resource_type_full_path}:CustomName\n"
-                    f"{seen_types}"
                 )
             seen_types[res_type] = msg
 


### PR DESCRIPTION
File-level resources (like imported dependencies) were previously starved of CLI aliases during dummy MessageType creation. This caused false-positive namespace collisions because the collision checker couldn't see the explicit aliases.

This wires `opts.resource_name_aliases` down through api.py into `CommonResource.build()` so the alias resolution works as originally intended.

Fixes: https://github.com/googleapis/google-cloud-python/issues/16952