### PR TITLE
fix(bigquery-magics): Drop support for Python 3.9

### DIFF
--- a/packages/bigquery-magics/CONTRIBUTING.rst
+++ b/packages/bigquery-magics/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.9, 3.11, 3.12 and 3.13 on both UNIX and Windows.
+  3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -198,12 +198,12 @@ Supported Python Versions
 
 We support:
 
--  `Python 3.9`_
+-  `Python 3.10`_
 -  `Python 3.11`_
 -  `Python 3.12`_
 -  `Python 3.13`_
 
-.. _Python 3.9: https://docs.python.org/3.9/
+.. _Python 3.10: https://docs.python.org/3.10/
 .. _Python 3.11: https://docs.python.org/3.11/
 .. _Python 3.12: https://docs.python.org/3.12/
 .. _Python 3.13: https://docs.python.org/3.13/

--- a/packages/bigquery-magics/README.rst
+++ b/packages/bigquery-magics/README.rst
@@ -52,11 +52,11 @@ dependencies.
 
 Supported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Python >= 3.9
+Python >= 3.10
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8.
+Python <= 3.9.
 
 
 Mac/Linux

--- a/packages/bigquery-magics/noxfile.py
+++ b/packages/bigquery-magics/noxfile.py
@@ -56,9 +56,6 @@ UNIT_TEST_LOCAL_DEPENDENCIES: List[str] = []
 UNIT_TEST_DEPENDENCIES: List[str] = []
 UNIT_TEST_EXTRAS: List[str] = []
 UNIT_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {
-    "3.9": [
-        "bqstorage",
-    ],
     "3.10": [
         "bqstorage",
     ],
@@ -91,9 +88,6 @@ SYSTEM_TEST_LOCAL_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_EXTRAS: List[str] = []
 SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {
-    "3.9": [
-        "bqstorage",
-    ],
     "3.10": [
         "bqstorage",
         "bigframes",

--- a/packages/bigquery-magics/noxfile.py
+++ b/packages/bigquery-magics/noxfile.py
@@ -40,10 +40,6 @@ UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.12",
     "3.13",
     "3.14",
-    # Not supported, but included so that we can explicitly skip the session
-    # from here. Keep unsupported versions last so that they don't conflict with
-    # the prerelease_deps session.
-    "3.9",
 ]
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [
@@ -224,9 +220,6 @@ def install_unittest_dependencies(session, *constraints):
 
 @nox.session(python=UNIT_TEST_PYTHON_VERSIONS)
 def unit(session):
-    if session.python == "3.9":
-        session.skip("Python 3.9 is not supported.")
-
     # Install all test dependencies, then install this package in-place.
 
     constraints_path = str(


### PR DESCRIPTION
This PR updates \`bigquery-magics\` to drop support for Python 3.9 and establish Python 3.10 as the minimum supported version. (Note: \`setup.py\` was already at Python 3.10, so this cleans up the remaining test configs!).

### Changes

* Configuration: Updated \`noxfile.py\` to remove 3.9 mappings from unit and system test extras, and updated supported versions.
* Documentation: Updated \`README.rst\` and \`CONTRIBUTING.rst\` to reflect supported Python versions.

Verified successfully with 126 passing tests under Python 3.10!

Fixes internal issue: http://b/482126936 🦕
