### PR TITLE
chore: add bigframes load test config to the kokoro configs

### DIFF
--- a/.kokoro/build-bigframes.sh
+++ b/.kokoro/build-bigframes.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+PROJECT_SCM="github/google-cloud-python/packages/bigframes"
+
+if [[ -z "${PROJECT_ROOT:-}" ]]; then
+    PROJECT_ROOT="${KOKORO_ARTIFACTS_DIR}/${PROJECT_SCM}"
+fi
+
+cd "${PROJECT_ROOT}"
+
+# Disable buffering, so that the logs stream through.
+export PYTHONUNBUFFERED=1
+
+# Workaround https://github.com/pytest-dev/pytest/issues/9567
+export PY_IGNORE_IMPORTMISMATCH=1
+
+# Debug: show build environment
+env | grep KOKORO
+
+# Install pip
+python3 -m pip install --upgrade --quiet pip
+python3 -m pip --version
+
+# Remove old nox
+python3 -m pip uninstall --yes --quiet nox-automation
+
+# Install nox
+python3 -m pip install --upgrade --quiet nox
+python3 -m nox --version
+
+# If NOX_SESSION is set, it only runs the specified session,
+# otherwise run all the sessions.
+if [[ -n "${NOX_SESSION:-}" ]]; then
+    python3 -m nox --stop-on-first-error -s ${NOX_SESSION:-}
+else
+    python3 -m nox --stop-on-first-error
+fi
+
+# Prevent kokoro from trying to collect many mb of artifacts, wasting several minutes
+sudo rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*

--- a/.kokoro/load/load-bigframes.cfg
+++ b/.kokoro/load/load-bigframes.cfg
@@ -1,0 +1,27 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Build logs will be here
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}
+
+build_file: "google-cloud-python/.kokoro/build-bigframes.sh"
+timeout_mins: 720
+
+# Only run this nox session.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "load"
+}
+
+env_vars: {
+    key: "GOOGLE_CLOUD_PROJECT"
+    value: "bigframes-load-testing"
+}
+
+env_vars: {
+    key: "BIGFRAMES_TEST_MODEL_VERTEX_ENDPOINT"
+    value: "https://us-central1-aiplatform.googleapis.com/v1/projects/272725758477/locations/us-central1/endpoints/590545496255234048"
+}


### PR DESCRIPTION
Changes are pulled from the old BigFrames repo:
* https://github.com/googleapis/python-bigquery-dataframes/blob/main/.kokoro/load/load.cfg
* https://github.com/googleapis/python-bigquery-dataframes/blob/main/.kokoro/load/common.cfg
* https://github.com/googleapis/python-bigquery-dataframes/blob/main/.kokoro/build.sh

We will also add configs to pipers so that the BigFrames load test will have its own dedicated Kokoro job.

Internal issue: b/509623551 