### PR TITLE
chore: copy sqlalchemy-bigquery README.rst to docs directory

### DIFF
--- a/packages/sqlalchemy-bigquery/docs/README.rst
+++ b/packages/sqlalchemy-bigquery/docs/README.rst
@@ -51,11 +51,11 @@ dependencies.
 
 Supported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Python >= 3.9, <3.14
+Python >= 3.10, <= 3.14
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.7.
+Python <= 3.9
 
 
 Mac/Linux


### PR DESCRIPTION
This commit was created by just regenerating all libraries. This was the only change.

Fixes #16969