### PR TITLE
fix(bigframes): Drop support for Python <= 3.9

### DIFF
--- a/packages/bigframes/CONTRIBUTING.rst
+++ b/packages/bigframes/CONTRIBUTING.rst
@@ -232,11 +232,11 @@ configure them just like the System Tests.
 
    # Run all tests in a folder
    $ cd samples/snippets
-   $ nox -s py-3.8
+   $ nox -s py-3.10
 
    # Run a single sample test
    $ cd samples/snippets
-   $ nox -s py-3.8 -- -k <name of test>
+   $ nox -s py-3.10 -- -k <name of test>
 
 ********************************************
 Note About ``README`` as it pertains to PyPI
@@ -276,17 +276,7 @@ Supported versions can be found in our ``noxfile.py`` `config`_.
 .. _config: https://github.com/googleapis/google-cloud-python/blob/main/packages/bigframes/noxfile.py
 
 
-We also explicitly decided to support Python 3 beginning with version 3.10.
-Reasons for this include:
 
--  Encouraging use of newest versions of Python 3
--  Taking the lead of `prominent`_ open-source `projects`_
--  `Unicode literal support`_ which allows for a cleaner codebase that
-   works in both Python 2 and Python 3
-
-.. _prominent: https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django
-.. _projects: http://flask.pocoo.org/docs/0.10/python3/
-.. _Unicode literal support: https://www.python.org/dev/peps/pep-0414/
 
 **********
 Versioning

--- a/packages/bigframes/noxfile.py
+++ b/packages/bigframes/noxfile.py
@@ -60,7 +60,7 @@ LINT_PATHS = [
 
 DEFAULT_PYTHON_VERSION = "3.14"
 
-ALL_PYTHON = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+ALL_PYTHON = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     PYTEST_VERSION,
@@ -274,8 +274,6 @@ def run_unit(session, install_test_extra):
 @nox.session(python=ALL_PYTHON)
 @nox.parametrize("test_extra", [True, False])
 def unit(session, test_extra):
-    if session.python in ("3.7", "3.8", "3.9"):
-        session.skip("Python 3.9 and below are not supported")
     if test_extra:
         run_unit(session, install_test_extra=test_extra)
     else:
@@ -378,9 +376,6 @@ def run_system(
 @nox.session(python="3.12")
 def system(session: nox.sessions.Session):
     """Run the system test suite."""
-    if session.python in ("3.7", "3.8", "3.9"):
-        session.skip("Python 3.9 and below are not supported")
-
     run_system(
         session=session,
         prefix_name="system",

--- a/packages/bigframes/tests/unit/test_pandas.py
+++ b/packages/bigframes/tests/unit/test_pandas.py
@@ -54,11 +54,6 @@ def all_session_methods():
     [(method_name,) for method_name in all_session_methods()],
 )
 def test_method_matches_session(method_name: str):
-    if sys.version_info < (3, 10):
-        pytest.skip(
-            "Need Python 3.10 to reconcile deferred annotations."
-        )  # pragma: no cover
-
     session_method = getattr(bigframes.session.Session, method_name)
     session_doc = inspect.getdoc(session_method)
     assert session_doc is not None, "docstrings are required"


### PR DESCRIPTION
> [!note]
> This is part of a larger effort across the monorepo to ensure that all packages are focused on currently supported Python runtimes. This package was already heavily focused on 3.10 support so changes should be fairly minimal. 

This PR updates `bigframes` to establish Python 3.10 as the minimum supported version, dropping support for Python 3.9 and below.

### Changes

* Configuration: Updated `noxfile.py` to remove references to Python 3.9 from the supported versions list.
* Documentation: Updated `CONTRIBUTING.rst` to use Python 3.10 in sample commands and removed stale Python 2 compatibility notes.
* Cleanup: Removed dead code in `noxfile.py` that was skipping Python 3.7, 3.8, and 3.9. 
Removed dead code in `tests/unit/test_pandas.py` checking for Python < 3.10.

Fixes internal issue: http://b/482126936 🦕