### PR TITLE
chore: librarian release pull request: 20260507T182255Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -387,7 +387,7 @@ libraries:
       - packages/google-area120-tables/docs/
     tag_format: '{id}-v{version}'
   - id: google-auth
-    version: 2.51.0
+    version: 2.52.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -224,7 +224,7 @@ libraries:
       metadata_name_override: area120tables
       default_version: v1alpha1
   - name: google-auth
-    version: 2.51.0
+    version: 2.52.0
     python:
       library_type: AUTH
   - name: google-auth-httplib2

--- a/packages/google-auth/CHANGELOG.md
+++ b/packages/google-auth/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/google-auth/#history
 
+## [2.52.0](https://github.com/googleapis/google-cloud-python/compare/google-auth-v2.51.0...google-auth-v2.52.0) (2026-05-07)
+
+
+### Features
+
+* make _CLOUD_RESOURCE_MANAGER URL universe-domain-aware (#16546) ([e938028bf17026cf0157fc7e8ce600fd96ca0955](https://github.com/googleapis/google-cloud-python/commit/e938028bf17026cf0157fc7e8ce600fd96ca0955))
+* implement in-place Regional Access Boundary configuration and add public RAB getters (#16987) ([df07fceb9e61f76e70a0954c3d59a52fbb31688d](https://github.com/googleapis/google-cloud-python/commit/df07fceb9e61f76e70a0954c3d59a52fbb31688d))
+
 ## [2.51.0](https://github.com/googleapis/google-cloud-python/compare/google-auth-v2.50.0...google-auth-v2.51.0) (2026-05-06)
 
 

--- a/packages/google-auth/google/auth/version.py
+++ b/packages/google-auth/google/auth/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.51.0"
+__version__ = "2.52.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.12.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-auth: v2.52.0</summary>

## [v2.52.0](https://github.com/googleapis/google-cloud-python/compare/google-auth-v2.51.0...google-auth-v2.52.0) (2026-05-07)

### Features

* implement in-place Regional Access Boundary configuration and add public RAB getters (#16987) ([df07fceb](https://github.com/googleapis/google-cloud-python/commit/df07fceb))

* make _CLOUD_RESOURCE_MANAGER URL universe-domain-aware (#16546) ([e938028b](https://github.com/googleapis/google-cloud-python/commit/e938028b))

</details>