### PR TITLE
fix(runtimeconfig): Drop support for Python 3.9

### DIFF
--- a/packages/google-cloud-runtimeconfig/CONTRIBUTING.rst
+++ b/packages/google-cloud-runtimeconfig/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
+  3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -197,14 +197,12 @@ Supported Python Versions
 
 We support:
 
--  `Python 3.9`_
 -  `Python 3.10`_
 -  `Python 3.11`_
 -  `Python 3.12`_
 -  `Python 3.13`_
 -  `Python 3.14`_
 
-.. _Python 3.9: https://docs.python.org/3.9/
 .. _Python 3.10: https://docs.python.org/3.10/
 .. _Python 3.11: https://docs.python.org/3.11/
 .. _Python 3.12: https://docs.python.org/3.12/

--- a/packages/google-cloud-runtimeconfig/README.rst
+++ b/packages/google-cloud-runtimeconfig/README.rst
@@ -53,14 +53,14 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9
+Python >= 3.10
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-runtimeconfig/noxfile.py
+++ b/packages/google-cloud-runtimeconfig/noxfile.py
@@ -35,7 +35,6 @@ LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 DEFAULT_PYTHON_VERSION = "3.14"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
-    "3.9",
     "3.10",
     "3.11",
     "3.12",

--- a/packages/google-cloud-runtimeconfig/pytest.ini
+++ b/packages/google-cloud-runtimeconfig/pytest.ini
@@ -7,7 +7,3 @@ filterwarnings =
     ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
     # Remove once https://github.com/protocolbuffers/protobuf/issues/12186 is fixed
     ignore:.*custom tp_new.*in Python 3.14:DeprecationWarning
-    # Remove after support for Python 3.7 is dropped
-    ignore:After January 1, 2024, new releases of this library will drop support for Python 3.7:DeprecationWarning
-    ignore:.*Please upgrade to the latest Python version.*:FutureWarning
-    ignore:(?s).*using a Python version.*past its end of life.*:FutureWarning

--- a/packages/google-cloud-runtimeconfig/setup.py
+++ b/packages/google-cloud-runtimeconfig/setup.py
@@ -74,7 +74,6 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
@@ -87,7 +86,7 @@ setuptools.setup(
     packages=packages,
     install_requires=dependencies,
     extras_require=extras,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     include_package_data=True,
     zip_safe=False,
 )

--- a/packages/google-cloud-runtimeconfig/testing/constraints-3.10.txt
+++ b/packages/google-cloud-runtimeconfig/testing/constraints-3.10.txt
@@ -1,0 +1,8 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
+google-cloud-core==1.4.4

--- a/packages/google-cloud-runtimeconfig/testing/constraints-3.9.txt
+++ b/packages/google-cloud-runtimeconfig/testing/constraints-3.9.txt
@@ -1,8 +1,0 @@
-# This constraints file is used to check that lower bounds
-# are correct in setup.py
-# List *all* library dependencies and extras in this file.
-# Pin the version to the lower bound.
-#
-# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
-# Then this file should have foo==1.14.0
-google-cloud-core==1.4.4


### PR DESCRIPTION
This PR updates \`google-cloud-runtimeconfig\` to establish Python 3.10 as the minimum supported version, dropping support for Python 3.9 and below.

### Changes

* Configuration: Updated \`setup.py\` and \`noxfile.py\` to require Python 3.10+ and remove references to Python 3.9.
* Documentation: Updated \`README.rst\` and \`CONTRIBUTING.rst\` to reflect supported Python versions.
* Cleanup: Removed dead deprecation warnings from \`pytest.ini\`.
* Constraints: Transferred lower bounds to \`constraints-3.10.txt\` and dropped \`constraints-3.9.txt\`.

Verified successfully with 49 passing unit tests under Python 3.10!

Fixes internal issue: http://b/482126936 🦕
