### PR TITLE
chore: librarian release pull request: 20260507T175102Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1361,7 +1361,7 @@ libraries:
       - packages/google-cloud-bigquery-storage/docs/
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigtable
-    version: 2.37.0
+    version: 2.38.0
     last_generated_commit: a6cbf809c4c165e618ee23a059442af90a80a0f5
     apis:
       - path: google/bigtable/admin/v2

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -608,7 +608,7 @@ libraries:
       metadata_name_override: bigquerystorage
       default_version: v1
   - name: google-cloud-bigtable
-    version: 2.37.0
+    version: 2.38.0
     apis:
       - path: google/bigtable/v2
       - path: google/bigtable/admin/v2
@@ -2196,7 +2196,6 @@ libraries:
       default_version: v1
   - name: google-crc32c
     version: 1.8.0
-    skip_release: false
     python:
       library_type: OTHER
   - name: google-geo-type

--- a/packages/google-cloud-bigtable/CHANGELOG.md
+++ b/packages/google-cloud-bigtable/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-cloud-bigtable/#history
 
+## [2.38.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigtable-v2.37.0...google-cloud-bigtable-v2.38.0) (2026-05-07)
+
+
+### Features
+
+* Add ValueBitmask to the filter DSL (#16981) ([3f429f23386a63e5e6773216b8d00dbed4940c0c](https://github.com/googleapis/google-cloud-python/commit/3f429f23386a63e5e6773216b8d00dbed4940c0c))
+
 ## [2.36.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigtable-v2.35.0...google-cloud-bigtable-v2.36.0) (2026-04-02)
 
 

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/gapic_version.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.37.0"  # {x-release-please-version}
+__version__ = "2.38.0"  # {x-release-please-version}

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin/gapic_version.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.37.0"  # {x-release-please-version}
+__version__ = "2.38.0"  # {x-release-please-version}

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/gapic_version.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.37.0"  # {x-release-please-version}
+__version__ = "2.38.0"  # {x-release-please-version}

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_v2/gapic_version.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_v2/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.37.0"  # {x-release-please-version}
+__version__ = "2.38.0"  # {x-release-please-version}

--- a/packages/google-cloud-bigtable/samples/generated_samples/snippet_metadata_google.bigtable.admin.v2.json
+++ b/packages/google-cloud-bigtable/samples/generated_samples/snippet_metadata_google.bigtable.admin.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-bigtable-admin",
-    "version": "2.37.0"
+    "version": "2.38.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.12.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-cloud-bigtable: v2.38.0</summary>

## [v2.38.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigtable-v2.37.0...google-cloud-bigtable-v2.38.0) (2026-05-07)

### Features

* Add ValueBitmask to the filter DSL (#16981) ([3f429f23](https://github.com/googleapis/google-cloud-python/commit/3f429f23))

</details>