### PR TITLE
fix(dns): Drop support for Python 3.9

### DIFF
--- a/packages/google-cloud-dns/CONTRIBUTING.rst
+++ b/packages/google-cloud-dns/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
+  3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -197,14 +197,12 @@ Supported Python Versions
 
 We support:
 
--  `Python 3.9`_
 -  `Python 3.10`_
 -  `Python 3.11`_
 -  `Python 3.12`_
 -  `Python 3.13`_
 -  `Python 3.14`_
 
-.. _Python 3.9: https://docs.python.org/3.9/
 .. _Python 3.10: https://docs.python.org/3.10/
 .. _Python 3.11: https://docs.python.org/3.11/
 .. _Python 3.12: https://docs.python.org/3.12/

--- a/packages/google-cloud-dns/CONTRIBUTING.rst
+++ b/packages/google-cloud-dns/CONTRIBUTING.rst
@@ -215,17 +215,6 @@ Supported versions can be found in our ``noxfile.py`` `config`_.
 .. _config: https://github.com/googleapis/google-cloud-python/blob/main/noxfile.py
 
 
-We also explicitly decided to support Python 3 beginning with version 3.9.
-Reasons for this include:
-
--  Encouraging use of newest versions of Python 3
--  Taking the lead of `prominent`_ open-source `projects`_
--  `Unicode literal support`_ which allows for a cleaner codebase that
-   works in both Python 2 and Python 3
-
-.. _prominent: https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django
-.. _projects: http://flask.pocoo.org/docs/0.10/python3/
-.. _Unicode literal support: https://www.python.org/dev/peps/pep-0414/
 
 **********
 Versioning

--- a/packages/google-cloud-dns/README.rst
+++ b/packages/google-cloud-dns/README.rst
@@ -60,14 +60,14 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9
+Python >= 3.10
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dns/README.rst
+++ b/packages/google-cloud-dns/README.rst
@@ -67,7 +67,6 @@ Python >= 3.10
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. version-scanner: ignore-next-line
 Python <= 3.9
 
 If you are using an `end-of-life`_

--- a/packages/google-cloud-dns/README.rst
+++ b/packages/google-cloud-dns/README.rst
@@ -67,6 +67,7 @@ Python >= 3.10
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. version-scanner: ignore-next-line
 Python <= 3.9
 
 If you are using an `end-of-life`_

