### PR TITLE
chore(firestore): disable auto-release

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -37,4 +37,8 @@ libraries:
   # Disable automatic releases until tests stabilize.
   - id: "pandas-gbq"
     release_blocked: true
+  # TODO(https://github.com/googleapis/google-cloud-python/issues/16970):
+  # Disable automatic releases until system tests are sped up or reorganized.
+  - id: "google-cloud-firestore"
+    release_blocked: true
 

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1123,6 +1123,7 @@ libraries:
       - docs/firestore_v1/transaction.rst
       - docs/firestore_v1/transforms.rst
       - docs/firestore_v1/types.rst
+    skip_release: true
     python:
       library_type: GAPIC_COMBO
       opt_args_by_api:
@@ -2512,9 +2513,9 @@ libraries:
       default_version: apiVersion
   - name: pandas-gbq
     version: 0.35.0
+    skip_release: true
     python:
       library_type: INTEGRATION
-    skip_release: true
   - name: proto-plus
     version: 1.27.2
     python:


### PR DESCRIPTION
Disables automatic releases for `google-cloud-firestore`. See https://github.com/googleapis/google-cloud-python/issues/16970.

Also runs `librarian tidy`, hence the moving of another config value.