### PR TITLE
chore: regenerate all libraries with librarian

### DIFF
--- a/packages/bigquery-magics/docs/README.rst
+++ b/packages/bigquery-magics/docs/README.rst
@@ -52,11 +52,11 @@ dependencies.
 
 Supported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Python >= 3.9
+Python >= 3.10
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8.
+Python <= 3.9.
 
 
 Mac/Linux

--- a/packages/google-cloud-runtimeconfig/docs/README.rst
+++ b/packages/google-cloud-runtimeconfig/docs/README.rst
@@ -53,14 +53,14 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9
+Python >= 3.10
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-storage/google/cloud/storage/_grpc_conversions.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_grpc_conversions.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from google.cloud import _storage_v2
 from google.protobuf import timestamp_pb2
+
+from google.cloud import _storage_v2
 
 # Map Python Blob attributes to GCS V2 Object proto field names.
 _BLOB_ATTR_TO_PROTO_FIELD = {

--- a/packages/google-cloud-storage/tests/unit/test__grpc_conversions.py
+++ b/packages/google-cloud-storage/tests/unit/test__grpc_conversions.py
@@ -15,8 +15,8 @@
 import datetime
 from unittest import mock
 
-from google.cloud.storage import _grpc_conversions
 from google.cloud import _storage_v2
+from google.cloud.storage import _grpc_conversions
 
 
 def test_blob_to_proto_simple_fields():

--- a/packages/google-resumable-media/docs/README.rst
+++ b/packages/google-resumable-media/docs/README.rst
@@ -16,12 +16,12 @@ support at `google._async_resumable_media`.
 
 Supported Python Versions
 -------------------------
-Python >= 3.9
+Python >= 3.10
 
 Unsupported Python Versions
 ---------------------------
 
-Python <= 3.8
+Python <= 3.9
 
 
 License


### PR DESCRIPTION
This has copied README.rst files which were modified in the package root but then not copied into docs.

Two files within google-cloud-storage are also reformatted.