--- a/packages/google-cloud-dns/docs/README.rst
+++ b/packages/google-cloud-dns/docs/README.rst
@@ -60,14 +60,14 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9
+Python >= 3.10
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dns/noxfile.py
+++ b/packages/google-cloud-dns/noxfile.py
@@ -35,7 +35,6 @@ LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 DEFAULT_PYTHON_VERSION = "3.14"
 
 ALL_PYTHON: List[str] = [
-    "3.9",
     "3.10",
     "3.11",
     "3.12",
@@ -69,7 +68,6 @@ SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
-    "unit-3.9",
     "unit-3.10",
     "unit-3.11",
     "unit-3.12",

--- a/packages/google-cloud-dns/pytest.ini
+++ b/packages/google-cloud-dns/pytest.ini
@@ -9,7 +9,9 @@ filterwarnings =
     # Remove once https://github.com/googleapis/python-api-common-protos/pull/187/files is merged
     ignore:.*pkg_resources.declare_namespace:DeprecationWarning
     ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
-    # Remove after support for Python 3.8, 3.9 and/or 3.10+ is dropped
+    # Remove after support for Python 3.8, 3.9 and/or 3.10+ is dropped # version-scanner: ignore
+    # version-scanner: ignore-next-line
     ignore:\s*You are using a (non-supported )?Python version \(?3\.(8|9|1[0-9]+):DeprecationWarning
+    # version-scanner: ignore-next-line
     ignore:\s*You are using a (non-supported )?Python version \(?3\.(8|9|1[0-9]+):FutureWarning
 

--- a/packages/google-cloud-dns/pytest.ini
+++ b/packages/google-cloud-dns/pytest.ini
@@ -9,4 +9,7 @@ filterwarnings =
     # Remove once https://github.com/googleapis/python-api-common-protos/pull/187/files is merged
     ignore:.*pkg_resources.declare_namespace:DeprecationWarning
     ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
+    # Remove after support for Python 3.8, 3.9 and/or 3.10+ is dropped
+    ignore:\s*You are using a (non-supported )?Python version \(?3\.(8|9|1[0-9]+):DeprecationWarning
+    ignore:\s*You are using a (non-supported )?Python version \(?3\.(8|9|1[0-9]+):FutureWarning
 

--- a/packages/google-cloud-dns/pytest.ini
+++ b/packages/google-cloud-dns/pytest.ini
@@ -9,9 +9,6 @@ filterwarnings =
     # Remove once https://github.com/googleapis/python-api-common-protos/pull/187/files is merged
     ignore:.*pkg_resources.declare_namespace:DeprecationWarning
     ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
-    # Remove after support for Python 3.8, 3.9 and/or 3.10+ is dropped # version-scanner: ignore
-    # version-scanner: ignore-next-line
+    # Remove after support for Python 3.8, 3.9 and/or 3.10+ is dropped
     ignore:\s*You are using a (non-supported )?Python version \(?3\.(8|9|1[0-9]+):DeprecationWarning
-    # version-scanner: ignore-next-line
     ignore:\s*You are using a (non-supported )?Python version \(?3\.(8|9|1[0-9]+):FutureWarning
-

--- a/packages/google-cloud-dns/pytest.ini
+++ b/packages/google-cloud-dns/pytest.ini
@@ -9,8 +9,4 @@ filterwarnings =
     # Remove once https://github.com/googleapis/python-api-common-protos/pull/187/files is merged
     ignore:.*pkg_resources.declare_namespace:DeprecationWarning
     ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
-    # Remove after support for Python 3.7 is dropped
-    ignore:After January 1, 2024, new releases of this library will drop support for Python 3.7:DeprecationWarning
-    # Remove after support for Python 3.8, 3.9 and/or 3.10+ is dropped
-    ignore:\s*You are using a (non-supported )?Python version \(?3\.(8|9|1[0-9]+):DeprecationWarning
-    ignore:\s*You are using a (non-supported )?Python version \(?3\.(8|9|1[0-9]+):FutureWarning
+

--- a/packages/google-cloud-dns/setup.py
+++ b/packages/google-cloud-dns/setup.py
@@ -77,7 +77,6 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
@@ -90,7 +89,7 @@ setuptools.setup(
     packages=packages,
     install_requires=dependencies,
     extras_require=extras,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     include_package_data=True,
     zip_safe=False,
 )

--- a/packages/google-cloud-dns/testing/constraints-3.10.txt
+++ b/packages/google-cloud-dns/testing/constraints-3.10.txt
@@ -1,0 +1,8 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
+google-cloud-core==1.4.4

--- a/packages/google-cloud-dns/testing/constraints-3.9.txt
+++ b/packages/google-cloud-dns/testing/constraints-3.9.txt
@@ -1,8 +1,0 @@
-# This constraints file is used to check that lower bounds
-# are correct in setup.py
-# List *all* library dependencies and extras in this file.
-# Pin the version to the lower bound.
-#
-# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
-# Then this file should have foo==1.14.0
-google-cloud-core==1.4.4


### PR DESCRIPTION
This PR updates \`google-cloud-dns\` to establish Python 3.10 as the minimum supported version, dropping support for Python 3.7, 3.8, and 3.9.

### Changes

* Configuration: Updated \`setup.py\` and \`noxfile.py\` to require Python 3.10+ and remove references to Python 3.9.
* Documentation: Updated \`README.rst\` and \`CONTRIBUTING.rst\` to reflect supported Python versions.
* Constraints: Transferred lower bounds to \`constraints-3.10.txt\` and dropped \`constraints-3.9.txt\`.

Verified successfully with 65 passing unit tests under Python 3.10!

Fixes internal issue: http://b/482126936 🦕
