### PR TITLE
chore(.gemini): add config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,11 @@
+# Configure the behavior of the gemini code assist bot.
+# More info:
+# https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github
+have_fun: false
+code_review:
+  pull_request_opened:
+    help: false
+    code_review: true
+    include_drafts: true
+ignore_patterns:
+  - "packages/**/services/**/client.py"


### PR DESCRIPTION
Proposal to further configure gemini assistance on the repo in the following ways:
* disable `have_fun` to keep feedback concise
* disable posting the help message, it's not particularly useful when we have public docs
* run code review and include draft PRs
* (the big one) attempt to limit the scope of review, excluding what I think would be GAPIC generate client libraries 

Context: Gemini posted comments to auto-generated code in #16998, which we will not address, and I'd like to reduce noise / save some compute.