### PR TITLE
chore: fix 'multimodel' typo to 'multimodal'

### DIFF
--- a/packages/bigframes/CHANGELOG.md
+++ b/packages/bigframes/CHANGELOG.md
@@ -447,7 +447,7 @@
 
 ### Bug Fixes
 
-* Deflake ai_gen_bool multimodel test ([#2085](https://github.com/googleapis/python-bigquery-dataframes/issues/2085)) ([566a37a](https://github.com/googleapis/python-bigquery-dataframes/commit/566a37a30ad5677aef0c5f79bdd46bca2139cc1e))
+* Deflake ai_gen_bool multimodal test ([#2085](https://github.com/googleapis/python-bigquery-dataframes/issues/2085)) ([566a37a](https://github.com/googleapis/python-bigquery-dataframes/commit/566a37a30ad5677aef0c5f79bdd46bca2139cc1e))
 * Do not scroll page selector in anywidget `repr_mode` ([#2082](https://github.com/googleapis/python-bigquery-dataframes/issues/2082)) ([5ce5d63](https://github.com/googleapis/python-bigquery-dataframes/commit/5ce5d63fcb51bfb3df2769108b7486287896ccb9))
 * Fix the potential invalid VPC egress configuration ([#2068](https://github.com/googleapis/python-bigquery-dataframes/issues/2068)) ([cce4966](https://github.com/googleapis/python-bigquery-dataframes/commit/cce496605385f2ac7ab0becc0773800ed5901aa5))
 * Return a DataFrame containing query stats for all non-SELECT statements ([#2071](https://github.com/googleapis/python-bigquery-dataframes/issues/2071)) ([a52b913](https://github.com/googleapis/python-bigquery-dataframes/commit/a52b913d9d8794b4b959ea54744a38d9f2f174e7))

--- a/packages/bigframes/CHANGELOG.md
+++ b/packages/bigframes/CHANGELOG.md
@@ -447,7 +447,7 @@
 
 ### Bug Fixes
 
-* Deflake ai_gen_bool multimodal test ([#2085](https://github.com/googleapis/python-bigquery-dataframes/issues/2085)) ([566a37a](https://github.com/googleapis/python-bigquery-dataframes/commit/566a37a30ad5677aef0c5f79bdd46bca2139cc1e))
+* Deflake ai_gen_bool multimodel test ([#2085](https://github.com/googleapis/python-bigquery-dataframes/issues/2085)) ([566a37a](https://github.com/googleapis/python-bigquery-dataframes/commit/566a37a30ad5677aef0c5f79bdd46bca2139cc1e))
 * Do not scroll page selector in anywidget `repr_mode` ([#2082](https://github.com/googleapis/python-bigquery-dataframes/issues/2082)) ([5ce5d63](https://github.com/googleapis/python-bigquery-dataframes/commit/5ce5d63fcb51bfb3df2769108b7486287896ccb9))
 * Fix the potential invalid VPC egress configuration ([#2068](https://github.com/googleapis/python-bigquery-dataframes/issues/2068)) ([cce4966](https://github.com/googleapis/python-bigquery-dataframes/commit/cce496605385f2ac7ab0becc0773800ed5901aa5))
 * Return a DataFrame containing query stats for all non-SELECT statements ([#2071](https://github.com/googleapis/python-bigquery-dataframes/issues/2071)) ([a52b913](https://github.com/googleapis/python-bigquery-dataframes/commit/a52b913d9d8794b4b959ea54744a38d9f2f174e7))

--- a/packages/bigframes/bigframes/bigquery/_operations/ai.py
+++ b/packages/bigframes/bigframes/bigquery/_operations/ai.py
@@ -1205,7 +1205,7 @@ def _convert_series(
     result = convert.to_bf_series(s, default_index=None, session=session)
 
     if result.dtype == dtypes.OBJ_REF_DTYPE:
-        # Support multimodel
+        # Support multimodal
         return result.blob.read_url()
     return result
 

--- a/packages/bigframes/bigframes/operations/ai.py
+++ b/packages/bigframes/bigframes/operations/ai.py
@@ -223,7 +223,7 @@ class AIAccessor:
                 bigframes.series.Series,
                 model.predict(
                     df,
-                    prompt=self._make_multimodel_prompt(
+                    prompt=self._make_multimodal_prompt(
                         df, columns, user_instruction, output_instruction
                     ),
                     temperature=0.0,
@@ -774,7 +774,7 @@ class AIAccessor:
         return result_df
 
     @staticmethod
-    def _make_multimodel_prompt(
+    def _make_multimodal_prompt(
         prompt_df, columns, user_instruction: str, output_instruction: str
     ):
         prompt = [f"{output_instruction}\n{user_instruction}\nContext: "]

--- a/packages/bigframes/bigframes/operations/semantics.py
+++ b/packages/bigframes/bigframes/operations/semantics.py
@@ -397,7 +397,7 @@ class Semantics:
                 bigframes.dataframe.DataFrame,
                 model.predict(
                     df,
-                    prompt=self._make_multimodel_prompt(
+                    prompt=self._make_multimodal_prompt(
                         df, columns, user_instruction, output_instruction
                     ),
                     temperature=0.0,
@@ -518,7 +518,7 @@ class Semantics:
                 bigframes.series.Series,
                 model.predict(
                     df,
-                    prompt=self._make_multimodel_prompt(
+                    prompt=self._make_multimodal_prompt(
                         df, columns, user_instruction, output_instruction
                     ),
                     temperature=0.0,
@@ -1094,7 +1094,7 @@ class Semantics:
         return result_df
 
     @staticmethod
-    def _make_multimodel_prompt(
+    def _make_multimodal_prompt(
         prompt_df, columns, user_instruction: str, output_instruction: str
     ):
         prompt = [f"{output_instruction}\n{user_instruction}\nContext: "]

--- a/packages/bigframes/tests/system/large/operations/test_ai.py
+++ b/packages/bigframes/tests/system/large/operations/test_ai.py
@@ -65,7 +65,7 @@ def test_filter_multi_model(session, gemini_flash_model):
         10,
     ):
         df = session.from_glob_path(
-            "gs://bigframes-dev-testing/a_multimodel/images/*", name="image"
+            "gs://bigframes-dev-testing/a_multimodal/images/*", name="image"
         )
         df["prey"] = series.Series(
             ["building", "cross road", "rock", "squirrel", "rabbit"], session=session
@@ -239,7 +239,7 @@ def test_map_multimodal(session, gemini_flash_model):
         10,
     ):
         df = session.from_glob_path(
-            "gs://bigframes-dev-testing/a_multimodel/images/*", name="image"
+            "gs://bigframes-dev-testing/a_multimodal/images/*", name="image"
         )
         df["scenario"] = series.Series(
             ["building", "cross road", "tree", "squirrel", "rabbit"], session=session

--- a/packages/bigframes/tests/system/large/operations/test_ai.py
+++ b/packages/bigframes/tests/system/large/operations/test_ai.py
@@ -229,7 +229,7 @@ def test_map(session, gemini_flash_model, output_schema, output_col):
     )
 
 
-def test_map_multimodel(session, gemini_flash_model):
+def test_map_multimodal(session, gemini_flash_model):
     with bigframes.option_context(
         AI_OP_EXP_OPTION,
         True,

--- a/packages/bigframes/tests/system/large/operations/test_semantics.py
+++ b/packages/bigframes/tests/system/large/operations/test_semantics.py
@@ -571,7 +571,7 @@ def test_map(session, gemini_flash_model):
     )
 
 
-def test_map_multimodel(session, gemini_flash_model):
+def test_map_multimodal(session, gemini_flash_model):
     with bigframes.option_context(
         SEM_OP_EXP_OPTION,
         True,

--- a/packages/bigframes/tests/system/large/operations/test_semantics.py
+++ b/packages/bigframes/tests/system/large/operations/test_semantics.py
@@ -412,7 +412,7 @@ def test_filter_multi_model(session, gemini_flash_model):
         10,
     ):
         df = session.from_glob_path(
-            "gs://bigframes-dev-testing/a_multimodel/images/*", name="image"
+            "gs://bigframes-dev-testing/a_multimodal/images/*", name="image"
         )
         df["prey"] = series.Series(
             ["building", "cross road", "rock", "squirrel", "rabbit"], session=session
@@ -581,7 +581,7 @@ def test_map_multimodal(session, gemini_flash_model):
         10,
     ):
         df = session.from_glob_path(
-            "gs://bigframes-dev-testing/a_multimodel/images/*", name="image"
+            "gs://bigframes-dev-testing/a_multimodal/images/*", name="image"
         )
         df["scenario"] = series.Series(
             ["building", "cross road", "tree", "squirrel", "rabbit"], session=session

--- a/packages/bigframes/tests/system/small/bigquery/test_ai.py
+++ b/packages/bigframes/tests/system/small/bigquery/test_ai.py
@@ -160,7 +160,7 @@ def test_ai_generate_bool(session):
 
 def test_ai_generate_bool_multi_model(session):
     df = session.from_glob_path(
-        "gs://bigframes-dev-testing/a_multimodel/images/*", name="image"
+        "gs://bigframes-dev-testing/a_multimodal/images/*", name="image"
     )
 
     result = bbq.ai.generate_bool((df["image"], " contains an animal"))
@@ -197,7 +197,7 @@ def test_ai_generate_int(session):
 
 def test_ai_generate_int_multi_model(session):
     df = session.from_glob_path(
-        "gs://bigframes-dev-testing/a_multimodel/images/*", name="image"
+        "gs://bigframes-dev-testing/a_multimodal/images/*", name="image"
     )
 
     result = bbq.ai.generate_int(
@@ -236,7 +236,7 @@ def test_ai_generate_double(session):
 
 def test_ai_generate_double_multi_model(session):
     df = session.from_glob_path(
-        "gs://bigframes-dev-testing/a_multimodel/images/*", name="image"
+        "gs://bigframes-dev-testing/a_multimodal/images/*", name="image"
     )
 
     result = bbq.ai.generate_double(
@@ -307,7 +307,7 @@ def test_ai_if(session):
 
 def test_ai_if_multi_model(session, bq_connection):
     df = session.from_glob_path(
-        "gs://bigframes-dev-testing/a_multimodel/images/*",
+        "gs://bigframes-dev-testing/a_multimodal/images/*",
         name="image",
         connection=bq_connection,
     )
@@ -338,7 +338,7 @@ def test_ai_classify_with_examples(session):
 
 def test_ai_classify_multi_model(session, bq_connection):
     df = session.from_glob_path(
-        "gs://bigframes-dev-testing/a_multimodel/images/*",
+        "gs://bigframes-dev-testing/a_multimodal/images/*",
         name="image",
         connection=bq_connection,
     )
@@ -361,7 +361,7 @@ def test_ai_score(session):
 
 def test_ai_score_multi_model(session):
     df = session.from_glob_path(
-        "gs://bigframes-dev-testing/a_multimodel/images/*", name="image"
+        "gs://bigframes-dev-testing/a_multimodal/images/*", name="image"
     )
     prompt = ("Rank the liveliness of ", df["image"], "on the scale from 1 to 3")
 


### PR DESCRIPTION
Corrects the typo "multimodel" to "multimodal" across the codebase. This includes internal method names, comments, test functions, and GCS paths in system tests. This aligns the naming with the standard term for models supporting multiple data modalities.

Fixes #<issue_number_goes_here> 🦕