### PR TITLE
chore: remove release field from librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -18,10 +18,6 @@ sources:
   googleapis:
     commit: 8bd905897f61fb6f2e7d8b7cb3e2ca41d0cbc9c8
     sha256: bad85ba8a113ccb3dbe9bf54b80f25068a76a2b9c7d59b6af98a524f40712e69
-release:
-  ignored_changes:
-    - .repo-metadata.json
-    - docs/README.rst
 default:
   output: packages
   tag_format: '{name}-v{version}'


### PR DESCRIPTION
Resolves https://github.com/googleapis/librarian/issues/4910

`.repo-metadata.json` and `docs/README.rst` are now hardcoded in https://github.com/googleapis/librarian/blob/d75f982bc29e081ced56c0abfe8045cc6a29aa63/internal/librarian/bump.go#L57.