### PR TITLE
fix(templates): resolve core dependencies locally and batch pip installs

### DIFF
--- a/packages/gapic-generator/gapic/templates/noxfile.py.j2
+++ b/packages/gapic-generator/gapic/templates/noxfile.py.j2
@@ -595,17 +595,20 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_dependencies_from_source = [        
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+    core_packages = [
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    packages_dir = CURRENT_DIRECTORY.parent
+
+    for pkg in core_packages:
+        pkg_path = str(packages_dir / pkg)
+        session.install(pkg_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {pkg_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/gapic/templates/noxfile.py.j2
+++ b/packages/gapic-generator/gapic/templates/noxfile.py.j2
@@ -509,24 +509,51 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) 
+        for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+    
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -607,10 +634,11 @@ def core_deps_from_source(session, protobuf_implementation):
     while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
         deps_dir = deps_dir.parent
 
-    for dep in core_dependencies_from_source:
-        dep_path = str(deps_dir / dep)
-        session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep} locally from {dep_path}")
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+    
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/gapic/templates/noxfile.py.j2
+++ b/packages/gapic-generator/gapic/templates/noxfile.py.j2
@@ -595,7 +595,7 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_packages = [
+    core_dependencies_from_source = [
         "googleapis-common-protos",
         "google-api-core",
         "google-auth",
@@ -603,12 +603,14 @@ def core_deps_from_source(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    packages_dir = CURRENT_DIRECTORY.parent
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-    for pkg in core_packages:
-        pkg_path = str(packages_dir / pkg)
-        session.install(pkg_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {pkg_path}")
+    for dep in core_dependencies_from_source:
+        dep_path = str(deps_dir / dep)
+        session.install(dep_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/gapic/templates/noxfile.py.j2
+++ b/packages/gapic-generator/gapic/templates/noxfile.py.j2
@@ -610,7 +610,7 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         dep_path = str(deps_dir / dep)
         session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {dep_path}")
+        print(f"Installed {dep} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
@@ -587,17 +587,20 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+    core_packages = [
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    packages_dir = CURRENT_DIRECTORY.parent
+
+    for pkg in core_packages:
+        pkg_path = str(packages_dir / pkg)
+        session.install(pkg_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {pkg_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
@@ -602,7 +602,7 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         dep_path = str(deps_dir / dep)
         session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {dep_path}")
+        print(f"Installed {dep} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
@@ -587,7 +587,7 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_packages = [
+    core_dependencies_from_source = [
         "googleapis-common-protos",
         "google-api-core",
         "google-auth",
@@ -595,12 +595,14 @@ def core_deps_from_source(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    packages_dir = CURRENT_DIRECTORY.parent
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-    for pkg in core_packages:
-        pkg_path = str(packages_dir / pkg)
-        session.install(pkg_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {pkg_path}")
+    for dep in core_dependencies_from_source:
+        dep_path = str(deps_dir / dep)
+        session.install(dep_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
@@ -501,24 +501,51 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1)
+        for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -599,10 +626,11 @@ def core_deps_from_source(session, protobuf_implementation):
     while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
         deps_dir = deps_dir.parent
 
-    for dep in core_dependencies_from_source:
-        dep_path = str(deps_dir / dep)
-        session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep} locally from {dep_path}")
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
@@ -587,17 +587,20 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+    core_packages = [
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    packages_dir = CURRENT_DIRECTORY.parent
+
+    for pkg in core_packages:
+        pkg_path = str(packages_dir / pkg)
+        session.install(pkg_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {pkg_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
@@ -602,7 +602,7 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         dep_path = str(deps_dir / dep)
         session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {dep_path}")
+        print(f"Installed {dep} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
@@ -587,7 +587,7 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_packages = [
+    core_dependencies_from_source = [
         "googleapis-common-protos",
         "google-api-core",
         "google-auth",
@@ -595,12 +595,14 @@ def core_deps_from_source(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    packages_dir = CURRENT_DIRECTORY.parent
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-    for pkg in core_packages:
-        pkg_path = str(packages_dir / pkg)
-        session.install(pkg_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {pkg_path}")
+    for dep in core_dependencies_from_source:
+        dep_path = str(deps_dir / dep)
+        session.install(dep_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
@@ -501,24 +501,51 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1)
+        for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -599,10 +626,11 @@ def core_deps_from_source(session, protobuf_implementation):
     while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
         deps_dir = deps_dir.parent
 
-    for dep in core_dependencies_from_source:
-        dep_path = str(deps_dir / dep)
-        session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep} locally from {dep_path}")
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
@@ -587,17 +587,20 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+    core_packages = [
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    packages_dir = CURRENT_DIRECTORY.parent
+
+    for pkg in core_packages:
+        pkg_path = str(packages_dir / pkg)
+        session.install(pkg_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {pkg_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
@@ -602,7 +602,7 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         dep_path = str(deps_dir / dep)
         session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {dep_path}")
+        print(f"Installed {dep} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
@@ -587,7 +587,7 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_packages = [
+    core_dependencies_from_source = [
         "googleapis-common-protos",
         "google-api-core",
         "google-auth",
@@ -595,12 +595,14 @@ def core_deps_from_source(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    packages_dir = CURRENT_DIRECTORY.parent
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-    for pkg in core_packages:
-        pkg_path = str(packages_dir / pkg)
-        session.install(pkg_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {pkg_path}")
+    for dep in core_dependencies_from_source:
+        dep_path = str(deps_dir / dep)
+        session.install(dep_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
@@ -501,24 +501,51 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1)
+        for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -599,10 +626,11 @@ def core_deps_from_source(session, protobuf_implementation):
     while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
         deps_dir = deps_dir.parent
 
-    for dep in core_dependencies_from_source:
-        dep_path = str(deps_dir / dep)
-        session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep} locally from {dep_path}")
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
@@ -587,17 +587,20 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+    core_packages = [
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    packages_dir = CURRENT_DIRECTORY.parent
+
+    for pkg in core_packages:
+        pkg_path = str(packages_dir / pkg)
+        session.install(pkg_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {pkg_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
@@ -602,7 +602,7 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         dep_path = str(deps_dir / dep)
         session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {dep_path}")
+        print(f"Installed {dep} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
@@ -587,7 +587,7 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_packages = [
+    core_dependencies_from_source = [
         "googleapis-common-protos",
         "google-api-core",
         "google-auth",
@@ -595,12 +595,14 @@ def core_deps_from_source(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    packages_dir = CURRENT_DIRECTORY.parent
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-    for pkg in core_packages:
-        pkg_path = str(packages_dir / pkg)
-        session.install(pkg_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {pkg_path}")
+    for dep in core_dependencies_from_source:
+        dep_path = str(deps_dir / dep)
+        session.install(dep_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
@@ -501,24 +501,51 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1)
+        for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -599,10 +626,11 @@ def core_deps_from_source(session, protobuf_implementation):
     while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
         deps_dir = deps_dir.parent
 
-    for dep in core_dependencies_from_source:
-        dep_path = str(deps_dir / dep)
-        session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep} locally from {dep_path}")
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
@@ -587,17 +587,20 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+    core_packages = [
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    packages_dir = CURRENT_DIRECTORY.parent
+
+    for pkg in core_packages:
+        pkg_path = str(packages_dir / pkg)
+        session.install(pkg_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {pkg_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
@@ -602,7 +602,7 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         dep_path = str(deps_dir / dep)
         session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {dep_path}")
+        print(f"Installed {dep} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
@@ -587,7 +587,7 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_packages = [
+    core_dependencies_from_source = [
         "googleapis-common-protos",
         "google-api-core",
         "google-auth",
@@ -595,12 +595,14 @@ def core_deps_from_source(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    packages_dir = CURRENT_DIRECTORY.parent
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-    for pkg in core_packages:
-        pkg_path = str(packages_dir / pkg)
-        session.install(pkg_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {pkg_path}")
+    for dep in core_dependencies_from_source:
+        dep_path = str(deps_dir / dep)
+        session.install(dep_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
@@ -501,24 +501,51 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1)
+        for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -599,10 +626,11 @@ def core_deps_from_source(session, protobuf_implementation):
     while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
         deps_dir = deps_dir.parent
 
-    for dep in core_dependencies_from_source:
-        dep_path = str(deps_dir / dep)
-        session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep} locally from {dep_path}")
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
@@ -587,17 +587,20 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+    core_packages = [
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    packages_dir = CURRENT_DIRECTORY.parent
+
+    for pkg in core_packages:
+        pkg_path = str(packages_dir / pkg)
+        session.install(pkg_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {pkg_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
@@ -602,7 +602,7 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         dep_path = str(deps_dir / dep)
         session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {dep_path}")
+        print(f"Installed {dep} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
@@ -587,7 +587,7 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_packages = [
+    core_dependencies_from_source = [
         "googleapis-common-protos",
         "google-api-core",
         "google-auth",
@@ -595,12 +595,14 @@ def core_deps_from_source(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    packages_dir = CURRENT_DIRECTORY.parent
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-    for pkg in core_packages:
-        pkg_path = str(packages_dir / pkg)
-        session.install(pkg_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {pkg_path}")
+    for dep in core_dependencies_from_source:
+        dep_path = str(deps_dir / dep)
+        session.install(dep_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
@@ -501,24 +501,51 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1)
+        for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -599,10 +626,11 @@ def core_deps_from_source(session, protobuf_implementation):
     while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
         deps_dir = deps_dir.parent
 
-    for dep in core_dependencies_from_source:
-        dep_path = str(deps_dir / dep)
-        session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep} locally from {dep_path}")
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
@@ -587,17 +587,20 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+    core_packages = [
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    packages_dir = CURRENT_DIRECTORY.parent
+
+    for pkg in core_packages:
+        pkg_path = str(packages_dir / pkg)
+        session.install(pkg_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {pkg_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
@@ -602,7 +602,7 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         dep_path = str(deps_dir / dep)
         session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {dep_path}")
+        print(f"Installed {dep} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
@@ -587,7 +587,7 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_packages = [
+    core_dependencies_from_source = [
         "googleapis-common-protos",
         "google-api-core",
         "google-auth",
@@ -595,12 +595,14 @@ def core_deps_from_source(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    packages_dir = CURRENT_DIRECTORY.parent
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-    for pkg in core_packages:
-        pkg_path = str(packages_dir / pkg)
-        session.install(pkg_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {pkg_path}")
+    for dep in core_dependencies_from_source:
+        dep_path = str(deps_dir / dep)
+        session.install(dep_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
@@ -501,24 +501,51 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1)
+        for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -599,10 +626,11 @@ def core_deps_from_source(session, protobuf_implementation):
     while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
         deps_dir = deps_dir.parent
 
-    for dep in core_dependencies_from_source:
-        dep_path = str(deps_dir / dep)
-        session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep} locally from {dep_path}")
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
@@ -587,17 +587,20 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+    core_packages = [
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    packages_dir = CURRENT_DIRECTORY.parent
+
+    for pkg in core_packages:
+        pkg_path = str(packages_dir / pkg)
+        session.install(pkg_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {pkg_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
@@ -602,7 +602,7 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         dep_path = str(deps_dir / dep)
         session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {dep_path}")
+        print(f"Installed {dep} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
@@ -587,7 +587,7 @@ def core_deps_from_source(session, protobuf_implementation):
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
-    core_packages = [
+    core_dependencies_from_source = [
         "googleapis-common-protos",
         "google-api-core",
         "google-auth",
@@ -595,12 +595,14 @@ def core_deps_from_source(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    packages_dir = CURRENT_DIRECTORY.parent
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-    for pkg in core_packages:
-        pkg_path = str(packages_dir / pkg)
-        session.install(pkg_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {pkg} locally from {pkg_path}")
+    for dep in core_dependencies_from_source:
+        dep_path = str(deps_dir / dep)
+        session.install(dep_path, "--no-deps", "--ignore-installed")
+        print(f"Installed {pkg} locally from {dep_path}")
 
     session.run(
         "py.test",

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
@@ -501,24 +501,51 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1)
+        for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -599,10 +626,11 @@ def core_deps_from_source(session, protobuf_implementation):
     while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
         deps_dir = deps_dir.parent
 
-    for dep in core_dependencies_from_source:
-        dep_path = str(deps_dir / dep)
-        session.install(dep_path, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep} locally from {dep_path}")
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}")
 
     session.run(
         "py.test",


### PR DESCRIPTION
fix(templates): resolve core dependencies locally and batch pip installs

Previously, the `core_deps_from_source` and `prerelease_deps` nox sessions installed core sibling packages sequentially. In a monorepo environment, this caused two major issues:
1. Correctness: It frequently fetched remote upstream code (or PyPI releases) instead of testing the actual local code modified in the active PR.
2. Performance: Sequential `pip install` commands triggered strict dependency resolution repeatedly, leading to severe CI timeouts.

This updates the noxfile template to:
* Dynamically resolve first-party dependencies from the local `packages/` directory to guarantee the presubmit tests the active PR's code.
* Batch the `pip install` commands using `--no-deps` and `--ignore-installed` to bypass the resolver overhead and eliminate the sequential network bottleneck.
* Dynamically sort packages in `prerelease_deps` into local vs. PyPI deployments using a regex parser, ensuring safe handling of complex version bounds (e.g., `grpcio>=1.75.1`) without hardcoding multiple lists.