### PR TITLE
feat: add generation of existing version of googleads resumable upload

### DIFF
--- a/packages/gapic-generator/gapic/generator/generator.py
+++ b/packages/gapic-generator/gapic/generator/generator.py
@@ -382,7 +382,12 @@ class Generator:
 
     def _is_desired_transport(self, template_name: str, opts: Options) -> bool:
         """Returns true if template name contains a desired transport"""
-        desired_transports = ["__init__", "base", "README"] + opts.transport
+        desired_transports = [
+            "__init__",
+            "base",
+            "README",
+            "resumable",
+        ] + opts.transport
         return any(transport in template_name for transport in desired_transports)
 
     def _get_file(

--- a/packages/gapic-generator/gapic/schema/api.py
+++ b/packages/gapic-generator/gapic/schema/api.py
@@ -997,6 +997,11 @@ class API:
             raise ClientLibrarySettingsError(yaml.dump(all_errors))
 
     @cached_property
+    def has_resumable_upload(self) -> bool:
+        """Return True if any service in the API has resumable upload enabled."""
+        return any(s.has_resumable_upload for s in self.services.values())
+
+    @cached_property
     def all_method_settings(self) -> Mapping[str, Sequence[client_pb2.MethodSettings]]:
         """Return a map of all `google.api.client.MethodSettings` to be used
         when generating methods.

--- a/packages/gapic-generator/gapic/schema/wrappers.py
+++ b/packages/gapic-generator/gapic/schema/wrappers.py
@@ -1939,6 +1939,27 @@ class Method:
         return tuple(answer)
 
     @property
+    def is_resumable_upload(self) -> bool:
+        """Return True if this method is a resumable upload method, False otherwise."""
+        fullMethodName = self.ident.proto
+        if fullMethodName.startswith("google.ads.googleads.v") and fullMethodName.endswith("YouTubeVideoUploadService.CreateYouTubeVideoUpload"):
+            if any(
+                [
+                    self.client_streaming,
+                    self.server_streaming,
+                    self.lro,
+                    self.extended_lro,
+                    self.paged_result_field,
+                ]
+            ):
+                raise ValueError(
+                    f"Method {self.ident.proto} is a resumable upload but "
+                    "also has other features which are mutually exclusive."
+                )
+            return True
+        return False
+
+    @property
     def void(self) -> bool:
         """Return True if this method has no return value, False otherwise."""
         return self.output.ident.proto == "google.protobuf.Empty"
@@ -2219,6 +2240,11 @@ class Service:
         if self.options.Extensions[client_pb2.default_host]:
             return self.options.Extensions[client_pb2.default_host]
         return ""
+
+    @property
+    def has_resumable_upload(self) -> bool:
+        """Return whether the service has a resumable upload method."""
+        return any(m.is_resumable_upload for m in self.methods.values())
 
     @property
     def version(self) -> str:

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
@@ -24,6 +24,9 @@
             {% for field in method.flattened_fields.values() %}
             {{ field.name }}: Optional[{{ field.ident }}] = None,
             {% endfor %}
+            {% if method.is_resumable_upload %}
+            stream: BinaryIO,
+            {% endif %}
             {% else %}
             requests: Optional[Iterator[{{ method.input.ident }}]] = None,
             *,
@@ -60,6 +63,10 @@
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
             {% endfor %}
+            {% if method.is_resumable_upload %}
+            stream (BinaryIO):
+                The stream to upload.
+            {% endif %}
             {% else %}
             requests (Iterator[{{ method.input.ident.sphinx }}]):
                 The request object iterator.{{ " " }}
@@ -140,6 +147,29 @@
             {% endfor %} {# method.flattened_fields.items() #}
             {% endif %} {# method.client_streaming #}
 
+        {% if method.is_resumable_upload %}
+        if stream is None:
+            raise ValueError("stream is required for resumable upload methods")
+
+{{ shared_macros.create_metadata(method) }}
+{{ shared_macros.add_api_version_header_to_metadata(service.version) }}
+{{ shared_macros.auto_populate_uuid4_fields(api, method) }}
+
+        # Validate the universe domain.
+        self._validate_universe_domain()
+
+        # Send the request.
+        response = self._rest_resumable_transport.{{ method.name|snake_case }}_resumable(
+            request=request,
+            stream=stream,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+
+        # Done; return the response.
+        return response
+        {% else %}
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
         rpc = self._transport._wrapped_methods[self._transport.{{ method.transport_safe_name|snake_case}}]
@@ -190,6 +220,7 @@
 
         # Done; return the response.
         return response
+        {% endif %}
         {% endif %}
         {{ "\n" }}
 

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -7,7 +7,7 @@
 import logging as std_logging
 from collections import OrderedDict
 import re
-from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, {% if service.any_server_streaming %}AsyncIterable, Awaitable, {% endif %}{% if service.any_client_streaming %}AsyncIterator, {% endif %}Sequence, Tuple, Type, Union
+from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, {% if service.any_server_streaming %}AsyncIterable, Awaitable, {% endif %}{% if service.any_client_streaming %}AsyncIterator, {% endif %}{% if service.has_resumable_upload %}BinaryIO, {% endif %}Sequence, Tuple, Type, Union
 {% if api.all_method_settings.values()|map(attribute="auto_populated_fields", default=[])|select|list %}
 import uuid
 {% endif %}
@@ -190,6 +190,12 @@ class {{ service.async_client_name }}:
 
     def __init__(self, *,
             credentials: Optional[ga_credentials.Credentials] = None,
+            {% if service.has_resumable_upload %}
+            developer_token: Optional[str] = None,
+            login_customer_id: Optional[str] = None,
+            linked_customer_id: Optional[str] = None,
+            use_cloud_org_for_api_access: bool = False,
+            {% endif %}
             transport: Optional[Union[str, {{ service.name }}Transport, Callable[..., {{ service.name }}Transport]]] = "grpc_asyncio",
             client_options: Optional[ClientOptions] = None,
             client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
@@ -202,6 +208,21 @@ class {{ service.async_client_name }}:
                 credentials identify the application to the service; if none
                 are specified, the client will attempt to ascertain the
                 credentials from the environment.
+            {% if service.has_resumable_upload %}
+            {% set resumable_methods = service.methods.values() | selectattr("is_resumable_upload") | map(attribute="name") | map("snake_case") | list %}
+            developer_token (Optional[str]): The developer token to use for the
+                resumable upload transport. This will be used by the resumable upload methods
+                ({{ resumable_methods | join(", ") }}) ONLY!
+            login_customer_id (Optional[str]): The login customer ID to use for
+                the resumable upload transport. This will be used by the resumable upload methods
+                ({{ resumable_methods | join(", ") }}) ONLY!
+            linked_customer_id (Optional[str]): The linked customer ID to use for
+                the resumable upload transport. This will be used by the resumable upload methods
+                ({{ resumable_methods | join(", ") }}) ONLY!
+            use_cloud_org_for_api_access (bool): Whether to use the cloud org for
+                API access for the resumable upload transport. This will be used by the resumable upload methods
+                ({{ resumable_methods | join(", ") }}) ONLY!
+            {% endif %}
             transport (Optional[Union[str,{{ service.name }}Transport,Callable[..., {{ service.name }}Transport]]]):
                 The transport to use, or a Callable that constructs and returns a new transport to use.
                 If a Callable is given, it will be called with the same set of initialization
@@ -252,6 +273,12 @@ class {{ service.async_client_name }}:
         {# NOTE(lidiz) Not using kwargs since we want the docstring and types. #}
         self._client = {{ service.client_name }}(
             credentials=credentials,
+            {% if service.has_resumable_upload %}
+            developer_token=developer_token,
+            login_customer_id=login_customer_id,
+            linked_customer_id=linked_customer_id,
+            use_cloud_org_for_api_access=use_cloud_org_for_api_access,
+            {% endif %}
             transport=transport,
             client_options=client_options,
             client_info=client_info,
@@ -282,6 +309,9 @@ class {{ service.async_client_name }}:
             {% for field in method.flattened_fields.values() %}
             {{ field.name }}: Optional[{{ field.ident }}] = None,
             {% endfor %}
+            {% if method.is_resumable_upload %}
+            stream: BinaryIO,
+            {% endif %}
             {% else %}
             requests: Optional[AsyncIterator[{{ method.input.ident }}]] = None,
             *,
@@ -316,6 +346,10 @@ class {{ service.async_client_name }}:
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
             {% endfor %}
+            {% if method.is_resumable_upload %}
+            stream (BinaryIO):
+                The stream to upload.
+            {% endif %}
             {% else %}
             requests (AsyncIterator[`{{ method.input.ident.sphinx }}`]):
                 The request object AsyncIterator.{{ " " }}
@@ -336,6 +370,11 @@ class {{ service.async_client_name }}:
                 {{ method.client_output_async.meta.doc|rst(width=72, indent=16, source_format='rst') }}
         {% endif %}
         """
+        {% if method.is_resumable_upload %}
+        raise NotImplementedError(
+            "Resumable upload is not yet supported in the async client."
+        )
+        {% else %}
         {% if method.is_deprecated %}
         warnings.warn("{{ service.async_client_name }}.{{ method.name|snake_case }} is deprecated",
             DeprecationWarning)
@@ -438,6 +477,7 @@ class {{ service.async_client_name }}:
 
         # Done; return the response.
         return response
+        {% endif %}
         {% endif %}
         {{ "\n" }}
     {% endfor %}

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -15,7 +15,7 @@ import json
 import logging as std_logging
 import os
 import re
-from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, {% if service.any_server_streaming %}Iterable, {% endif %}{% if service.any_client_streaming %}Iterator, {% endif %}Sequence, Tuple, Type, Union, cast
+from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, {% if service.any_server_streaming %}Iterable, {% endif %}{% if service.any_client_streaming %}Iterator, {% endif %}{% if service.has_resumable_upload %}BinaryIO, {% endif %}Sequence, Tuple, Type, Union, cast
 {% if api.all_method_settings.values()|map(attribute="auto_populated_fields", default=[])|select|list %}
 import uuid
 {% endif %}
@@ -70,6 +70,9 @@ from google.longrunning import operations_pb2 # type: ignore
 {% endif %}
 {% endfilter %}
 from .transports.base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
+{% if service.has_resumable_upload %}
+from .transports.rest_resumable import {{ service.name }}RestResumableTransport
+{% endif %}
 {% if 'grpc' in opts.transport %}
 from .transports.grpc import {{ service.grpc_transport_name }}
 from .transports.grpc_asyncio import {{ service.grpc_asyncio_transport_name }}
@@ -529,6 +532,12 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
     
     def __init__(self, *,
             credentials: Optional[ga_credentials.Credentials] = None,
+            {% if service.has_resumable_upload %}
+            developer_token: Optional[str] = None,
+            login_customer_id: Optional[str] = None,
+            linked_customer_id: Optional[str] = None,
+            use_cloud_org_for_api_access: bool = False,
+            {% endif %}
             transport: Optional[Union[str, {{ service.name }}Transport, Callable[..., {{ service.name }}Transport]]] = None,
             client_options: Optional[Union[client_options_lib.ClientOptions, dict]] = None,
             client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
@@ -541,6 +550,21 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 credentials identify the application to the service; if none
                 are specified, the client will attempt to ascertain the
                 credentials from the environment.
+            {% if service.has_resumable_upload %}
+            {% set resumable_methods = service.methods.values() | selectattr("is_resumable_upload") | map(attribute="name") | map("snake_case") | list %}
+            developer_token (Optional[str]): The developer token to use for the
+                resumable upload transport. This will be used by the resumable upload methods
+                ({{ resumable_methods | join(", ") }}) ONLY!
+            login_customer_id (Optional[str]): The login customer ID to use for
+                the resumable upload transport. This will be used by the resumable upload methods
+                ({{ resumable_methods | join(", ") }}) ONLY!
+            linked_customer_id (Optional[str]): The linked customer ID to use for
+                the resumable upload transport. This will be used by the resumable upload methods
+                ({{ resumable_methods | join(", ") }}) ONLY!
+            use_cloud_org_for_api_access (bool): Whether to use the cloud org for
+                API access for the resumable upload transport. This will be used by the resumable upload methods
+                ({{ resumable_methods | join(", ") }}) ONLY!
+            {% endif %}
             transport (Optional[Union[str,{{ service.name }}Transport,Callable[..., {{ service.name }}Transport]]]):
                 The transport to use, or a Callable that constructs and returns a new transport.
                 If a Callable is given, it will be called with the same set of initialization
@@ -619,9 +643,15 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         transport_provided = isinstance(transport, {{ service.name }}Transport)
         if transport_provided:
             # transport is a {{ service.name }}Transport instance.
+            {% if service.has_resumable_upload %}
+            if (self._client_options.credentials_file or api_key_value):
+                raise ValueError("When providing a transport instance, "
+                                 "provide its credentials directly.")
+            {% else %}
             if credentials or self._client_options.credentials_file or api_key_value:
                 raise ValueError("When providing a transport instance, "
                                  "provide its credentials directly.")
+            {% endif %}
             if self._client_options.scopes:
                 raise ValueError(
                     "When providing a transport instance, provide its scopes "
@@ -629,6 +659,25 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 )
             self._transport = cast({{ service.name }}Transport, transport)
             self._api_endpoint = self._transport.host
+            {% if service.has_resumable_upload %}
+            resumable_creds = credentials or getattr(self._transport, "_credentials", None)
+
+            if resumable_creds is None:
+                raise ValueError(
+                    "For the correct REST resumable transport initialization, either the credentials should be explicitly provided as a `credentials` parameter, or the transport passed should contain readable `_credentials` property. E.g. passing a GRPC channel as a transport does not satisfy this since the credentials cannot be extracted from it. This requirement is unique to the {{ service.name }}."
+                )
+
+            self._rest_resumable_transport = {{ service.name }}RestResumableTransport(
+                credentials=resumable_creds,
+                credentials_file=None,
+                host=self._transport.host,
+                scopes=self._transport._scopes,
+                developer_token=developer_token,
+                login_customer_id=login_customer_id,
+                linked_customer_id=linked_customer_id,
+                use_cloud_org_for_api_access=use_cloud_org_for_api_access,
+            )
+            {% endif %}
 
         self._api_endpoint = (self._api_endpoint or
             {{ service.client_name }}._get_api_endpoint(
@@ -695,6 +744,27 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 always_use_jwt_access=True,
                 api_audience=self._client_options.api_audience,
             )
+            {% if service.has_resumable_upload %}
+            
+            # Initialize a separate transport for the rest resumable uploads
+            self._rest_resumable_transport = {{ service.name }}RestResumableTransport(
+                credentials=credentials,
+                credentials_file=self._client_options.credentials_file,
+                host=self._api_endpoint,
+                scopes=self._client_options.scopes,
+                client_cert_source_for_mtls=self._client_cert_source,
+                quota_project_id=self._client_options.quota_project_id,
+                client_info=client_info,
+                always_use_jwt_access=True,
+                api_audience=self._client_options.api_audience,
+                {% if service.has_resumable_upload %}
+                developer_token=developer_token,
+                login_customer_id=login_customer_id,
+                linked_customer_id=linked_customer_id,
+                use_cloud_org_for_api_access=use_cloud_org_for_api_access,
+                {% endif %}
+            )
+            {% endif %}
         
         if "async" not in str(self._transport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(std_logging.DEBUG):  # pragma: NO COVER

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_resumable.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_resumable.py.j2
@@ -1,0 +1,321 @@
+{% if service.has_resumable_upload %}
+{% extends "_base.py.j2" %}
+
+{% block content %}
+
+import base64
+import dataclasses
+import json  # type: ignore
+import logging
+import os
+import sys
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, BinaryIO
+import warnings
+from datetime import datetime, timedelta, timezone
+
+from google.api_core import exceptions as core_exceptions
+from google.api_core import gapic_v1, rest_helpers, rest_streaming
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials  # type: ignore
+from google.auth.transport.requests import AuthorizedSession  # type: ignore
+
+import google.protobuf
+from google.protobuf import empty_pb2  # type: ignore
+from google.protobuf import json_format
+from requests import __version__ as requests_version
+
+{% filter sort_lines %}
+{% for method in service.methods.values() if method.is_resumable_upload %}
+{{ method.input.ident.python_import }}
+{{ method.output.ident.python_import }}
+{% endfor %}
+{% endfilter %}
+
+from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
+from .rest_resumable_base import _Base{{ service.name }}RestResumableTransport
+from .resumable_upload import ResumableUpload, make_resumable_upload
+
+
+try:
+    OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
+except AttributeError:  # pragma: NO COVER
+    OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
+
+_DEFAULT_CHUNK_SIZE = 10 * 1024 * 1024 # 10MB
+_DEFAULT_TIMEOUT = 14400
+_DEFAULT_CONTENT_TYPE = "application/octet-stream"
+
+_DEFAULT_RETRY = retries.Retry(predicate=retries.if_exception_type(
+    core_exceptions.ServiceUnavailable,
+    core_exceptions.DeadlineExceeded,
+), initial=1.0, maximum=60.0, multiplier=1.3)
+
+DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
+
+if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
+    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+
+class {{ service.name }}RestResumableInterceptor:
+    """Interceptor for {{ service.name }}. Not implemented yet"""
+
+class {{ service.name }}RestResumableTransport(_Base{{ service.name }}RestResumableTransport):
+    """REST backend synchronous transport for {{ service.name }}.
+    It is only used by Resumable Media Upload functionality
+    """
+
+    def __init__(
+        self,
+        *,
+        host: str = "{{ service.host }}",
+        credentials: Optional[ga_credentials.Credentials] = None,
+        credentials_file: Optional[str] = None,
+        scopes: Optional[Sequence[str]] = None,
+        client_cert_source_for_mtls: Optional[Callable[[], Tuple[bytes, bytes]]] = None,
+        quota_project_id: Optional[str] = None,
+        client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
+        always_use_jwt_access: Optional[bool] = False,
+        url_scheme: str = "https",
+        interceptor: Optional[{{ service.name }}RestResumableInterceptor] = None,
+        api_audience: Optional[str] = None,
+        {% if service.has_resumable_upload %}
+        developer_token: Optional[str] = None,
+        login_customer_id: Optional[str] = None,
+        linked_customer_id: Optional[str] = None,
+        use_cloud_org_for_api_access: bool = False,
+        {% endif %}
+        **kwargs # Catch-all for forward compatibility
+    ) -> None:
+        """Instantiate the transport.
+
+        Args:
+            host (Optional[str]):
+                 The hostname to connect to (default: '{{ service.host }}').
+            credentials (Optional[google.auth.credentials.Credentials]): The
+                authorization credentials to attach to requests. These
+                credentials identify the application to the service; if none
+                are specified, the client will attempt to ascertain the
+                credentials from the environment.
+
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
+                be loaded with :func:`google.auth.load_credentials_from_file`.
+                This argument is ignored if ``channel`` is provided. This argument will be
+                removed in the next major version of this library.
+            scopes (Optional(Sequence[str])): A list of scopes. This argument is
+                ignored if ``channel`` is provided.
+            client_cert_source_for_mtls (Callable[[], Tuple[bytes, bytes]]): Client
+                certificate to configure mutual TLS HTTP channel. It is ignored
+                if ``channel`` is provided.
+            quota_project_id (Optional[str]): An optional project to use for billing
+                and quota.
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you are developing
+                your own client library.
+            always_use_jwt_access (Optional[bool]): Whether self signed JWT should
+                be used for service account credentials.
+            url_scheme: the protocol scheme for the API endpoint.  Normally
+                "https", but for testing or local servers,
+                "http" can be specified.
+            {% if service.has_resumable_upload %}
+            developer_token (Optional[str]): The developer token to use for the
+                resumable upload transport.
+            login_customer_id (Optional[str]): The login customer ID to use for
+                the resumable upload transport.
+            linked_customer_id (Optional[str]): The linked customer ID to use for
+                the resumable upload transport.
+            use_cloud_org_for_api_access (bool): Whether to use the cloud org for
+                API access for the resumable upload transport.
+            {% endif %}
+        """
+        # Run the base constructor
+        super().__init__(
+            host=host,
+            credentials=credentials,
+            client_info=client_info,
+            always_use_jwt_access=always_use_jwt_access,
+            url_scheme=url_scheme,
+            api_audience=api_audience,
+        )
+        self._session = AuthorizedSession(
+            self._credentials, default_host=self.DEFAULT_HOST
+        )
+        if client_cert_source_for_mtls:
+            self._session.configure_mtls_channel(client_cert_source_for_mtls)
+        
+        {% if service.has_resumable_upload %}
+        self._developer_token = developer_token
+        self._login_customer_id = login_customer_id
+        self._linked_customer_id = linked_customer_id
+        self._use_cloud_org_for_api_access = use_cloud_org_for_api_access
+        {% endif %}
+
+    def _sanitize_headers_for_rest(
+        self, 
+        metadata: Union[Dict, Sequence[Tuple[str, Union[str, bytes]]]]
+    ) -> Dict[str, str]:
+        """
+        Converts gRPC metadata into REST-friendly headers.
+        
+        - Decodes byte keys to strings.
+        - Base64 encodes byte values if the key ends with '-bin'.
+        - Raises ValueError if binary data is found in a non-'-bin' key.
+        """
+        # Normalize input to a dict if it's a sequence
+        raw_headers = dict(metadata) if not isinstance(metadata, dict) else metadata
+        clean_headers = {}
+
+        for key, value in raw_headers.items():
+            # Ensure Key is a String
+            k_str = key.decode("utf-8") if isinstance(key, bytes) else key
+
+            if isinstance(value, bytes):
+                if not k_str.endswith("-bin"):
+                    raise ValueError(
+                        f"Invalid binary header '{k_str}'. Binary data is only "
+                        "allowed in keys ending with '-bin'."
+                    )
+                # Valid binary header: Base64 encode
+                clean_headers[k_str] = base64.b64encode(value).decode("ascii")
+            else:
+                # String value: Keep as is
+                clean_headers[k_str] = str(value)
+
+        return clean_headers
+
+    def _update_headers_with_googleads(self, headers: dict[str, str]) -> dict[str, str]:
+        """
+        Returns a new dictionary with identity headers injected, mirroring the 
+        MetadataInterceptor logic. Does not modify the input dictionary.
+        """
+        # Create a shallow copy to avoid in-place modification
+        new_headers = headers.copy() if headers else {}
+
+        # 1. Developer Token Logic
+        # Only add if we are NOT using Cloud Org access AND the token exists.
+        # This prevents the crash if developer_token is None.
+        if not self._use_cloud_org_for_api_access and self._developer_token:
+            new_headers["developer-token"] = self._developer_token
+
+        # 2. Login Customer ID Logic
+        if self._login_customer_id:
+            new_headers["login-customer-id"] = self._login_customer_id
+
+        # 3. Linked Customer ID Logic
+        if self._linked_customer_id:
+            new_headers["linked-customer-id"] = self._linked_customer_id
+            
+        return new_headers
+
+    @staticmethod
+    def _maybe_rewind(stream, rewind=False):
+        """Rewind the stream if desired.
+
+        :type stream: IO[bytes]
+        :param stream: A bytes IO object open for reading.
+
+        :type rewind: bool
+        :param rewind: Indicates if we should seek to the beginning of the stream.
+        """
+        if rewind:
+            stream.seek(0, os.SEEK_SET)
+
+    {% for method in service.methods.values() if method.is_resumable_upload %}
+    def {{ method.name|snake_case }}_resumable(self,
+        request: {{ method.input.ident }},
+        *,
+        stream: BinaryIO,
+        rewind: bool = False,
+        size: Optional[int] = None,
+        content_type: Optional[str] = None,
+        chunk_size: Optional[int] = None,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+        ) -> {{ method.output.ident }}:
+        r"""{{ method.meta.doc|rst(width=72, indent=8)|trim }}
+
+        Args:
+            request (Union[{{ method.input.ident.sphinx }}, dict]):
+                The request object.{{ " " }}
+                {{- method.input.meta.doc|rst(width=72, indent=16, nl=False) }}
+            stream (BinaryIO):
+                A stream of bytes, such as a file opened in binary mode for reading.
+            rewind (bool):
+                If True, seek to the beginning of the file handle before uploading from the stream.
+            size (int):
+                The number of bytes to be uploaded (which will be read from
+                ``stream``). If not provided, the upload will be concluded once
+                ``stream`` is exhausted.
+            content_type (str):
+                The MIME type of the content being uploaded.
+            chunk_size (int):
+                The size of each chunk to be uploaded.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+
+        Returns:
+            {{ method.output.ident.sphinx }}:
+                {{ method.output.meta.doc|rst(width=72, indent=16, source_format="rst") }}
+
+        """
+
+        self._maybe_rewind(stream, rewind=rewind)
+
+        http_options = _Base{{ service.name }}RestResumableTransport._Base{{ method.name }}Request._get_http_options()
+        transcoded_request = _Base{{ service.name }}RestResumableTransport._Base{{ method.name }}Request._get_transcoded_request(http_options, request)
+        request_url = "{host}/resumable/upload{uri}".format(host=self._host, uri=transcoded_request['uri'])
+
+        # preserving_proto_field_name=True ensures we get snake case "customer_id" 
+        json_body = json_format.MessageToJson(
+            request._pb,
+            preserving_proto_field_name=True,
+        )
+
+        if chunk_size is None:
+            chunk_size = _DEFAULT_CHUNK_SIZE
+        if retry is gapic_v1.method.DEFAULT:
+            retry = _DEFAULT_RETRY
+        if timeout is None or timeout is gapic_v1.method.DEFAULT:
+            timeout = _DEFAULT_TIMEOUT
+        if content_type is None:
+            content_type = _DEFAULT_CONTENT_TYPE
+
+        deadline = datetime.now(timezone.utc) + timedelta(seconds=timeout)
+        headers = dict(metadata)
+        
+        # 1. Sanitize (will raise ValueError if headers are invalid)
+        headers = self._sanitize_headers_for_rest(headers or {})
+        
+        # 2. Inject google-ads specific metadata
+        headers = self._update_headers_with_googleads(headers)
+
+        response = make_resumable_upload(
+            transport=self._session,
+            request_body=json_body,
+            stream=stream,
+            upload_url=request_url,
+            size=size,
+            content_type=content_type,
+            chunk_size=chunk_size,
+            request_retry=retry,
+            deadline=deadline,
+            headers=headers,
+            on_progress=None
+        )  
+
+        data = response.json()
+        response_message = {{ method.output.ident }}()
+        json_format.ParseDict(data, response_message._pb, ignore_unknown_fields=True)
+        
+        return response_message
+    {% endfor %}
+
+__all__ = ("{{ service.name }}RestResumableTransport",)
+{% endblock %}
+{% endif %}

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_resumable_base.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_resumable_base.py.j2
@@ -1,0 +1,102 @@
+{% import "%namespace/%name_%version/%sub/services/%service/_shared_macros.j2" as shared_macros %}
+{% if service.has_resumable_upload %}
+{% extends "_base.py.j2" %}
+
+{% block content %}
+
+import json  # type: ignore
+import re
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+from google.api_core import gapic_v1, path_template
+from google.protobuf import empty_pb2  # type: ignore
+from google.protobuf import json_format
+
+{% filter sort_lines %}
+{% for method in service.methods.values() if method.is_resumable_upload %}
+{{ method.input.ident.python_import }}
+{{ method.output.ident.python_import }}
+{% endfor %}
+{% endfilter %}
+
+from .base import DEFAULT_CLIENT_INFO, {{ service.name }}Transport
+
+class _Base{{ service.name }}RestResumableTransport({{ service.name }}Transport):
+    """Base REST Resumable backend transport for {{ service.name }}.
+
+    Note: This class is not meant to be used directly. Only services that has RPCs
+    that should be invoked as resumable upload should instantiate it and use it.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: str = "{{ service.host }}",
+        credentials: Optional[Any] = None,
+        client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
+        always_use_jwt_access: Optional[bool] = False,
+        url_scheme: str = "https",
+        api_audience: Optional[str] = None,
+    ) -> None:
+        """Instantiate the transport.
+        Args:
+            host (Optional[str]):
+                 The hostname to connect to (default: '{{ service.host }}').
+            credentials (Optional[Any]): The
+                authorization credentials to attach to requests. These
+                credentials identify the application to the service; if none
+                are specified, the client will attempt to ascertain the
+                credentials from the environment.
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you are developing
+                your own client library.
+            always_use_jwt_access (Optional[bool]): Whether self signed JWT should
+                be used for service account credentials.
+            url_scheme: the protocol scheme for the API endpoint.  Normally
+                "https", but for testing or local servers,
+                "http" can be specified.
+        """
+        # Run the base constructor
+        maybe_url_match = re.match("^(?P<scheme>http(?:s)?://)?(?P<host>.*)$", host)
+        if maybe_url_match is None:
+            raise ValueError(
+                f"Unexpected hostname structure: {host}"
+            )  # pragma: NO COVER
+
+        url_match_items = maybe_url_match.groupdict()
+
+        host = f"{url_scheme}://{host}" if not url_match_items["scheme"] else host
+
+        super().__init__(
+            host=host,
+            credentials=credentials,
+            client_info=client_info,
+            always_use_jwt_access=always_use_jwt_access,
+            api_audience=api_audience,
+        )
+
+    {% for method in service.methods.values() if method.is_resumable_upload %}
+    class _Base{{ method.name }}Request:
+        def __hash__(self):  # pragma: NO COVER
+            return NotImplementedError("__hash__ must be implemented.")
+        
+        {% set method_http_options = method.http_options %}
+        {{ shared_macros.http_options_method(method_http_options)|indent(8) }}
+
+        @staticmethod
+        def _get_transcoded_request(http_options, request):
+            {% if method.input.ident.is_proto_plus_type %}
+            pb_request = {{method.input.ident}}.pb(request)
+            {% else %}
+            pb_request = request
+            {% endif %}
+            transcoded_request = path_template.transcode(http_options, pb_request)
+            return transcoded_request
+
+    {% endfor %}
+
+__all__ = ("_Base{{ service.name }}RestResumableTransport",)
+{% endblock %}
+{% endif %}

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/resumable_upload.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/resumable_upload.py.j2
@@ -94,7 +94,7 @@ class ResumableUpload:
             now = datetime.datetime.now(datetime.timezone.utc)
             timeout = (self.deadline - now).total_seconds()
             if timeout <= 0:
-                raise Exception(f"Upload deadline {self.deadline} (as calculated from the timeout argument) was exceeded")
+                raise RuntimeError(f"Upload deadline {self.deadline} (as calculated from the timeout argument) was exceeded")
             return timeout
         return None
 

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/resumable_upload.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/resumable_upload.py.j2
@@ -1,0 +1,386 @@
+{% if service.has_resumable_upload %}
+{% extends "_base.py.j2" %}
+
+{% block content %}
+
+import datetime
+import logging
+
+from dataclasses import dataclass
+from typing import Any, BinaryIO, Callable, Dict, Optional, Sequence, Tuple, Union
+
+import google.api_core.retry
+import requests
+from .resumable_upload_error_adapter import raise_formatted_for_status
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_CHUNK_SIZE = 10 * 1024 * 1024 # 10MB
+
+@dataclass(frozen=True)
+class ResumableUploadStatus:
+    """Status of a resumable upload.
+
+    Attributes:
+        upload_url (str):
+            The session URL for the resumable upload.
+        total_bytes (Optional[int]):
+            The total number of bytes to be uploaded, if known.
+        bytes_uploaded (int):
+            The number of bytes successfully uploaded so far.
+        finished (bool):
+            Whether the upload has completed.
+    """
+    upload_url: str
+    total_bytes: Optional[int]
+    bytes_uploaded: int
+    finished: bool
+
+class ResumableUpload:
+    """Manages a resumable upload session.
+
+    This class handles the initiation, chunk transmission, and recovery
+    of a resumable upload according to the Google Resumable Upload protocol.
+    """
+
+    def __init__(
+        self,
+        upload_url: str,
+        stream: BinaryIO,
+        size: Optional[int] = None,
+        content_type: Optional[str] = None,
+        chunk_size: Optional[int] = None,
+        deadline: Optional[datetime.datetime] = None,
+        headers: Optional[Sequence[Tuple[str, Union[str, bytes]]]] = None,
+        on_progress: Optional[Callable[[ResumableUploadStatus], None]] = None,
+    ):
+        """Initializes the ResumableUpload object.
+
+        Args:
+            upload_url (str):
+                The initial URL to start the resumable upload.
+            stream (BinaryIO):
+                A stream of bytes to be uploaded.
+            size (Optional[int]):
+                The total number of bytes to be uploaded. If not provided,
+                the upload continues until the stream is exhausted.
+            content_type (Optional[str]):
+                The MIME type of the content being uploaded.
+            chunk_size (Optional[int]):
+                The size of each chunk to be uploaded. Defaults to 10MB.
+            deadline (Optional[datetime.datetime]):
+                The deadline for the entire upload process.
+            headers (Optional[Sequence[Tuple[str, Union[str, bytes]]]]):
+                Extra headers to be sent with the initiation and chunk requests.
+            on_progress (Optional[Callable[[ResumableUploadStatus], None]]):
+                A callback function called after each successful chunk upload.
+        """
+        self.initial_url = upload_url
+        self.stream = stream
+        self.size = size
+        self.content_type = content_type
+        self.chunk_size = chunk_size or _DEFAULT_CHUNK_SIZE
+        self.deadline = deadline
+        self.extra_headers = dict(headers or [])
+        self.on_progress = on_progress
+
+        self.session_url = None
+        self.bytes_uploaded = 0
+        self.finished = False
+        self.chunk_granularity = None
+
+    def _check_deadline(self) -> Optional[float]:
+        if self.deadline:
+            now = datetime.datetime.now(datetime.timezone.utc)
+            timeout = (self.deadline - now).total_seconds()
+            if timeout <= 0:
+                raise Exception(f"Upload deadline {self.deadline} (as calculated from the timeout argument) was exceeded")
+            return timeout
+        return None
+
+    def _get_retry_predicate(self):
+        def should_retry(exc):
+            if isinstance(exc, requests.exceptions.RequestException):
+                if isinstance(exc, (requests.exceptions.ConnectionError, requests.exceptions.Timeout)):
+                    return True
+                if exc.response is not None:
+                    status_code = exc.response.status_code
+                    return status_code in (408, 429, 500, 502, 503, 504)
+            return False
+        return should_retry
+
+    def _log_request(self, method: str, url: str, headers: Dict[str, str], data: Any = None):
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        
+        display_data = data
+        if isinstance(data, bytes) and len(data) > 64:
+            display_data = f"{data[:64]!r}... ({len(data)} bytes)"
+        
+        _LOGGER.debug("HTTP Request: %s %s\nHeaders: %s\nBody: %s", method, url, headers, display_data)
+
+    def _log_response(self, response: requests.Response):
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        
+        _LOGGER.debug("HTTP Response: %s %s\nHeaders: %s\nBody: %s", 
+                     response.status_code, response.reason, response.headers, response.text)
+
+    def _prepare_initiate_request(self, body: str) -> Tuple[str, str, str, Dict[str, str]]:
+        headers = {
+            "X-Goog-Upload-Protocol": "resumable",
+            "X-Goog-Upload-Command": "start",
+        }
+        
+        # Prefix logical headers
+        if self.content_type:
+            headers["X-Goog-Upload-Header-Content-Type"] = self.content_type
+        if self.size is not None:
+            headers["X-Goog-Upload-Header-Content-Length"] = str(self.size)
+            
+        # Add extra headers, prefixing if necessary
+        for k, v in self.extra_headers.items():
+            if k.lower() in ("content-length", "content-type", "content-encoding", "transfer-encoding"):
+                headers[f"X-Goog-Upload-Header-{k}"] = str(v)
+            else:
+                headers[k] = str(v)
+        
+        return "POST", self.initial_url, body, headers
+
+    def _process_initiate_response(self, response: requests.Response):
+        raise_formatted_for_status(response)
+        
+        self.session_url = response.headers.get("X-Goog-Upload-URL")
+        if not self.session_url:
+            raise ValueError("Server did not return X-Goog-Upload-URL")
+            
+        granularity = response.headers.get("X-Goog-Upload-Chunk-Granularity")
+        if granularity:
+            self.chunk_granularity = int(granularity)
+            _LOGGER.debug("Server requested chunk granularity: %d", self.chunk_granularity)
+            
+        if self.on_progress:
+            self.on_progress(ResumableUploadStatus(
+                upload_url=self.session_url,
+                total_bytes=self.size,
+                bytes_uploaded=0,
+                finished=False
+            ))
+
+    def initiate(
+        self,
+        transport: requests.Session,
+        request_body: str = "",
+        request_retry: Optional[google.api_core.retry.Retry] = None,
+    ):
+        """Initiates the resumable upload session.
+
+        This method sends the initial request to the server to start a new
+        resumable upload session and retrieves the session URL.
+
+        Args:
+            transport (requests.Session):
+                The authorized session to use for the initiation request.
+            request_body (str):
+                The JSON-encoded request body for the initiation request.
+            request_retry (Optional[google.api_core.retry.Retry]):
+                Designation of what errors, if any, should be retried.
+        """
+        _LOGGER.info("Initiating resumable upload to %s", self.initial_url)
+        method, url, body, headers = self._prepare_initiate_request(request_body)
+
+        def do_initiate():
+            timeout = self._check_deadline()
+            self._log_request(method, url, headers, body)
+            response = transport.request(method, url, data=body, headers=headers, timeout=timeout)
+            self._log_response(response)
+            raise_formatted_for_status(response)
+            return response
+
+        if request_retry:
+            response = request_retry(do_initiate)()
+        else:
+            response = do_initiate()
+
+        self._process_initiate_response(response)
+
+    def _prepare_chunk_request(self) -> Tuple[str, str, bytes, Dict[str, str], int]:
+        # Adjust chunk size based on granularity if needed
+        actual_chunk_size = self.chunk_size
+        if self.chunk_granularity:
+            if actual_chunk_size % self.chunk_granularity != 0:
+                actual_chunk_size = ((actual_chunk_size // self.chunk_granularity) + 1) * self.chunk_granularity
+                _LOGGER.debug("Adjusted chunk size to %d based on granularity %d", actual_chunk_size, self.chunk_granularity)
+
+        data = self.stream.read(actual_chunk_size)
+        data_len = len(data)
+        is_last_chunk = data_len < actual_chunk_size or (self.size is not None and self.bytes_uploaded + data_len >= self.size)
+        
+        command = "upload"
+        if is_last_chunk:
+            command = "upload, finalize"
+            
+        headers = {
+            "X-Goog-Upload-Command": command,
+            "X-Goog-Upload-Offset": str(self.bytes_uploaded),
+        }
+        
+        return "POST", self.session_url, data, headers, data_len
+
+    def _process_chunk_response(self, response: requests.Response, chunk_len: int):
+        raise_formatted_for_status(response)
+        
+        status = response.headers.get("X-Goog-Upload-Status")
+        if status == "active":
+            self.bytes_uploaded += chunk_len
+        elif status == "final":
+            self.finished = True
+            self.bytes_uploaded += chunk_len
+
+    def transmit_next_chunk(self, transport: requests.Session) -> requests.Response:
+        """Uploads the next chunk of data from the stream.
+
+        This method reads a chunk from the stream, prepares the upload request,
+        transmits it to the server, and processes the response.
+
+        Args:
+            transport (requests.Session):
+                The authorized session to use for the upload.
+
+        Returns:
+            requests.Response:
+                The response from the server for this chunk upload.
+        """
+        self._check_deadline()
+        method, url, data, headers, chunk_len = self._prepare_chunk_request()
+
+        retry = google.api_core.retry.Retry(
+            predicate=self._get_retry_predicate(),
+            deadline=self._check_deadline()
+        )
+
+        def do_upload():
+            _LOGGER.info("Uploading chunk at offset %s, size %d, command %s", headers["X-Goog-Upload-Offset"], chunk_len, headers["X-Goog-Upload-Command"])
+            timeout = self._check_deadline()
+            self._log_request(method, url, headers, data)
+            response = transport.request(method, url, data=data, headers=headers, timeout=timeout)
+            self._log_response(response)
+            raise_formatted_for_status(response)
+            return response
+
+        try:
+            response = retry(do_upload)()
+            self._process_chunk_response(response, chunk_len)
+        except Exception as e:
+            _LOGGER.error("Error during chunk upload: %s", e)
+            self._recover(transport, retry)
+            if isinstance(e, requests.exceptions.HTTPError) and e.response is not None:
+                return e.response
+            raise
+
+        if self.on_progress:
+            self.on_progress(ResumableUploadStatus(
+                upload_url=self.session_url,
+                total_bytes=self.size,
+                bytes_uploaded=self.bytes_uploaded,
+                finished=self.finished
+            ))
+            
+        return response
+
+    def _prepare_recovery_request(self) -> Tuple[str, str, Dict[str, str]]:
+        headers = {"X-Goog-Upload-Command": "query"}
+        return "POST", self.session_url, headers
+
+    def _process_recovery_response(self, response: requests.Response):
+        raise_formatted_for_status(response)
+        status = response.headers.get("X-Goog-Upload-Status")
+        
+        if status == "active":
+            received = int(response.headers.get("X-Goog-Upload-Size-Received", 0))
+            _LOGGER.info("Server reported %d bytes received. Seeking stream.", received)
+            self.bytes_uploaded = received
+            self.stream.seek(received)
+        elif status == "final":
+            _LOGGER.info("Upload already finalized according to server.")
+            self.finished = True
+        elif status == "cancelled":
+            raise RuntimeError("Upload was cancelled by server")
+
+    def _recover(self, transport: requests.Session, retry: google.api_core.retry.Retry):
+        _LOGGER.info("Attempting recovery via query command")
+        method, url, headers = self._prepare_recovery_request()
+        
+        def do_query():
+            timeout = self._check_deadline()
+            self._log_request(method, url, headers)
+            response = transport.request(method, url, headers=headers, timeout=timeout)
+            self._log_response(response)
+            raise_formatted_for_status(response)
+            return response
+            
+        response = retry(do_query)()
+        self._process_recovery_response(response)
+
+def make_resumable_upload(
+    transport: requests.Session,
+    request_body: str,
+    stream: BinaryIO,
+    upload_url: str,
+    size: Optional[int] = None,
+    content_type: Optional[str] = None,
+    chunk_size: Optional[int] = None,
+    request_retry: Optional[google.api_core.retry.Retry] = None,
+    deadline: Optional[datetime.datetime] = None,
+    headers: Optional[Sequence[Tuple[str, Union[str, bytes]]]] = None,
+    on_progress: Optional[Callable[[ResumableUploadStatus], None]] = None,
+) -> requests.Response:
+    """Makes a resumable upload.
+
+    Args:
+        transport (requests.Session):
+            The authorized session to use for the upload.
+        request_body (str):
+            The JSON-encoded request body to send during initiation.
+        stream (BinaryIO):
+            A stream of bytes to be uploaded.
+        upload_url (str):
+            The initial URL to start the resumable upload.
+        size (int):
+            The number of bytes to be uploaded. If not provided,
+            the upload will continue until the stream is exhausted.
+        content_type (str):
+            The MIME type of the content being uploaded.
+        chunk_size (int):
+            The size of each chunk to be uploaded.
+        request_retry (google.api_core.retry.Retry):
+            Designation of what errors, if any, should be retried during initiation.
+        deadline (datetime.datetime):
+            The deadline for the entire upload process.
+        headers (Sequence[Tuple[str, Union[str, bytes]]]):
+            Key/value pairs which should be sent along with the request as metadata.
+        on_progress (Callable[[ResumableUploadStatus], None]):
+            A callback function that will be called after each chunk is uploaded.
+
+    Returns:
+        requests.Response:
+            The final response from the server after the upload is complete.
+    """
+    upload = ResumableUpload(
+        upload_url,
+        stream=stream,
+        size=size,
+        content_type=content_type,
+        chunk_size=chunk_size,
+        deadline=deadline,
+        headers=headers,
+        on_progress=on_progress,
+    )
+    upload.initiate(transport=transport, request_body=request_body, request_retry=request_retry)
+
+    final_response = None
+    while not upload.finished:
+        final_response = upload.transmit_next_chunk(transport=transport)
+    return final_response
+{% endblock %}
+{% endif %}

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/resumable_upload_error_adapter.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/resumable_upload_error_adapter.py.j2
@@ -1,0 +1,111 @@
+{% if service.has_resumable_upload %}
+{% extends "_base.py.j2" %}
+
+{% block content %}
+
+import grpc
+import requests
+from typing import Any, Optional, Tuple
+from google.api_core import exceptions as core_exceptions
+
+{% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
+from google.ads.googleads.errors import GoogleAdsException
+from {{ package_path }}.errors.types.errors import GoogleAdsError, GoogleAdsFailure, ErrorCode
+
+class ResumableUploadErrorAdapter(grpc.RpcError, grpc.Call):
+    """
+    A concrete implementation of gRPC abstract classes.
+    Wraps a requests.Response to mimic a gRPC call for GoogleAdsException.
+    """
+    def __init__(self, response: requests.Response, mapped_grpc_code: grpc.StatusCode):
+        self._response = response
+        self._mapped_code = mapped_grpc_code
+
+    # --- grpc.Call & grpc.RpcContext Required Methods ---
+    def code(self) -> grpc.StatusCode:
+        return self._mapped_code
+
+    def details(self) -> str:
+        # RUP specifies error details are in the response body
+        return self._response.text
+
+    def initial_metadata(self) -> Any:
+        return None
+
+    def trailing_metadata(self) -> Any:
+        # HTTP headers serve as trailing metadata in RUP
+        return tuple(self._response.headers.items())
+
+    def is_active(self) -> bool:
+        return False
+
+    def time_remaining(self) -> Optional[float]:
+        return None
+
+    def cancel(self) -> None:
+        pass
+
+    def add_callback(self, callback: Any) -> None:
+        pass
+
+def raise_formatted_ads_exception(response: requests.Response):
+    """Converts a RUP HTTP response into a rich GoogleAdsException.
+
+    Args:
+        response (requests.Response):
+            The HTTP response containing error details.
+
+    Raises:
+        GoogleAdsException:
+            A rich exception containing the mapped gRPC status, failure details,
+            and request ID.
+    """
+    # 1. Map HTTP status (e.g., 400) to gRPC status (e.g., INVALID_ARGUMENT)
+    core_error = core_exceptions.from_http_response(response)
+    grpc_code = core_error.grpc_status_code or grpc.StatusCode.INTERNAL
+
+    # 2. Build the ErrorCode using the specific oneof member 'request_error'
+    # Setting this automatically sets the 'error_code' oneof group.
+    # We use '1' (UNSPECIFIED/UNKNOWN) for the enum value within RequestError.
+    e_code = ErrorCode(request_error=1)
+
+    # 3. Build the GoogleAdsError
+    # Message is populated from the RUP response text
+    g_error = GoogleAdsError(
+        message=core_error.message,
+        error_code=e_code
+    )
+
+    # 4. Build the GoogleAdsFailure container
+    # request_id comes from X-Goog-Upload-Status per protocol
+    request_id = response.headers.get("X-Goog-Upload-Status", "unknown")
+    failure = GoogleAdsFailure(
+        errors=[g_error],
+        request_id=request_id
+    )
+
+    # 5. Instantiate the adapter and raise the final exception
+    adapter = ResumableUploadErrorAdapter(response, grpc_code)
+    
+    raise GoogleAdsException(
+        error=adapter,
+        call=adapter,
+        failure=failure,
+        request_id=request_id
+    )
+
+def raise_formatted_for_status(response: requests.Response):
+    """Replacement for response.raise_for_status() that raises GoogleAdsException.
+
+    Args:
+        response (requests.Response):
+            The HTTP response to check for errors.
+
+    Raises:
+        GoogleAdsException:
+            If the response status code indicates an error.
+    """
+    if not response.ok:
+        raise_formatted_ads_exception(response)
+{% endblock %}
+{% endif %}

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/resumable_upload_error_adapter.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/resumable_upload_error_adapter.py.j2
@@ -48,6 +48,8 @@ class ResumableUploadErrorAdapter(grpc.RpcError, grpc.Call):
     def add_callback(self, callback: Any) -> None:
         pass
 
+_ADS_ERROR_CODE_UNKNOWN = 1 # Ads-specific error code to be used with the `ErrorCode`'s `request_error`.
+
 def raise_formatted_ads_exception(response: requests.Response):
     """Converts a RUP HTTP response into a rich GoogleAdsException.
 
@@ -66,8 +68,7 @@ def raise_formatted_ads_exception(response: requests.Response):
 
     # 2. Build the ErrorCode using the specific oneof member 'request_error'
     # Setting this automatically sets the 'error_code' oneof group.
-    # We use '1' (UNSPECIFIED/UNKNOWN) for the enum value within RequestError.
-    e_code = ErrorCode(request_error=1)
+    e_code = ErrorCode(request_error=_ADS_ERROR_CODE_UNKNOWN)
 
     # 3. Build the GoogleAdsError
     # Message is populated from the RUP response text

--- a/packages/gapic-generator/tests/unit/schema/test_api.py
+++ b/packages/gapic-generator/tests/unit/schema/test_api.py
@@ -4745,3 +4745,54 @@ def test_api_build_selective_multiple_protos_kept():
     assert len(api_schema.protos) == 2
     assert "proto1.proto" in api_schema.protos
     assert "proto2.proto" in api_schema.protos
+
+def test_api_has_resumable_upload():
+    # Setup a service with a method that is a resumable upload.
+    # The implementation of is_resumable_upload currently hardcodes certain Ads methods.
+    fd = make_file_pb2(
+        name="foo.proto",
+        package="google.ads.googleads.v555.services",
+        messages=(
+            make_message_pb2(name="CreateYouTubeVideoUploadRequest"),
+            make_message_pb2(name="CreateYouTubeVideoUploadResponse"),
+        ),
+        services=(
+            descriptor_pb2.ServiceDescriptorProto(
+                name="YouTubeVideoUploadService",
+                method=(
+                    descriptor_pb2.MethodDescriptorProto(
+                        name="CreateYouTubeVideoUpload",
+                        input_type="google.ads.googleads.v555.services.CreateYouTubeVideoUploadRequest",
+                        output_type="google.ads.googleads.v555.services.CreateYouTubeVideoUploadResponse",
+                    ),
+                ),
+            ),
+        ),
+    )
+    api_schema = api.API.build([fd], package="google.ads.googleads.v555.services")
+    assert api_schema.has_resumable_upload
+
+def test_api_not_has_resumable_upload():
+    # Setup a service with a method that is NOT a resumable upload.
+    fd = make_file_pb2(
+        name="foo.proto",
+        package="google.example.v1",
+        messages=(
+            make_message_pb2(name="GetFooRequest"),
+            make_message_pb2(name="GetFooResponse"),
+        ),
+        services=(
+            descriptor_pb2.ServiceDescriptorProto(
+                name="FooService",
+                method=(
+                    descriptor_pb2.MethodDescriptorProto(
+                        name="GetFoo",
+                        input_type="google.example.v1.GetFooRequest",
+                        output_type="google.example.v1.GetFooResponse",
+                    ),
+                ),
+            ),
+        ),
+    )
+    api_schema = api.API.build([fd], package="google.example.v1")
+    assert not api_schema.has_resumable_upload

--- a/packages/gapic-generator/tests/unit/schema/wrappers/test_method.py
+++ b/packages/gapic-generator/tests/unit/schema/wrappers/test_method.py
@@ -711,6 +711,138 @@ def test_method_stream_stream():
     assert method.grpc_stub_type == "stream_stream"
 
 
+def test_method_is_resumable_upload():
+    # Correct positive
+    method = make_method(
+        name="ExportAssets",
+        package="google.cloud.asset.v1",
+    )
+    # override parent
+    method = dataclasses.replace(
+        method,
+        meta=dataclasses.replace(
+            method.meta,
+            address=dataclasses.replace(
+                method.meta.address,
+                parent=("AssetService",),
+            )
+        )
+    )
+    assert method.is_resumable_upload
+
+    # Normal method
+    method = make_method(
+        name="GetAsset",
+        package="google.cloud.asset.v1",
+    )
+    method = dataclasses.replace(
+        method,
+        meta=dataclasses.replace(
+            method.meta,
+            address=dataclasses.replace(
+                method.meta.address,
+                parent=("AssetService",),
+            )
+        )
+    )
+    assert not method.is_resumable_upload
+
+    # Method with same name but different package
+    method = make_method(
+        name="ExportAssets",
+        package="foo.bar.v1",
+    )
+    method = dataclasses.replace(
+        method,
+        meta=dataclasses.replace(
+            method.meta,
+            address=dataclasses.replace(
+                method.meta.address,
+                parent=("AssetService",),
+            )
+        )
+    )
+    assert not method.is_resumable_upload
+
+
+def test_method_is_resumable_upload_exclusive():
+    # Resumable + LRO
+    method = make_method(
+        name="ExportAssets",
+        package="google.cloud.asset.v1",
+    )
+    method = dataclasses.replace(
+        method,
+        meta=dataclasses.replace(
+            method.meta,
+            address=dataclasses.replace(
+                method.meta.address,
+                parent=("AssetService",),
+            ),
+        ),
+        lro=wrappers.OperationInfo(
+            response_type=make_message("Res"), metadata_type=make_message("Meta")
+        ),
+    )
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        method.is_resumable_upload
+
+    # Resumable + Client Streaming
+    method = make_method(
+        name="ExportAssets",
+        package="google.cloud.asset.v1",
+        client_streaming=True,
+    )
+    method = dataclasses.replace(
+        method,
+        meta=dataclasses.replace(
+            method.meta,
+            address=dataclasses.replace(
+                method.meta.address,
+                parent=("AssetService",),
+            ),
+        ),
+    )
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        method.is_resumable_upload
+
+    # Resumable + Pagination
+    paged = make_field(name="foos", message=make_message("Foo"), repeated=True)
+    input_msg = make_message(
+        name="ExportAssetsRequest",
+        fields=(
+            make_field(name="page_size", type=5),
+            make_field(name="page_token", type=9),
+        ),
+    )
+    output_msg = make_message(
+        name="ExportAssetsResponse",
+        fields=(
+            paged,
+            make_field(name="next_page_token", type=9),
+        ),
+    )
+    method = make_method(
+        name="ExportAssets",
+        package="google.cloud.asset.v1",
+        input_message=input_msg,
+        output_message=output_msg,
+    )
+    method = dataclasses.replace(
+        method,
+        meta=dataclasses.replace(
+            method.meta,
+            address=dataclasses.replace(
+                method.meta.address,
+                parent=("AssetService",),
+            ),
+        ),
+    )
+    assert method.paged_result_field is not None
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        method.is_resumable_upload
+
+
 def test_method_flattened_fields():
     a = make_field("a", type=5)  # int
     b = make_field("b", type=5)

--- a/packages/gapic-generator/tests/unit/schema/wrappers/test_method.py
+++ b/packages/gapic-generator/tests/unit/schema/wrappers/test_method.py
@@ -714,8 +714,8 @@ def test_method_stream_stream():
 def test_method_is_resumable_upload():
     # Correct positive
     method = make_method(
-        name="ExportAssets",
-        package="google.cloud.asset.v1",
+        name="CreateYouTubeVideoUpload",
+        package="google.ads.googleads.v25",
     )
     # override parent
     method = dataclasses.replace(
@@ -724,7 +724,7 @@ def test_method_is_resumable_upload():
             method.meta,
             address=dataclasses.replace(
                 method.meta.address,
-                parent=("AssetService",),
+                parent=("YouTubeVideoUploadService",),
             )
         )
     )
@@ -732,8 +732,8 @@ def test_method_is_resumable_upload():
 
     # Normal method
     method = make_method(
-        name="GetAsset",
-        package="google.cloud.asset.v1",
+        name="DeleteYouTubeVideoUpload",
+        package="google.ads.googleads.v25",
     )
     method = dataclasses.replace(
         method,
@@ -741,7 +741,7 @@ def test_method_is_resumable_upload():
             method.meta,
             address=dataclasses.replace(
                 method.meta.address,
-                parent=("AssetService",),
+                parent=("YouTubeVideoUploadService",),
             )
         )
     )
@@ -749,7 +749,7 @@ def test_method_is_resumable_upload():
 
     # Method with same name but different package
     method = make_method(
-        name="ExportAssets",
+        name="CreateYouTubeVideoUpload",
         package="foo.bar.v1",
     )
     method = dataclasses.replace(
@@ -758,7 +758,7 @@ def test_method_is_resumable_upload():
             method.meta,
             address=dataclasses.replace(
                 method.meta.address,
-                parent=("AssetService",),
+                parent=("YouTubeVideoUploadService",),
             )
         )
     )
@@ -768,8 +768,8 @@ def test_method_is_resumable_upload():
 def test_method_is_resumable_upload_exclusive():
     # Resumable + LRO
     method = make_method(
-        name="ExportAssets",
-        package="google.cloud.asset.v1",
+        name="CreateYouTubeVideoUpload",
+        package="google.ads.googleads.v25",
     )
     method = dataclasses.replace(
         method,
@@ -777,7 +777,7 @@ def test_method_is_resumable_upload_exclusive():
             method.meta,
             address=dataclasses.replace(
                 method.meta.address,
-                parent=("AssetService",),
+                parent=("YouTubeVideoUploadService",),
             ),
         ),
         lro=wrappers.OperationInfo(
@@ -789,8 +789,8 @@ def test_method_is_resumable_upload_exclusive():
 
     # Resumable + Client Streaming
     method = make_method(
-        name="ExportAssets",
-        package="google.cloud.asset.v1",
+        name="CreateYouTubeVideoUpload",
+        package="google.ads.googleads.v25",
         client_streaming=True,
     )
     method = dataclasses.replace(
@@ -799,7 +799,7 @@ def test_method_is_resumable_upload_exclusive():
             method.meta,
             address=dataclasses.replace(
                 method.meta.address,
-                parent=("AssetService",),
+                parent=("YouTubeVideoUploadService",),
             ),
         ),
     )
@@ -809,22 +809,22 @@ def test_method_is_resumable_upload_exclusive():
     # Resumable + Pagination
     paged = make_field(name="foos", message=make_message("Foo"), repeated=True)
     input_msg = make_message(
-        name="ExportAssetsRequest",
+        name="CreateYouTubeVideoUploadRequest",
         fields=(
             make_field(name="page_size", type=5),
             make_field(name="page_token", type=9),
         ),
     )
     output_msg = make_message(
-        name="ExportAssetsResponse",
+        name="CreateYouTubeVideoUploadResponse",
         fields=(
             paged,
             make_field(name="next_page_token", type=9),
         ),
     )
     method = make_method(
-        name="ExportAssets",
-        package="google.cloud.asset.v1",
+        name="CreateYouTubeVideoUpload",
+        package="google.ads.googleads.v25",
         input_message=input_msg,
         output_message=output_msg,
     )
@@ -834,7 +834,7 @@ def test_method_is_resumable_upload_exclusive():
             method.meta,
             address=dataclasses.replace(
                 method.meta.address,
-                parent=("AssetService",),
+                parent=("YouTubeVideoUploadService",),
             ),
         ),
     )


### PR DESCRIPTION
This enables Resumable Upload ("Scotty") features generation for Google Ads "Simply" libraries only. 

Briefly the changes consist of three parts:
* The protocol implementation (and the error adapter)
* The Rest-Resumable transport
* The changes in the client for the service, including RPC generation changes and the addition of the new Rest-Resumable transport initialization.

Full description of the changes in the internal document go/cloudsdk-scotty-python-q226 .