### PR TITLE
chore: remove Python 3.9 from default nox session

### DIFF
--- a/packages/google-cloud-spanner/noxfile.py
+++ b/packages/google-cloud-spanner/noxfile.py
@@ -71,7 +71,6 @@ SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
-    "unit-3.9",
     "unit-3.10",
     "unit-3.11",
     "unit-3.12",


### PR DESCRIPTION
This PR removes Python 3.9 from the default nox session which is used in continuous builds. Python 3.9 unit tests are still running in presubmits via Github actions but cannot be tested in continuous builds since Python 3.9 has been removed from the testing image as of https://github.com/googleapis/testing-infra-docker/pull/524. 