### PR TITLE
chore(firestore): improve typing for collection

### DIFF
--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/collection.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/collection.py
@@ -136,7 +136,7 @@ class CollectionReference(BaseCollectionReference[query_mod.Query]):
         return write_result.update_time, document_ref
 
 
-    def document(self, document_id: str | None = None) -> DocumentReference:
+    def document(self, document_id: Union[str, None] = None) -> "DocumentReference":
         """Create a sub-document underneath the current collection.
 
         Args:

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/collection.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/collection.py
@@ -149,7 +149,7 @@ class CollectionReference(BaseCollectionReference[query_mod.Query]):
             :class:~google.cloud.firestore_v1.document.DocumentReference:
             The child document.
         """
-        doc = super(CollectionReference, self).document(document_id)
+        doc = super().document(document_id)
         return cast("DocumentReference", doc)
     
     def list_documents(

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/collection.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/collection.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Generator, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Generator, Optional, Tuple, Union, cast
 
 from google.api_core import gapic_v1
 from google.api_core import retry as retries

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/collection.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/collection.py
@@ -33,8 +33,8 @@ from google.cloud.firestore_v1.watch import Watch
 if TYPE_CHECKING:  # pragma: NO COVER
     import datetime
 
-    from google.cloud.firestore_v1.document import DocumentReference
     from google.cloud.firestore_v1.base_document import DocumentSnapshot
+    from google.cloud.firestore_v1.document import DocumentReference
     from google.cloud.firestore_v1.query_profile import ExplainOptions
     from google.cloud.firestore_v1.stream_generator import StreamGenerator
 
@@ -135,7 +135,6 @@ class CollectionReference(BaseCollectionReference[query_mod.Query]):
         write_result = document_ref.create(document_data, **kwargs)
         return write_result.update_time, document_ref
 
-
     def document(self, document_id: Union[str, None] = None) -> "DocumentReference":
         """Create a sub-document underneath the current collection.
 
@@ -151,7 +150,7 @@ class CollectionReference(BaseCollectionReference[query_mod.Query]):
         """
         doc = super().document(document_id)
         return cast("DocumentReference", doc)
-    
+
     def list_documents(
         self,
         page_size: Union[int, None] = None,

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/collection.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/collection.py
@@ -33,6 +33,7 @@ from google.cloud.firestore_v1.watch import Watch
 if TYPE_CHECKING:  # pragma: NO COVER
     import datetime
 
+    from google.cloud.firestore_v1.document import DocumentReference
     from google.cloud.firestore_v1.base_document import DocumentSnapshot
     from google.cloud.firestore_v1.query_profile import ExplainOptions
     from google.cloud.firestore_v1.stream_generator import StreamGenerator
@@ -134,6 +135,23 @@ class CollectionReference(BaseCollectionReference[query_mod.Query]):
         write_result = document_ref.create(document_data, **kwargs)
         return write_result.update_time, document_ref
 
+
+    def document(self, document_id: str | None = None) -> DocumentReference:
+        """Create a sub-document underneath the current collection.
+
+        Args:
+            document_id (Optional[str]): The document identifier
+                within the current collection. If not provided, will default
+                to a random 20 character string composed of digits,
+                uppercase and lowercase and letters.
+
+        Returns:
+            :class:`~google.cloud.firestore_v1.document.document.DocumentReference`:
+            The child document.
+        """
+        doc = super(CollectionReference, self).document(document_id)
+        return cast("DocumentReference", doc)
+    
     def list_documents(
         self,
         page_size: Union[int, None] = None,

--- a/packages/google-cloud-firestore/google/cloud/firestore_v1/collection.py
+++ b/packages/google-cloud-firestore/google/cloud/firestore_v1/collection.py
@@ -146,7 +146,7 @@ class CollectionReference(BaseCollectionReference[query_mod.Query]):
                 uppercase and lowercase and letters.
 
         Returns:
-            :class:`~google.cloud.firestore_v1.document.document.DocumentReference`:
+            :class:~google.cloud.firestore_v1.document.DocumentReference:
             The child document.
         """
         doc = super(CollectionReference, self).document(document_id)


### PR DESCRIPTION
Previously, `CollectionReference` didn't define `.document()`, so it inherited the typing of `BaseCollectionReference`. This PR adds an override to ensure that documents are annotated as returning `DocumentReference` types