### PR TITLE
feat(auth): implement regional access boundary support for standalone JWT and async service accounts

### DIFF
--- a/packages/google-auth/google/auth/_credentials_async.py
+++ b/packages/google-auth/google/auth/_credentials_async.py
@@ -18,6 +18,7 @@
 import abc
 import inspect
 
+from google.auth import _regional_access_boundary_utils
 from google.auth import credentials
 
 
@@ -189,3 +190,74 @@ def with_scopes_if_required(credentials, scopes):
 
 class Signing(credentials.Signing, metaclass=abc.ABCMeta):
     """Interface for credentials that can cryptographically sign messages."""
+
+
+class CredentialsWithRegionalAccessBoundary(
+    Credentials, credentials.CredentialsWithRegionalAccessBoundary
+):
+    """Async base for credentials supporting regional access boundary configuration."""
+
+    def __init__(self):
+        super().__init__()
+        self._rab_manager.refresh_manager = (
+            _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
+        )
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self._rab_manager.refresh_manager = (
+            _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
+        )
+
+    async def _after_refresh(self, request, method, url, headers):
+        """Triggers the Regional Access Boundary lookup asynchronously if necessary."""
+        await self._maybe_start_regional_access_boundary_refresh_async(request, url)
+
+    async def _maybe_start_regional_access_boundary_refresh_async(self, request, url):
+        """Starts a background refresh or performs a blocking refresh asynchronously.
+
+        Args:
+            request (google.auth.aio.transport.Request): The object used to make
+                HTTP requests.
+            url (str): The URL of the request.
+        """
+        # Do not perform a lookup if the request is for a regional endpoint.
+        if self._is_regional_endpoint(url):
+            return
+
+        # A refresh is only needed if the feature is enabled.
+        if not self._is_regional_access_boundary_lookup_required():
+            return
+
+        # Trigger background or blocking refresh if needed.
+        await self._rab_manager.maybe_start_refresh_async(self, request)
+
+    async def _lookup_regional_access_boundary(self, request, fail_fast=False):
+        """Calls the Regional Access Boundary lookup API asynchronously.
+
+        Args:
+            request (google.auth.aio.transport.Request): The object used to make
+                HTTP requests.
+            fail_fast (bool): Whether the lookup should fail fast (short timeout, no retries).
+
+        Returns:
+            Optional[Dict[str, str]]: The Regional Access Boundary information
+                returned by the lookup API, or None if the lookup failed.
+        """
+        url_builder = self._build_regional_access_boundary_lookup_url
+        if inspect.iscoroutinefunction(url_builder):
+            url = await url_builder(request=request)
+        else:
+            url = url_builder(request=request)
+
+        if not url:
+            return None
+
+        headers = {}
+        self._apply(headers)
+
+        from google.oauth2 import _client_async
+
+        return await _client_async._lookup_regional_access_boundary(
+            request, url, headers=headers, fail_fast=fail_fast
+        )

--- a/packages/google-auth/google/auth/_credentials_async.py
+++ b/packages/google-auth/google/auth/_credentials_async.py
@@ -64,7 +64,27 @@ class Credentials(credentials.Credentials, metaclass=abc.ABCMeta):
                 await self.refresh(request)
             else:
                 self.refresh(request)
+
+        if inspect.iscoroutinefunction(self._after_refresh):
+            await self._after_refresh(request, method, url, headers)
+        else:
+            self._after_refresh(request, method, url, headers)
+
         self.apply(headers)
+
+    def _after_refresh(self, request, method, url, headers):
+        """Hook for subclasses to perform actions after refresh but before
+        applying credentials to headers.
+
+        Args:
+            request (google.auth.transport.Request): The object used to make
+                HTTP requests.
+            method (str): The request's HTTP method or the RPC method being
+                invoked.
+            url (str): The request's URI or the RPC service's URI.
+            headers (Mapping[str, str]): The request's headers.
+        """
+        pass
 
 
 class CredentialsWithQuotaProject(credentials.CredentialsWithQuotaProject):

--- a/packages/google-auth/google/auth/_helpers.py
+++ b/packages/google-auth/google/auth/_helpers.py
@@ -28,6 +28,8 @@ import urllib
 from google.auth import exceptions
 
 
+DEFAULT_UNIVERSE_DOMAIN = "googleapis.com"
+
 # _BASE_LOGGER_NAME is the base logger for all google-based loggers.
 _BASE_LOGGER_NAME = "google"
 

--- a/packages/google-auth/google/auth/_jwt_async.py
+++ b/packages/google-auth/google/auth/_jwt_async.py
@@ -91,7 +91,9 @@ def decode(token, certs=None, verify=True, audience=None):
 
 
 class Credentials(
-    jwt.Credentials, _credentials_async.Signing, _credentials_async.Credentials
+    jwt.Credentials,
+    _credentials_async.Signing,
+    _credentials_async.CredentialsWithRegionalAccessBoundary,
 ):
     """Credentials that use a JWT as the bearer token.
 
@@ -141,6 +143,15 @@ class Credentials(
             'https://pubsub.googleapis.com/google.pubsub.v1.Subscriber')
         new_credentials = credentials.with_claims(audience=new_audience)
     """
+
+    def __setstate__(self, state):
+        """Restores the credential state and ensures the async refresh manager is attached."""
+        super().__setstate__(state)
+        from google.auth import _regional_access_boundary_utils
+
+        self._rab_manager.refresh_manager = (
+            _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
+        )
 
 
 class OnDemandCredentials(

--- a/packages/google-auth/google/auth/_jwt_async.py
+++ b/packages/google-auth/google/auth/_jwt_async.py
@@ -46,6 +46,7 @@ change in minor releases.
 from google.auth import _credentials_async
 from google.auth import _helpers
 from google.auth import jwt
+from google.auth import _regional_access_boundary_utils
 
 
 def encode(signer, payload, header=None, key_id=None):
@@ -148,7 +149,6 @@ class Credentials(
     def __setstate__(self, state):
         """Restores the credential state and ensures the async refresh manager is attached."""
         super().__setstate__(state)
-        from google.auth import _regional_access_boundary_utils
 
         self._rab_manager.refresh_manager = (
             _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()

--- a/packages/google-auth/google/auth/_jwt_async.py
+++ b/packages/google-auth/google/auth/_jwt_async.py
@@ -44,6 +44,7 @@ change in minor releases.
 """
 
 from google.auth import _credentials_async
+from google.auth import _helpers
 from google.auth import jwt
 
 
@@ -173,3 +174,7 @@ class OnDemandCredentials(
 
     .. _grpc: http://www.grpc.io/
     """
+
+    @_helpers.copy_docstring(jwt.OnDemandCredentials)
+    async def before_request(self, request, method, url, headers):
+        super(OnDemandCredentials, self).before_request(request, method, url, headers)

--- a/packages/google-auth/google/auth/_jwt_async.py
+++ b/packages/google-auth/google/auth/_jwt_async.py
@@ -45,8 +45,8 @@ change in minor releases.
 
 from google.auth import _credentials_async
 from google.auth import _helpers
-from google.auth import jwt
 from google.auth import _regional_access_boundary_utils
+from google.auth import jwt
 
 
 def encode(signer, payload, header=None, key_id=None):

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -171,12 +171,11 @@ class _RegionalAccessBoundaryManager(object):
         else:
             headers.pop(_REGIONAL_ACCESS_BOUNDARY_HEADER, None)
 
-    def maybe_start_refresh(self, credentials, request):
-        """Starts a background thread to refresh the Regional Access Boundary if needed.
+    def _should_refresh(self):
+        """Checks if the Regional Access Boundary data needs a refresh and is not in cooldown.
 
-        Args:
-            credentials (google.auth.credentials.Credentials): The credentials to refresh.
-            request (google.auth.transport.Request): The object used to make HTTP requests.
+        Returns:
+            bool: True if a refresh is required, False otherwise.
         """
         rab_data = self._data
 
@@ -187,15 +186,43 @@ class _RegionalAccessBoundaryManager(object):
             and _helpers.utcnow()
             < (rab_data.expiry - REGIONAL_ACCESS_BOUNDARY_REFRESH_THRESHOLD)
         ):
-            return
+            return False
 
         # Don't start a new refresh if the cooldown is still in effect.
         if rab_data.cooldown_expiry and _helpers.utcnow() < rab_data.cooldown_expiry:
+            return False
+
+        return True
+
+    def maybe_start_refresh(self, credentials, request):
+        """Starts a background thread to refresh the Regional Access Boundary if needed.
+
+        Args:
+            credentials (google.auth.credentials.Credentials): The credentials to refresh.
+            request (google.auth.transport.Request): The object used to make HTTP requests.
+        """
+        if not self._should_refresh():
             return
 
         # If all checks pass, start the background refresh.
         if self._use_blocking_regional_access_boundary_lookup:
             self.start_blocking_refresh(credentials, request)
+        else:
+            self.refresh_manager.start_refresh(credentials, request, self)
+
+    async def maybe_start_refresh_async(self, credentials, request):
+        """Starts a background refresh or performs a blocking refresh asynchronously.
+
+        Args:
+            credentials (google.auth.credentials.Credentials): The credentials to refresh.
+            request (google.auth.aio.transport.Request): The object used to make HTTP requests.
+        """
+        if not self._should_refresh():
+            return
+
+        # If all checks pass, start the refresh.
+        if self._use_blocking_regional_access_boundary_lookup:
+            await self.start_blocking_refresh_async(credentials, request)
         else:
             self.refresh_manager.start_refresh(credentials, request, self)
 
@@ -221,6 +248,37 @@ class _RegionalAccessBoundaryManager(object):
             if _helpers.is_logging_enabled(_LOGGER):
                 _LOGGER.warning(
                     "Blocking Regional Access Boundary lookup raised an exception: %s",
+                    e,
+                    exc_info=True,
+                )
+            regional_access_boundary_info = None
+
+        self.process_regional_access_boundary_info(regional_access_boundary_info)
+
+    async def start_blocking_refresh_async(self, credentials, request):
+        """Initiates a blocking lookup of the Regional Access Boundary asynchronously.
+
+        If the lookup raises an exception, it is caught and logged as a warning,
+        and the lookup is treated as a failure (entering cooldown). Exceptions
+        are not propagated to the caller.
+
+        Args:
+            credentials (google.auth.credentials.Credentials): The credentials to refresh.
+            request (google.auth.aio.transport.Request): The object used to make HTTP requests.
+        """
+        try:
+            # The fail_fast parameter is set to True to ensure we don't block the calling
+            # thread for too long. This will do two things: 1) set a timeout to 3s
+            # instead of the default 120s and 2) ensure we do not retry at all
+            regional_access_boundary_info = (
+                await credentials._lookup_regional_access_boundary(
+                    request, fail_fast=True
+                )
+            )
+        except Exception as e:
+            if _helpers.is_logging_enabled(_LOGGER):
+                _LOGGER.warning(
+                    "Regional Access Boundary lookup raised an exception: %s",
                     e,
                     exc_info=True,
                 )

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -395,14 +395,14 @@ class _AsyncRegionalAccessBoundaryRefreshManager(object):
         self._worker_task = None
 
     def __getstate__(self):
-        """Pickle helper that serializes the _lock and _worker_task attributes."""
+        """Pickle helper that excludes the un-picklable _lock and _worker_task attributes from serialization."""
         state = self.__dict__.copy()
         state["_lock"] = None
         state["_worker_task"] = None
         return state
 
     def __setstate__(self, state):
-        """Pickle helper that deserializes the _lock and _worker_task attributes."""
+        """Pickle helper that restores state and re-initializes the _lock and _worker_task attributes."""
         self.__dict__.update(state)
         self._lock = threading.Lock()
         self._worker_task = None

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -16,9 +16,9 @@
 
 import asyncio
 import copy
-import inspect
 import datetime
 import functools
+import inspect
 import logging
 import os
 import threading

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -16,6 +16,7 @@
 
 import asyncio
 import copy
+import inspect
 import datetime
 import functools
 import logging
@@ -237,6 +238,15 @@ class _RegionalAccessBoundaryManager(object):
             credentials (google.auth.credentials.Credentials): The credentials to refresh.
             request (google.auth.transport.Request): The object used to make HTTP requests.
         """
+        # Async credentials do not support blocking lookups.
+        if inspect.iscoroutinefunction(credentials._lookup_regional_access_boundary):
+            if _helpers.is_logging_enabled(_LOGGER):
+                _LOGGER.warning(
+                    "Blocking Regional Access Boundary lookup is not supported for async credentials."
+                )
+            self.process_regional_access_boundary_info(None)
+            return
+
         try:
             # The fail_fast parameter is set to True to ensure we don't block the calling
             # thread for too long. This will do two things: 1) set a timeout to 3s
@@ -500,7 +510,12 @@ class _AsyncRegionalAccessBoundaryRefreshManager(object):
                     regional_access_boundary_info
                 )
 
-            self._worker_task = asyncio.create_task(_worker())
+            coro = _worker()
+            try:
+                self._worker_task = asyncio.create_task(coro)
+            except Exception:
+                coro.close()
+                raise
 
 
 def _get_domain() -> str:

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -14,8 +14,8 @@
 
 """Utilities for Regional Access Boundary management."""
 
-import copy
 import asyncio
+import copy
 import datetime
 import functools
 import logging

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -385,6 +385,8 @@ class _RegionalAccessBoundaryRefreshManager(object):
                 credentials, copied_request, rab_manager
             )
             self._worker.start()
+
+
 class _AsyncRegionalAccessBoundaryRefreshManager(object):
     """Manages a task for background refreshing of the Regional Access Boundary in async flows."""
 

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -15,6 +15,7 @@
 """Utilities for Regional Access Boundary management."""
 
 import copy
+import asyncio
 import datetime
 import functools
 import logging
@@ -384,3 +385,59 @@ class _RegionalAccessBoundaryRefreshManager(object):
                 credentials, copied_request, rab_manager
             )
             self._worker.start()
+class _AsyncRegionalAccessBoundaryRefreshManager(object):
+    """Manages a task for background refreshing of the Regional Access Boundary in async flows."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._worker_task = None
+
+    def __getstate__(self):
+        """Pickle helper that serializes the _lock and _worker_task attributes."""
+        state = self.__dict__.copy()
+        state["_lock"] = None
+        state["_worker_task"] = None
+        return state
+
+    def __setstate__(self, state):
+        """Pickle helper that deserializes the _lock and _worker_task attributes."""
+        self.__dict__.update(state)
+        self._lock = threading.Lock()
+        self._worker_task = None
+
+    def start_refresh(self, credentials, request, rab_manager):
+        """
+        Starts a background task to refresh the Regional Access Boundary if one is not already running.
+
+        Args:
+            credentials (CredentialsWithRegionalAccessBoundary): The credentials
+                to refresh.
+            request (google.auth.aio.transport.Request): The object used to make
+                HTTP requests.
+            rab_manager (_RegionalAccessBoundaryManager): The manager container to update.
+        """
+        with self._lock:
+            if self._worker_task and not self._worker_task.done():
+                # A refresh is already in progress.
+                return
+
+            async def _worker():
+                try:
+                    # credentials._lookup_regional_access_boundary should be async in the async creds class
+                    regional_access_boundary_info = (
+                        await credentials._lookup_regional_access_boundary(request)
+                    )
+                except Exception as e:
+                    if _helpers.is_logging_enabled(_LOGGER):
+                        _LOGGER.warning(
+                            "Asynchronous Regional Access Boundary lookup raised an exception: %s",
+                            e,
+                            exc_info=True,
+                        )
+                    regional_access_boundary_info = None
+
+                rab_manager.process_regional_access_boundary_info(
+                    regional_access_boundary_info
+                )
+
+            self._worker_task = asyncio.create_task(_worker())

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -501,3 +501,57 @@ class _AsyncRegionalAccessBoundaryRefreshManager(object):
                 )
 
             self._worker_task = asyncio.create_task(_worker())
+
+
+def _get_domain() -> str:
+    """Dynamically determines the domain for IAM credentials based on active mTLS configuration.
+
+    Returns:
+        str: The dynamic domain string.
+    """
+    from google.auth.transport import _mtls_helper
+
+    if (
+        hasattr(_mtls_helper, "check_use_client_cert")
+        and _mtls_helper.check_use_client_cert()
+    ):
+        return f"iamcredentials.mtls.{_helpers.DEFAULT_UNIVERSE_DOMAIN}"
+    else:
+        return f"iamcredentials.{_helpers.DEFAULT_UNIVERSE_DOMAIN}"
+
+
+def get_service_account_rab_endpoint(service_account_email: str) -> str:
+    """Builds the Regional Access Boundary lookup URL for service accounts.
+
+    Args:
+        service_account_email: The service account email.
+
+    Returns:
+        str: The complete lookup URL.
+    """
+    return f"https://{_get_domain()}/v1/projects/-/serviceAccounts/{service_account_email}/allowedLocations"
+
+
+def get_workforce_pool_rab_endpoint(pool_id: str) -> str:
+    """Builds the Regional Access Boundary lookup URL for workforce pools.
+
+    Args:
+        pool_id: The workforce pool ID.
+
+    Returns:
+        str: The complete lookup URL.
+    """
+    return f"https://{_get_domain()}/v1/locations/global/workforcePools/{pool_id}/allowedLocations"
+
+
+def get_workload_identity_pool_rab_endpoint(project_number: str, pool_id: str) -> str:
+    """Builds the Regional Access Boundary lookup URL for workload identity pools.
+
+    Args:
+        project_number: The Google Cloud project number.
+        pool_id: The workload identity pool ID.
+
+    Returns:
+        str: The complete lookup URL.
+    """
+    return f"https://{_get_domain()}/v1/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/allowedLocations"

--- a/packages/google-auth/google/auth/compute_engine/_metadata.py
+++ b/packages/google-auth/google/auth/compute_engine/_metadata.py
@@ -502,3 +502,20 @@ def get_service_account_token(request, service_account="default", scopes=None):
         seconds=token_json["expires_in"]
     )
     return token_json["access_token"], token_expiry
+
+
+def _is_email(email):
+    """Checks if the provided string is in an email format.
+
+    This is a simple check that ensures the candidate string is non-empty
+    and contains the '@' character.
+
+    Args:
+        email (str): The candidate string to check.
+
+    Returns:
+        bool: True if the string is non-empty and contains '@', False otherwise.
+    """
+    if not email:
+        return False
+    return "@" in email

--- a/packages/google-auth/google/auth/compute_engine/_metadata.py
+++ b/packages/google-auth/google/auth/compute_engine/_metadata.py
@@ -38,9 +38,7 @@ from google.auth.compute_engine import _mtls
 
 _LOGGER = logging.getLogger(__name__)
 
-_SERVICE_ACCOUNT_EMAIL_PATTERN = re.compile(
-    r"^[^@]+@[^@]+\.[^@]+$"
-)
+_SERVICE_ACCOUNT_EMAIL_PATTERN = re.compile(r"^[^@]+@[^@]+\.[^@]+$")
 
 _GCE_DEFAULT_MDS_IP = "169.254.169.254"
 _GCE_DEFAULT_HOST = "metadata.google.internal"

--- a/packages/google-auth/google/auth/compute_engine/_metadata.py
+++ b/packages/google-auth/google/auth/compute_engine/_metadata.py
@@ -22,6 +22,7 @@ import http.client as http_client
 import json
 import logging
 import os
+import re
 from urllib.parse import urljoin
 
 import requests
@@ -36,6 +37,10 @@ from google.auth.compute_engine import _mtls
 
 
 _LOGGER = logging.getLogger(__name__)
+
+_SERVICE_ACCOUNT_EMAIL_PATTERN = re.compile(
+    r"^[^@]+@[^@]+\.[^@]+$"
+)
 
 _GCE_DEFAULT_MDS_IP = "169.254.169.254"
 _GCE_DEFAULT_HOST = "metadata.google.internal"
@@ -504,18 +509,18 @@ def get_service_account_token(request, service_account="default", scopes=None):
     return token_json["access_token"], token_expiry
 
 
-def _is_email(email):
-    """Checks if the provided string is in an email format.
+def _is_service_account_email(email):
+    """Checks if the provided string is a service account email.
 
-    This is a simple check that ensures the candidate string is non-empty
-    and contains the '@' character.
+    This is a check that ensures the candidate string is non-empty
+    and matches a standard email format.
 
     Args:
         email (str): The candidate string to check.
 
     Returns:
-        bool: True if the string is non-empty and contains '@', False otherwise.
+        bool: True if the string is non-empty and matches email format, False otherwise.
     """
     if not email:
         return False
