### PR TITLE
chore: add a presubmit that checks for librarian config consistency

### DIFF
--- a/.github/workflows/librarian_config_check.yml
+++ b/.github/workflows/librarian_config_check.yml
@@ -1,0 +1,43 @@
+name: check that Librarian and legacylibrarian configs are consistent
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+jobs:
+  config-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # Use this action, rather than a file filter so that we can make this
+      # mandatory.
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-including-branches
+      # for more details.
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            librarian:
+              - 'librarian.yaml'
+              - '.librarian/config.yaml'
+              - '.librarian/state.yaml'
+      - name: Config check
+        id: config-check
+        if: steps.filter.outputs.librarian == 'true'
+        run: |
+          V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
+          go run "github.com/googleapis/librarian/tool/cmd/configcheck@${V}" .
+      - name: Report any failures
+        if: failure() && steps.config-check.outcome == 'failure'
+        run: |
+          echo "Library configuration is different between state.yaml and librarian.yaml.
+          Update library configuration in the configs according to the error message and
+          regenerate libraries using:
+          
+          V=\$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
+          go run github.com/googleapis/librarian/cmd/librarian@\${V} generate --all
+          "
+          # Make sure this step fails too, so that it's highlighted in the action logs.
+          exit 1

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -55,6 +55,7 @@ default:
 libraries:
   - name: bigframes
     version: 2.39.0
+    skip_release: true
     python:
       library_type: INTEGRATION
   - name: bigquery-magics
@@ -1933,6 +1934,7 @@ libraries:
     version: 3.10.1
     apis:
       - path: google/storage/v2
+    skip_release: true
     python:
       library_type: GAPIC_MANUAL
       opt_args_by_api:
@@ -2194,6 +2196,7 @@ libraries:
       default_version: v1
   - name: google-crc32c
     version: 1.8.0
+    skip_release: false
     python:
       library_type: OTHER
   - name: google-geo-type


### PR DESCRIPTION
Currently we're using librarian for generation and legacylibrarian for releasing. This check makes sure that the relevant aspects of the two configurations (which libraries are configured, their versions, and whether releases are blocked) are consistent.

This commit also ensures that we're starting from a consistent state.
