### PR TITLE
chore: skip generate datacatalog lineage

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -854,6 +854,7 @@ libraries:
       default_version: v1
   - name: google-cloud-datacatalog-lineage
     version: 0.6.0
+    skip_generate: true
     apis:
       - path: google/cloud/datacatalog/lineage/v1
     python:


### PR DESCRIPTION
`skip_generate: true` until b/508597813 is fixed