-    return "@" in email
+    return bool(_SERVICE_ACCOUNT_EMAIL_PATTERN.match(email))

--- a/packages/google-auth/google/auth/compute_engine/credentials.py
+++ b/packages/google-auth/google/auth/compute_engine/credentials.py
@@ -171,7 +171,7 @@ class Credentials(
         if self.service_account_email == "default":
             return True
 
-        return _metadata._is_email(self.service_account_email)
+        return _metadata._is_service_account_email(self.service_account_email)
 
     def _build_regional_access_boundary_lookup_url(
         self, request: "Optional[google.auth.transport.Request]" = None  # noqa: F821
@@ -218,7 +218,7 @@ class Credentials(
                 )
                 return None
 
-        if not _metadata._is_email(self.service_account_email):
+        if not _metadata._is_service_account_email(self.service_account_email):
             _LOGGER.info(
                 "Service account email '%s' is not a valid email. Skipping Regional Access Boundary lookup.",
                 self.service_account_email,

--- a/packages/google-auth/google/auth/compute_engine/credentials.py
+++ b/packages/google-auth/google/auth/compute_engine/credentials.py
@@ -100,6 +100,7 @@ class Credentials(
             self._universe_domain_cached = True
 
         self._trust_boundary = trust_boundary
+        self._rab_disabled = False
 
     def _retrieve_info(self, request):
         """Retrieve information about the service account.
@@ -152,6 +153,26 @@ class Credentials(
             new_exc = exceptions.RefreshError(caught_exc)
             raise new_exc from caught_exc
 
+    def _is_regional_access_boundary_lookup_required(self):
+        """Checks if a Regional Access Boundary lookup is required.
+
+        Returns:
+            bool: True if a Regional Access Boundary lookup is required, False otherwise.
+        """
+        if not super()._is_regional_access_boundary_lookup_required():
+            return False
+
+        if getattr(self, "_rab_disabled", False):
+            return False
+
+        # If the field is 'default', the actual value hasn't been fetched from the metadata
+        # server yet. Allow it to proceed so the actual value can be retrieved and checked
+        # during the URL construction.
+        if self.service_account_email == "default":
+            return True
+
+        return _metadata._is_email(self.service_account_email)
+
     def _build_regional_access_boundary_lookup_url(
         self, request: "Optional[google.auth.transport.Request]" = None  # noqa: F821
     ):
@@ -196,6 +217,14 @@ class Credentials(
                     e,
                 )
                 return None
+
+        if not _metadata._is_email(self.service_account_email):
+            _LOGGER.info(
+                "Service account email '%s' is not a valid email. Skipping Regional Access Boundary lookup.",
+                self.service_account_email,
+            )
+            self._rab_disabled = True
+            return None
 
         return _regional_access_boundary_utils.get_service_account_rab_endpoint(
             self.service_account_email

--- a/packages/google-auth/google/auth/compute_engine/credentials.py
+++ b/packages/google-auth/google/auth/compute_engine/credentials.py
@@ -25,6 +25,7 @@ from typing import Optional, TYPE_CHECKING
 
 
 from google.auth import _helpers
+from google.auth import _regional_access_boundary_utils
 from google.auth import credentials
 from google.auth import exceptions
 from google.auth import iam
@@ -196,8 +197,8 @@ class Credentials(
                 )
                 return None
 
-        return iam._SERVICE_ACCOUNT_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT.format(
-            service_account_email=self.service_account_email
+        return _regional_access_boundary_utils.get_service_account_rab_endpoint(
+            self.service_account_email
         )
 
     @property

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -401,6 +401,8 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
         # but share the immutable data reference to avoid unnecessary initial lookups.
         new_manager = _regional_access_boundary_utils._RegionalAccessBoundaryManager()
         new_manager._data = self._rab_manager._data
+        # Preserve the type of refresh manager (sync or async)
+        new_manager.refresh_manager = self._rab_manager.refresh_manager.__class__()
         target._rab_manager = new_manager
 
     def _set_regional_access_boundary(self, seed):

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -434,6 +434,29 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
         self._rab_manager.enable_blocking_lookup()
         return self
 
+    def _is_regional_endpoint(self, url):
+        """Checks if the request URL is for a regional endpoint.
+
+        Args:
+            url (str): The URL of the request.
+
+        Returns:
+            bool: True if the URL is a regional endpoint, False otherwise.
+        """
+        try:
+            # Do not perform a lookup if the request is for a regional endpoint.
+            hostname = urlparse(url).hostname
+            if hostname and (
+                hostname.endswith(".rep.googleapis.com")
+                or hostname.endswith(".rep.sandbox.googleapis.com")
+            ):
+                return True
+        except (ValueError, TypeError, AttributeError):
+            # If the URL is malformed, proceed with the default lookup behavior.
+            pass
+
+        return False
+
     def _maybe_start_regional_access_boundary_refresh(self, request, url):
         """
         Starts a background thread to refresh the Regional Access Boundary if needed.
@@ -447,23 +470,15 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
                 HTTP requests.
             url (str): The URL of the request.
         """
-        try:
-            # Do not perform a lookup if the request is for a regional endpoint.
-            hostname = urlparse(url).hostname
-            if hostname and (
-                hostname.endswith(".rep.googleapis.com")
-                or hostname.endswith(".rep.sandbox.googleapis.com")
-            ):
-                return
-        except (ValueError, TypeError):
-            # If the URL is malformed, proceed with the default lookup behavior.
-            pass
+        # Do not perform a lookup if the request is for a regional endpoint.
+        if self._is_regional_endpoint(url):
+            return
 
         # A refresh is only needed if the feature is enabled.
         if not self._is_regional_access_boundary_lookup_required():
             return
 
-        # Start the background refresh if needed.
+        # Trigger background or blocking refresh if needed
         self._rab_manager.maybe_start_refresh(self, request)
 
     def _is_regional_access_boundary_lookup_required(self):
@@ -475,11 +490,11 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
         Returns:
             bool: True if a Regional Access Boundary lookup is required, False otherwise.
         """
-        # 1. Check if the feature is enabled.
+        # Check if the feature is enabled.
         if not _regional_access_boundary_utils.is_regional_access_boundary_enabled():
             return False
 
-        # 2. Skip for non-default universe domains.
+        # Skip for non-default universe domains.
         if self.universe_domain != DEFAULT_UNIVERSE_DOMAIN:
             return False
 
@@ -526,7 +541,6 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
 
         headers: Dict[str, str] = {}
         self._apply(headers)
-        self._rab_manager.apply_headers(headers)
         return _client._lookup_regional_access_boundary(
             request, url, headers=headers, fail_fast=fail_fast
         )

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -239,8 +239,24 @@ class Credentials(_BaseCredentials):
         else:
             self._blocking_refresh(request)
 
+        self._after_refresh(request, method, url, headers)
+
         metrics.add_metric_header(headers, self._metric_header_for_usage())
         self.apply(headers)
+
+    def _after_refresh(self, request, method, url, headers):
+        """Hook for subclasses to perform actions after refresh but before
+        applying credentials to headers.
+
+        Args:
+            request (google.auth.transport.Request): The object used to make
+                HTTP requests.
+            method (str): The request's HTTP method or the RPC method being
+                invoked.
+            url (str): The request's URI or the RPC service's URI.
+            headers (Mapping): The request's headers.
+        """
+        pass
 
     def with_non_blocking_refresh(self):
         self._use_non_blocking_refresh = True
@@ -459,19 +475,9 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
         super().apply(headers, token)
         self._rab_manager.apply_headers(headers)
 
-    def before_request(self, request, method, url, headers):
-        """Refreshes the access token and triggers the Regional Access Boundary
-        lookup if necessary.
-        """
-        if self._use_non_blocking_refresh:
-            self._non_blocking_refresh(request)
-        else:
-            self._blocking_refresh(request)
-
+    def _after_refresh(self, request, method, url, headers):
+        """Triggers the Regional Access Boundary lookup if necessary."""
         self._maybe_start_regional_access_boundary_refresh(request, url)
-
-        metrics.add_metric_header(headers, self._metric_header_for_usage())
-        self.apply(headers)
 
     def refresh(self, request):
         """Refreshes the access token.

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -536,7 +536,7 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
 
         url = self._build_regional_access_boundary_lookup_url(request=request)
         if not url:
-            _LOGGER.error("Failed to build Regional Access Boundary lookup URL.")
+            _LOGGER.warning("Failed to build Regional Access Boundary lookup URL.")
             return None
 
         headers: Dict[str, str] = {}

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -325,6 +325,22 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
             _regional_access_boundary_utils._RegionalAccessBoundaryManager()
         )
 
+    def __setstate__(self, state):
+        """Pickle helper that restores state, safely reconstructing RAB fields if missing."""
+        self.__dict__.update(state)
+        if "_rab_manager" not in self.__dict__:
+            from google.auth import _regional_access_boundary_utils
+
+            self._rab_manager = (
+                _regional_access_boundary_utils._RegionalAccessBoundaryManager()
+            )
+        if "_use_non_blocking_refresh" not in self.__dict__:
+            self._use_non_blocking_refresh = False
+        if "_refresh_worker" not in self.__dict__:
+            from google.auth._refresh_worker import RefreshThreadManager
+
+            self._refresh_worker = RefreshThreadManager()
+
     @property
     def regional_access_boundary(self):
         """Optional[str]: The encoded Regional Access Boundary locations."""

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -34,7 +34,7 @@ from google.auth._refresh_worker import RefreshThreadManager
 if TYPE_CHECKING:  # pragma: NO COVER
     import google.auth.transport
 
-DEFAULT_UNIVERSE_DOMAIN = "googleapis.com"
+DEFAULT_UNIVERSE_DOMAIN = _helpers.DEFAULT_UNIVERSE_DOMAIN
 
 # These constants are deprecated and no longer used.
 # They are kept solely for backward compatibility with older implementations.

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -396,14 +396,11 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
             )
 
     def _copy_regional_access_boundary_manager(self, target):
-        """Copies the regional access boundary manager to another instance."""
-        # Create a new manager for the clone to isolate background refresh locks and threads,
-        # but share the immutable data reference to avoid unnecessary initial lookups.
-        new_manager = _regional_access_boundary_utils._RegionalAccessBoundaryManager()
-        new_manager._data = self._rab_manager._data
-        # Preserve the type of refresh manager (sync or async)
-        new_manager.refresh_manager = self._rab_manager.refresh_manager.__class__()
-        target._rab_manager = new_manager
+        """Copies the regional access boundary manager state to another instance."""
+        target._rab_manager._data = self._rab_manager._data
+        target._rab_manager._use_blocking_regional_access_boundary_lookup = (
+            self._rab_manager._use_blocking_regional_access_boundary_lookup
+        )
 
     def _set_regional_access_boundary(self, seed):
         """Applies the regional_access_boundary provided via the seed on these

--- a/packages/google-auth/google/auth/external_account.py
+++ b/packages/google-auth/google/auth/external_account.py
@@ -619,7 +619,7 @@ class Credentials(
 
         scopes = self._scopes if self._scopes is not None else self._default_scopes
         # Initialize and return impersonated credentials.
-        return impersonated_credentials.Credentials(
+        impersonated_creds = impersonated_credentials.Credentials(
             source_credentials=source_credentials,
             target_principal=target_principal,
             target_scopes=scopes,
@@ -630,6 +630,9 @@ class Credentials(
             ),
             trust_boundary=self._trust_boundary,
         )
+        if self._rab_manager._use_blocking_regional_access_boundary_lookup:
+            impersonated_creds._set_blocking_regional_access_boundary_lookup()
+        return impersonated_creds
 
     def _create_default_metrics_options(self):
         metrics_options = {}

--- a/packages/google-auth/google/auth/external_account.py
+++ b/packages/google-auth/google/auth/external_account.py
@@ -40,9 +40,9 @@ from typing import Optional, TYPE_CHECKING
 
 
 from google.auth import _helpers
+from google.auth import _regional_access_boundary_utils
 from google.auth import credentials
 from google.auth import exceptions
-from google.auth import iam
 from google.auth import impersonated_credentials
 from google.auth import metrics
 from google.oauth2 import sts
@@ -526,9 +526,10 @@ class Credentials(
         )
         if workload_match:
             project_number, pool_id = workload_match.groups()
-            url = iam._WORKLOAD_IDENTITY_POOL_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT.format(
-                project_number=project_number,
-                pool_id=pool_id,
+            url = (
+                _regional_access_boundary_utils.get_workload_identity_pool_rab_endpoint(
+                    project_number, pool_id
+                )
             )
         else:
             # If that fails, try to parse as a workforce pool.
@@ -538,10 +539,8 @@ class Credentials(
             )
             if workforce_match:
                 pool_id = workforce_match.groups()[0]
-                url = (
-                    iam._WORKFORCE_POOL_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT.format(
-                        pool_id=pool_id
-                    )
+                url = _regional_access_boundary_utils.get_workforce_pool_rab_endpoint(
+                    pool_id
                 )
 
         if url:

--- a/packages/google-auth/google/auth/external_account_authorized_user.py
+++ b/packages/google-auth/google/auth/external_account_authorized_user.py
@@ -42,9 +42,9 @@ from typing import Optional, TYPE_CHECKING
 
 
 from google.auth import _helpers
+from google.auth import _regional_access_boundary_utils
 from google.auth import credentials
 from google.auth import exceptions
-from google.auth import iam
 from google.oauth2 import sts
 from google.oauth2 import utils
 
@@ -337,9 +337,7 @@ class Credentials(
 
         pool_id = match.groups()[0]
 
-        return iam._WORKFORCE_POOL_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT.format(
-            pool_id=pool_id
-        )
+        return _regional_access_boundary_utils.get_workforce_pool_rab_endpoint(pool_id)
 
     def revoke(self, request):
         """Revokes the refresh token.

--- a/packages/google-auth/google/auth/iam.py
+++ b/packages/google-auth/google/auth/iam.py
@@ -49,21 +49,15 @@ if (
 else:
     _IAM_DOMAIN = f"iamcredentials.{credentials.DEFAULT_UNIVERSE_DOMAIN}"
 
-# 3. Create the common base URL template
+# Create the common base URL template
 # We use double brackets {{}} so .format() can be called later for the email.
 _IAM_BASE_URL = f"https://{_IAM_DOMAIN}/v1/projects/-/serviceAccounts/{{}}"
 
-# 4. Define the endpoints as templates
+# Define the endpoints as static templates
 _IAM_ENDPOINT = _IAM_BASE_URL + ":generateAccessToken"
 _IAM_SIGN_ENDPOINT = _IAM_BASE_URL + ":signBlob"
 _IAM_SIGNJWT_ENDPOINT = _IAM_BASE_URL + ":signJwt"
 _IAM_IDTOKEN_ENDPOINT = _IAM_BASE_URL + ":generateIdToken"
-
-
-# Regional Access Boundary (RAB) Lookup Endpoints
-_SERVICE_ACCOUNT_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT = f"https://{_IAM_DOMAIN}/v1/projects/-/serviceAccounts/{{service_account_email}}/allowedLocations"
-_WORKFORCE_POOL_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT = f"https://{_IAM_DOMAIN}/v1/locations/global/workforcePools/{{pool_id}}/allowedLocations"
-_WORKLOAD_IDENTITY_POOL_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT = f"https://{_IAM_DOMAIN}/v1/projects/{{project_number}}/locations/global/workloadIdentityPools/{{pool_id}}/allowedLocations"
 
 
 class Signer(crypt.Signer):

--- a/packages/google-auth/google/auth/impersonated_credentials.py
+++ b/packages/google-auth/google/auth/impersonated_credentials.py
@@ -36,6 +36,7 @@ from typing import Optional, TYPE_CHECKING
 
 from google.auth import _exponential_backoff
 from google.auth import _helpers
+from google.auth import _regional_access_boundary_utils
 from google.auth import credentials
 from google.auth import exceptions
 from google.auth import iam
@@ -368,8 +369,8 @@ class Credentials(
                 "Service account email is required to build the Regional Access Boundary lookup URL for impersonated credentials."
             )
             return None
-        return iam._SERVICE_ACCOUNT_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT.format(
-            service_account_email=self.service_account_email
+        return _regional_access_boundary_utils.get_service_account_rab_endpoint(
+            self.service_account_email
         )
 
     def sign_bytes(self, message):

--- a/packages/google-auth/google/auth/jwt.py
+++ b/packages/google-auth/google/auth/jwt.py
@@ -55,6 +55,7 @@ from google.auth import _helpers
 from google.auth import _service_account_info
 from google.auth import crypt
 from google.auth import exceptions
+from google.auth import iam
 import google.auth.credentials
 
 try:
@@ -317,7 +318,9 @@ def decode(token, certs=None, verify=True, audience=None, clock_skew_in_seconds=
 
 
 class Credentials(
-    google.auth.credentials.Signing, google.auth.credentials.CredentialsWithQuotaProject
+    google.auth.credentials.Signing,
+    google.auth.credentials.CredentialsWithQuotaProject,
+    google.auth.credentials.CredentialsWithRegionalAccessBoundary,
 ):
     """Credentials that use a JWT as the bearer token.
 
@@ -490,7 +493,15 @@ class Credentials(
         """
         kwargs.setdefault("issuer", credentials.signer_email)
         kwargs.setdefault("subject", credentials.signer_email)
-        return cls(credentials.signer, audience=audience, **kwargs)
+        jwt_creds = cls(credentials.signer, audience=audience, **kwargs)
+
+        if isinstance(
+            credentials,
+            google.auth.credentials.CredentialsWithRegionalAccessBoundary,
+        ):
+            credentials._copy_regional_access_boundary_manager(jwt_creds)
+
+        return jwt_creds
 
     def with_claims(
         self, issuer=None, subject=None, audience=None, additional_claims=None
@@ -514,7 +525,7 @@ class Credentials(
         new_additional_claims = copy.deepcopy(self._additional_claims)
         new_additional_claims.update(additional_claims or {})
 
-        return self.__class__(
+        cred = self.__class__(
             self._signer,
             issuer=issuer if issuer is not None else self._issuer,
             subject=subject if subject is not None else self._subject,
@@ -522,10 +533,12 @@ class Credentials(
             additional_claims=new_additional_claims,
             quota_project_id=self._quota_project_id,
         )
+        self._copy_regional_access_boundary_manager(cred)
+        return cred
 
     @_helpers.copy_docstring(google.auth.credentials.CredentialsWithQuotaProject)
     def with_quota_project(self, quota_project_id):
-        return self.__class__(
+        cred = self.__class__(
             self._signer,
             issuer=self._issuer,
             subject=self._subject,
@@ -533,6 +546,8 @@ class Credentials(
             additional_claims=self._additional_claims,
             quota_project_id=quota_project_id,
         )
+        self._copy_regional_access_boundary_manager(cred)
+        return cred
 
     def _make_jwt(self):
         """Make a signed JWT.
@@ -559,7 +574,7 @@ class Credentials(
 
         return jwt, expiry
 
-    def refresh(self, request):
+    def _perform_refresh_token(self, request):
         """Refreshes the access token.
 
         Args:
@@ -568,6 +583,15 @@ class Credentials(
         # pylint: disable=unused-argument
         # (pylint doesn't correctly recognize overridden methods.)
         self.token, self.expiry = self._make_jwt()
+
+    def _build_regional_access_boundary_lookup_url(self, request=None):
+        """Builds the lookup URL using the service account's email address."""
+        if not self.signer_email:
+            return None
+
+        return iam._SERVICE_ACCOUNT_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT.format(
+            service_account_email=self.signer_email
+        )
 
     @_helpers.copy_docstring(google.auth.credentials.Signing)
     def sign_bytes(self, message):

--- a/packages/google-auth/google/auth/jwt.py
+++ b/packages/google-auth/google/auth/jwt.py
@@ -52,10 +52,10 @@ import urllib
 
 from google.auth import _cache
 from google.auth import _helpers
+from google.auth import _regional_access_boundary_utils
 from google.auth import _service_account_info
 from google.auth import crypt
 from google.auth import exceptions
-from google.auth import iam
 import google.auth.credentials
 
 try:
@@ -589,8 +589,8 @@ class Credentials(
         if not self.signer_email:
             return None
 
-        return iam._SERVICE_ACCOUNT_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT.format(
-            service_account_email=self.signer_email
+        return _regional_access_boundary_utils.get_service_account_rab_endpoint(
+            self.signer_email
         )
 
     @_helpers.copy_docstring(google.auth.credentials.Signing)

--- a/packages/google-auth/google/oauth2/_client.py
+++ b/packages/google-auth/google/oauth2/_client.py
@@ -549,7 +549,7 @@ def _lookup_regional_access_boundary(request, url, headers=None, fail_fast=False
         # Error was already logged by _lookup_regional_access_boundary_request
         return None
 
-    if "encodedLocations" not in response_data:
+    if not isinstance(response_data, dict) or "encodedLocations" not in response_data:
         _LOGGER.error(
             "Regional Access Boundary response malformed: missing 'encodedLocations' key in %s",
             response_data,

--- a/packages/google-auth/google/oauth2/_client_async.py
+++ b/packages/google-auth/google/oauth2/_client_async.py
@@ -387,16 +387,19 @@ async def _lookup_regional_access_boundary_request_no_throw(
     response_data = {}
     retryable_error = False
 
-    timeout = client._BLOCKING_REGIONAL_ACCESS_BOUNDARY_LOOKUP_TIMEOUT if fail_fast else None
+    timeout = (
+        client._BLOCKING_REGIONAL_ACCESS_BOUNDARY_LOOKUP_TIMEOUT if fail_fast else None
+    )
     total_attempts = 1 if fail_fast else 6
-    retries = _exponential_backoff.AsyncExponentialBackoff(total_attempts=total_attempts)
+    retries = _exponential_backoff.AsyncExponentialBackoff(
+        total_attempts=total_attempts
+    )
 
     async for _ in retries:
         try:
             if timeout:
                 response = await asyncio.wait_for(
-                    request(method="GET", url=url, headers=headers),
-                    timeout=timeout
+                    request(method="GET", url=url, headers=headers), timeout=timeout
                 )
             else:
                 response = await request(method="GET", url=url, headers=headers)

--- a/packages/google-auth/google/oauth2/_client_async.py
+++ b/packages/google-auth/google/oauth2/_client_async.py
@@ -23,10 +23,10 @@ For more information about the token endpoint, see
 .. _Section 3.1 of rfc6749: https://tools.ietf.org/html/rfc6749#section-3.2
 """
 
+import asyncio
 import http.client as http_client
 import json
 import urllib
-import asyncio
 
 from google.auth import _exponential_backoff
 from google.auth import _helpers

--- a/packages/google-auth/google/oauth2/_client_async.py
+++ b/packages/google-auth/google/oauth2/_client_async.py
@@ -404,22 +404,24 @@ async def _lookup_regional_access_boundary_request_no_throw(
                 )
             else:
                 response = await request(method="GET", url=url, headers=headers)
-        except asyncio.TimeoutError:
-            return False, {}, False
-        except exceptions.TransportError:
-            return False, {}, False
 
-        response_bytes = await response.content()
-        response_body = (
-            response_bytes.decode("utf-8")
-            if hasattr(response_bytes, "decode")
-            else response_bytes
-        )
+            # Supports both modern google.auth.aio (exposing read()) and legacy transports (exposing content())
+            if hasattr(response, "read"):
+                response_bytes = await response.read()
+            else:
+                response_bytes = await response.content()
+        except (asyncio.TimeoutError, exceptions.TransportError):
+            return False, {}, False
 
         try:
+            response_body = (
+                response_bytes.decode("utf-8")
+                if hasattr(response_bytes, "decode")
+                else response_bytes
+            )
             response_data = json.loads(response_body)
-        except ValueError:
-            response_data = response_body
+        except (UnicodeDecodeError, ValueError):
+            return False, {}, False
 
         status_code = (
             response.status_code

--- a/packages/google-auth/google/oauth2/_client_async.py
+++ b/packages/google-auth/google/oauth2/_client_async.py
@@ -424,7 +424,8 @@ async def _lookup_regional_access_boundary_request_no_throw(
             )
             response_data = json.loads(response_body)
         except (UnicodeDecodeError, ValueError):
-            return False, {}, False
+            # Keep types safe and allow status-code checks below to determine retryability
+            response_data = {}
 
         status_code = (
             response.status_code

--- a/packages/google-auth/google/oauth2/_client_async.py
+++ b/packages/google-auth/google/oauth2/_client_async.py
@@ -413,8 +413,13 @@ async def _lookup_regional_access_boundary_request_no_throw(
                 response_bytes = await response.read()
             else:
                 response_bytes = await response.content()
-        # Catch raw transport/socket exceptions raised during body streaming.
+        except (asyncio.TimeoutError, exceptions.TransportError):
+            retryable_error = True
+            if not can_retry:
+                return False, {}, retryable_error
+            continue
         except Exception:
+            # Catch raw transport/socket exceptions raised during body streaming.
             return False, {}, False
 
         try:

--- a/packages/google-auth/google/oauth2/_client_async.py
+++ b/packages/google-auth/google/oauth2/_client_async.py
@@ -413,7 +413,8 @@ async def _lookup_regional_access_boundary_request_no_throw(
                 response_bytes = await response.read()
             else:
                 response_bytes = await response.content()
-        except (asyncio.TimeoutError, exceptions.TransportError):
+        # Catch raw transport/socket exceptions raised during body streaming.
+        except Exception:
             return False, {}, False
 
         try:

--- a/packages/google-auth/google/oauth2/_client_async.py
+++ b/packages/google-auth/google/oauth2/_client_async.py
@@ -26,6 +26,7 @@ For more information about the token endpoint, see
 import http.client as http_client
 import json
 import urllib
+import asyncio
 
 from google.auth import _exponential_backoff
 from google.auth import _helpers
@@ -288,3 +289,142 @@ async def refresh_grant(
         request, token_uri, body, can_retry=can_retry
     )
     return client._handle_refresh_grant_response(response_data, refresh_token)
+
+
+async def _lookup_regional_access_boundary(request, url, headers=None, fail_fast=False):
+    """Implements the global lookup of a credential Regional Access Boundary.
+    For the lookup, we send a request to the global lookup endpoint and then
+    parse the response. Service account credentials, workload identity
+    pools and workforce pools implementation may have Regional Access Boundaries configured.
+    Args:
+        request (google.auth.aio.transport.Request): A callable used to make
+            HTTP requests.
+        url (str): The Regional Access Boundary lookup url.
+        headers (Optional[Mapping[str, str]]): The headers for the request.
+        fail_fast (bool): Whether the lookup should fail fast (uses a short timeout and no retries).
+    Returns:
+        Optional[Mapping[str,list|str]]: A dictionary containing
+            "locations" as a list of allowed locations as strings and
+            "encodedLocations" as a hex string.
+            e.g:
+            {
+                "locations": [
+                    "us-central1", "us-east1", "europe-west1", "asia-east1"
+                ],
+                "encodedLocations": "0xA30"
+            }
+    """
+    response_data = await _lookup_regional_access_boundary_request(
+        request, url, headers=headers, fail_fast=fail_fast
+    )
+    if response_data is None:
+        # Error was already logged by _lookup_regional_access_boundary_request
+        return None
+
+    if "encodedLocations" not in response_data:
+        client._LOGGER.error(
+            "Regional Access Boundary response malformed: missing 'encodedLocations' key in %s",
+            response_data,
+        )
+        return None
+    return response_data
+
+
+async def _lookup_regional_access_boundary_request(
+    request, url, can_retry=True, headers=None, fail_fast=False
+):
+    """Makes a request to the Regional Access Boundary lookup endpoint.
+
+    Args:
+        request (google.auth.aio.transport.Request): A callable used to make
+            HTTP requests.
+        url (str): The Regional Access Boundary lookup url.
+        can_retry (bool): Enable or disable request retry behavior. Defaults to true.
+        headers (Optional[Mapping[str, str]]): The headers for the request.
+        fail_fast (bool): Whether the lookup should fail fast (uses a short timeout and no retries).
+
+    Returns:
+        Optional[Mapping[str, str]]: The JSON-decoded response data on success, or None on failure.
+    """
+    (
+        response_status_ok,
+        response_data,
+        retryable_error,
+    ) = await _lookup_regional_access_boundary_request_no_throw(
+        request, url, can_retry=can_retry, headers=headers, fail_fast=fail_fast
+    )
+    if not response_status_ok:
+        client._LOGGER.warning(
+            "Regional Access Boundary HTTP request failed after retries: response_data=%s, retryable_error=%s",
+            response_data,
+            retryable_error,
+        )
+        return None
+    return response_data
+
+
+async def _lookup_regional_access_boundary_request_no_throw(
+    request, url, can_retry=True, headers=None, fail_fast=False
+):
+    """Makes a request to the Regional Access Boundary lookup endpoint. This
+        function doesn't throw on response errors.
+
+    Args:
+        request (google.auth.aio.transport.Request): A callable used to make
+            HTTP requests.
+        url (str): The Regional Access Boundary lookup url.
+        can_retry (bool): Enable or disable request retry behavior. Defaults to true.
+        headers (Optional[Mapping[str, str]]): The headers for the request.
+        fail_fast (bool): Whether the lookup should fail fast (uses a short timeout and no retries).
+
+    Returns:
+        Tuple(bool, Mapping[str, str], Optional[bool]): A boolean indicating
+          if the request is successful, a mapping for the JSON-decoded response
+          data and in the case of an error a boolean indicating if the error
+          is retryable.
+    """
+
+    response_data = {}
+    retryable_error = False
+
+    timeout = client._BLOCKING_REGIONAL_ACCESS_BOUNDARY_LOOKUP_TIMEOUT if fail_fast else None
+    total_attempts = 1 if fail_fast else 6
+    retries = _exponential_backoff.AsyncExponentialBackoff(total_attempts=total_attempts)
+
+    async for _ in retries:
+        try:
+            if timeout:
+                response = await asyncio.wait_for(
+                    request(method="GET", url=url, headers=headers),
+                    timeout=timeout
+                )
+            else:
+                response = await request(method="GET", url=url, headers=headers)
+        except asyncio.TimeoutError:
+            return False, {}, False
+
+        response_body1 = await response.content()
+        response_body = (
+            response_body1.decode("utf-8")
+            if hasattr(response_body1, "decode")
+            else response_body1
+        )
+
+        try:
+            response_data = json.loads(response_body)
+        except ValueError:
+            response_data = response_body
+
+        if response.status == http_client.OK:
+            return True, response_data, None
+
+        retryable_error = client._can_retry(
+            status_code=response.status, response_data=response_data
+        )
+        if response.status == http_client.BAD_GATEWAY:
+            retryable_error = True
+
+        if not can_retry or not retryable_error:
+            return False, response_data, retryable_error
+
+    return False, response_data, retryable_error

--- a/packages/google-auth/google/oauth2/_client_async.py
+++ b/packages/google-auth/google/oauth2/_client_async.py
@@ -91,17 +91,11 @@ async def _token_endpoint_request_no_throw(
         except ValueError:
             response_data = response_body
 
-        status_code = (
-            response.status_code
-            if hasattr(response, "status_code")
-            else response.status
-        )
-
-        if status_code == http_client.OK:
+        if response.status == http_client.OK:
             return True, response_data, None
 
         retryable_error = client._can_retry(
-            status_code=status_code, response_data=response_data
+            status_code=response.status, response_data=response_data
         )
 
         if not can_retry or not retryable_error:

--- a/packages/google-auth/google/oauth2/_client_async.py
+++ b/packages/google-auth/google/oauth2/_client_async.py
@@ -91,11 +91,17 @@ async def _token_endpoint_request_no_throw(
         except ValueError:
             response_data = response_body
 
-        if response.status == http_client.OK:
+        status_code = (
+            response.status_code
+            if hasattr(response, "status_code")
+            else response.status
+        )
+
+        if status_code == http_client.OK:
             return True, response_data, None
 
         retryable_error = client._can_retry(
-            status_code=response.status, response_data=response_data
+            status_code=status_code, response_data=response_data
         )
 
         if not can_retry or not retryable_error:
@@ -321,7 +327,7 @@ async def _lookup_regional_access_boundary(request, url, headers=None, fail_fast
         # Error was already logged by _lookup_regional_access_boundary_request
         return None
 
-    if "encodedLocations" not in response_data:
+    if not isinstance(response_data, dict) or "encodedLocations" not in response_data:
         client._LOGGER.error(
             "Regional Access Boundary response malformed: missing 'encodedLocations' key in %s",
             response_data,
@@ -399,18 +405,21 @@ async def _lookup_regional_access_boundary_request_no_throw(
         try:
             if timeout:
                 response = await asyncio.wait_for(
-                    request(method="GET", url=url, headers=headers), timeout=timeout
+                    request(method="GET", url=url, headers=headers, timeout=timeout),
+                    timeout=timeout,
                 )
             else:
                 response = await request(method="GET", url=url, headers=headers)
         except asyncio.TimeoutError:
             return False, {}, False
+        except exceptions.TransportError:
+            return False, {}, False
 
-        response_body1 = await response.content()
+        response_bytes = await response.content()
         response_body = (
-            response_body1.decode("utf-8")
-            if hasattr(response_body1, "decode")
-            else response_body1
+            response_bytes.decode("utf-8")
+            if hasattr(response_bytes, "decode")
+            else response_bytes
         )
 
         try:
@@ -418,13 +427,19 @@ async def _lookup_regional_access_boundary_request_no_throw(
         except ValueError:
             response_data = response_body
 
-        if response.status == http_client.OK:
+        status_code = (
+            response.status_code
+            if hasattr(response, "status_code")
+            else response.status
+        )
+
+        if status_code == http_client.OK:
             return True, response_data, None
 
         retryable_error = client._can_retry(
-            status_code=response.status, response_data=response_data
+            status_code=status_code, response_data=response_data
         )
-        if response.status == http_client.BAD_GATEWAY:
+        if status_code == http_client.BAD_GATEWAY:
             retryable_error = True
 
         if not can_retry or not retryable_error:

--- a/packages/google-auth/google/oauth2/_client_async.py
+++ b/packages/google-auth/google/oauth2/_client_async.py
@@ -298,7 +298,8 @@ async def _lookup_regional_access_boundary(request, url, headers=None, fail_fast
     pools and workforce pools implementation may have Regional Access Boundaries configured.
     Args:
         request (google.auth.aio.transport.Request): A callable used to make
-            HTTP requests.
+            HTTP requests. The returned response must support `await response.read()`
+            (standard async transport) or `await response.content()` (legacy/custom transport).
         url (str): The Regional Access Boundary lookup url.
         headers (Optional[Mapping[str, str]]): The headers for the request.
         fail_fast (bool): Whether the lookup should fail fast (uses a short timeout and no retries).
@@ -337,7 +338,8 @@ async def _lookup_regional_access_boundary_request(
 
     Args:
         request (google.auth.aio.transport.Request): A callable used to make
-            HTTP requests.
+            HTTP requests. The returned response must support `await response.read()`
+            (standard async transport) or `await response.content()` (legacy/custom transport).
         url (str): The Regional Access Boundary lookup url.
         can_retry (bool): Enable or disable request retry behavior. Defaults to true.
         headers (Optional[Mapping[str, str]]): The headers for the request.
@@ -371,7 +373,8 @@ async def _lookup_regional_access_boundary_request_no_throw(
 
     Args:
         request (google.auth.aio.transport.Request): A callable used to make
-            HTTP requests.
+            HTTP requests. The returned response must support `await response.read()`
+            (standard async transport) or `await response.content()` (legacy/custom transport).
         url (str): The Regional Access Boundary lookup url.
         can_retry (bool): Enable or disable request retry behavior. Defaults to true.
         headers (Optional[Mapping[str, str]]): The headers for the request.

--- a/packages/google-auth/google/oauth2/_service_account_async.py
+++ b/packages/google-auth/google/oauth2/_service_account_async.py
@@ -24,13 +24,14 @@ credentials file google.oauth2.service_account
 
 from google.auth import _credentials_async as credentials_async
 from google.auth import _helpers
-from google.auth import _regional_access_boundary_utils
 from google.oauth2 import _client_async
 from google.oauth2 import service_account
 
 
 class Credentials(
-    service_account.Credentials, credentials_async.Scoped, credentials_async.Credentials
+    service_account.Credentials,
+    credentials_async.Scoped,
+    credentials_async.CredentialsWithRegionalAccessBoundary,
 ):
     """Service account credentials
 
@@ -67,15 +68,11 @@ class Credentials(
         credentials = credentials.with_quota_project('myproject-123')
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._rab_manager.refresh_manager = (
-            _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
-        )
-
     def __setstate__(self, state):
         """Restores the credential state and ensures the async refresh manager is attached."""
         super().__setstate__(state)
+        from google.auth import _regional_access_boundary_utils
+
         self._rab_manager.refresh_manager = (
             _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
         )
@@ -88,29 +85,6 @@ class Credentials(
         )
         self.token = access_token
         self.expiry = expiry
-
-    async def _lookup_regional_access_boundary(self, request, fail_fast=False):
-        """Calls the Regional Access Boundary lookup API to retrieve the Regional Access Boundary information.
-
-        Args:
-            request (google.auth.aio.transport.Request): The object used to make
-                HTTP requests.
-            fail_fast (bool): Whether the lookup should fail fast.
-
-        Returns:
-            Optional[Dict[str, str]]: The Regional Access Boundary information.
-        """
-        url = self._build_regional_access_boundary_lookup_url(request=request)
-        if not url:
-            return None
-
-        headers = {}
-        self._apply(headers)
-        self._rab_manager.apply_headers(headers)
-
-        return await _client_async._lookup_regional_access_boundary(
-            request, url, headers=headers, fail_fast=fail_fast
-        )
 
 
 class IDTokenCredentials(

--- a/packages/google-auth/google/oauth2/_service_account_async.py
+++ b/packages/google-auth/google/oauth2/_service_account_async.py
@@ -22,9 +22,9 @@ credentials file google.oauth2.service_account
 
 """
 
-from google.auth import _regional_access_boundary_utils
 from google.auth import _credentials_async as credentials_async
 from google.auth import _helpers
+from google.auth import _regional_access_boundary_utils
 from google.oauth2 import _client_async
 from google.oauth2 import service_account
 

--- a/packages/google-auth/google/oauth2/_service_account_async.py
+++ b/packages/google-auth/google/oauth2/_service_account_async.py
@@ -69,7 +69,9 @@ class Credentials(
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._rab_manager.refresh_manager = _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
+        self._rab_manager.refresh_manager = (
+            _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
+        )
 
     @_helpers.copy_docstring(credentials_async.Credentials)
     async def refresh(self, request):
@@ -98,7 +100,7 @@ class Credentials(
         headers = {}
         self._apply(headers)
         self._rab_manager.apply_headers(headers)
-        
+
         return await _client_async._lookup_regional_access_boundary(
             request, url, headers=headers, fail_fast=fail_fast
         )

--- a/packages/google-auth/google/oauth2/_service_account_async.py
+++ b/packages/google-auth/google/oauth2/_service_account_async.py
@@ -24,6 +24,7 @@ credentials file google.oauth2.service_account
 
 from google.auth import _credentials_async as credentials_async
 from google.auth import _helpers
+from google.auth import _regional_access_boundary_utils
 from google.oauth2 import _client_async
 from google.oauth2 import service_account
 
@@ -66,6 +67,10 @@ class Credentials(
         credentials = credentials.with_quota_project('myproject-123')
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._rab_manager.refresh_manager = _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
+
     @_helpers.copy_docstring(credentials_async.Credentials)
     async def refresh(self, request):
         assertion = self._make_authorization_grant_assertion()
@@ -75,12 +80,36 @@ class Credentials(
         self.token = access_token
         self.expiry = expiry
 
+    async def _lookup_regional_access_boundary(self, request, fail_fast=False):
+        """Calls the Regional Access Boundary lookup API to retrieve the Regional Access Boundary information.
+
+        Args:
+            request (google.auth.aio.transport.Request): The object used to make
+                HTTP requests.
+            fail_fast (bool): Whether the lookup should fail fast.
+
+        Returns:
+            Optional[Dict[str, str]]: The Regional Access Boundary information.
+        """
+        url = self._build_regional_access_boundary_lookup_url(request=request)
+        if not url:
+            return None
+
+        headers = {}
+        self._apply(headers)
+        self._rab_manager.apply_headers(headers)
+        
+        return await _client_async._lookup_regional_access_boundary(
+            request, url, headers=headers, fail_fast=fail_fast
+        )
+
     @_helpers.copy_docstring(credentials_async.Credentials)
     async def before_request(self, request, method, url, headers):
-        # Explicit override to bypass synchronous CredentialsWithRegionalAccessBoundary.
         await credentials_async.Credentials.before_request(
             self, request, method, url, headers
         )
+        self._maybe_start_regional_access_boundary_refresh(request, url)
+        self._rab_manager.apply_headers(headers)
 
 
 class IDTokenCredentials(

--- a/packages/google-auth/google/oauth2/_service_account_async.py
+++ b/packages/google-auth/google/oauth2/_service_account_async.py
@@ -105,14 +105,6 @@ class Credentials(
             request, url, headers=headers, fail_fast=fail_fast
         )
 
-    @_helpers.copy_docstring(credentials_async.Credentials)
-    async def before_request(self, request, method, url, headers):
-        await credentials_async.Credentials.before_request(
-            self, request, method, url, headers
-        )
-        self._maybe_start_regional_access_boundary_refresh(request, url)
-        self._rab_manager.apply_headers(headers)
-
 
 class IDTokenCredentials(
     service_account.IDTokenCredentials,
@@ -168,11 +160,3 @@ class IDTokenCredentials(
         )
         self.token = access_token
         self.expiry = expiry
-
-    @_helpers.copy_docstring(credentials_async.Credentials)
-    async def before_request(self, request, method, url, headers):
-        # Explicit override to bypass synchronous CredentialsWithRegionalAccessBoundary
-        # and disable Regional Access Boundary refresh for async credentials.
-        await credentials_async.Credentials.before_request(
-            self, request, method, url, headers
-        )

--- a/packages/google-auth/google/oauth2/_service_account_async.py
+++ b/packages/google-auth/google/oauth2/_service_account_async.py
@@ -73,6 +73,13 @@ class Credentials(
             _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
         )
 
+    def __setstate__(self, state):
+        """Restores the credential state and ensures the async refresh manager is attached."""
+        super().__setstate__(state)
+        self._rab_manager.refresh_manager = (
+            _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
+        )
+
     @_helpers.copy_docstring(credentials_async.Credentials)
     async def refresh(self, request):
         assertion = self._make_authorization_grant_assertion()

--- a/packages/google-auth/google/oauth2/_service_account_async.py
+++ b/packages/google-auth/google/oauth2/_service_account_async.py
@@ -22,6 +22,7 @@ credentials file google.oauth2.service_account
 
 """
 
+from google.auth import _regional_access_boundary_utils
 from google.auth import _credentials_async as credentials_async
 from google.auth import _helpers
 from google.oauth2 import _client_async
@@ -71,7 +72,6 @@ class Credentials(
     def __setstate__(self, state):
         """Restores the credential state and ensures the async refresh manager is attached."""
         super().__setstate__(state)
-        from google.auth import _regional_access_boundary_utils
 
         self._rab_manager.refresh_manager = (
             _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()

--- a/packages/google-auth/google/oauth2/service_account.py
+++ b/packages/google-auth/google/oauth2/service_account.py
@@ -77,6 +77,7 @@ from typing import Optional, TYPE_CHECKING
 
 
 from google.auth import _helpers
+from google.auth import _regional_access_boundary_utils
 from google.auth import _service_account_info
 from google.auth import credentials
 from google.auth import exceptions
@@ -520,8 +521,8 @@ class Credentials(
                 "Service account email is required to build the Regional Access Boundary lookup URL for service account credentials."
             )
             return None
-        return iam._SERVICE_ACCOUNT_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT.format(
-            service_account_email=self._service_account_email,
+        return _regional_access_boundary_utils.get_service_account_rab_endpoint(
+            self._service_account_email
         )
 
     @_helpers.copy_docstring(credentials.Signing)

--- a/packages/google-auth/tests/compute_engine/test__metadata.py
+++ b/packages/google-auth/tests/compute_engine/test__metadata.py
@@ -985,3 +985,25 @@ def test__prepare_request_for_mds_mtls_http_request(mock_mds_mtls_adapter):
     _metadata._prepare_request_for_mds(request, use_mtls=True)
 
     assert mock_mds_mtls_adapter.call_count == 0
+
+
+def test__is_email():
+    # Valid email formats
+    assert _metadata._is_email("my-sa@my-project.iam.gserviceaccount.com") is True
+    assert _metadata._is_email("test@example.com") is True
+
+    # Empty inputs and standard string placeholders
+    assert _metadata._is_email("default") is False
+    assert _metadata._is_email("") is False
+    assert _metadata._is_email(None) is False
+
+    # Workload identity principal URI formats
+    assert (
+        _metadata._is_email(
+            "principal://iam.googleapis.com/projects/1234567890/locations/global/workloadIdentityPools/my-project.svc.id.goog/subject/ns/my-namespace/sa/my-kubernetes-sa"
+        )
+        is False
+    )
+
+    # Workforce or workload pool identifier paths
+    assert _metadata._is_email("my-gcp-project.svc.id.goog") is False

--- a/packages/google-auth/tests/compute_engine/test__metadata.py
+++ b/packages/google-auth/tests/compute_engine/test__metadata.py
@@ -987,23 +987,23 @@ def test__prepare_request_for_mds_mtls_http_request(mock_mds_mtls_adapter):
     assert mock_mds_mtls_adapter.call_count == 0
 
 
-def test__is_email():
+def test__is_service_account_email():
     # Valid email formats
-    assert _metadata._is_email("my-sa@my-project.iam.gserviceaccount.com") is True
-    assert _metadata._is_email("test@example.com") is True
+    assert _metadata._is_service_account_email("my-sa@my-project.iam.gserviceaccount.com") is True
+    assert _metadata._is_service_account_email("test@example.com") is True
 
     # Empty inputs and standard string placeholders
-    assert _metadata._is_email("default") is False
-    assert _metadata._is_email("") is False
-    assert _metadata._is_email(None) is False
+    assert _metadata._is_service_account_email("default") is False
+    assert _metadata._is_service_account_email("") is False
+    assert _metadata._is_service_account_email(None) is False
 
     # Workload identity principal URI formats
     assert (
-        _metadata._is_email(
+        _metadata._is_service_account_email(
             "principal://iam.googleapis.com/projects/1234567890/locations/global/workloadIdentityPools/my-project.svc.id.goog/subject/ns/my-namespace/sa/my-kubernetes-sa"
         )
         is False
     )
 
     # Workforce or workload pool identifier paths
-    assert _metadata._is_email("my-gcp-project.svc.id.goog") is False
+    assert _metadata._is_service_account_email("my-gcp-project.svc.id.goog") is False

--- a/packages/google-auth/tests/compute_engine/test__metadata.py
+++ b/packages/google-auth/tests/compute_engine/test__metadata.py
@@ -989,7 +989,10 @@ def test__prepare_request_for_mds_mtls_http_request(mock_mds_mtls_adapter):
 
 def test__is_service_account_email():
     # Valid email formats
-    assert _metadata._is_service_account_email("my-sa@my-project.iam.gserviceaccount.com") is True
+    assert (
+        _metadata._is_service_account_email("my-sa@my-project.iam.gserviceaccount.com")
+        is True
+    )
     assert _metadata._is_service_account_email("test@example.com") is True
 
     # Empty inputs and standard string placeholders

--- a/packages/google-auth/tests/compute_engine/test_credentials.py
+++ b/packages/google-auth/tests/compute_engine/test_credentials.py
@@ -410,6 +410,68 @@ class TestCredentials(object):
         url = creds._build_regional_access_boundary_lookup_url()
         assert url is None
 
+    @mock.patch(
+        "google.auth._regional_access_boundary_utils.is_regional_access_boundary_enabled",
+        return_value=True,
+    )
+    def test_is_regional_access_boundary_lookup_required(self, mock_enabled):
+        creds = self.credentials
+        creds._universe_domain_cached = True
+
+        # Valid email formats should pass.
+        creds._service_account_email = "my-sa@my-project.iam.gserviceaccount.com"
+        assert creds._is_regional_access_boundary_lookup_required() is True
+
+        # GCE default email placeholder should pass to allow dynamic resolution.
+        creds._service_account_email = "default"
+        assert creds._is_regional_access_boundary_lookup_required() is True
+
+        # Lookup for non-email based identities should be skipped.
+        creds._service_account_email = "my-gcp-project.svc.id.goog"
+        assert creds._is_regional_access_boundary_lookup_required() is False
+
+        creds._service_account_email = "principal://iam.googleapis.com/projects/1234567890/locations/global/workloadIdentityPools/my-project.svc.id.goog/subject/ns/my-namespace/sa/my-kubernetes-sa"
+        assert creds._is_regional_access_boundary_lookup_required() is False
+
+    def test_build_regional_access_boundary_lookup_url_with_invalid_email(self):
+        creds = self.credentials
+        creds._universe_domain_cached = True
+
+        # Set a non-email identity.
+        creds._service_account_email = "my-gcp-project.svc.id.goog"
+        url = creds._build_regional_access_boundary_lookup_url()
+        assert url is None
+
+    @mock.patch(
+        "google.auth._regional_access_boundary_utils.is_regional_access_boundary_enabled",
+        return_value=True,
+    )
+    @mock.patch(
+        "google.auth.compute_engine._metadata.get_service_account_info", autospec=True
+    )
+    def test_regional_access_boundary_disabled_state_transitions(
+        self, mock_get_service_account_info, mock_enabled
+    ):
+        mock_get_service_account_info.return_value = {
+            "email": "spiffe://trust-domain/ns/ns/sa/sa",
+            "scopes": ["one", "two"],
+        }
+        creds = self.credentials
+        creds._universe_domain_cached = True
+        creds._service_account_email = "default"
+
+        # Initially, GCE 'default' placeholder passes the pre-check
+        assert not creds._rab_disabled
+        assert creds._is_regional_access_boundary_lookup_required() is True
+
+        # Resolving a non-email identity should disable RAB lookup
+        url = creds._build_regional_access_boundary_lookup_url()
+        assert url is None
+        assert creds._rab_disabled is True
+
+        # Subsequent check calls should return False early
+        assert creds._is_regional_access_boundary_lookup_required() is False
+
     @mock.patch("google.auth.compute_engine._metadata.get")
     @mock.patch("google.auth._agent_identity_utils.get_agent_identity_certificate_path")
     @mock.patch("google.auth._agent_identity_utils.parse_certificate")

--- a/packages/google-auth/tests/compute_engine/test_credentials.py
+++ b/packages/google-auth/tests/compute_engine/test_credentials.py
@@ -306,8 +306,9 @@ class TestCredentials(object):
         url = creds._build_regional_access_boundary_lookup_url(request=mock_request)
 
         mock_get_service_account_info.assert_called_once_with(mock_request, "default")
-        expected_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/resolved-email@example.com/allowedLocations"
-        assert url == expected_url
+        expected_url_standard = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/resolved-email@example.com/allowedLocations"
+        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/resolved-email@example.com/allowedLocations"
+        assert url in (expected_url_standard, expected_url_mtls)
 
     @mock.patch("google.auth.compute_engine._metadata.get", autospec=True)
     def test_build_regional_access_boundary_lookup_url_http_client_request(
@@ -323,8 +324,9 @@ class TestCredentials(object):
 
         url = creds._build_regional_access_boundary_lookup_url(request=req)
 
-        expected_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/resolved-email@example.com/allowedLocations"
-        assert url == expected_url
+        expected_url_standard = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/resolved-email@example.com/allowedLocations"
+        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/resolved-email@example.com/allowedLocations"
+        assert url in (expected_url_standard, expected_url_mtls)
 
     @mock.patch(
         "google.auth.compute_engine._metadata.get_service_account_info", autospec=True
@@ -343,9 +345,9 @@ class TestCredentials(object):
         url = creds._build_regional_access_boundary_lookup_url()
 
         mock_get_service_account_info.assert_not_called()
-        assert url == (
-            "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.com/allowedLocations"
-        )
+        expected_url_standard = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.com/allowedLocations"
+        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.com/allowedLocations"
+        assert url in (expected_url_standard, expected_url_mtls)
 
     @mock.patch(
         "google.auth.compute_engine._metadata.get_universe_domain", autospec=True

--- a/packages/google-auth/tests/compute_engine/test_credentials.py
+++ b/packages/google-auth/tests/compute_engine/test_credentials.py
@@ -334,9 +334,14 @@ class TestCredentials(object):
     @mock.patch(
         "google.auth.compute_engine._metadata.get_universe_domain", autospec=True
     )
-    def test_build_regional_access_boundary_lookup_url_explicit_email(
-        self, mock_get_universe_domain, mock_get_service_account_info
+    def test_build_regional_access_boundary_lookup_url_explicit_email_standard(
+        self, mock_get_universe_domain, mock_get_service_account_info, monkeypatch
     ):
+        from google.auth.transport import _mtls_helper
+
+        # Mock check_use_client_cert to return False
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: False)
+
         # Test with an explicit service account email, no resolution needed
         creds = self.credentials
         creds._service_account_email = FAKE_SERVICE_ACCOUNT_EMAIL
@@ -345,9 +350,33 @@ class TestCredentials(object):
         url = creds._build_regional_access_boundary_lookup_url()
 
         mock_get_service_account_info.assert_not_called()
-        expected_url_standard = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.com/allowedLocations"
-        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.com/allowedLocations"
-        assert url in (expected_url_standard, expected_url_mtls)
+        expected_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.com/allowedLocations"
+        assert url == expected_url
+
+    @mock.patch(
+        "google.auth.compute_engine._metadata.get_service_account_info", autospec=True
+    )
+    @mock.patch(
+        "google.auth.compute_engine._metadata.get_universe_domain", autospec=True
+    )
+    def test_build_regional_access_boundary_lookup_url_explicit_email_mtls(
+        self, mock_get_universe_domain, mock_get_service_account_info, monkeypatch
+    ):
+        from google.auth.transport import _mtls_helper
+
+        # Mock check_use_client_cert to return True
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
+
+        # Test with an explicit service account email, no resolution needed
+        creds = self.credentials
+        creds._service_account_email = FAKE_SERVICE_ACCOUNT_EMAIL
+        mock_get_universe_domain.return_value = "googleapis.com"
+
+        url = creds._build_regional_access_boundary_lookup_url()
+
+        mock_get_service_account_info.assert_not_called()
+        expected_url = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.com/allowedLocations"
+        assert url == expected_url
 
     @mock.patch(
         "google.auth.compute_engine._metadata.get_universe_domain", autospec=True

--- a/packages/google-auth/tests/oauth2/test__client.py
+++ b/packages/google-auth/tests/oauth2/test__client.py
@@ -185,7 +185,8 @@ def test__token_endpoint_request_error():
         _client._token_endpoint_request(request, "http://example.com", {})
 
 
-def test__token_endpoint_request_internal_failure_error():
+@mock.patch("time.sleep", return_value=None)
+def test__token_endpoint_request_internal_failure_error(mock_sleep):
     request = make_request(
         {"error_description": "internal_failure"}, status=http_client.BAD_REQUEST
     )
@@ -207,9 +208,11 @@ def test__token_endpoint_request_internal_failure_error():
         )
     # request with 2 retries
     assert request.call_count == 3
+    assert mock_sleep.call_count == 4
 
 
-def test__token_endpoint_request_internal_failure_and_retry_failure_error():
+@mock.patch("time.sleep", return_value=None)
+def test__token_endpoint_request_internal_failure_and_retry_failure_error(mock_sleep):
     retryable_error = mock.create_autospec(transport.Response, instance=True)
     retryable_error.status = http_client.BAD_REQUEST
     retryable_error.data = json.dumps({"error_description": "internal_failure"}).encode(
@@ -233,9 +236,11 @@ def test__token_endpoint_request_internal_failure_and_retry_failure_error():
     # request should be called three times. Two retryable errors and one
     # unretryable error to break the retry loop.
     assert request.call_count == 3
+    assert mock_sleep.call_count == 2
 
 
-def test__token_endpoint_request_internal_failure_and_retry_succeeds():
+@mock.patch("time.sleep", return_value=None)
+def test__token_endpoint_request_internal_failure_and_retry_succeeds(mock_sleep):
     retryable_error = mock.create_autospec(transport.Response, instance=True)
     retryable_error.status = http_client.BAD_REQUEST
     retryable_error.data = json.dumps({"error_description": "internal_failure"}).encode(
@@ -255,6 +260,7 @@ def test__token_endpoint_request_internal_failure_and_retry_succeeds():
     )
 
     assert request.call_count == 2
+    assert mock_sleep.call_count == 1
 
 
 def test__token_endpoint_request_string_error():
@@ -611,7 +617,8 @@ def test_refresh_grant_retry_with_retry(
 
 
 @pytest.mark.parametrize("can_retry", [True, False])
-def test__token_endpoint_request_no_throw_with_retry(can_retry):
+@mock.patch("time.sleep", return_value=None)
+def test__token_endpoint_request_no_throw_with_retry(mock_sleep, can_retry):
     response_data = {"error": "help", "error_description": "I'm alive"}
     body = "dummy body"
 
@@ -628,8 +635,10 @@ def test__token_endpoint_request_no_throw_with_retry(can_retry):
 
     if can_retry:
         assert mock_request.call_count == 3
+        assert mock_sleep.call_count == 2
     else:
         assert mock_request.call_count == 1
+        mock_sleep.assert_not_called()
 
 
 def test_lookup_regional_access_boundary():
@@ -706,7 +715,8 @@ def test_lookup_regional_access_boundary_non_retryable_error(status_code):
     )
 
 
-def test_lookup_regional_access_boundary_internal_failure_and_retry_failure_error():
+@mock.patch("time.sleep", return_value=None)
+def test_lookup_regional_access_boundary_internal_failure_and_retry_failure_error(mock_sleep):
     retryable_error = mock.create_autospec(transport.Response, instance=True)
     retryable_error.status = http_client.BAD_REQUEST
     retryable_error.data = json.dumps({"error_description": "internal_failure"}).encode(
@@ -731,11 +741,13 @@ def test_lookup_regional_access_boundary_internal_failure_and_retry_failure_erro
     # request should be called three times. Two retryable errors and one
     # unretryable error to break the retry loop.
     assert request.call_count == 3
+    assert mock_sleep.call_count == 2
     for call in request.call_args_list:
         assert call[1]["headers"] == headers
 
 
-def test_lookup_regional_access_boundary_internal_failure_and_retry_succeeds():
+@mock.patch("time.sleep", return_value=None)
+def test_lookup_regional_access_boundary_internal_failure_and_retry_succeeds(mock_sleep):
     retryable_error = mock.create_autospec(transport.Response, instance=True)
     retryable_error.status = http_client.BAD_REQUEST
     retryable_error.data = json.dumps({"error_description": "internal_failure"}).encode(
@@ -760,6 +772,7 @@ def test_lookup_regional_access_boundary_internal_failure_and_retry_succeeds():
     )
 
     assert request.call_count == 2
+    assert mock_sleep.call_count == 1
     for call in request.call_args_list:
         assert call[1]["headers"] == headers
 

--- a/packages/google-auth/tests/oauth2/test__client.py
+++ b/packages/google-auth/tests/oauth2/test__client.py
@@ -716,7 +716,9 @@ def test_lookup_regional_access_boundary_non_retryable_error(status_code):
 
 
 @mock.patch("time.sleep", return_value=None)
-def test_lookup_regional_access_boundary_internal_failure_and_retry_failure_error(mock_sleep):
+def test_lookup_regional_access_boundary_internal_failure_and_retry_failure_error(
+    mock_sleep,
+):
     retryable_error = mock.create_autospec(transport.Response, instance=True)
     retryable_error.status = http_client.BAD_REQUEST
     retryable_error.data = json.dumps({"error_description": "internal_failure"}).encode(
@@ -747,7 +749,9 @@ def test_lookup_regional_access_boundary_internal_failure_and_retry_failure_erro
 
 
 @mock.patch("time.sleep", return_value=None)
-def test_lookup_regional_access_boundary_internal_failure_and_retry_succeeds(mock_sleep):
+def test_lookup_regional_access_boundary_internal_failure_and_retry_succeeds(
+    mock_sleep,
+):
     retryable_error = mock.create_autospec(transport.Response, instance=True)
     retryable_error.status = http_client.BAD_REQUEST
     retryable_error.data = json.dumps({"error_description": "internal_failure"}).encode(

--- a/packages/google-auth/tests/oauth2/test_service_account.py
+++ b/packages/google-auth/tests/oauth2/test_service_account.py
@@ -230,13 +230,16 @@ class TestCredentials(object):
 
     def test_build_regional_access_boundary_lookup_url(self):
         credentials = self.make_credentials()
-        expected_url = (
-            "https://iamcredentials.googleapis.com/v1/projects/-/"
-            "serviceAccounts/{}/allowedLocations".format(
-                credentials.service_account_email
-            )
+        url = credentials._build_regional_access_boundary_lookup_url()
+
+        expected_url_standard = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+            credentials.service_account_email
         )
-        assert credentials._build_regional_access_boundary_lookup_url() == expected_url
+        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+            credentials.service_account_email
+        )
+
+        assert url in (expected_url_standard, expected_url_mtls)
 
     def test_with_token_uri(self):
         credentials = self.make_credentials()

--- a/packages/google-auth/tests/oauth2/test_service_account.py
+++ b/packages/google-auth/tests/oauth2/test_service_account.py
@@ -238,11 +238,16 @@ class TestCredentials(object):
         # Verify references to boundary data are shared
         assert new_credentials._rab_manager._data == mock.sentinel.rab_data
         # Verify blocking config flag is preserved
-        assert new_credentials._rab_manager._use_blocking_regional_access_boundary_lookup is True
+        assert (
+            new_credentials._rab_manager._use_blocking_regional_access_boundary_lookup
+            is True
+        )
         # Verify target manager object is not replaced
         assert new_credentials._rab_manager is not credentials._rab_manager
 
-    def test_copy_regional_access_boundary_manager_state_and_config_with_quota_project(self):
+    def test_copy_regional_access_boundary_manager_state_and_config_with_quota_project(
+        self,
+    ):
         credentials = self.make_credentials()
         credentials._rab_manager._data = mock.sentinel.rab_data
         credentials._rab_manager._use_blocking_regional_access_boundary_lookup = True
@@ -252,22 +257,36 @@ class TestCredentials(object):
         # Verify references to boundary data are shared
         assert new_credentials._rab_manager._data == mock.sentinel.rab_data
         # Verify blocking config flag is preserved
-        assert new_credentials._rab_manager._use_blocking_regional_access_boundary_lookup is True
+        assert (
+            new_credentials._rab_manager._use_blocking_regional_access_boundary_lookup
+            is True
+        )
         # Verify target manager object is not replaced
         assert new_credentials._rab_manager is not credentials._rab_manager
 
-    def test_build_regional_access_boundary_lookup_url(self):
+    def test_build_regional_access_boundary_lookup_url_standard(self, monkeypatch):
+        from google.auth.transport import _mtls_helper
+
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: False)
+
         credentials = self.make_credentials()
         url = credentials._build_regional_access_boundary_lookup_url()
-
-        expected_url_standard = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+        expected_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
             credentials.service_account_email
         )
-        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+        assert url == expected_url
+
+    def test_build_regional_access_boundary_lookup_url_mtls(self, monkeypatch):
+        from google.auth.transport import _mtls_helper
+
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
+
+        credentials = self.make_credentials()
+        url = credentials._build_regional_access_boundary_lookup_url()
+        expected_url = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
             credentials.service_account_email
         )
-
-        assert url in (expected_url_standard, expected_url_mtls)
+        assert url == expected_url
 
     def test_with_token_uri(self):
         credentials = self.make_credentials()

--- a/packages/google-auth/tests/oauth2/test_service_account.py
+++ b/packages/google-auth/tests/oauth2/test_service_account.py
@@ -228,6 +228,34 @@ class TestCredentials(object):
         new_credentials.apply(hdrs, token="tok")
         assert "x-goog-user-project" in hdrs
 
+    def test_copy_regional_access_boundary_manager_state_and_config_with_scopes(self):
+        credentials = self.make_credentials()
+        credentials._rab_manager._data = mock.sentinel.rab_data
+        credentials._rab_manager._use_blocking_regional_access_boundary_lookup = True
+
+        new_credentials = credentials.with_scopes(["scope-foo"])
+
+        # Verify references to boundary data are shared
+        assert new_credentials._rab_manager._data == mock.sentinel.rab_data
+        # Verify blocking config flag is preserved
+        assert new_credentials._rab_manager._use_blocking_regional_access_boundary_lookup is True
+        # Verify target manager object is not replaced
+        assert new_credentials._rab_manager is not credentials._rab_manager
+
+    def test_copy_regional_access_boundary_manager_state_and_config_with_quota_project(self):
+        credentials = self.make_credentials()
+        credentials._rab_manager._data = mock.sentinel.rab_data
+        credentials._rab_manager._use_blocking_regional_access_boundary_lookup = True
+
+        new_credentials = credentials.with_quota_project("new-project-foo")
+
+        # Verify references to boundary data are shared
+        assert new_credentials._rab_manager._data == mock.sentinel.rab_data
+        # Verify blocking config flag is preserved
+        assert new_credentials._rab_manager._use_blocking_regional_access_boundary_lookup is True
+        # Verify target manager object is not replaced
+        assert new_credentials._rab_manager is not credentials._rab_manager
+
     def test_build_regional_access_boundary_lookup_url(self):
         credentials = self.make_credentials()
         url = credentials._build_regional_access_boundary_lookup_url()

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -302,8 +302,6 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         assert unpickled.refresh_manager._worker is None
 
     def test_unpickle_old_credentials_without_rab(self):
-        import pickle
-
         creds = CredentialsImpl()
         old_state = creds.__dict__.copy()
         if "_rab_manager" in old_state:

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -678,3 +678,71 @@ class TestAsyncCredentialsWithRegionalAccessBoundary(object):
         # Verify that the lookup was still triggered but failed open cleanly
         credentials._lookup_regional_access_boundary.assert_called_once_with(request)
         rab_manager.process_regional_access_boundary_info.assert_called_once_with(None)
+
+
+def test_get_service_account_rab_endpoint(monkeypatch):
+    from google.auth.transport import _mtls_helper
+
+    # Test Standard TLS
+    monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: False)
+    url = _regional_access_boundary_utils.get_service_account_rab_endpoint(
+        "test@example.com"
+    )
+    assert (
+        url
+        == "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/test@example.com/allowedLocations"
+    )
+
+    # Test mTLS
+    monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
+    url = _regional_access_boundary_utils.get_service_account_rab_endpoint(
+        "test@example.com"
+    )
+    assert (
+        url
+        == "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/test@example.com/allowedLocations"
+    )
+
+
+def test_get_workforce_pool_rab_endpoint(monkeypatch):
+    from google.auth.transport import _mtls_helper
+
+    # Test Standard TLS
+    monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: False)
+    url = _regional_access_boundary_utils.get_workforce_pool_rab_endpoint("POOL_ID")
+    assert (
+        url
+        == "https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+    )
+
+    # Test mTLS
+    monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
+    url = _regional_access_boundary_utils.get_workforce_pool_rab_endpoint("POOL_ID")
+    assert (
+        url
+        == "https://iamcredentials.mtls.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+    )
+
+
+def test_get_workload_identity_pool_rab_endpoint(monkeypatch):
+    from google.auth.transport import _mtls_helper
+
+    # Test Standard TLS
+    monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: False)
+    url = _regional_access_boundary_utils.get_workload_identity_pool_rab_endpoint(
+        "PROJECT_NUM", "POOL_ID"
+    )
+    assert (
+        url
+        == "https://iamcredentials.googleapis.com/v1/projects/PROJECT_NUM/locations/global/workloadIdentityPools/POOL_ID/allowedLocations"
+    )
+
+    # Test mTLS
+    monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
+    url = _regional_access_boundary_utils.get_workload_identity_pool_rab_endpoint(
+        "PROJECT_NUM", "POOL_ID"
+    )
+    assert (
+        url
+        == "https://iamcredentials.mtls.googleapis.com/v1/projects/PROJECT_NUM/locations/global/workloadIdentityPools/POOL_ID/allowedLocations"
+    )

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -301,6 +301,26 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         assert unpickled.refresh_manager._lock is not None
         assert unpickled.refresh_manager._worker is None
 
+    def test_unpickle_old_credentials_without_rab(self):
+        import pickle
+
+        creds = CredentialsImpl()
+        old_state = creds.__dict__.copy()
+        if "_rab_manager" in old_state:
+            del old_state["_rab_manager"]
+        if "_use_non_blocking_refresh" in old_state:
+            del old_state["_use_non_blocking_refresh"]
+        if "_refresh_worker" in old_state:
+            del old_state["_refresh_worker"]
+
+        new_instance = CredentialsImpl.__new__(CredentialsImpl)
+        new_instance.__setstate__(old_state)
+
+        assert hasattr(new_instance, "_rab_manager")
+        assert new_instance._rab_manager is not None
+        assert new_instance._use_non_blocking_refresh is False
+        assert new_instance._refresh_worker is not None
+
     @mock.patch(
         "google.auth._regional_access_boundary_utils._RegionalAccessBoundaryRefreshManager.start_refresh"
     )

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Google Inc.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ from unittest import mock
 
 import pytest  # type: ignore
 
+from google.auth import _credentials_async
 from google.auth import _helpers
 from google.auth import _regional_access_boundary_utils
 from google.auth import credentials
@@ -570,6 +571,88 @@ class TestCredentialsWithRegionalAccessBoundary(object):
 
             mock_thread_class.assert_not_called()
             assert manager._worker == mock_worker
+
+
+class AsyncCredentialsImpl(_credentials_async.CredentialsWithRegionalAccessBoundary):
+    def __init__(self, universe_domain=None):
+        super().__init__()
+        if universe_domain:
+            self._universe_domain = universe_domain
+
+    async def _perform_refresh_token(self, request):
+        self.token = "refreshed-token"
+        self.expiry = (
+            _helpers.utcnow()
+            + _helpers.REFRESH_THRESHOLD
+            + datetime.timedelta(seconds=5)
+        )
+
+    def with_quota_project(self, quota_project_id):
+        raise NotImplementedError()
+
+    def _build_regional_access_boundary_lookup_url(self, request=None):
+        # Using self.token here to make the URL dynamic for testing purposes
+        return "http://mock.url/lookup_for_{}".format(self.token)
+
+    def _make_copy(self):
+        new_credentials = self.__class__()
+        self._copy_regional_access_boundary_manager(new_credentials)
+        return new_credentials
+
+
+class TestAsyncCredentialsWithRegionalAccessBoundary(object):
+    @pytest.mark.asyncio
+    async def test_maybe_start_refresh_async_blocking(self):
+        creds = AsyncCredentialsImpl()
+        creds._rab_manager._use_blocking_regional_access_boundary_lookup = True
+        request = mock.Mock()
+
+        with mock.patch.dict(
+            os.environ,
+            {environment_vars.GOOGLE_AUTH_TRUST_BOUNDARY_ENABLED: "true"},
+        ):
+            with mock.patch.object(
+                creds._rab_manager,
+                "start_blocking_refresh_async",
+                new_callable=mock.AsyncMock,
+            ) as mock_start_blocking:
+                await creds._maybe_start_regional_access_boundary_refresh_async(
+                    request, "http://example.com"
+                )
+                mock_start_blocking.assert_called_once_with(creds, request)
+
+    @pytest.mark.asyncio
+    async def test_start_blocking_refresh_async_success(self):
+        creds = AsyncCredentialsImpl()
+        request = mock.Mock()
+
+        with mock.patch.object(
+            creds,
+            "_lookup_regional_access_boundary",
+            new_callable=mock.AsyncMock,
+            return_value={"encodedLocations": "0xABC"},
+        ) as mock_lookup:
+            await creds._rab_manager.start_blocking_refresh_async(creds, request)
+
+            mock_lookup.assert_called_once_with(request, fail_fast=True)
+            assert creds._rab_manager._data.encoded_locations == "0xABC"
+
+    @pytest.mark.asyncio
+    async def test_start_blocking_refresh_async_failure(self):
+        creds = AsyncCredentialsImpl()
+        request = mock.Mock()
+
+        with mock.patch.object(
+            creds,
+            "_lookup_regional_access_boundary",
+            new_callable=mock.AsyncMock,
+            side_effect=Exception("error"),
+        ) as mock_lookup:
+            await creds._rab_manager.start_blocking_refresh_async(creds, request)
+
+            mock_lookup.assert_called_once_with(request, fail_fast=True)
+            assert creds._rab_manager._data.encoded_locations is None
+            assert creds._rab_manager._data.cooldown_expiry is not None
 
     @pytest.mark.asyncio
     async def test_async_refresh_manager_session_closed_ignored(self):

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -398,6 +398,21 @@ class TestCredentialsWithRegionalAccessBoundary(object):
             assert creds._rab_manager._data.encoded_locations is None
             assert creds._rab_manager._data.cooldown_expiry is not None
 
+    def test_start_blocking_refresh_with_async_credentials(self):
+        creds = CredentialsImpl()
+        request = mock.Mock()
+
+        with mock.patch.object(
+            creds,
+            "_lookup_regional_access_boundary",
+            new_callable=mock.AsyncMock,
+        ) as mock_lookup:
+            creds._rab_manager.start_blocking_refresh(creds, request)
+
+            mock_lookup.assert_not_called()
+            assert creds._rab_manager._data.encoded_locations is None
+            assert creds._rab_manager._data.cooldown_expiry is not None
+
     @mock.patch("copy.deepcopy")
     def test_start_refresh_deepcopy_failure(self, mock_deepcopy):
         mock_deepcopy.side_effect = Exception("deepcopy error")

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -570,3 +570,28 @@ class TestCredentialsWithRegionalAccessBoundary(object):
 
             mock_thread_class.assert_not_called()
             assert manager._worker == mock_worker
+
+    @pytest.mark.asyncio
+    async def test_async_refresh_manager_session_closed_ignored(self):
+        credentials = mock.AsyncMock()
+        # Simulate a closed session RuntimeError when invoking the boundary lookup
+        credentials._lookup_regional_access_boundary.side_effect = RuntimeError(
+            "Session is closed"
+        )
+
+        request = mock.Mock()
+        rab_manager = mock.Mock()
+
+        manager = (
+            _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
+        )
+
+        # Trigger refresh, which starts a background task that should swallow the error
+        manager.start_refresh(credentials, request, rab_manager)
+
+        # Wait for the background worker task to terminate
+        await manager._worker_task
+
+        # Verify that the lookup was still triggered but failed open cleanly
+        credentials._lookup_regional_access_boundary.assert_called_once_with(request)
+        rab_manager.process_regional_access_boundary_info.assert_called_once_with(None)

--- a/packages/google-auth/tests/test_credentials.py
+++ b/packages/google-auth/tests/test_credentials.py
@@ -439,3 +439,17 @@ def test_before_request_triggers_rab_refresh():
             lookup.assert_called_once()
             args, kwargs = lookup.call_args
             assert args[1] == "http://mock.url/lookup_for_refreshed-token"
+
+
+def test_maybe_start_regional_access_boundary_refresh_invalid_url():
+    credentials_instance = CredentialsImpl()
+    request = mock.Mock()
+
+    # Verifies that passing invalid/non-string URLs synchronously fails safe without crashing.
+    credentials_instance._maybe_start_regional_access_boundary_refresh(
+        request, url=None
+    )
+    credentials_instance._maybe_start_regional_access_boundary_refresh(request, url=123)
+    credentials_instance._maybe_start_regional_access_boundary_refresh(
+        request, url=object()
+    )

--- a/packages/google-auth/tests/test_credentials.py
+++ b/packages/google-auth/tests/test_credentials.py
@@ -154,6 +154,18 @@ def test_before_request_with_regional_access_boundary():
     assert headers["x-allowed-locations"] == DUMMY_BOUNDARY
 
 
+def test_copy_regional_access_boundary_manager_preserves_type():
+    class CustomRefreshManager(object):
+        pass
+
+    creds = CredentialsImpl()
+    creds._rab_manager.refresh_manager = CustomRefreshManager()
+
+    new_creds = creds._make_copy()
+
+    assert isinstance(new_creds._rab_manager.refresh_manager, CustomRefreshManager)
+
+
 def test_before_request_metrics():
     credentials = CredentialsImplWithMetrics()
     request = "token"

--- a/packages/google-auth/tests/test_credentials.py
+++ b/packages/google-auth/tests/test_credentials.py
@@ -154,16 +154,19 @@ def test_before_request_with_regional_access_boundary():
     assert headers["x-allowed-locations"] == DUMMY_BOUNDARY
 
 
-def test_copy_regional_access_boundary_manager_preserves_type():
-    class CustomRefreshManager(object):
-        pass
-
+def test_copy_regional_access_boundary_manager_state_and_config():
     creds = CredentialsImpl()
-    creds._rab_manager.refresh_manager = CustomRefreshManager()
+    creds._rab_manager._data = mock.sentinel.rab_data
+    creds._rab_manager._use_blocking_regional_access_boundary_lookup = True
 
     new_creds = creds._make_copy()
 
-    assert isinstance(new_creds._rab_manager.refresh_manager, CustomRefreshManager)
+    # Verify references to immutable boundary data are shared
+    assert new_creds._rab_manager._data == mock.sentinel.rab_data
+    # Verify blocking config flag is preserved
+    assert new_creds._rab_manager._use_blocking_regional_access_boundary_lookup is True
+    # Verify target manager object is isolated (kept from constructor, not replaced)
+    assert new_creds._rab_manager is not creds._rab_manager
 
 
 def test_before_request_metrics():

--- a/packages/google-auth/tests/test_external_account.py
+++ b/packages/google-auth/tests/test_external_account.py
@@ -1007,14 +1007,26 @@ class TestCredentials(object):
             scopes=self.SCOPES,
         )
         credentials._set_blocking_regional_access_boundary_lookup()
-        assert credentials._rab_manager._use_blocking_regional_access_boundary_lookup is True
+        assert (
+            credentials._rab_manager._use_blocking_regional_access_boundary_lookup
+            is True
+        )
 
         credentials.refresh(request)
 
         assert credentials._impersonated_credentials is not None
-        assert credentials._impersonated_credentials._rab_manager._use_blocking_regional_access_boundary_lookup is True
-        assert credentials._rab_manager._use_blocking_regional_access_boundary_lookup is True
-        assert credentials._rab_manager is credentials._impersonated_credentials._rab_manager
+        assert (
+            credentials._impersonated_credentials._rab_manager._use_blocking_regional_access_boundary_lookup
+            is True
+        )
+        assert (
+            credentials._rab_manager._use_blocking_regional_access_boundary_lookup
+            is True
+        )
+        assert (
+            credentials._rab_manager
+            is credentials._impersonated_credentials._rab_manager
+        )
 
     @mock.patch(
         "google.auth.metrics.token_request_access_token_impersonate",

--- a/packages/google-auth/tests/test_external_account.py
+++ b/packages/google-auth/tests/test_external_account.py
@@ -403,29 +403,22 @@ class TestCredentials(object):
             service_account_impersonation_options={"token_lifetime_seconds": 2800},
         )
 
-        with mock.patch.object(
-            external_account.Credentials, "__init__", return_value=None
-        ) as mock_init:
-            credentials.with_scopes(["email"], ["default2"])
+        cloned = credentials.with_scopes(["email"], ["default2"])
 
-        # Confirm with_scopes initialized the credential with the expected
-        # parameters and scopes.
-        mock_init.assert_called_once_with(
-            audience=self.AUDIENCE,
-            subject_token_type=self.SUBJECT_TOKEN_TYPE,
-            token_url=self.TOKEN_URL,
-            token_info_url=self.TOKEN_INFO_URL,
-            credential_source=self.CREDENTIAL_SOURCE,
-            service_account_impersonation_url=self.SERVICE_ACCOUNT_IMPERSONATION_URL,
-            service_account_impersonation_options={"token_lifetime_seconds": 2800},
-            client_id=CLIENT_ID,
-            client_secret=CLIENT_SECRET,
-            quota_project_id=self.QUOTA_PROJECT_ID,
-            scopes=["email"],
-            default_scopes=["default2"],
-            universe_domain=DEFAULT_UNIVERSE_DOMAIN,
-            trust_boundary=None,
+        assert cloned.scopes == ["email"]
+        assert cloned.default_scopes == ["default2"]
+        assert cloned.quota_project_id == self.QUOTA_PROJECT_ID
+        assert cloned._client_id == CLIENT_ID
+        assert cloned._client_secret == CLIENT_SECRET
+        assert cloned._token_info_url == self.TOKEN_INFO_URL
+        assert (
+            cloned._service_account_impersonation_url
+            == self.SERVICE_ACCOUNT_IMPERSONATION_URL
         )
+        assert cloned._service_account_impersonation_options == {
+            "token_lifetime_seconds": 2800
+        }
+        assert cloned.universe_domain == DEFAULT_UNIVERSE_DOMAIN
 
     def test_with_token_uri(self):
         credentials = self.make_credentials()
@@ -492,33 +485,21 @@ class TestCredentials(object):
             service_account_impersonation_options={"token_lifetime_seconds": 2800},
         )
 
-        with mock.patch.object(
-            external_account.Credentials, "__init__", return_value=None
-        ) as mock_init:
-            new_cred = credentials.with_quota_project("project-foo")
+        new_cred = credentials.with_quota_project("project-foo")
 
-            # Confirm with_quota_project initialized the credential with the
-            # expected parameters.
-            mock_init.assert_called_once_with(
-                audience=self.AUDIENCE,
-                subject_token_type=self.SUBJECT_TOKEN_TYPE,
-                token_url=self.TOKEN_URL,
-                token_info_url=self.TOKEN_INFO_URL,
-                credential_source=self.CREDENTIAL_SOURCE,
-                service_account_impersonation_url=self.SERVICE_ACCOUNT_IMPERSONATION_URL,
-                service_account_impersonation_options={"token_lifetime_seconds": 2800},
-                client_id=CLIENT_ID,
-                client_secret=CLIENT_SECRET,
-                quota_project_id=self.QUOTA_PROJECT_ID,
-                scopes=self.SCOPES,
-                default_scopes=["default1"],
-                universe_domain=DEFAULT_UNIVERSE_DOMAIN,
-                trust_boundary=None,
-            )
-
-            # Confirm with_quota_project sets the correct quota project after
-            # initialization.
-            assert new_cred.quota_project_id == "project-foo"
+        assert new_cred.quota_project_id == "project-foo"
+        assert new_cred.scopes == self.SCOPES
+        assert new_cred.default_scopes == ["default1"]
+        assert new_cred._client_id == CLIENT_ID
+        assert new_cred._client_secret == CLIENT_SECRET
+        assert new_cred._token_info_url == self.TOKEN_INFO_URL
+        assert (
+            new_cred._service_account_impersonation_url
+            == self.SERVICE_ACCOUNT_IMPERSONATION_URL
+        )
+        assert new_cred._service_account_impersonation_options == {
+            "token_lifetime_seconds": 2800
+        }
 
     def test_info(self):
         credentials = self.make_credentials(universe_domain="dummy_universe.com")

--- a/packages/google-auth/tests/test_external_account.py
+++ b/packages/google-auth/tests/test_external_account.py
@@ -535,7 +535,10 @@ class TestCredentials(object):
         # Verify references to boundary data are shared
         assert new_credentials._rab_manager._data == mock.sentinel.rab_data
         # Verify blocking config flag is preserved
-        assert new_credentials._rab_manager._use_blocking_regional_access_boundary_lookup is True
+        assert (
+            new_credentials._rab_manager._use_blocking_regional_access_boundary_lookup
+            is True
+        )
         # Verify target manager object is not replaced
         assert new_credentials._rab_manager is not credentials._rab_manager
 
@@ -1722,23 +1725,51 @@ class TestCredentials(object):
             "authorization": "Bearer {}".format(self.SUCCESS_RESPONSE["access_token"])
         }
 
-    def test_build_regional_access_boundary_lookup_url_workload(self):
+    def test_build_regional_access_boundary_lookup_url_workload_standard(
+        self, monkeypatch
+    ):
+        from google.auth.transport import _mtls_helper
+
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: False)
+
         credentials = self.make_credentials()
         url = credentials._build_regional_access_boundary_lookup_url()
+        expected_url = "https://iamcredentials.googleapis.com/v1/projects/123456/locations/global/workloadIdentityPools/POOL_ID/allowedLocations"
+        assert url == expected_url
 
-        expected_url_standard = "https://iamcredentials.googleapis.com/v1/projects/123456/locations/global/workloadIdentityPools/POOL_ID/allowedLocations"
-        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/projects/123456/locations/global/workloadIdentityPools/POOL_ID/allowedLocations"
+    def test_build_regional_access_boundary_lookup_url_workload_mtls(self, monkeypatch):
+        from google.auth.transport import _mtls_helper
 
-        assert url in (expected_url_standard, expected_url_mtls)
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
 
-    def test_build_regional_access_boundary_lookup_url_workforce(self):
+        credentials = self.make_credentials()
+        url = credentials._build_regional_access_boundary_lookup_url()
+        expected_url = "https://iamcredentials.mtls.googleapis.com/v1/projects/123456/locations/global/workloadIdentityPools/POOL_ID/allowedLocations"
+        assert url == expected_url
+
+    def test_build_regional_access_boundary_lookup_url_workforce_standard(
+        self, monkeypatch
+    ):
+        from google.auth.transport import _mtls_helper
+
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: False)
+
         credentials = self.make_workforce_pool_credentials()
         url = credentials._build_regional_access_boundary_lookup_url()
+        expected_url = "https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+        assert url == expected_url
 
-        expected_url_standard = "https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
-        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+    def test_build_regional_access_boundary_lookup_url_workforce_mtls(
+        self, monkeypatch
+    ):
+        from google.auth.transport import _mtls_helper
 
-        assert url in (expected_url_standard, expected_url_mtls)
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
+
+        credentials = self.make_workforce_pool_credentials()
+        url = credentials._build_regional_access_boundary_lookup_url()
+        expected_url = "https://iamcredentials.mtls.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+        assert url == expected_url
 
     @pytest.mark.parametrize(
         "audience",

--- a/packages/google-auth/tests/test_external_account.py
+++ b/packages/google-auth/tests/test_external_account.py
@@ -985,6 +985,45 @@ class TestCredentials(object):
         "google.auth.metrics.python_and_auth_lib_version",
         return_value=LANG_LIBRARY_METRICS_HEADER_VALUE,
     )
+    def test_refresh_impersonation_propagates_rab_config(
+        self, mock_metrics_header_value, mock_auth_lib_value
+    ):
+        expire_time = (
+            _helpers.utcnow().replace(microsecond=0) + datetime.timedelta(seconds=2800)
+        ).isoformat("T") + "Z"
+        token_response = self.SUCCESS_RESPONSE.copy()
+        impersonation_response = {
+            "accessToken": "SA_ACCESS_TOKEN",
+            "expireTime": expire_time,
+        }
+        request = self.make_mock_request(
+            status=http_client.OK,
+            data=token_response,
+            impersonation_status=http_client.OK,
+            impersonation_data=impersonation_response,
+        )
+        credentials = self.make_credentials(
+            service_account_impersonation_url=self.SERVICE_ACCOUNT_IMPERSONATION_URL,
+            scopes=self.SCOPES,
+        )
+        credentials._set_blocking_regional_access_boundary_lookup()
+        assert credentials._rab_manager._use_blocking_regional_access_boundary_lookup is True
+
+        credentials.refresh(request)
+
+        assert credentials._impersonated_credentials is not None
+        assert credentials._impersonated_credentials._rab_manager._use_blocking_regional_access_boundary_lookup is True
+        assert credentials._rab_manager._use_blocking_regional_access_boundary_lookup is True
+        assert credentials._rab_manager is credentials._impersonated_credentials._rab_manager
+
+    @mock.patch(
+        "google.auth.metrics.token_request_access_token_impersonate",
+        return_value=IMPERSONATE_ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
+    )
+    @mock.patch(
+        "google.auth.metrics.python_and_auth_lib_version",
+        return_value=LANG_LIBRARY_METRICS_HEADER_VALUE,
+    )
     @mock.patch(
         "google.auth.external_account.Credentials._mtls_required", return_value=True
     )

--- a/packages/google-auth/tests/test_external_account.py
+++ b/packages/google-auth/tests/test_external_account.py
@@ -1729,13 +1729,21 @@ class TestCredentials(object):
 
     def test_build_regional_access_boundary_lookup_url_workload(self):
         credentials = self.make_credentials()
-        expected_url = "https://iamcredentials.googleapis.com/v1/projects/123456/locations/global/workloadIdentityPools/POOL_ID/allowedLocations"
-        assert credentials._build_regional_access_boundary_lookup_url() == expected_url
+        url = credentials._build_regional_access_boundary_lookup_url()
+
+        expected_url_standard = "https://iamcredentials.googleapis.com/v1/projects/123456/locations/global/workloadIdentityPools/POOL_ID/allowedLocations"
+        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/projects/123456/locations/global/workloadIdentityPools/POOL_ID/allowedLocations"
+
+        assert url in (expected_url_standard, expected_url_mtls)
 
     def test_build_regional_access_boundary_lookup_url_workforce(self):
         credentials = self.make_workforce_pool_credentials()
-        expected_url = "https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
-        assert credentials._build_regional_access_boundary_lookup_url() == expected_url
+        url = credentials._build_regional_access_boundary_lookup_url()
+
+        expected_url_standard = "https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+
+        assert url in (expected_url_standard, expected_url_mtls)
 
     @pytest.mark.parametrize(
         "audience",

--- a/packages/google-auth/tests/test_external_account.py
+++ b/packages/google-auth/tests/test_external_account.py
@@ -525,6 +525,20 @@ class TestCredentials(object):
         new_credentials = credentials.with_universe_domain("dummy_universe.com")
         assert new_credentials.universe_domain == "dummy_universe.com"
 
+    def test_copy_regional_access_boundary_manager_state_and_config(self):
+        credentials = self.make_credentials()
+        credentials._rab_manager._data = mock.sentinel.rab_data
+        credentials._rab_manager._use_blocking_regional_access_boundary_lookup = True
+
+        new_credentials = credentials.with_universe_domain("dummy_universe.com")
+
+        # Verify references to boundary data are shared
+        assert new_credentials._rab_manager._data == mock.sentinel.rab_data
+        # Verify blocking config flag is preserved
+        assert new_credentials._rab_manager._use_blocking_regional_access_boundary_lookup is True
+        # Verify target manager object is not replaced
+        assert new_credentials._rab_manager is not credentials._rab_manager
+
     def test_info_workforce_pool(self):
         credentials = self.make_workforce_pool_credentials(
             workforce_pool_user_project=self.WORKFORCE_POOL_USER_PROJECT

--- a/packages/google-auth/tests/test_external_account_authorized_user.py
+++ b/packages/google-auth/tests/test_external_account_authorized_user.py
@@ -601,14 +601,25 @@ class TestCredentials(object):
         assert creds._revoke_url == REVOKE_URL
         assert creds._quota_project_id == QUOTA_PROJECT_ID
 
-    def test_build_regional_access_boundary_lookup_url(self):
+    def test_build_regional_access_boundary_lookup_url_standard(self, monkeypatch):
+        from google.auth.transport import _mtls_helper
+
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: False)
+
         credentials = self.make_credentials()
         url = credentials._build_regional_access_boundary_lookup_url()
+        expected_url = "https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+        assert url == expected_url
 
-        expected_url_standard = "https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
-        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+    def test_build_regional_access_boundary_lookup_url_mtls(self, monkeypatch):
+        from google.auth.transport import _mtls_helper
 
-        assert url in (expected_url_standard, expected_url_mtls)
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
+
+        credentials = self.make_credentials()
+        url = credentials._build_regional_access_boundary_lookup_url()
+        expected_url = "https://iamcredentials.mtls.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+        assert url == expected_url
 
     @pytest.mark.parametrize(
         "audience",

--- a/packages/google-auth/tests/test_external_account_authorized_user.py
+++ b/packages/google-auth/tests/test_external_account_authorized_user.py
@@ -603,8 +603,12 @@ class TestCredentials(object):
 
     def test_build_regional_access_boundary_lookup_url(self):
         credentials = self.make_credentials()
-        expected_url = "https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
-        assert credentials._build_regional_access_boundary_lookup_url() == expected_url
+        url = credentials._build_regional_access_boundary_lookup_url()
+
+        expected_url_standard = "https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+        expected_url_mtls = "https://iam`credentials.mtls.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+
+        assert url in (expected_url_standard, expected_url_mtls)
 
     @pytest.mark.parametrize(
         "audience",

--- a/packages/google-auth/tests/test_external_account_authorized_user.py
+++ b/packages/google-auth/tests/test_external_account_authorized_user.py
@@ -606,7 +606,7 @@ class TestCredentials(object):
         url = credentials._build_regional_access_boundary_lookup_url()
 
         expected_url_standard = "https://iamcredentials.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
-        expected_url_mtls = "https://iam`credentials.mtls.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
+        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/locations/global/workforcePools/POOL_ID/allowedLocations"
 
         assert url in (expected_url_standard, expected_url_mtls)
 

--- a/packages/google-auth/tests/test_iam.py
+++ b/packages/google-auth/tests/test_iam.py
@@ -15,6 +15,7 @@
 import base64
 import datetime
 import http.client as http_client
+import importlib
 import json
 from unittest import mock
 
@@ -113,3 +114,37 @@ class TestSigner(object):
         with pytest.raises(exceptions.TransportError):
             signer.sign("123")
         request.call_count == 3
+
+
+def test_endpoint_constants_mtls(monkeypatch):
+    from google.auth.transport import _mtls_helper
+
+    # Mock check_use_client_cert to return True (simulating mTLS environment)
+    monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
+
+    # Force a reload of the iam module to trigger the top-level domain computation
+    importlib.reload(iam)
+
+    try:
+        # Verify it constructed the mTLS domain for ALL endpoints
+        assert (
+            "iamcredentials.mtls.googleapis.com"
+            in iam._SERVICE_ACCOUNT_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT
+        )
+        assert (
+            "iamcredentials.mtls.googleapis.com"
+            in iam._WORKFORCE_POOL_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT
+        )
+        assert (
+            "iamcredentials.mtls.googleapis.com"
+            in iam._WORKLOAD_IDENTITY_POOL_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT
+        )
+        assert "iamcredentials.mtls.googleapis.com" in iam._IAM_ENDPOINT
+        assert "iamcredentials.mtls.googleapis.com" in iam._IAM_SIGN_ENDPOINT
+        assert "iamcredentials.mtls.googleapis.com" in iam._IAM_SIGNJWT_ENDPOINT
+        assert "iamcredentials.mtls.googleapis.com" in iam._IAM_IDTOKEN_ENDPOINT
+        
+    finally:
+        # Restore the original state for other tests by undoing the patch and reloading again
+        monkeypatch.undo()
+        importlib.reload(iam)

--- a/packages/google-auth/tests/test_iam.py
+++ b/packages/google-auth/tests/test_iam.py
@@ -15,7 +15,6 @@
 import base64
 import datetime
 import http.client as http_client
-import importlib
 import json
 from unittest import mock
 
@@ -114,37 +113,3 @@ class TestSigner(object):
         with pytest.raises(exceptions.TransportError):
             signer.sign("123")
         request.call_count == 3
-
-
-def test_endpoint_constants_mtls(monkeypatch):
-    from google.auth.transport import _mtls_helper
-
-    # Mock check_use_client_cert to return True (simulating mTLS environment)
-    monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
-
-    # Force a reload of the iam module to trigger the top-level domain computation
-    importlib.reload(iam)
-
-    try:
-        # Verify it constructed the mTLS domain for ALL endpoints
-        assert (
-            "iamcredentials.mtls.googleapis.com"
-            in iam._SERVICE_ACCOUNT_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT
-        )
-        assert (
-            "iamcredentials.mtls.googleapis.com"
-            in iam._WORKFORCE_POOL_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT
-        )
-        assert (
-            "iamcredentials.mtls.googleapis.com"
-            in iam._WORKLOAD_IDENTITY_POOL_REGIONAL_ACCESS_BOUNDARY_LOOKUP_ENDPOINT
-        )
-        assert "iamcredentials.mtls.googleapis.com" in iam._IAM_ENDPOINT
-        assert "iamcredentials.mtls.googleapis.com" in iam._IAM_SIGN_ENDPOINT
-        assert "iamcredentials.mtls.googleapis.com" in iam._IAM_SIGNJWT_ENDPOINT
-        assert "iamcredentials.mtls.googleapis.com" in iam._IAM_IDTOKEN_ENDPOINT
-
-    finally:
-        # Restore the original state for other tests by undoing the patch and reloading again
-        monkeypatch.undo()
-        importlib.reload(iam)

--- a/packages/google-auth/tests/test_iam.py
+++ b/packages/google-auth/tests/test_iam.py
@@ -143,7 +143,7 @@ def test_endpoint_constants_mtls(monkeypatch):
         assert "iamcredentials.mtls.googleapis.com" in iam._IAM_SIGN_ENDPOINT
         assert "iamcredentials.mtls.googleapis.com" in iam._IAM_SIGNJWT_ENDPOINT
         assert "iamcredentials.mtls.googleapis.com" in iam._IAM_IDTOKEN_ENDPOINT
-        
+
     finally:
         # Restore the original state for other tests by undoing the patch and reloading again
         monkeypatch.undo()

--- a/packages/google-auth/tests/test_impersonated_credentials.py
+++ b/packages/google-auth/tests/test_impersonated_credentials.py
@@ -719,11 +719,16 @@ class TestImpersonatedCredentials(object):
 
     def test_build_regional_access_boundary_lookup_url_success(self):
         credentials = self.make_credentials()
-        # Ensure service_account_email is properly set by default mock
-        expected_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+        url = credentials._build_regional_access_boundary_lookup_url()
+
+        expected_url_standard = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
             credentials.service_account_email
         )
-        assert credentials._build_regional_access_boundary_lookup_url() == expected_url
+        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+            credentials.service_account_email
+        )
+
+        assert url in (expected_url_standard, expected_url_mtls)
 
     def test_with_scopes_provide_default_scopes(self):
         credentials = self.make_credentials()

--- a/packages/google-auth/tests/test_impersonated_credentials.py
+++ b/packages/google-auth/tests/test_impersonated_credentials.py
@@ -717,18 +717,31 @@ class TestImpersonatedCredentials(object):
 
         assert credentials._build_regional_access_boundary_lookup_url() is None
 
-    def test_build_regional_access_boundary_lookup_url_success(self):
+    def test_build_regional_access_boundary_lookup_url_success_standard(
+        self, monkeypatch
+    ):
+        from google.auth.transport import _mtls_helper
+
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: False)
+
         credentials = self.make_credentials()
         url = credentials._build_regional_access_boundary_lookup_url()
-
-        expected_url_standard = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+        expected_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
             credentials.service_account_email
         )
-        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+        assert url == expected_url
+
+    def test_build_regional_access_boundary_lookup_url_success_mtls(self, monkeypatch):
+        from google.auth.transport import _mtls_helper
+
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
+
+        credentials = self.make_credentials()
+        url = credentials._build_regional_access_boundary_lookup_url()
+        expected_url = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
             credentials.service_account_email
         )
-
-        assert url in (expected_url_standard, expected_url_mtls)
+        assert url == expected_url
 
     def test_with_scopes_provide_default_scopes(self):
         credentials = self.make_credentials()

--- a/packages/google-auth/tests/test_jwt.py
+++ b/packages/google-auth/tests/test_jwt.py
@@ -553,6 +553,44 @@ class TestCredentials(object):
         self.credentials.before_request(None, "GET", "http://example.com?a=1#3", {})
         assert self.credentials.valid
 
+    def test_build_regional_access_boundary_lookup_url(self):
+        url = self.credentials._build_regional_access_boundary_lookup_url()
+        expected_url_standard = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+            self.SERVICE_ACCOUNT_EMAIL
+        )
+        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+            self.SERVICE_ACCOUNT_EMAIL
+        )
+
+        assert url in (expected_url_standard, expected_url_mtls)
+
+    def test_cloning_retains_rab_manager_data(self):
+        self.credentials._rab_manager._data = mock.sentinel.rab_data
+
+        cloned_claims = self.credentials.with_claims(audience="new-audience")
+        cloned_quota = self.credentials.with_quota_project("new-quota")
+
+        # Verify references to immutable boundary data are shared
+        assert cloned_claims._rab_manager._data == mock.sentinel.rab_data
+        assert cloned_quota._rab_manager._data == mock.sentinel.rab_data
+
+        # Verify manager objects and lock properties are isolated to prevent race conditions
+        assert cloned_claims._rab_manager is not self.credentials._rab_manager
+        assert cloned_quota._rab_manager is not self.credentials._rab_manager
+
+    def test_from_signing_credentials_copies_rab_state(self):
+        from google.oauth2 import service_account
+
+        sa_creds = service_account.Credentials.from_service_account_info(
+            SERVICE_ACCOUNT_INFO
+        )
+        sa_creds._rab_manager._data = mock.sentinel.rab_data
+
+        jwt_creds = jwt.Credentials.from_signing_credentials(sa_creds, audience="aud")
+
+        assert jwt_creds._rab_manager._data == mock.sentinel.rab_data
+        assert jwt_creds._rab_manager is not sa_creds._rab_manager
+
 
 class TestOnDemandCredentials(object):
     SERVICE_ACCOUNT_EMAIL = "service-account@example.com"

--- a/packages/google-auth/tests/test_jwt.py
+++ b/packages/google-auth/tests/test_jwt.py
@@ -553,16 +553,29 @@ class TestCredentials(object):
         self.credentials.before_request(None, "GET", "http://example.com?a=1#3", {})
         assert self.credentials.valid
 
-    def test_build_regional_access_boundary_lookup_url(self):
-        url = self.credentials._build_regional_access_boundary_lookup_url()
-        expected_url_standard = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
-            self.SERVICE_ACCOUNT_EMAIL
-        )
-        expected_url_mtls = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
-            self.SERVICE_ACCOUNT_EMAIL
-        )
+    def test_build_regional_access_boundary_lookup_url_standard(self, monkeypatch):
+        from google.auth.transport import _mtls_helper
 
-        assert url in (expected_url_standard, expected_url_mtls)
+        # Mock check_use_client_cert to return False to simulate standard TLS
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: False)
+
+        url = self.credentials._build_regional_access_boundary_lookup_url()
+        expected_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+            self.SERVICE_ACCOUNT_EMAIL
+        )
+        assert url == expected_url
+
+    def test_build_regional_access_boundary_lookup_url_mtls(self, monkeypatch):
+        from google.auth.transport import _mtls_helper
+
+        # Mock check_use_client_cert to return True to simulate mTLS
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
+
+        url = self.credentials._build_regional_access_boundary_lookup_url()
+        expected_url = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+            self.SERVICE_ACCOUNT_EMAIL
+        )
+        assert url == expected_url
 
     def test_cloning_retains_rab_manager_data(self):
         self.credentials._rab_manager._data = mock.sentinel.rab_data

--- a/packages/google-auth/tests_async/oauth2/test__client_async.py
+++ b/packages/google-auth/tests_async/oauth2/test__client_async.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import asyncio
+import datetime
 import http.client as http_client
 import json
 from unittest import mock

--- a/packages/google-auth/tests_async/oauth2/test__client_async.py
+++ b/packages/google-auth/tests_async/oauth2/test__client_async.py
@@ -486,7 +486,8 @@ async def test_refresh_grant_retry_with_retry(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("can_retry", [True, False])
-async def test__token_endpoint_request_no_throw_with_retry(can_retry):
+@mock.patch("time.sleep", return_value=None)
+async def test__token_endpoint_request_no_throw_with_retry(mock_sleep, can_retry):
     mock_request = make_request(
         {"error": "help", "error_description": "I'm alive"},
         http_client.INTERNAL_SERVER_ERROR,
@@ -503,8 +504,10 @@ async def test__token_endpoint_request_no_throw_with_retry(can_retry):
 
     if can_retry:
         assert mock_request.call_count == 3
+        assert mock_sleep.call_count == 2
     else:
         assert mock_request.call_count == 1
+        mock_sleep.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -580,7 +583,7 @@ async def test__lookup_regional_access_boundary_request_no_throw_timeout(mock_wa
 
     assert success is False
     assert data == {}
-    assert retryable is False
+    assert retryable is True
 
 
 @pytest.mark.asyncio
@@ -613,7 +616,10 @@ async def test__lookup_regional_access_boundary_request_no_throw_bad_gateway_ret
 
 
 @pytest.mark.asyncio
-async def test__lookup_regional_access_boundary_request_no_throw_transport_error():
+@mock.patch("asyncio.sleep", new_callable=mock.AsyncMock)
+async def test__lookup_regional_access_boundary_request_no_throw_transport_error(
+    mock_sleep,
+):
     request = mock.AsyncMock(spec=["transport.Request"])
     request.side_effect = exceptions.TransportError("Socket connection failed")
 
@@ -627,7 +633,9 @@ async def test__lookup_regional_access_boundary_request_no_throw_transport_error
 
     assert success is False
     assert data == {}
-    assert retryable is False
+    assert retryable is True
+    assert request.call_count == 6
+    assert mock_sleep.call_count == 5
 
 
 @pytest.mark.asyncio

--- a/packages/google-auth/tests_async/oauth2/test__client_async.py
+++ b/packages/google-auth/tests_async/oauth2/test__client_async.py
@@ -637,7 +637,9 @@ async def test__lookup_regional_access_boundary_request_no_throw_non_json_bad_ga
 ):
     bad_gateway_response = mock.AsyncMock(spec=["status", "content"])
     bad_gateway_response.status = http_client.BAD_GATEWAY
-    bad_gateway_response.content = mock.AsyncMock(return_value=b"<html>Bad Gateway</html>")
+    bad_gateway_response.content = mock.AsyncMock(
+        return_value=b"<html>Bad Gateway</html>"
+    )
 
     ok_response = mock.AsyncMock(spec=["status", "content"])
     ok_response.status = http_client.OK

--- a/packages/google-auth/tests_async/oauth2/test__client_async.py
+++ b/packages/google-auth/tests_async/oauth2/test__client_async.py
@@ -24,9 +24,9 @@ import pytest  # type: ignore
 from google.auth import _helpers
 from google.auth import _jwt_async as jwt
 from google.auth import exceptions
+from google.auth.aio import transport as aio_transport
 from google.oauth2 import _client as sync_client
 from google.oauth2 import _client_async as _client
-from google.auth.aio import transport as aio_transport
 from tests.oauth2 import test__client as test_client
 
 
@@ -509,7 +509,9 @@ async def test__token_endpoint_request_no_throw_with_retry(can_retry):
 
 @pytest.mark.asyncio
 async def test__lookup_regional_access_boundary_success():
-    request = make_aio_request({"encodedLocations": "0xA30", "locations": ["us-central1"]})
+    request = make_aio_request(
+        {"encodedLocations": "0xA30", "locations": ["us-central1"]}
+    )
     result = await _client._lookup_regional_access_boundary(
         request, "http://example.com"
     )
@@ -522,7 +524,9 @@ async def test__lookup_regional_access_boundary_legacy_transport():
     response = mock.AsyncMock(spec=["transport.Response"])
     response.status = http_client.OK
 
-    data = json.dumps({"encodedLocations": "0xA30", "locations": ["us-central1"]}).encode("utf-8")
+    data = json.dumps(
+        {"encodedLocations": "0xA30", "locations": ["us-central1"]}
+    ).encode("utf-8")
     response.content = mock.AsyncMock(return_value=data)
 
     request = mock.AsyncMock(spec=["transport.Request"])
@@ -624,6 +628,3 @@ async def test__lookup_regional_access_boundary_request_no_throw_transport_error
     assert success is False
     assert data == {}
     assert retryable is False
-
-
-

--- a/packages/google-auth/tests_async/oauth2/test__client_async.py
+++ b/packages/google-auth/tests_async/oauth2/test__client_async.py
@@ -628,3 +628,34 @@ async def test__lookup_regional_access_boundary_request_no_throw_transport_error
     assert success is False
     assert data == {}
     assert retryable is False
+
+
+@pytest.mark.asyncio
+@mock.patch("asyncio.sleep", new_callable=mock.AsyncMock)
+async def test__lookup_regional_access_boundary_request_no_throw_non_json_bad_gateway_retry(
+    mock_sleep,
+):
+    bad_gateway_response = mock.AsyncMock(spec=["status", "content"])
+    bad_gateway_response.status = http_client.BAD_GATEWAY
+    bad_gateway_response.content = mock.AsyncMock(return_value=b"<html>Bad Gateway</html>")
+
+    ok_response = mock.AsyncMock(spec=["status", "content"])
+    ok_response.status = http_client.OK
+    ok_response.content = mock.AsyncMock(return_value=b'{"encodedLocations": "0xA30"}')
+
+    request = mock.AsyncMock(spec=["__call__"])
+    request.side_effect = [bad_gateway_response, ok_response]
+
+    (
+        success,
+        data,
+        retryable,
+    ) = await _client._lookup_regional_access_boundary_request_no_throw(
+        request, "http://example.com"
+    )
+
+    assert success is True
+    assert data == {"encodedLocations": "0xA30"}
+    assert retryable is None
+    assert request.call_count == 2
+    mock_sleep.assert_called_once()

--- a/packages/google-auth/tests_async/oauth2/test__client_async.py
+++ b/packages/google-auth/tests_async/oauth2/test__client_async.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import asyncio
 import http.client as http_client
 import json
 from unittest import mock

--- a/packages/google-auth/tests_async/oauth2/test__client_async.py
+++ b/packages/google-auth/tests_async/oauth2/test__client_async.py
@@ -26,6 +26,7 @@ from google.auth import _jwt_async as jwt
 from google.auth import exceptions
 from google.oauth2 import _client as sync_client
 from google.oauth2 import _client_async as _client
+from google.auth.aio import transport as aio_transport
 from tests.oauth2 import test__client as test_client
 
 
@@ -37,6 +38,17 @@ def make_request(response_data, status=http_client.OK, text=False):
     response.data.read = mock.AsyncMock(spec=["__call__"], return_value=data)
     response.content = mock.AsyncMock(spec=["__call__"], return_value=data)
     request = mock.AsyncMock(spec=["transport.Request"])
+    request.return_value = response
+    return request
+
+
+def make_aio_request(response_data, status_code=http_client.OK, text=False):
+    """Creates a mock request/response conforming to the google.auth.aio.transport interface (exposing .status_code and .read())."""
+    response = mock.AsyncMock(spec=aio_transport.Response)
+    response.status_code = status_code
+    data = response_data if text else json.dumps(response_data).encode("utf-8")
+    response.read = mock.AsyncMock(return_value=data)
+    request = mock.AsyncMock(spec=aio_transport.Request)
     request.return_value = response
     return request
 
@@ -497,7 +509,25 @@ async def test__token_endpoint_request_no_throw_with_retry(can_retry):
 
 @pytest.mark.asyncio
 async def test__lookup_regional_access_boundary_success():
-    request = make_request({"encodedLocations": "0xA30", "locations": ["us-central1"]})
+    request = make_aio_request({"encodedLocations": "0xA30", "locations": ["us-central1"]})
+    result = await _client._lookup_regional_access_boundary(
+        request, "http://example.com"
+    )
+    assert result == {"encodedLocations": "0xA30", "locations": ["us-central1"]}
+
+
+@pytest.mark.asyncio
+async def test__lookup_regional_access_boundary_legacy_transport():
+    # Create a legacy mock response that has .status and .content()
+    response = mock.AsyncMock(spec=["transport.Response"])
+    response.status = http_client.OK
+
+    data = json.dumps({"encodedLocations": "0xA30", "locations": ["us-central1"]}).encode("utf-8")
+    response.content = mock.AsyncMock(return_value=data)
+
+    request = mock.AsyncMock(spec=["transport.Request"])
+    request.return_value = response
+
     result = await _client._lookup_regional_access_boundary(
         request, "http://example.com"
     )
@@ -506,7 +536,25 @@ async def test__lookup_regional_access_boundary_success():
 
 @pytest.mark.asyncio
 async def test__lookup_regional_access_boundary_malformed():
-    request = make_request({"locations": ["us-central1"]})
+    request = make_aio_request({"locations": ["us-central1"]})
+    result = await _client._lookup_regional_access_boundary(
+        request, "http://example.com"
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test__lookup_regional_access_boundary_invalid_json():
+    request = make_aio_request("Service Unavailable", text=True)
+    result = await _client._lookup_regional_access_boundary(
+        request, "http://example.com"
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test__lookup_regional_access_boundary_non_dict_response():
+    request = make_aio_request(123)
     result = await _client._lookup_regional_access_boundary(
         request, "http://example.com"
     )
@@ -558,3 +606,24 @@ async def test__lookup_regional_access_boundary_request_no_throw_bad_gateway_ret
     assert success is True
     assert data == {"encodedLocations": "0xA30"}
     assert request.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test__lookup_regional_access_boundary_request_no_throw_transport_error():
+    request = mock.AsyncMock(spec=["transport.Request"])
+    request.side_effect = exceptions.TransportError("Socket connection failed")
+
+    (
+        success,
+        data,
+        retryable,
+    ) = await _client._lookup_regional_access_boundary_request_no_throw(
+        request, "http://example.com"
+    )
+
+    assert success is False
+    assert data == {}
+    assert retryable is False
+
+
+

--- a/packages/google-auth/tests_async/oauth2/test__client_async.py
+++ b/packages/google-auth/tests_async/oauth2/test__client_async.py
@@ -492,3 +492,68 @@ async def test__token_endpoint_request_no_throw_with_retry(can_retry):
         assert mock_request.call_count == 3
     else:
         assert mock_request.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test__lookup_regional_access_boundary_success():
+    request = make_request({"encodedLocations": "0xA30", "locations": ["us-central1"]})
+    result = await _client._lookup_regional_access_boundary(
+        request, "http://example.com"
+    )
+    assert result == {"encodedLocations": "0xA30", "locations": ["us-central1"]}
+
+
+@pytest.mark.asyncio
+async def test__lookup_regional_access_boundary_malformed():
+    request = make_request({"locations": ["us-central1"]})
+    result = await _client._lookup_regional_access_boundary(
+        request, "http://example.com"
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+@mock.patch("asyncio.wait_for", side_effect=asyncio.TimeoutError)
+async def test__lookup_regional_access_boundary_request_no_throw_timeout(mock_wait_for):
+    request = mock.AsyncMock(spec=["transport.Request"])
+
+    (
+        success,
+        data,
+        retryable,
+    ) = await _client._lookup_regional_access_boundary_request_no_throw(
+        request, "http://example.com", fail_fast=True
+    )
+
+    assert success is False
+    assert data == {}
+    assert retryable is False
+
+
+@pytest.mark.asyncio
+@mock.patch("asyncio.sleep", new_callable=mock.AsyncMock)
+async def test__lookup_regional_access_boundary_request_no_throw_bad_gateway_retry(
+    mock_sleep,
+):
+    bad_gateway_response = mock.AsyncMock(spec=["transport.Response"])
+    bad_gateway_response.status = http_client.BAD_GATEWAY
+    bad_gateway_response.content = mock.AsyncMock(return_value=b"{}")
+
+    ok_response = mock.AsyncMock(spec=["transport.Response"])
+    ok_response.status = http_client.OK
+    ok_response.content = mock.AsyncMock(return_value=b'{"encodedLocations": "0xA30"}')
+
+    request = mock.AsyncMock(spec=["transport.Request"])
+    request.side_effect = [bad_gateway_response, ok_response]
+
+    (
+        success,
+        data,
+        retryable,
+    ) = await _client._lookup_regional_access_boundary_request_no_throw(
+        request, "http://example.com"
+    )
+
+    assert success is True
+    assert data == {"encodedLocations": "0xA30"}
+    assert request.call_count == 2

--- a/packages/google-auth/tests_async/oauth2/test_service_account_async.py
+++ b/packages/google-auth/tests_async/oauth2/test_service_account_async.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import datetime
 from unittest import mock
 
@@ -228,6 +229,66 @@ class TestCredentials(object):
 
         # Credentials should now be valid.
         assert credentials.valid
+
+    @mock.patch(
+        "google.oauth2._client_async._lookup_regional_access_boundary", autospec=True
+    )
+    @pytest.mark.asyncio
+    async def test_before_request_triggers_rab_refresh(self, mock_lookup):
+        credentials = self.make_credentials()
+        credentials.token = "tok"
+
+        mock_lookup.return_value = {
+            "locations": ["us-central1", "europe-west1"],
+            "encodedLocations": "0xA30",
+        }
+
+        request = mock.AsyncMock(spec=["transport.Request"])
+        headers = {}
+
+        with mock.patch.object(
+            credentials,
+            "_is_regional_access_boundary_lookup_required",
+            return_value=True,
+        ):
+            await credentials.before_request(
+                request, "GET", "https://storage.googleapis.com/bucket", headers
+            )
+
+            # Yield control to allow the background refresh task to run
+            await asyncio.sleep(0)
+
+            assert mock_lookup.called
+            assert headers["x-allowed-locations"] == "0xA30"
+
+    @mock.patch(
+        "google.oauth2._client_async._lookup_regional_access_boundary", autospec=True
+    )
+    @pytest.mark.asyncio
+    async def test_before_request_rab_refresh_failure_ignored(self, mock_lookup):
+        credentials = self.make_credentials()
+        credentials.token = "tok"
+
+        mock_lookup.side_effect = Exception("Transport failed")
+
+        request = mock.AsyncMock(spec=["transport.Request"])
+        headers = {}
+
+        with mock.patch.object(
+            credentials,
+            "_is_regional_access_boundary_lookup_required",
+            return_value=True,
+        ):
+            # The exception must be caught gracefully and not bubble up
+            await credentials.before_request(
+                request, "GET", "https://storage.googleapis.com/bucket", headers
+            )
+
+            # Yield control to allow the background refresh task to run
+            await asyncio.sleep(0)
+
+            assert mock_lookup.called
+            assert "x-allowed-locations" not in headers
 
 
 class TestIDTokenCredentials(object):

--- a/packages/google-auth/tests_async/oauth2/test_service_account_async.py
+++ b/packages/google-auth/tests_async/oauth2/test_service_account_async.py
@@ -296,6 +296,29 @@ class TestCredentials(object):
             assert mock_lookup.called
             assert "x-allowed-locations" not in headers
 
+    def test_unpickle_old_credentials_without_rab(self):
+        import pickle
+        from google.auth import _regional_access_boundary_utils
+
+        credentials = self.make_credentials()
+        old_state = credentials.__dict__.copy()
+        if "_rab_manager" in old_state:
+            del old_state["_rab_manager"]
+        if "_use_non_blocking_refresh" in old_state:
+            del old_state["_use_non_blocking_refresh"]
+        if "_refresh_worker" in old_state:
+            del old_state["_refresh_worker"]
+
+        new_instance = type(credentials).__new__(type(credentials))
+        new_instance.__setstate__(old_state)
+
+        # Verify the manager was correctly restored with the async refresh manager!
+        assert hasattr(new_instance, "_rab_manager")
+        assert isinstance(
+            new_instance._rab_manager.refresh_manager,
+            _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager,
+        )
+
 
 class TestIDTokenCredentials(object):
     SERVICE_ACCOUNT_EMAIL = "service-account@example.com"

--- a/packages/google-auth/tests_async/oauth2/test_service_account_async.py
+++ b/packages/google-auth/tests_async/oauth2/test_service_account_async.py
@@ -229,75 +229,122 @@ class TestCredentials(object):
         # Credentials should now be valid.
         assert credentials.valid
 
-    @mock.patch(
-        "google.oauth2._client_async._lookup_regional_access_boundary", autospec=True
-    )
     @pytest.mark.asyncio
-    async def test_before_request_triggers_rab_refresh(self, mock_lookup):
+    async def test_before_request_triggers_rab_refresh(self):
         credentials = self.make_credentials()
         credentials.token = "tok"
-
-        mock_lookup.return_value = {
-            "locations": ["us-central1", "europe-west1"],
-            "encodedLocations": "0xA30",
-        }
 
         request = mock.AsyncMock(spec=["transport.Request"])
         headers1 = {}
 
         with mock.patch.object(
             credentials,
+            "_lookup_regional_access_boundary",
+            new_callable=mock.AsyncMock,
+        ) as mock_lookup, mock.patch.object(
+            credentials,
             "_is_regional_access_boundary_lookup_required",
             return_value=True,
         ):
-            # First request triggers background refresh, but proceeds without the header
+            mock_lookup.return_value = {
+                "locations": ["us-central1", "europe-west1"],
+                "encodedLocations": "0xA30",
+            }
+
+            # The first request triggers a background refresh and returns immediately.
             await credentials.before_request(
                 request, "GET", "https://storage.googleapis.com/bucket", headers1
             )
             assert "x-allowed-locations" not in headers1
 
-            # Wait for the background task to finish and update the cache
+            # Wait for the background task to finish and update the cache.
             await credentials._rab_manager.refresh_manager._worker_task
-            assert mock_lookup.called
+            mock_lookup.assert_called_once_with(request)
 
-            # Second request should now find the data in the cache and attach the header
+            # The second request retrieves the locations from the cache.
             headers2 = {}
             await credentials.before_request(
                 request, "GET", "https://storage.googleapis.com/bucket", headers2
             )
             assert headers2["x-allowed-locations"] == "0xA30"
 
-    @mock.patch(
-        "google.oauth2._client_async._lookup_regional_access_boundary", autospec=True
-    )
     @pytest.mark.asyncio
-    async def test_before_request_rab_refresh_failure_ignored(self, mock_lookup):
+    async def test_before_request_rab_refresh_failure_ignored(self):
         credentials = self.make_credentials()
         credentials.token = "tok"
-
-        mock_lookup.side_effect = Exception("Transport failed")
 
         request = mock.AsyncMock(spec=["transport.Request"])
         headers = {}
 
         with mock.patch.object(
             credentials,
+            "_lookup_regional_access_boundary",
+            new_callable=mock.AsyncMock,
+            side_effect=Exception("Transport failed"),
+        ) as mock_lookup, mock.patch.object(
+            credentials,
             "_is_regional_access_boundary_lookup_required",
             return_value=True,
         ):
-            # The exception must be caught gracefully and not bubble up
+            # Any transport/lookup failure must be caught gracefully during refresh.
             await credentials.before_request(
                 request, "GET", "https://storage.googleapis.com/bucket", headers
             )
 
-            # Wait for the background task to finish
+            # Wait for the background task to finish.
             await credentials._rab_manager.refresh_manager._worker_task
 
-            assert mock_lookup.called
+            mock_lookup.assert_called_once_with(request)
             assert "x-allowed-locations" not in headers
 
+    @pytest.mark.asyncio
+    async def test_before_request_triggers_blocking_rab_refresh(self):
+        credentials = self.make_credentials()
+        credentials.token = "tok"
+        credentials._set_blocking_regional_access_boundary_lookup()
+
+        request = mock.AsyncMock(spec=["transport.Request"])
+        headers = {}
+
+        with mock.patch.object(
+            credentials,
+            "_lookup_regional_access_boundary",
+            new_callable=mock.AsyncMock,
+        ) as mock_lookup, mock.patch.object(
+            credentials,
+            "_is_regional_access_boundary_lookup_required",
+            return_value=True,
+        ):
+            mock_lookup.return_value = {
+                "locations": ["us-central1", "europe-west1"],
+                "encodedLocations": "0xA30",
+            }
+
+            # When blocking lookup is enabled, the first request awaits the lookup sequentially.
+            await credentials.before_request(
+                request, "GET", "https://storage.googleapis.com/bucket", headers
+            )
+
+            mock_lookup.assert_called_once_with(request, fail_fast=True)
+            assert headers["x-allowed-locations"] == "0xA30"
+
+    @pytest.mark.asyncio
+    async def test_maybe_start_regional_access_boundary_refresh_async_invalid_url(self):
+        credentials = self.make_credentials()
+        request = mock.create_autospec(transport.Request)
+
+        # Verifies that passing invalid/non-string URLs asynchronously fails safe without crashing.
+        await credentials._maybe_start_regional_access_boundary_refresh_async(
+            request, url=None
+        )
+        await credentials._maybe_start_regional_access_boundary_refresh_async(
+            request, url=123
+        )
+        await credentials._maybe_start_regional_access_boundary_refresh_async(
+            request, url=object()
+        )
+
     def test_unpickle_old_credentials_without_rab(self):
-        import pickle
         from google.auth import _regional_access_boundary_utils
 
         credentials = self.make_credentials()

--- a/packages/google-auth/tests_async/oauth2/test_service_account_async.py
+++ b/packages/google-auth/tests_async/oauth2/test_service_account_async.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import datetime
 from unittest import mock
 

--- a/packages/google-auth/tests_async/oauth2/test_service_account_async.py
+++ b/packages/google-auth/tests_async/oauth2/test_service_account_async.py
@@ -244,22 +244,29 @@ class TestCredentials(object):
         }
 
         request = mock.AsyncMock(spec=["transport.Request"])
-        headers = {}
+        headers1 = {}
 
         with mock.patch.object(
             credentials,
             "_is_regional_access_boundary_lookup_required",
             return_value=True,
         ):
+            # First request triggers background refresh, but proceeds without the header
             await credentials.before_request(
-                request, "GET", "https://storage.googleapis.com/bucket", headers
+                request, "GET", "https://storage.googleapis.com/bucket", headers1
             )
+            assert "x-allowed-locations" not in headers1
 
-            # Yield control to allow the background refresh task to run
-            await asyncio.sleep(0)
-
+            # Wait for the background task to finish and update the cache
+            await credentials._rab_manager.refresh_manager._worker_task
             assert mock_lookup.called
-            assert headers["x-allowed-locations"] == "0xA30"
+
+            # Second request should now find the data in the cache and attach the header
+            headers2 = {}
+            await credentials.before_request(
+                request, "GET", "https://storage.googleapis.com/bucket", headers2
+            )
+            assert headers2["x-allowed-locations"] == "0xA30"
 
     @mock.patch(
         "google.oauth2._client_async._lookup_regional_access_boundary", autospec=True
@@ -284,8 +291,8 @@ class TestCredentials(object):
                 request, "GET", "https://storage.googleapis.com/bucket", headers
             )
 
-            # Yield control to allow the background refresh task to run
-            await asyncio.sleep(0)
+            # Wait for the background task to finish
+            await credentials._rab_manager.refresh_manager._worker_task
 
             assert mock_lookup.called
             assert "x-allowed-locations" not in headers

--- a/packages/google-auth/tests_async/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests_async/test__regional_access_boundary_utils.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from unittest import mock
+
+import pytest  # type: ignore
+
+from google.auth import _regional_access_boundary_utils
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_manager_start_refresh():
+    credentials = mock.AsyncMock()
+    credentials._lookup_regional_access_boundary.return_value = {
+        "encodedLocations": "0xA30"
+    }
+
+    request = mock.Mock()
+    rab_manager = mock.Mock()
+
+    manager = (
+        _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
+    )
+
+    manager.start_refresh(credentials, request, rab_manager)
+
+    # Wait for the background task to finish
+    await manager._worker_task
+
+    credentials._lookup_regional_access_boundary.assert_called_once_with(request)
+    rab_manager.process_regional_access_boundary_info.assert_called_once_with(
+        {"encodedLocations": "0xA30"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_manager_duplicate_refresh_prevented():
+    credentials = mock.AsyncMock()
+
+    # Use events to control the concurrency timing
+    lookup_started = asyncio.Event()
+    lookup_finish = asyncio.Event()
+
+    async def controlled_lookup(*args, **kwargs):
+        lookup_started.set()  # Signal that the background lookup has started.
+        await lookup_finish.wait()  # Block until the test allows the lookup to complete.
+        return {"encodedLocations": "0xA30"}
+
+    credentials._lookup_regional_access_boundary.side_effect = controlled_lookup
+
+    request = mock.Mock()
+    rab_manager = mock.Mock()
+
+    manager = (
+        _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
+    )
+
+    # Start the initial refresh task in the background.
+    manager.start_refresh(credentials, request, rab_manager)
+
+    # Wait until the background task has begun executing the lookup.
+    await lookup_started.wait()
+
+    # Attempt a second refresh while the initial task is still in progress.
+    manager.start_refresh(credentials, request, rab_manager)
+
+    # Unblock the initial task and wait for it to complete.
+    lookup_finish.set()
+    await manager._worker_task
+
+    # Verify that the second refresh request was ignored and only one lookup occurred.
+    assert credentials._lookup_regional_access_boundary.call_count == 1

--- a/packages/google-auth/tests_async/test_jwt_async.py
+++ b/packages/google-auth/tests_async/test_jwt_async.py
@@ -143,6 +143,30 @@ class TestCredentials(object):
         assert new_credentials._additional_claims == self.credentials._additional_claims
         assert new_credentials._quota_project_id == quota_project_id
 
+    def test_build_regional_access_boundary_lookup_url_standard(self, monkeypatch):
+        from google.auth.transport import _mtls_helper
+
+        # Mock check_use_client_cert to return False to simulate standard TLS
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: False)
+
+        url = self.credentials._build_regional_access_boundary_lookup_url()
+        expected_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+            self.SERVICE_ACCOUNT_EMAIL
+        )
+        assert url == expected_url
+
+    def test_build_regional_access_boundary_lookup_url_mtls(self, monkeypatch):
+        from google.auth.transport import _mtls_helper
+
+        # Mock check_use_client_cert to return True to simulate mTLS
+        monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
+
+        url = self.credentials._build_regional_access_boundary_lookup_url()
+        expected_url = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
+            self.SERVICE_ACCOUNT_EMAIL
+        )
+        assert url == expected_url
+
     def test_unpickle_old_credentials_without_rab(self):
         from google.auth import _regional_access_boundary_utils
 

--- a/packages/google-auth/tests_async/test_jwt_async.py
+++ b/packages/google-auth/tests_async/test_jwt_async.py
@@ -367,10 +367,11 @@ class TestOnDemandCredentials(object):
         with pytest.raises(exceptions.RefreshError):
             self.credentials.refresh(None)
 
-    def test_before_request(self):
+    @pytest.mark.asyncio
+    async def test_before_request(self):
         headers = {}
 
-        self.credentials.before_request(
+        await self.credentials.before_request(
             None, "GET", "http://example.com?a=1#3", headers
         )
 
@@ -380,7 +381,9 @@ class TestOnDemandCredentials(object):
         assert payload["aud"] == "http://example.com"
 
         # Making another request should re-use the same token.
-        self.credentials.before_request(None, "GET", "http://example.com?b=2", headers)
+        await self.credentials.before_request(
+            None, "GET", "http://example.com?b=2", headers
+        )
 
         _, new_token = headers["authorization"].split(" ")
 

--- a/packages/google-auth/tests_async/test_jwt_async.py
+++ b/packages/google-auth/tests_async/test_jwt_async.py
@@ -143,6 +143,23 @@ class TestCredentials(object):
         assert new_credentials._additional_claims == self.credentials._additional_claims
         assert new_credentials._quota_project_id == quota_project_id
 
+    def test_unpickle_old_credentials_without_rab(self):
+        from google.auth import _regional_access_boundary_utils
+
+        credentials = self.credentials
+        old_state = credentials.__dict__.copy()
+        if "_rab_manager" in old_state:
+            del old_state["_rab_manager"]
+
+        new_instance = type(credentials).__new__(type(credentials))
+        new_instance.__setstate__(old_state)
+
+        assert hasattr(new_instance, "_rab_manager")
+        assert isinstance(
+            new_instance._rab_manager.refresh_manager,
+            _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager,
+        )
+
     def test_sign_bytes(self):
         to_sign = b"123"
         signature = self.credentials.sign_bytes(to_sign)


### PR DESCRIPTION
This PR implements the following changes:

- Add RAB support to async service account credential type, by providing async manager and fetching methods. 
- Update unit tests to accept both mtls and standard lookup endpoint urls. 
- Refactor before_request to use a _after_refresh hook so we don't have to override the method.
- Add RAb support for self signed jwt flow through jwt.py
- some small enhancements for test coverage and backward compatibility